### PR TITLE
Feat/language menu

### DIFF
--- a/.styleguidist/styleguidist.require.js
+++ b/.styleguidist/styleguidist.require.js
@@ -2,9 +2,8 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 
 var ReachMenuButton = require('@reach/menu-button');
-var { MenuItem: DropdownItem, MenuLink: DropdownLink } = ReachMenuButton;
+var { MenuItem: DropdownItem } = ReachMenuButton;
 global.DropdownItem = DropdownItem;
-global.DropdownLink = DropdownLink;
 
 import '../src/core/theme/fontFaces.css';
 

--- a/.styleguidist/styleguidist.require.js
+++ b/.styleguidist/styleguidist.require.js
@@ -1,9 +1,11 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 
-var ReachMenuButton = require('@reach/menu-button');
-var { MenuItem: DropdownItem } = ReachMenuButton;
+var { DropdownItem } = require('../src/core/Dropdown/Dropdown');
+var { MenuItem, MenuLink } = require('../src/core/Menu/Menu');
 global.DropdownItem = DropdownItem;
+global.MenuItem = MenuItem;
+global.MenuLink = MenuLink;
 
 import '../src/core/theme/fontFaces.css';
 

--- a/package.json
+++ b/package.json
@@ -91,12 +91,12 @@
   "dependencies": {
     "@emotion/core": "10.0.0",
     "@emotion/styled": "10.0.0",
-    "@reach/menu-button": "0.1.8",
+    "@reach/menu-button": "0.1.7",
     "classnames": "2.2.6",
     "normalize.cssinjs": "1.0.5",
     "polished": "2.3.1",
     "react-svg": "7.2.2",
-    "suomifi-icons": "0.0.1"
+    "suomifi-icons": "0.0.2"
   },
   "peerDependencies": {
     "react": "16.6.3",

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -29,6 +29,12 @@ export interface DropdownProps {
   changeNameToSelection?: boolean;
   /** Custom classname to extend or customize */
   className?: string;
+  /** Custom classname to extend or customize */
+  dropdownButtonClassName?: string;
+  /** Custom classname to extend or customize */
+  dropdownListClassName?: string;
+  /** Custom classname to extend or customize */
+  dropdownItemClassName?: string;
   /** DropdownItems */
   children?:
     | Array<ReactElement<DropdownListItems>>
@@ -40,19 +46,27 @@ export class Dropdown extends Component<DropdownProps> {
 
   changeName = (name: ReactNode) => this.setState({ selectedName: name });
 
-  list = (children: ReactNode) =>
+  list = (
+    children: ReactNode,
+    changeNameToSelection: boolean,
+    dropdownItemClassname?: string,
+  ) =>
     React.Children.map(children, (child: React.ReactElement<MenuItemProps>) => {
       const { children: childChildren } = child.props;
-      if (
-        React.isValidElement(child) &&
+      const className = { className: dropdownItemClassname };
+      const isChildString =
+        !!changeNameToSelection &&
         !!childChildren &&
-        typeof childChildren === 'string'
-      ) {
+        typeof childChildren === 'string';
+      if (React.isValidElement(child)) {
         return React.cloneElement(child, {
-          onSelect: () => {
-            child.props.onSelect();
-            this.changeName.bind(this)(childChildren);
-          },
+          ...className,
+          ...(!!isChildString && {
+            onSelect: () => {
+              child.props.onSelect();
+              this.changeName.bind(this)(childChildren);
+            },
+          }),
         });
       }
       return child;
@@ -63,6 +77,9 @@ export class Dropdown extends Component<DropdownProps> {
       children,
       name,
       className,
+      dropdownButtonClassName,
+      dropdownListClassName,
+      dropdownItemClassName,
       changeNameToSelection = true,
       ...passProps
     } = this.props;
@@ -76,9 +93,11 @@ export class Dropdown extends Component<DropdownProps> {
     return (
       <span className={className}>
         <Menu {...passProps}>
-          <MenuButton>{!!selectedName ? selectedName : name}</MenuButton>
-          <MenuList>
-            {!!changeNameToSelection ? this.list(children) : children}
+          <MenuButton className={dropdownButtonClassName}>
+            {!!selectedName ? selectedName : name}
+          </MenuButton>
+          <MenuList className={dropdownListClassName}>
+            {this.list(children, changeNameToSelection, dropdownItemClassName)}
           </MenuList>
         </Menu>
       </span>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,44 +1,32 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, ReactElement } from 'react';
 import {
   Menu,
   MenuButton,
   MenuList,
   MenuItem,
   MenuItemProps,
-  MenuLink,
-  MenuLinkProps,
 } from '@reach/menu-button';
 import { logger } from '../../utils/logger';
 import '@reach/menu-button/styles.css';
 
-export {
-  MenuItem as DropdownItem,
-  MenuItemProps as DropdownItemProps,
-  MenuLink as DropdownLink,
-  MenuLinkProps as DropdownLinkProps,
-};
+export { MenuItem as DropdownItem };
 
-interface DropdownItemProps {
+export interface DropdownItemProps {
   /** Operation to run on select */
   onSelect: () => void;
   /** Item content */
   children: ReactNode;
 }
 
-interface DropdownLinkProps {
-  /** Url to direct to */
-  href: string;
-  /** Item content */
-  children: ReactNode;
-}
-
-type DropdownListItems = DropdownItemProps | DropdownLinkProps;
+type DropdownListItems = DropdownItemProps;
 
 export interface DropdownProps extends MenuNameProps {
   /** Custom classname to extend or customize */
   className?: string;
-  /** Dropdown items */
-  children?: Array<React.ReactElement<DropdownListItems>>;
+  /** Array of DropdownItem's */
+  children?:
+    | Array<ReactElement<DropdownListItems>>
+    | ReactElement<DropdownListItems>;
 }
 
 interface MenuNameProps {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -35,28 +35,28 @@ export interface DropdownProps {
     | ReactElement<DropdownListItems>;
 }
 
-const list = (children: ReactNode) =>
-  React.Children.map(children, (child: React.ReactElement<MenuItemProps>) => {
-    const { children: childChildren } = child.props;
-    if (
-      React.isValidElement(child) &&
-      !!childChildren &&
-      typeof childChildren === 'string'
-    ) {
-      return React.cloneElement(child, {
-        onSelect: () => {
-          child.props.onSelect();
-          this.changeName.bind(this)(childChildren);
-        },
-      });
-    }
-    return child;
-  });
-
 export class Dropdown extends Component<DropdownProps> {
   state = { selectedName: undefined };
 
   changeName = (name: ReactNode) => this.setState({ selectedName: name });
+
+  list = (children: ReactNode) =>
+    React.Children.map(children, (child: React.ReactElement<MenuItemProps>) => {
+      const { children: childChildren } = child.props;
+      if (
+        React.isValidElement(child) &&
+        !!childChildren &&
+        typeof childChildren === 'string'
+      ) {
+        return React.cloneElement(child, {
+          onSelect: () => {
+            child.props.onSelect();
+            this.changeName.bind(this)(childChildren);
+          },
+        });
+      }
+      return child;
+    });
 
   render() {
     const {
@@ -78,7 +78,7 @@ export class Dropdown extends Component<DropdownProps> {
         <Menu {...passProps}>
           <MenuButton>{!!selectedName ? selectedName : name}</MenuButton>
           <MenuList>
-            {!!changeNameToSelection ? list(children) : children}
+            {!!changeNameToSelection ? this.list(children) : children}
           </MenuList>
         </Menu>
       </span>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -20,45 +20,52 @@ export interface DropdownItemProps {
 
 type DropdownListItems = DropdownItemProps;
 
-export interface DropdownProps extends MenuNameProps {
+export interface DropdownProps {
+  /** Name to show for the dropdown */
+  name: ReactNode;
+  /** Change name by selection
+   * @default true
+   */
+  changeNameToSelection?: boolean;
   /** Custom classname to extend or customize */
   className?: string;
-  /** Array of DropdownItem's */
+  /** DropdownItems */
   children?:
     | Array<ReactElement<DropdownListItems>>
     | ReactElement<DropdownListItems>;
 }
 
-interface MenuNameProps {
-  /** Name to show for the dropdown, after selection give selections name */
-  name: string;
-}
+const list = (children: ReactNode) =>
+  React.Children.map(children, (child: React.ReactElement<MenuItemProps>) => {
+    const { children: childChildren } = child.props;
+    if (
+      React.isValidElement(child) &&
+      !!childChildren &&
+      typeof childChildren === 'string'
+    ) {
+      return React.cloneElement(child, {
+        onSelect: () => {
+          child.props.onSelect();
+          this.changeName.bind(this)(childChildren);
+        },
+      });
+    }
+    return child;
+  });
 
 export class Dropdown extends Component<DropdownProps> {
   state = { selectedName: undefined };
 
-  changeName = (name: string) => this.setState({ selectedName: name });
-
-  list = (children: ReactNode) =>
-    React.Children.map(children, (child: React.ReactElement<MenuItemProps>) => {
-      const { children: childChildren } = child.props;
-      if (
-        React.isValidElement(child) &&
-        !!childChildren &&
-        typeof childChildren === 'string'
-      ) {
-        return React.cloneElement(child, {
-          onSelect: () => {
-            child.props.onSelect();
-            this.changeName.bind(this)(childChildren);
-          },
-        });
-      }
-      return child;
-    });
+  changeName = (name: ReactNode) => this.setState({ selectedName: name });
 
   render() {
-    const { children, name, className, ...passProps } = this.props;
+    const {
+      children,
+      name,
+      className,
+      changeNameToSelection = true,
+      ...passProps
+    } = this.props;
     const { selectedName } = this.state;
 
     if (React.Children.count(children) < 1) {
@@ -70,7 +77,9 @@ export class Dropdown extends Component<DropdownProps> {
       <span className={className}>
         <Menu {...passProps}>
           <MenuButton>{!!selectedName ? selectedName : name}</MenuButton>
-          <MenuList>{this.list(this.props.children)}</MenuList>
+          <MenuList>
+            {!!changeNameToSelection ? list(children) : children}
+          </MenuList>
         </Menu>
       </span>
     );

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,0 +1,73 @@
+import React, { Component, ReactNode } from 'react';
+import {
+  Menu as ReachMenu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  MenuLink,
+} from '@reach/menu-button';
+import { logger } from '../../utils/logger';
+import '@reach/menu-button/styles.css';
+
+export { MenuItem, MenuLink };
+
+export interface MenuItemProps {
+  /** Operation to run on select */
+  onSelect: () => void;
+  /** Item content */
+  children: ReactNode;
+}
+
+type SupportedMenuLinkComponent = object | keyof JSX.IntrinsicElements;
+
+export interface MenuLinkProps {
+  type: 'menulink';
+  /** Url to direct to */
+  href: string;
+  /** Item content */
+  children: ReactNode;
+  component?: SupportedMenuLinkComponent;
+  className?: string;
+}
+
+export type MenuListItemsProps = MenuItemProps | MenuLinkProps;
+
+export interface MenuProps {
+  /** Name or content of menubutton */
+  name: ReactNode;
+  /** Custom classname to extend or customize */
+  className?: string;
+  /** Custom classname to extend or customize */
+  menuButtonClassName?: string;
+  /** Custom classname to extend or customize */
+  menuListClassName?: string;
+  /** Menu items: MenuItem or MenuLink */
+  children?: Array<React.ReactElement<MenuListItemsProps>>;
+}
+
+export class Menu extends Component<MenuProps> {
+  render() {
+    const {
+      children,
+      name,
+      className,
+      menuButtonClassName,
+      menuListClassName,
+      ...passProps
+    } = this.props;
+
+    if (React.Children.count(children) < 1) {
+      logger.warn(`Menu '${name}' does not contain items`);
+      return null;
+    }
+
+    return (
+      <span className={className}>
+        <ReachMenu {...passProps}>
+          <MenuButton className={menuButtonClassName}>{name}</MenuButton>
+          <MenuList className={menuListClassName}>{children}</MenuList>
+        </ReachMenu>
+      </span>
+    );
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,8 +4,6 @@ export {
   DropdownProps,
   DropdownItem,
   DropdownItemProps,
-  DropdownLink,
-  DropdownLinkProps,
 } from './Dropdown/Dropdown';
 export { Icon, IconProps } from './Icon/Icon';
 export { Svg, SvgProps } from './Svg/Svg';

--- a/src/components/utils/aria.ts
+++ b/src/components/utils/aria.ts
@@ -1,5 +1,11 @@
+const ifAriaNoLabel = (ariaLabel?: string) => !!ariaLabel || ariaLabel === '';
+
 export const ariaLabelOrHidden = (ariaLabel?: string) => {
-  return ariaLabel === undefined || ariaLabel === ''
-    ? { 'aria-hidden': true }
-    : { 'aria-label': ariaLabel };
+  return ifAriaNoLabel(ariaLabel)
+    ? { 'aria-label': ariaLabel }
+    : { 'aria-hidden': true };
+};
+
+export const ariaFocusableNoLabel = (ariaLabel?: string) => {
+  return ifAriaNoLabel(ariaLabel) ? {} : { focusable: false };
 };

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import { suomifiTheme, Theme } from '../theme';
 import { ButtonProps } from './Button';
-import { element, font } from '../theme/reset';
+import { element, fontSemibold } from '../theme/reset';
 
 const fullWidthStyles = css`
   display: block;
@@ -89,14 +89,12 @@ export const baseStyles = ({
   variant = 'default',
 }: ButtonProps) => css`
   ${element}
+  ${fontSemibold}
   padding: 10px 20px;
   min-height: 40px;
   color: ${theme.colors.invertText};
   background: ${theme.gradients.basic};
   border-radius: 2px;
-  ${font}
-  font-size: ${theme.typography.buttonFontSize};
-  font-weight: ${theme.typography.fontWeightSemibold};
   text-align: center;
   letter-spacing: ${theme.typography.letterspacingBasic};
   text-shadow: ${theme.shadows.invertTextShadow};

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -128,9 +128,7 @@ export const baseStyles = ({
 `;
 
 export const iconBaseStyles = ({ right = false }: { right?: boolean }) => css`
-  display: inline-block;
   width: 16px;
   height: 16px;
   margin-${right ? 'left' : 'right'}: 8px;
-  vertical-align: text-bottom;
 `;

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -18,13 +18,9 @@ exports[`calling render with the same component on the same container does not r
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
-  padding: 10px 20px;
-  min-height: 40px;
-  color: #FFFFFF;
-  background: linear-gradient(0deg,#2562a7 0%,#2A6EBB 100%);
-  border-radius: 2px;
   font-family: 'Source Sans Pro','Helvetica Neue',Arial;
   font-size: 18px;
+  line-height: 18px;
   font-weight: 400;
   line-height: 1em;
   -webkit-letter-spacing: 0;
@@ -36,7 +32,13 @@ exports[`calling render with the same component on the same container does not r
   text-decoration: none;
   -webkit-font-smoothing: antialiased;
   font-size: 14px;
+  line-height: 14px;
   font-weight: 600;
+  padding: 10px 20px;
+  min-height: 40px;
+  color: #FFFFFF;
+  background: linear-gradient(0deg,#2562a7 0%,#2A6EBB 100%);
+  border-radius: 2px;
   text-align: center;
   -webkit-letter-spacing: 0.4px;
   -moz-letter-spacing: 0.4px;

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import { suomifiTheme } from '../theme';
 import { DropdownProps } from './Dropdown';
-import { element, input, font } from '../theme/reset';
+import { element, input, fontInput } from '../theme/reset';
 import { Omit } from '../../utils/typescript';
 import { dataReachMenu } from '../Menu/Menu.baseStyles';
 
@@ -10,7 +10,7 @@ export const baseStyles = ({
 }: Omit<DropdownProps, 'name'>) => css`
   & > [data-reach-menu-button].fi-dropdown-button {
     ${input}
-    ${font}
+    ${fontInput}
     position: relative;
     padding-right: 30px;
     &:after {
@@ -35,7 +35,7 @@ export const globalStyles = ({ theme = suomifiTheme }: DropdownProps) => css`
 
   [data-reach-menu-list].fi-dropdown-list {
     ${element}
-    ${font}
+    ${fontInput}
     padding: 0;
     font-size: 100%;
     border: 0;
@@ -49,11 +49,11 @@ export const globalStyles = ({ theme = suomifiTheme }: DropdownProps) => css`
 
   [data-reach-menu-item].fi-dropdown-item {
     ${element}
-    ${font}
+    ${fontInput}
     padding: 8px 12px;
     border: 0;
     &[data-selected] {
-      ${font}
+      ${fontInput}
       color: ${theme.colors.text};
       background-image: none;
       background-color: ${theme.colors.elementHover};

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -3,11 +3,12 @@ import { suomifiTheme } from '../theme';
 import { DropdownProps } from './Dropdown';
 import { element, input, font } from '../theme/reset';
 import { Omit } from '../../utils/typescript';
+import { dataReachMenu } from '../Menu/Menu.baseStyles';
 
 export const baseStyles = ({
   theme = suomifiTheme,
 }: Omit<DropdownProps, 'name'>) => css`
-  & > [data-reach-menu-button] {
+  & > [data-reach-menu-button].fi-dropdown-button {
     ${input}
     ${font}
     position: relative;
@@ -30,20 +31,15 @@ export const baseStyles = ({
 `;
 
 export const globalStyles = ({ theme = suomifiTheme }: DropdownProps) => css`
-  [data-reach-menu] {
-    ${element}
-    ${font}
-    margin-top: -2px;
-    font-family: inherit;
-  }
+  ${dataReachMenu}
 
-  [data-reach-menu-list] {
+  [data-reach-menu-list].fi-dropdown-list {
     ${element}
     ${font}
     padding: 0;
     font-size: 100%;
     border: 0;
-    background-color: white;
+    background-color: ${theme.colors.white};
     border-color: ${theme.colors.elementBorder};
     border-style: solid;
     border-width: 0 1px 1px 1px;
@@ -51,7 +47,7 @@ export const globalStyles = ({ theme = suomifiTheme }: DropdownProps) => css`
     overflow: hidden;
   }
 
-  [data-reach-menu-item] {
+  [data-reach-menu-item].fi-dropdown-item {
     ${element}
     ${font}
     padding: 8px 12px;
@@ -59,7 +55,8 @@ export const globalStyles = ({ theme = suomifiTheme }: DropdownProps) => css`
     &[data-selected] {
       ${font}
       color: ${theme.colors.text};
-      background: ${theme.colors.elementHover} none;
+      background-image: none;
+      background-color: ${theme.colors.elementHover};
       border: 0;
     }
   }

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -31,7 +31,7 @@ export const baseStyles = ({
 `;
 
 export const globalStyles = ({ theme = suomifiTheme }: DropdownProps) => css`
-  ${dataReachMenu}
+  ${dataReachMenu(theme)}
 
   [data-reach-menu-list].fi-dropdown-list {
     ${element}

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/core';
 import { suomifiTheme } from '../theme';
 import { DropdownProps } from './Dropdown';
 import { element, input, font } from '../theme/reset';
-import { Omit } from '../utils/typescript';
+import { Omit } from '../../utils/typescript';
 
 export const baseStyles = ({
   theme = suomifiTheme,

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -20,7 +20,13 @@ const baseClassName = 'fi-dropdown';
 
 const StyledDropdown = styled(
   ({ theme, className, ...props }: DropdownProps) => (
-    <CompDropdown {...props} className={classnames(className, baseClassName)} />
+    <CompDropdown
+      {...props}
+      className={classnames(className, baseClassName)}
+      dropdownButtonClassName="fi-dropdown-button"
+      dropdownItemClassName="fi-dropdown-item"
+      dropdownListClassName="fi-dropdown-list"
+    />
   ),
 )`
   label: ${baseClassName};

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -12,8 +12,6 @@ import {
 export {
   DropdownItem,
   DropdownItemProps,
-  DropdownLink,
-  DropdownLinkProps,
 } from '../../components/Dropdown/Dropdown';
 
 export interface DropdownProps extends CompDropdownProps, ThemeComponent {}

--- a/src/core/Icon/Icon.baseStyles.tsx
+++ b/src/core/Icon/Icon.baseStyles.tsx
@@ -1,0 +1,6 @@
+import { css } from '@emotion/core';
+
+export const iconBaseStyles = css`
+  display: inline-block;
+  vertical-align: text-bottom;
+`;

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import styled from '@emotion/styled';
+import { iconBaseStyles } from './Icon.baseStyles';
 import { suomifiTheme } from '../theme';
 import {
   ariaLabelOrHidden,
@@ -10,7 +12,7 @@ import {
   IconProps as CompIconProps,
 } from '../../components/Icon/Icon';
 import { Omit } from '../../utils/typescript';
-import { SuomifiIcon, IconKeys } from 'suomifi-icons';
+import { SuomifiIcon, SuomifiIconInterface, IconKeys } from 'suomifi-icons';
 export { IconKeys } from 'suomifi-icons';
 
 export interface IconProps extends Omit<CompIconProps, 'src'> {
@@ -20,7 +22,29 @@ export interface IconProps extends Omit<CompIconProps, 'src'> {
   src?: string;
 }
 
-const className = 'fi-icon';
+const baseClassName = 'fi-icon';
+
+const StyledSuomifiIcon = styled(
+  ({
+    ariaLabel,
+    propsClassName,
+    className,
+    ...passProps
+  }: SuomifiIconInterface & {
+    ariaLabel?: string;
+    propsClassName?: string;
+    className?: string;
+  }) => (
+    <SuomifiIcon
+      {...passProps}
+      {...ariaLabelOrHidden(ariaLabel)}
+      {...ariaFocusableNoLabel(ariaLabel)}
+      className={classnames(className, propsClassName, baseClassName)}
+    />
+  ),
+)`
+  ${iconBaseStyles}
+`;
 
 /**
  * General icon-component
@@ -42,12 +66,11 @@ export class Icon extends Component<IconProps> {
 
     if (icon !== undefined) {
       return (
-        <SuomifiIcon
+        <StyledSuomifiIcon
           {...rest}
           icon={icon}
-          {...ariaLabelOrHidden(ariaLabel)}
-          {...ariaFocusableNoLabel(ariaLabel)}
-          className={classnames(propsClassName, className)}
+          ariaLabel={ariaLabel}
+          propsClassName={propsClassName}
         />
       );
     }
@@ -57,7 +80,7 @@ export class Icon extends Component<IconProps> {
         src={src}
         {...rest}
         ariaLabel={ariaLabel}
-        className={classnames(propsClassName, className)}
+        className={classnames(propsClassName, baseClassName)}
       />
     ) : null;
   }

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
 import { suomifiTheme } from '../theme';
-import { ariaLabelOrHidden } from '../../components/utils/aria';
+import {
+  ariaLabelOrHidden,
+  ariaFocusableNoLabel,
+} from '../../components/utils/aria';
 import classnames from 'classnames';
 import {
   Icon as CompIcon,
@@ -43,6 +46,7 @@ export class Icon extends Component<IconProps> {
           {...rest}
           icon={icon}
           {...ariaLabelOrHidden(ariaLabel)}
+          {...ariaFocusableNoLabel(ariaLabel)}
           className={classnames(propsClassName, className)}
         />
       );

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -9,7 +9,7 @@ import {
   Icon as CompIcon,
   IconProps as CompIconProps,
 } from '../../components/Icon/Icon';
-import { Omit } from '../utils/typescript';
+import { Omit } from '../../utils/typescript';
 import { SuomifiIcon, IconKeys } from 'suomifi-icons';
 export { IconKeys } from 'suomifi-icons';
 

--- a/src/core/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/core/Icon/__snapshots__/Icon.test.tsx.snap
@@ -1,10 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`calling render with the same component on the same container does not remount 1`] = `
+.emotion-0 {
+  display: inline-block;
+  vertical-align: text-bottom;
+}
+
 <svg
   aria-hidden="true"
-  class="fi-icon"
+  class="emotion-0 fi-icon"
   data-testid="icon"
+  focusable="false"
   height="1em"
   style="fill: #003479;"
   viewBox="0 0 24 24"

--- a/src/core/Menu/Menu.baseStyles.tsx
+++ b/src/core/Menu/Menu.baseStyles.tsx
@@ -1,0 +1,107 @@
+import { css } from '@emotion/core';
+import { suomifiTheme, Theme } from '../theme';
+import { MenuProps } from './Menu';
+import { element, font, fontInput, fontSemibold } from '../theme/reset';
+import { Omit } from '../../utils/typescript';
+
+export const baseStyles = ({
+  theme = suomifiTheme,
+}: Omit<MenuProps, 'name'>) => css`
+  & > [data-reach-menu-button].fi-menu-button {
+    ${element}
+    ${font}
+    &.fi-menu-language-button {
+      ${element}
+      ${fontSemibold}
+      padding: 8px 6px 8px 10px;
+      border: 1px solid ${suomifiTheme.colors.elementBorder};
+      border-radius: 2px;
+      text-transform: uppercase;
+    }
+    &:focus {
+      ${theme.outlines.basic}
+    }
+  }
+`;
+
+export const iconBaseStyles = css`
+  height: 16px;
+  width: 16px;
+  margin-left: 2px;
+`;
+
+export const dataReachMenu = (theme: Theme = suomifiTheme) => css`
+  [data-reach-menu] {
+    ${element}
+    ${font}
+    z-index: ${theme.zindexes.menu};
+    margin-top: -2px;
+    font-family: inherit;
+  }
+`;
+
+export const globalStyles = ({ theme = suomifiTheme }: MenuProps) => css`
+  ${dataReachMenu(theme)}
+
+  [data-reach-menu-list].fi-menu-list {
+    ${element}
+    ${font}
+    background-color: ${theme.colors.white};
+    border: none;
+    box-shadow: ${theme.shadows.menuShadow};
+    &.fi-menu-language-list {
+      ${fontInput}
+      position: absolute;
+      right: 0;
+      top: 0;
+      margin-top: 12px;
+      padding: 10px 0;
+      border: 1px solid ${suomifiTheme.colors.elementBorder};
+      border-radius: 2px;
+      &:before,
+      &:after {
+        content: '';
+        position: absolute;
+        height: 0;
+        width: 0;
+        bottom: 100%;
+        right: 20px;
+        border: solid transparent;
+        pointer-events: none;
+      }
+      &:before {
+        border-bottom-color: ${suomifiTheme.colors.elementBorder};
+        border-width: 8px;
+        margin-right: -8px;
+      }
+      &:after {
+        border-bottom-color: ${suomifiTheme.colors.white};
+        border-width: 7px;
+        margin-right: -7px;
+      }
+    }
+  }
+
+  [data-reach-menu-item].fi-menu-item {
+    ${element}
+    ${font}
+    &[data-selected] {
+      ${font}
+      color: ${theme.colors.text};
+      background-color: ${theme.colors.elementHover};
+    }
+    &.fi-menu-language-item,
+    &[data-selected].fi-menu-language-item {
+      ${fontInput}
+      padding: 6px 20px 6px 14px;
+      border-left: 6px solid transparent;
+      background-color: transparent;
+      &.fi-menu-lang-item-selected {
+        font-weight: ${theme.typography.fontWeightSemibold};
+      }
+    }
+    &[data-selected].fi-menu-language-item {
+      border-left-color: ${theme.colors.secondaryColor};
+    }
+  }
+`;

--- a/src/core/Menu/Menu.md
+++ b/src/core/Menu/Menu.md
@@ -1,0 +1,12 @@
+```js
+<Menu className="menu-test" name="Menu">
+  <MenuItem onSelect={() => console.log('Menu test 1')}>Item 1</MenuItem>
+  <MenuItem onSelect={() => console.log('Menu test 2')}>Item 2</MenuItem>
+  <MenuLink href="http://www.suomi.fi/">Suomi.fi</MenuLink>
+</Menu>
+
+<Menu.language className="menu-language-test" name="FI">
+  <MenuItem onSelect={() => console.log('FI')} selected>Suomeksi (FI)</MenuItem>
+  <MenuLink href="/sv">På svenska (SV)</MenuLink>
+</Menu.language>
+```

--- a/src/core/Menu/Menu.test.tsx
+++ b/src/core/Menu/Menu.test.tsx
@@ -1,0 +1,7 @@
+import { cssFromBaseStyles } from '../utils';
+import { baseStyles } from './Menu.baseStyles';
+
+test('CSS export', () => {
+  const css = cssFromBaseStyles(baseStyles);
+  expect(css).toEqual(expect.stringContaining('position'));
+});

--- a/src/core/Menu/Menu.test.tsx
+++ b/src/core/Menu/Menu.test.tsx
@@ -3,5 +3,5 @@ import { baseStyles } from './Menu.baseStyles';
 
 test('CSS export', () => {
   const css = cssFromBaseStyles(baseStyles);
-  expect(css).toEqual(expect.stringContaining('position'));
+  expect(css).toEqual(expect.stringContaining('data-reach-menu-button'));
 });

--- a/src/core/Menu/Menu.tsx
+++ b/src/core/Menu/Menu.tsx
@@ -1,0 +1,126 @@
+import React, { Component, ReactNode, Fragment } from 'react';
+import styled from '@emotion/styled';
+import classnames from 'classnames';
+import { classnamesValue } from '../../utils/typescript';
+import { defaultPropsTheme } from '../utils';
+import { ThemeComponent } from '../theme';
+import { Global } from '@emotion/core';
+import { baseStyles, globalStyles, iconBaseStyles } from './Menu.baseStyles';
+import {
+  Menu as CompMenu,
+  MenuProps as CompMenuProps,
+  MenuListItemsProps,
+  MenuItem as CompMenuItem,
+  MenuItemProps,
+  MenuLink,
+  MenuLinkProps,
+} from '../../components/Menu/Menu';
+export { MenuItemProps, MenuLink, MenuLinkProps };
+import { Icon, IconProps } from '../Icon/Icon';
+
+type ButtonVariant = 'default' | 'language';
+
+export interface MenuProps extends CompMenuProps, ThemeComponent {
+  /**
+   * 'default' | 'language'
+   * @default default
+   */
+  variant?: ButtonVariant;
+}
+
+const baseClassName = 'fi-menu';
+
+const StyledMenu = styled(({ theme, className, ...props }: MenuProps) => (
+  <CompMenu {...props} className={classnames(className, baseClassName)} />
+))`
+  label: ${baseClassName};
+  ${props => baseStyles(props)}
+`;
+
+const MenuListWithProps = (children: ReactNode, addClass?: classnamesValue) =>
+  React.Children.map(
+    children,
+    (child: React.ReactElement<MenuListItemsProps>) => {
+      // Set defaul component-prop/type to be 'a' needed for links
+      if (React.isValidElement(child)) {
+        return React.cloneElement(child, {
+          component: 'a',
+          className: classnames('fi-menu-item', addClass),
+        });
+      }
+      return child;
+    },
+  );
+
+const StyledIcon = styled((props: IconProps) => (
+  <Icon icon="chevronDown" {...props} />
+))`
+  ${iconBaseStyles}
+`;
+
+const languageName = (name: ReactNode) => (
+  <Fragment>
+    {name}
+    <StyledIcon />
+  </Fragment>
+);
+
+class MenuVariation extends Component<MenuProps> {
+  static defaultProps = defaultPropsTheme(CompMenu);
+
+  render() {
+    const { children, variant, name, ...passProps } = this.props;
+    const ifMenuLanguage = variant === 'language';
+
+    return (
+      <Fragment>
+        <Global styles={globalStyles(this.props)} />
+        <StyledMenu
+          {...passProps}
+          name={!!ifMenuLanguage ? languageName(name) : name}
+          children={MenuListWithProps(children, {
+            'fi-menu-language-item': ifMenuLanguage,
+          })}
+          menuButtonClassName={classnames('fi-menu-button', {
+            'fi-menu-language-button': ifMenuLanguage,
+          })}
+          menuListClassName={classnames('fi-menu-list', {
+            'fi-menu-language-list': ifMenuLanguage,
+          })}
+        />
+      </Fragment>
+    );
+  }
+}
+
+export interface MenuLanguageItemProps extends MenuItemProps {
+  /** Show item as selected one */
+  selected?: boolean;
+  className?: string;
+}
+
+/**
+ * Use for dropdown menu.
+ */
+export class Menu extends Component<MenuProps> {
+  static language = (props: MenuProps) => {
+    return <MenuVariation {...props} variant="language" />;
+  };
+
+  render() {
+    return <MenuVariation {...this.props} />;
+  }
+}
+
+export const MenuItem = ({
+  selected,
+  className,
+  ...passProps
+}: MenuLanguageItemProps) => (
+  <CompMenuItem
+    {...passProps}
+    className={classnames(className, {
+      'fi-menu-lang-item-selected': selected,
+    })}
+  />
+);

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -133,6 +133,7 @@ export type IShadows = typeof shadows;
 
 export const shadows = {
   invertTextShadow: `0 1px 1px ${alphaHex50(palette.suomiDarkest)}`,
+  menuShadow: '0 2px 3px 0 rgba(0,0,0,.2)',
 };
 
 export type IGradients = typeof gradients;

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -1,5 +1,6 @@
 import { typography } from './typography';
 import { colors, shadows, gradients, outlines } from './colors';
+import { zindexes } from './zindexes';
 
 export type Theme = typeof suomifiTheme;
 
@@ -14,4 +15,5 @@ export const suomifiTheme = {
   shadows,
   gradients,
   outlines,
+  zindexes,
 };

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/core';
 import { suomifiTheme } from '../';
-export { font } from './typography';
+export { font, fontInput, fontSemibold } from './typography';
 
 export const element = css`
   margin: 0;

--- a/src/core/theme/reset/typography.ts
+++ b/src/core/theme/reset/typography.ts
@@ -4,10 +4,24 @@ import { typography } from '../typography';
 export const font = css`
   font-family: ${typography.fontFamily};
   font-size: ${typography.fontSize};
+  line-height: ${typography.fontSize};
   font-weight: ${typography.fontWeight};
   line-height: 1em;
   letter-spacing: 0;
   white-space: nowrap;
   text-decoration: none;
   -webkit-font-smoothing: antialiased;
+`;
+
+export const fontSemibold = css`
+  ${font}
+  font-size: ${typography.fontSizeSemibold};
+  line-height: ${typography.fontSizeSemibold};
+  font-weight: ${typography.fontWeightSemibold};
+`;
+
+export const fontInput = css`
+  ${font}
+  font-size: ${typography.fontSizeInput};
+  line-height: ${typography.fontSizeInput};
 `;

--- a/src/core/theme/typography.ts
+++ b/src/core/theme/typography.ts
@@ -3,8 +3,9 @@ export type ITypography = typeof typography;
 export const typography = {
   fontFamily: `'Source Sans Pro','Helvetica Neue', Arial`,
   fontSize: '18px',
+  fontSizeInput: '16px',
+  fontSizeSemibold: '14px',
   fontWeight: '400',
   fontWeightSemibold: '600',
   letterspacingBasic: '0.4px',
-  buttonFontSize: '14px',
 };

--- a/src/core/theme/zindexes.ts
+++ b/src/core/theme/zindexes.ts
@@ -1,0 +1,3 @@
+export const zindexes = {
+  menu: 888,
+};

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -1,0 +1,3 @@
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export type classnamesValue = string | { [key: string]: string | boolean };

--- a/tslint.json
+++ b/tslint.json
@@ -13,7 +13,7 @@
     "interface-name": [true, "never-prefix"],
     "import-name": [true, { "react": "React", "reactSvg": "ReactSVG" }],
     "jsx-alignment": true,
-    "max-classes-per-file": [true, 2],
+    "max-classes-per-file": [true, 3],
     "max-line-length": [
       true,
       { "limit": 140, "ignore-pattern": "^import |^export {(.*?)}" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,22 +221,22 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@reach/component-component@^0.1.2":
+"@reach/component-component@^0.1.1", "@reach/component-component@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.1.2.tgz#f3c2a53de56d54c8f0ee398485d5831d66e3cc34"
   integrity sha512-LSsLxBA13qLsfjLtytiuB0siVJSTp0h3hhlJybr90Ynx1SuQ4pRtMi5aUIk7HM3wDswj22YbGC2zOpzibNyN3w==
 
-"@reach/menu-button@0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.1.8.tgz#922f632a63d132d46a6255217f4e70670ff150ff"
-  integrity sha512-oYIWe5C88f5DP8Lis9IRZdM4/uvNnjac+nX2+awwGhdJESO1DvDvT0LV0p6c9pWiQWzcPrRbHdpdh3gr9mKGdA==
+"@reach/menu-button@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.1.7.tgz#48666636b5774066839a312e37cc03f0bd770bad"
+  integrity sha512-xPweR+luu5sgW8OeRHt8SN3dlV3d8S6fqABXAqfuI5Aebq0lOcSxZuL2gxlpH742OzrkjteBE/LV5Jt0vJUsOA==
   dependencies:
-    "@reach/component-component" "^0.1.2"
-    "@reach/portal" "^0.1.2"
-    "@reach/rect" "^0.1.2"
+    "@reach/component-component" "^0.1.1"
+    "@reach/portal" "^0.1.1"
+    "@reach/rect" "^0.1.1"
     "@reach/router" "^1.1.0"
     "@reach/utils" "^0.1.2"
-    "@reach/window-size" "^0.1.2"
+    "@reach/window-size" "^0.1.1"
     warning "^4.0.2"
 
 "@reach/observe-rect@^1.0.3":
@@ -244,14 +244,14 @@
   resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.0.3.tgz#2ea3dcc369ab22bd9f050a92ea319321356a61e8"
   integrity sha1-LqPcw2mrIr2fBQqS6jGTITVqYeg=
 
-"@reach/portal@^0.1.2":
+"@reach/portal@^0.1.1":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.1.2.tgz#4c3cb4e587be73f172362c4938d7526794adc2c0"
   integrity sha512-9jvdmlThI4l5MpNiN2S0235TmzN99pafD6K6tKMUHsEzIhmIIn5qap6Yx06LE96bHj2D2LARbQV5oVBzaKjLFg==
   dependencies:
     "@reach/component-component" "^0.1.2"
 
-"@reach/rect@^0.1.2":
+"@reach/rect@^0.1.1":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.1.2.tgz#8f5dbd90152f8e865cc6c1622266403dcfe26691"
   integrity sha512-2zgOdngtfAiykcVrjsgyjBhLItqc0TpuMCK0RrYydkhjKuHazjhtB5NEGuzp3TFDl3dlR++U28P55Gt4MkN3+g==
@@ -275,7 +275,7 @@
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.1.2.tgz#72f547b5c9b0401a56de303d9e508abf6d3fa56a"
   integrity sha512-HpDR5BeCApr3HufQtpg0P5b9sl0S66zikZSMtC/2jZBvrDzjVaT9O8PbKTQqW0PdkMNrnBkX1UtlrrM1TN3/Og==
 
-"@reach/window-size@^0.1.2":
+"@reach/window-size@^0.1.1":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@reach/window-size/-/window-size-0.1.2.tgz#52e02dfef86a922344493242e1e366b5a2b6a3d6"
   integrity sha512-R3wdjy/AWMIfLPjU/XduC30CqZWwdwM7q3F571F5DgeQaJIw1EKF1/nVFoZc9Jw9/+y+0QGBU0OlMKDMc5ekfA==
@@ -8198,10 +8198,10 @@ style-loader@0.23.1, style-loader@^0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-suomifi-icons@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.0.1.tgz#c0ba91b6fc42d3147efef427c51c390f6d947412"
-  integrity sha512-tYMkJjOn0rIdN1/3Xx7WRa9/aQn7h/LdzF08DGsUi3ihZlMdskFEJ+mdG0ymmxpxDxzOw1+GRtNFyyO/g3BhSg==
+suomifi-icons@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.0.2.tgz#6cabebcce78cbc311496f7b4bb1fd278847c45c8"
+  integrity sha512-AumRVP/4BbIRhirBzaTHILvSYZwHuhBidCrQxY2HIaRoV5AzMU2ySs/vWXHi7+Hmh5rC37Lph21sd8X2TbzXCw==
   dependencies:
     "@types/react" "16.7.20"
     "@types/react-dom" "16.0.11"


### PR DESCRIPTION
- Remove support of dropdown to have link for now on
- Set also SVG-icon focusable to false when aria-label not set
- Set Dropdown-component custom classNames to props and use them in core Dropdown
- Create typography theme for fontSemibold and fontInput
- Create core Icon baseStyles
- Create zindexes to theme
- Install updated suomifi-icons
- Create basic (dropdown)menu and menu.language