### PR TITLE
Add '<constains semantic elements>'-tags to component styleguide pages

### DIFF
--- a/.styleguidist/styleguidist.styles.js
+++ b/.styleguidist/styleguidist.styles.js
@@ -42,7 +42,7 @@ module.exports = {
           position: 'relative',
           top: '-.75em',
           display: 'block',
-          content: '"<constains semantic elements>"',
+          content: '"<contains semantic elements>"',
           fontSize: '.8em',
           color: 'hsl(23, 82%, 53%)',
         },

--- a/.styleguidist/styleguidist.styles.js
+++ b/.styleguidist/styleguidist.styles.js
@@ -38,9 +38,13 @@ module.exports = {
       order: '1',
       marginBottom: '24px',
       '& i.semantics': {
-        '&:after': {
+        '&:before': {
+          position: 'relative',
+          top: '-.75em',
           display: 'block',
-          content: '"Contains semantics"',
+          content: '"<constains semantic elements>"',
+          fontSize: '.8em',
+          color: 'hsl(23, 82%, 53%)',
         },
       },
     },

--- a/.styleguidist/styleguidist.styles.js
+++ b/.styleguidist/styleguidist.styles.js
@@ -37,6 +37,12 @@ module.exports = {
     docs: {
       order: '1',
       marginBottom: '24px',
+      '& i.semantics': {
+        '&:after': {
+          display: 'block',
+          content: '"Contains semantics"',
+        },
+      },
     },
     tabs: {
       order: '3',

--- a/src/components/utils/aria.ts
+++ b/src/components/utils/aria.ts
@@ -6,6 +6,10 @@ export const ariaLabelOrHidden = (ariaLabel?: string) => {
     : { 'aria-hidden': true };
 };
 
+/**
+ * Set element ability to be focusable based on aria-label
+ * @param {String} ariaLabel optional aria-label
+ */
 export const ariaFocusableNoLabel = (ariaLabel?: string) => {
   return ifAriaNoLabel(ariaLabel) ? {} : { focusable: false };
 };

--- a/src/core/Breadcrumb/Breadcrumb.tsx
+++ b/src/core/Breadcrumb/Breadcrumb.tsx
@@ -31,6 +31,7 @@ type VariantBreadcrumbProps =
   | LinkProps & { variant?: BreadcrumbVariant };
 
 /**
+ * <i class="semantics" />
  * Used for navigation path
  */
 export class Breadcrumb extends Component<VariantBreadcrumbProps> {

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -133,6 +133,7 @@ class ButtonWithIcon extends Component<ButtonProps> {
 }
 
 /**
+ * <i class="semantics" />
  * Use for inside Application onClick events.<br />
  * When using Button.secondaryNoborder with other than white background,<br />
  * define styles background color for all needed states (:hover, :active, :disabled)<br /><br />

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -22,6 +22,7 @@ const StyledDropdown = styled(({ theme, ...passProps }: DropdownProps) => (
 `;
 
 /**
+ * <i class="semantics" />
  * Use for selectable dropdown list.
  */
 export class Dropdown extends Component<DropdownProps> {

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -28,6 +28,7 @@ const StyledTextInput = styled(
 `;
 
 /**
+ * <i class="semantics" />
  * Use for user inputting search text
  */
 export class SearchInput extends Component<TextInputProps> {

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -58,6 +58,7 @@ const StyledTextInput = styled(
 `;
 
 /**
+ * <i class="semantics" />
  * Use for user inputting text
  */
 export class TextInput extends Component<TextInputProps> {

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -28,6 +28,7 @@ const StyledToggle = styled(({ theme, ...passProps }: ToggleProps) => (
 `;
 
 /**
+ * <i class="semantics" />
  * Use for toggling form selection or application state
  */
 export class Toggle extends Component<ToggleProps> {

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -51,6 +51,7 @@ const StyledHeading = styled(
 `;
 
 /**
+ * <i class="semantics" />
  * Used displaying headings with correct fonts
  */
 export class Heading extends Component<HeadingProps> {

--- a/src/core/Link/Link.md
+++ b/src/core/Link/Link.md
@@ -1,5 +1,5 @@
 ```js
-import { Link, LinkExternal, Paragraph } from 'suomifi-ui-components';
+import { Link, Paragraph } from 'suomifi-ui-components';
 
 <Paragraph>
   <Link

--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -22,6 +22,7 @@ const StyledLink = styled(({ theme, ...passProps }: LinkProps) => (
 `;
 
 /**
+ * <i class="semantics" />
  * Used for adding a link
  */
 export class Link extends Component<LinkProps | LinkExternalProps> {

--- a/src/core/Link/LinkExternal.tsx
+++ b/src/core/Link/LinkExternal.tsx
@@ -37,6 +37,7 @@ const StyledLinkExternal = styled(
 `;
 
 /**
+ * <i class="semantics" />
  * Used for adding a external site link
  */
 export class LinkExternal extends Component<LinkExternalProps> {

--- a/src/core/Menu/Menu.tsx
+++ b/src/core/Menu/Menu.tsx
@@ -108,6 +108,7 @@ class MenuVariation extends Component<MenuProps> {
 }
 
 /**
+ * <i class="semantics" />
  * Use for dropdown menu.
  */
 export class Menu extends Component<MenuProps> {

--- a/src/core/Panel/PanelExpansion.tsx
+++ b/src/core/Panel/PanelExpansion.tsx
@@ -43,6 +43,7 @@ interface PanelExpansionState {
 }
 
 /**
+ * <i class="semantics" />
  * Used for openable panel
  */
 export class PanelExpansion extends Component<PanelExpansionProps> {

--- a/src/core/Panel/PanelExpansionGroup.tsx
+++ b/src/core/Panel/PanelExpansionGroup.tsx
@@ -42,6 +42,7 @@ const OpenAllButton = ({
 );
 
 /**
+ * <i class="semantics" />
  * Used for grouping expansion panels
  */
 export class PanelExpansionGroup extends Component<PanelExpansionGroupProps> {


### PR DESCRIPTION
To make more clear when using components when is semantic structure within app to be noted.