### PR TITLE
Create asProp for withDefaultTheme-util

### DIFF
--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
+import { AsProp } from '../../utils/typescript';
 import { HtmlH, HtmlHProps, hLevels } from '../../reset/HtmlH/HtmlH';
 export { hLevels };
 
@@ -7,13 +8,21 @@ export interface HeadingProps extends HtmlHProps {
   /** Change HTML-element */
   variant: hLevels;
   className?: string;
+  asProp?: AsProp;
 }
 
 const baseClassName = 'fi-heading';
 
 export class Heading extends Component<HeadingProps> {
   render() {
-    const { className, variant = 'h1', as, ...passProps } = this.props;
+    const {
+      className,
+      variant = 'h1',
+      as: asStyled,
+      asProp,
+      ...passProps
+    } = this.props;
+    const as = !!asProp ? asProp : asStyled;
     return (
       <HtmlH
         {...passProps}

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { AsProp } from '../../utils/typescript';
+import { AsPropType } from '../../utils/typescript';
 import { HtmlH, HtmlHProps, hLevels } from '../../reset/HtmlH/HtmlH';
 export { hLevels };
 
@@ -8,7 +8,7 @@ export interface HeadingProps extends HtmlHProps {
   /** Change HTML-element */
   variant: hLevels;
   className?: string;
-  asProp?: AsProp;
+  asProp?: AsPropType;
 }
 
 const baseClassName = 'fi-heading';

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -22,6 +22,8 @@ export class Heading extends Component<HeadingProps> {
       asProp,
       ...passProps
     } = this.props;
+
+    // Use if internal API asProp defined, if not use public API as if defined
     const as = !!asProp ? asProp : asStyled;
     return (
       <HtmlH

--- a/src/core/Heading/Heading.md
+++ b/src/core/Heading/Heading.md
@@ -4,6 +4,7 @@ import { Heading } from 'suomifi-ui-components';
 <>
   <Heading.h1>h1 text</Heading.h1>
   <Heading.h2>h2 text</Heading.h2>
+  <Heading.h3 as="h2">h3 as h2 text</Heading.h3>
   <Heading.h3>h3 text</Heading.h3>
   <Heading.h4>h4 text</Heading.h4>
   <Heading.h5>h5 text</Heading.h5>

--- a/src/core/Heading/Heading.test.tsx
+++ b/src/core/Heading/Heading.test.tsx
@@ -9,6 +9,7 @@ const TestHeadings = (
     <Heading.h1hero>Test Heading</Heading.h1hero>
     <Heading.h1>Test Heading</Heading.h1>
     <Heading.h2>Test Heading</Heading.h2>
+    <Heading.h3 as="h2">h3 as h2 text</Heading.h3>
     <Heading.h3>Test Heading</Heading.h3>
     <Heading.h4>Test Heading</Heading.h4>
     <Heading.h5>Test Heading</Heading.h5>

--- a/src/core/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/core/Heading/__snapshots__/Heading.test.tsx.snap
@@ -301,6 +301,11 @@ exports[`calling render with the same component on the same container does not r
   >
     Test Heading
   </h2>
+  <h2
+    class="fi-heading c0 fi-heading--h3 c1"
+  >
+    h3 as h2 text
+  </h2>
   <h3
     class="fi-heading c0 fi-heading--h3 c1"
   >

--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -32,7 +32,7 @@ export class Link extends Component<LinkProps | LinkExternalProps> {
     const { variant, ...passProps } = withDefaultTheme(this.props);
 
     if (variant === 'external')
-      return <LinkExternal {...passProps as LinkExternalProps} />;
+      return <LinkExternal {...this.props as LinkExternalProps} />;
     return <StyledLink {...passProps} />;
   }
 }

--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
+import { AsPropType } from '../../utils/typescript';
 import { withDefaultTheme } from '../theme/utils';
 import { ThemeComponent } from '../theme';
 import {
@@ -13,6 +14,7 @@ export { LinkExternal, LinkExternalProps };
 type LinkVariant = 'default' | 'external';
 export interface LinkProps extends CompLinkProps, ThemeComponent {
   variant?: LinkVariant;
+  asProp?: AsPropType;
 }
 
 const StyledLink = styled(({ theme, ...passProps }: LinkProps) => (

--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -31,10 +31,10 @@ export class Link extends Component<LinkProps | LinkExternalProps> {
   static external = (props: LinkExternalProps) => <LinkExternal {...props} />;
 
   render() {
-    const { variant, ...passProps } = withDefaultTheme(this.props);
+    const { variant, asProp, ...passProps } = withDefaultTheme(this.props);
 
     if (variant === 'external')
       return <LinkExternal {...this.props as LinkExternalProps} />;
-    return <StyledLink {...passProps} />;
+    return <StyledLink {...passProps} as={asProp} />;
   }
 }

--- a/src/core/Link/LinkExternal.tsx
+++ b/src/core/Link/LinkExternal.tsx
@@ -30,7 +30,7 @@ const StyledLinkExternal = styled(
     theme,
     ...passProps
   }: Omit<LinkExternalProps, 'labelNewWindow' | 'hideIcon'>) => (
-    <Link {...passProps} as={CompLinkExternal} />
+    <Link {...passProps} asProp={CompLinkExternal} />
   ),
 )`
   ${props => externalStyles(props)};

--- a/src/core/theme/utils/defaultTheme.ts
+++ b/src/core/theme/utils/defaultTheme.ts
@@ -17,5 +17,5 @@ export const withDefaultTheme = <
   ({
     ...props,
     theme,
-    asProp: !!asProp ? asProp : asStyled,
+    ...(!!asProp || !!asStyled ? { asProp: asProp || asStyled } : {}),
   } as T);

--- a/src/core/theme/utils/defaultTheme.ts
+++ b/src/core/theme/utils/defaultTheme.ts
@@ -1,12 +1,21 @@
 import { suomifiTheme, ThemeProp } from '../';
+import { AsProp } from '../../../utils/typescript';
 
+/**
+ * Add default theme to props if not assinged,
+ * also reassign styled as-prop to asProp (it would replace internal component usage with styled-tag)
+ * @param props Component-props
+ */
 export const withDefaultTheme = <
-  T extends { theme: ThemeProp; [k: string]: any }
+  T extends { theme: ThemeProp; as?: AsProp; asProp?: AsProp; [k: string]: any }
 >({
   theme = suomifiTheme,
+  as: asStyled,
+  asProp,
   ...props
 }: Partial<T>): T =>
   ({
     ...props,
     theme,
+    asProp: !!asProp ? asProp : asStyled,
   } as T);

--- a/src/core/theme/utils/defaultTheme.ts
+++ b/src/core/theme/utils/defaultTheme.ts
@@ -1,5 +1,5 @@
 import { suomifiTheme, ThemeProp } from '../';
-import { AsProp } from '../../../utils/typescript';
+import { AsPropType } from '../../../utils/typescript';
 
 /**
  * Add default theme to props if not assinged,
@@ -7,7 +7,12 @@ import { AsProp } from '../../../utils/typescript';
  * @param props Component-props
  */
 export const withDefaultTheme = <
-  T extends { theme: ThemeProp; as?: AsProp; asProp?: AsProp; [k: string]: any }
+  T extends {
+    theme: ThemeProp;
+    as?: AsPropType;
+    asProp?: AsPropType;
+    [k: string]: any;
+  }
 >({
   theme = suomifiTheme,
   as: asStyled,

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -5,3 +5,6 @@ export type classnamesValue = string | { [key: string]: string | boolean };
 export function objValue<T, K extends keyof T>(obj: T, key: K) {
   return obj[key];
 }
+
+// `as`-prop from styled-components
+export type AsProp = keyof JSX.IntrinsicElements | React.ComponentType<any>;

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -7,4 +7,4 @@ export function objValue<T, K extends keyof T>(obj: T, key: K) {
 }
 
 // `as`-prop from styled-components
-export type AsProp = keyof JSX.IntrinsicElements | React.ComponentType<any>;
+export type AsPropType = keyof JSX.IntrinsicElements | React.ComponentType<any>;


### PR DESCRIPTION
Styled-components has `as`-prop that replaces `styled`-template literal tags' element/component. Our components use internal components with `styled` that are not the ones to be replaced. Using withDefaultTheme-util (will be later refactor at another fix) `as`-prop is now internally changed to `asProp` and implementations with that when needed. Link-component supports both public API `as` and internal API `asProp`.

closes #157 