### PR TITLE
Create internal asProp for defaultTheme-util

### DIFF
--- a/src/core/Heading/Heading.md
+++ b/src/core/Heading/Heading.md
@@ -4,6 +4,7 @@ import { Heading } from 'suomifi-ui-components';
 <>
   <Heading.h1>h1 text</Heading.h1>
   <Heading.h2>h2 text</Heading.h2>
+  <Heading.h3 as="h2">h3 as h2 text</Heading.h3>
   <Heading.h3>h3 text</Heading.h3>
   <Heading.h4>h4 text</Heading.h4>
   <Heading.h5>h5 text</Heading.h5>

--- a/src/core/Heading/Heading.test.tsx
+++ b/src/core/Heading/Heading.test.tsx
@@ -9,6 +9,7 @@ const TestHeadings = (
     <Heading.h1hero>Test Heading</Heading.h1hero>
     <Heading.h1>Test Heading</Heading.h1>
     <Heading.h2>Test Heading</Heading.h2>
+    <Heading.h3 as="h2">h3 as h2 text</Heading.h3>
     <Heading.h3>Test Heading</Heading.h3>
     <Heading.h4>Test Heading</Heading.h4>
     <Heading.h5>Test Heading</Heading.h5>

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -37,7 +37,7 @@ const StyledHeading = styled(
     smallScreen,
     className,
     variant,
-    asProp,
+    asProp, // as-property is defined internally as asProp and need to be implemented back if used
     ...passProps
   }: HeadingProps) => (
     <CompHeading

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../components/Heading/Heading';
 import { baseStyles } from './Heading.baseStyles';
 import classnames from 'classnames';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 import { logger } from '../../utils/logger';
 
 const baseClassName = 'fi-heading';
@@ -27,6 +27,7 @@ export interface HeadingProps
   smallScreen?: boolean;
   /** Change font to smaller screen size and style */
   color?: ColorProp;
+  asProp?: asPropType;
 }
 
 const StyledHeading = styled(
@@ -36,6 +37,7 @@ const StyledHeading = styled(
     smallScreen,
     className,
     variant,
+    asProp,
     ...passProps
   }: HeadingProps) => (
     <CompHeading
@@ -44,6 +46,7 @@ const StyledHeading = styled(
         [smallScreenClassName]: smallScreen,
       })}
       variant={variant === 'h1hero' ? 'h1' : variant}
+      as={asProp}
     />
   ),
 )`

--- a/src/core/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/core/Heading/__snapshots__/Heading.test.tsx.snap
@@ -301,6 +301,11 @@ exports[`calling render with the same component on the same container does not r
   >
     Test Heading
   </h2>
+  <h2
+    class="fi-heading c0 fi-heading--h3 c1"
+  >
+    h3 as h2 text
+  </h2>
   <h3
     class="fi-heading c0 fi-heading--h3 c1"
   >

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { iconBaseStyles } from './Icon.baseStyles';
+import { ThemeComponent } from '../theme';
 import { withDefaultTheme } from '../theme/utils';
 import {
   ariaLabelOrHidden,
@@ -20,7 +21,7 @@ import {
 export { IconKeys, StaticIconKeys } from 'suomifi-icons';
 import { logger } from '../../utils/logger';
 
-export interface IconProps extends Omit<CompIconProps, 'src'> {
+export interface IconProps extends Omit<CompIconProps, 'src'>, ThemeComponent {
   /** Icon-name from suomifi-icons */
   icon?: IconKeys | StaticIconKeys;
   /** Image file */

--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -6,6 +6,7 @@ import {
   Link as CompLink,
   LinkProps as CompLinkProps,
 } from '../../components/Link/Link';
+import { asPropType } from '../../utils/typescript';
 import { LinkExternal, LinkExternalProps } from './LinkExternal';
 import { baseStyles } from './Link.baseStyles';
 export { LinkExternal, LinkExternalProps };
@@ -13,10 +14,12 @@ export { LinkExternal, LinkExternalProps };
 type LinkVariant = 'default' | 'external';
 export interface LinkProps extends CompLinkProps, ThemeComponent {
   variant?: LinkVariant;
+  asProp?: asPropType;
 }
 
-const StyledLink = styled(({ theme, ...passProps }: LinkProps) => (
-  <CompLink {...passProps} />
+const StyledLink = styled(({ theme, asProp, ...passProps }: LinkProps) => (
+  // as-property is defined internally as asProp and need to be implemented back if used
+  <CompLink {...passProps} as={asProp} />
 ))`
   ${props => baseStyles(props)};
 `;

--- a/src/core/Link/LinkExternal.tsx
+++ b/src/core/Link/LinkExternal.tsx
@@ -30,7 +30,7 @@ const StyledLinkExternal = styled(
     theme,
     ...passProps
   }: Omit<LinkExternalProps, 'labelNewWindow' | 'hideIcon'>) => (
-    <Link {...passProps} as={CompLinkExternal} />
+    <Link {...passProps} asProp={CompLinkExternal} />
   ),
 )`
   ${props => externalStyles(props)};

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 <a
-  class="c0 c1 fi-link--external c2"
+  class="c0 c1 fi-link c2 fi-link--external sc-bdVaJa c2"
   data-testid="test-link"
   href="/"
   rel="noopener"

--- a/src/core/theme/utils/defaultTheme.ts
+++ b/src/core/theme/utils/defaultTheme.ts
@@ -1,6 +1,12 @@
 import { suomifiTheme, ThemeProp } from '../';
 import { asPropType } from '../../../utils/typescript';
 
+/**
+ * Do defaults for component props
+ * Add default theme if theme not defined,
+ * Remove as-prop and change it to asProp if defined
+ * @param props Component props
+ */
 export const withDefaultTheme = <
   T extends { theme: ThemeProp; asProp?: asPropType }
 >({

--- a/src/core/theme/utils/defaultTheme.ts
+++ b/src/core/theme/utils/defaultTheme.ts
@@ -1,12 +1,15 @@
 import { suomifiTheme, ThemeProp } from '../';
+import { asPropType } from '../../../utils/typescript';
 
 export const withDefaultTheme = <
-  T extends { theme: ThemeProp; [k: string]: any }
+  T extends { theme: ThemeProp; asProp?: asPropType }
 >({
-  theme = suomifiTheme,
+  theme,
+  as,
   ...props
-}: Partial<T>): T =>
+}: Partial<T> & { as?: asPropType }): T =>
   ({
     ...props,
-    theme,
+    ...(!!as ? { asProp: as } : {}),
+    theme: !!theme ? theme : suomifiTheme,
   } as T);

--- a/src/reset/HtmlA/HtmlA.tsx
+++ b/src/reset/HtmlA/HtmlA.tsx
@@ -2,12 +2,12 @@ import React, { ReactNode, HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
 import { allStates } from '../../utils/css/pseudo';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 export interface HtmlAProps
   extends Omit<HTMLProps<HTMLAnchorElement>, 'ref' | 'as'> {
   children: ReactNode;
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
 }
 
 const aResets = css`

--- a/src/reset/HtmlButton/HtmlButton.tsx
+++ b/src/reset/HtmlButton/HtmlButton.tsx
@@ -1,11 +1,11 @@
 import React, { HTMLProps, ButtonHTMLAttributes } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets, resetWithSelectors } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 export interface HtmlButtonProps
   extends Omit<HTMLProps<HTMLButtonElement>, 'ref' | 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
   /**
    * HTML Button type (button, submit, reset)
    * @default button

--- a/src/reset/HtmlDiv/HtmlDiv.tsx
+++ b/src/reset/HtmlDiv/HtmlDiv.tsx
@@ -1,11 +1,11 @@
 import React, { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 export interface HtmlDivProps
   extends Omit<HTMLProps<HTMLDivElement>, 'ref' | 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
 }
 
 const divResets = css`

--- a/src/reset/HtmlH/HtmlH.tsx
+++ b/src/reset/HtmlH/HtmlH.tsx
@@ -1,13 +1,13 @@
 import { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 export type hLevels = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 export interface HtmlHProps
   extends Omit<HTMLProps<HTMLHeadingElement>, 'ref' | 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
 }
 
 const hResets = css`

--- a/src/reset/HtmlInput/HtmlInput.tsx
+++ b/src/reset/HtmlInput/HtmlInput.tsx
@@ -1,10 +1,10 @@
 import React, { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets, resetWithSelectors } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 export interface HtmlInputProps
   extends Omit<HTMLProps<HTMLInputElement>, 'ref' | 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
   /**
    * HTML Input type
    * @default text

--- a/src/reset/HtmlLabel/HtmlLabel.tsx
+++ b/src/reset/HtmlLabel/HtmlLabel.tsx
@@ -1,14 +1,14 @@
 import React, { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 /* Only style reseted label-element, no need to check accessibility here */
 /* eslint-disable jsx-a11y/label-has-associated-control */
 
 export interface HtmlLabelProps
   extends Omit<HTMLProps<HTMLLabelElement>, 'ref' | 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
   /**
    * HTML Label for ID-name of the element
    */

--- a/src/reset/HtmlLi/HtmlLi.tsx
+++ b/src/reset/HtmlLi/HtmlLi.tsx
@@ -1,10 +1,10 @@
 import React, { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 export interface HtmlLiProps extends Omit<HTMLProps<HTMLLIElement>, 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
 }
 
 const liResets = css`

--- a/src/reset/HtmlNav/HtmlNav.tsx
+++ b/src/reset/HtmlNav/HtmlNav.tsx
@@ -1,11 +1,11 @@
 import React, { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 export interface HtmlNavProps
   extends Omit<HTMLProps<HTMLElement>, 'ref' | 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
 }
 
 const aResets = css`

--- a/src/reset/HtmlOl/HtmlOl.tsx
+++ b/src/reset/HtmlOl/HtmlOl.tsx
@@ -1,11 +1,11 @@
 import React, { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 export interface HtmlOlProps
   extends Omit<HTMLProps<HTMLOListElement>, 'type' | 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
 }
 
 const olResets = css`

--- a/src/reset/HtmlP/HtmlP.tsx
+++ b/src/reset/HtmlP/HtmlP.tsx
@@ -1,11 +1,11 @@
 import React, { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 export interface HtmlPProps
   extends Omit<HTMLProps<HTMLParagraphElement>, 'ref' | 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
 }
 
 const spanResets = css`

--- a/src/reset/HtmlSpan/HtmlSpan.tsx
+++ b/src/reset/HtmlSpan/HtmlSpan.tsx
@@ -1,11 +1,11 @@
 import React, { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
-import { Omit } from '../../utils/typescript';
+import { Omit, asPropType } from '../../utils/typescript';
 
 export interface HtmlSpanProps
   extends Omit<HTMLProps<HTMLSpanElement>, 'ref' | 'as'> {
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
+  as?: asPropType;
 }
 
 const spanResets = css`

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -5,3 +5,6 @@ export type classnamesValue = string | { [key: string]: string | boolean };
 export function objValue<T, K extends keyof T>(obj: T, key: K) {
   return obj[key];
 }
+
+// From styled-components, does not export from there
+export type asPropType = keyof JSX.IntrinsicElements | React.ComponentType<any>;


### PR DESCRIPTION
Styled-components has as-prop that replaces styled-template literal tags' element/component. Our components use internal components with styled that are not the ones to be replaced. Using defaultTheme-util (will be later refactor at another fix) as-prop is now internally changed to asProp and implementations with that when needed. Link-component supports both public API as and internal API asProp.

closes #157