### PR TITLE
Refactor theme-usage to be able to implement suomifi-desing-tokens

### DIFF
--- a/.styleguidist/typography.md
+++ b/.styleguidist/typography.md
@@ -4,7 +4,10 @@ Suomifi-styleguide typography
 import { default as styled } from 'styled-components';
 import { Text } from '../src/core/Text/Text';
 import { Heading } from '../src/core/Heading/Heading';
-import { typography, fontFamily } from '../src/core/theme/typography';
+import {
+  typographyTokens,
+  fontFamily
+} from '../src/core/theme/typography';
 import clipboardCopy from 'clipboard-copy';
 
 const Row = styled(({ mb, code, ...passProps }) => (
@@ -61,7 +64,7 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
   <TextSet
     variant="body"
     name="Body text"
-    size={typography.fontSize.body}
+    size={typographyTokens.bodyText.fontSize}
     code="<Text></Text>"
   />
   <TextSet
@@ -69,14 +72,14 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
     smallScreen
     variant="body"
     name="Body text"
-    size={typography.smallResolution.fontSize.body}
+    size={typographyTokens.bodyTextSmallScreen.fontSize}
     code="<Text smallScreen></Text>"
   />
 
   <TextSet
     variant="lead"
     name="Lead text"
-    size={typography.fontSize.lead}
+    size={typographyTokens.leadText.fontSize}
     code="<Text.lead></Text.lead>"
   />
   <TextSet
@@ -84,14 +87,14 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
     smallScreen
     variant="lead"
     name="Lead text"
-    size={typography.smallResolution.fontSize.lead}
+    size={typographyTokens.leadTextSmallScreen.fontSize}
     code="<Text.lead smallScreen></Text.lead>"
   />
 
   <HeadingSet
     variant="h1hero"
     name="Heading 1 hero"
-    size={typography.fontSize.h1}
+    size={typographyTokens.heading1.fontSize}
     code="<Heading.h1hero></Heading.h1hero>"
   />
   <HeadingSet
@@ -99,7 +102,7 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
     smallScreen
     variant="h1hero"
     name="Heading 1 hero"
-    size={typography.smallResolution.fontSize.h1}
+    size={typographyTokens.heading1SmallScreen.fontSize}
     code="<Heading.h1hero smallScreen></Heading.h1hero>"
   />
 
@@ -108,7 +111,7 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
       <HeadingSet
         variant={`h${n}`}
         name={`Heading ${n}`}
-        size={typography.fontSize[`h${n !== 6 ? n : 5}`]}
+        size={typographyTokens[`heading${n !== 6 ? n : 5}`].fontSize}
         code={`<Heading.h${n}></Heading.h${n}>`}
       />
       <HeadingSet
@@ -117,7 +120,8 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
         variant={`h${n}`}
         name={`Heading ${n}`}
         size={
-          typography.smallResolution.fontSize[`h${n !== 6 ? n : 5}`]
+          typographyTokens[`heading${n !== 6 ? n : 5}SmallScreen`]
+            .fontSize
         }
         code={`<Heading.h${n} smallScreen></Heading.h${n}>`}
       />

--- a/src/core/Block/Block.baseStyles.ts
+++ b/src/core/Block/Block.baseStyles.ts
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { BlockProps } from './Block';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { element, font } from '../theme/reset';
 import { spacingModifiers } from '../theme/utils';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme, tokens }: BlockProps & SuomifiThemeComponent) => css`
+  ({ theme, tokens }: BlockProps & SuomifiThemeProp) => css`
   ${element({ theme })}
   ${font({ theme })('bodyText')}
   ${spacingModifiers(tokens)('margin')('&.fi-block--margin')}

--- a/src/core/Block/Block.baseStyles.ts
+++ b/src/core/Block/Block.baseStyles.ts
@@ -1,12 +1,14 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../theme';
 import { BlockProps } from './Block';
-import { element, fonts } from '../theme/reset';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { element, font } from '../theme/reset';
 import { spacingModifiers } from '../theme/utils';
 
-export const baseStyles = ({ theme = suomifiTheme }: BlockProps) => css`
-  ${element(theme)}
-  ${fonts(theme).body}
-  ${spacingModifiers(theme)('margin')('&.fi-block--margin')}
-  ${spacingModifiers(theme)('padding')('&.fi-block--padding')}
-`;
+export const baseStyles = withSuomifiTheme(
+  ({ theme, tokens }: BlockProps & SuomifiThemeComponent) => css`
+  ${element({ theme })}
+  ${font({ theme })('bodyText')}
+  ${spacingModifiers(tokens)('margin')('&.fi-block--margin')}
+  ${spacingModifiers(tokens)('padding')('&.fi-block--padding')}
+`,
+);

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import {
   Block as CompBlock,
@@ -39,26 +39,26 @@ const StyledBlock = styled(
  */
 export class Block extends Component<BlockProps> {
   static section = (props: BlockProps) => (
-    <StyledBlock {...withSuomifiDefaults(props)} variant="section" />
+    <StyledBlock {...withSuomifiDefaultProps(props)} variant="section" />
   );
 
   static header = (props: BlockProps) => (
-    <StyledBlock {...withSuomifiDefaults(props)} variant="header" />
+    <StyledBlock {...withSuomifiDefaultProps(props)} variant="header" />
   );
 
   static nav = (props: BlockProps) => (
-    <StyledBlock {...withSuomifiDefaults(props)} variant="nav" />
+    <StyledBlock {...withSuomifiDefaultProps(props)} variant="nav" />
   );
 
   static main = (props: BlockProps) => (
-    <StyledBlock {...withSuomifiDefaults(props)} variant="main" />
+    <StyledBlock {...withSuomifiDefaultProps(props)} variant="main" />
   );
 
   static footer = (props: BlockProps) => (
-    <StyledBlock {...withSuomifiDefaults(props)} variant="footer" />
+    <StyledBlock {...withSuomifiDefaultProps(props)} variant="footer" />
   );
 
   render() {
-    return <StyledBlock {...withSuomifiDefaults(this.props)} />;
+    return <StyledBlock {...withSuomifiDefaultProps(this.props)} />;
   }
 }

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import {
   Block as CompBlock,
   BlockProps as CompBlockProps,
@@ -12,7 +12,7 @@ import classnames from 'classnames';
 
 const baseClassName = 'fi-block';
 
-export interface BlockProps extends CompBlockProps, TokensComponent {
+export interface BlockProps extends CompBlockProps, TokensProp {
   /** Padding from theme */
   padding?: spacingSuomifiTokens;
   /** Margin from theme */

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import {
   Block as CompBlock,
   BlockProps as CompBlockProps,
@@ -12,7 +12,7 @@ import classnames from 'classnames';
 
 const baseClassName = 'fi-block';
 
-export interface BlockProps extends CompBlockProps, ThemeComponent {
+export interface BlockProps extends CompBlockProps, TokensComponent {
   /** Padding from theme */
   padding?: spacingTokensProp;
   /** Margin from theme */
@@ -20,7 +20,7 @@ export interface BlockProps extends CompBlockProps, ThemeComponent {
 }
 
 const StyledBlock = styled(
-  ({ theme, className, padding, margin, ...passProps }: BlockProps) => (
+  ({ tokens, className, padding, margin, ...passProps }: BlockProps) => (
     <CompBlock
       {...passProps}
       className={classnames(className, {
@@ -39,27 +39,26 @@ const StyledBlock = styled(
  */
 export class Block extends Component<BlockProps> {
   static section = (props: BlockProps) => (
-    <StyledBlock {...withDefaultTheme(props)} variant="section" />
+    <StyledBlock {...withSuomifiDefaults(props)} variant="section" />
   );
 
   static header = (props: BlockProps) => (
-    <StyledBlock {...withDefaultTheme(props)} variant="header" />
+    <StyledBlock {...withSuomifiDefaults(props)} variant="header" />
   );
 
   static nav = (props: BlockProps) => (
-    <StyledBlock {...withDefaultTheme(props)} variant="nav" />
+    <StyledBlock {...withSuomifiDefaults(props)} variant="nav" />
   );
 
   static main = (props: BlockProps) => (
-    <StyledBlock {...withDefaultTheme(props)} variant="main" />
+    <StyledBlock {...withSuomifiDefaults(props)} variant="main" />
   );
 
   static footer = (props: BlockProps) => (
-    <StyledBlock {...withDefaultTheme(props)} variant="footer" />
+    <StyledBlock {...withSuomifiDefaults(props)} variant="footer" />
   );
 
   render() {
-    const passProps = withDefaultTheme(this.props);
-    return <StyledBlock {...passProps} />;
+    return <StyledBlock {...withSuomifiDefaults(this.props)} />;
   }
 }

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -6,7 +6,7 @@ import {
   Block as CompBlock,
   BlockProps as CompBlockProps,
 } from '../../components/Block/Block';
-import { spacingTokensProp } from '../theme/spacing';
+import { spacingSuomifiTokens } from '../theme/spacing';
 import { baseStyles } from './Block.baseStyles';
 import classnames from 'classnames';
 
@@ -14,9 +14,9 @@ const baseClassName = 'fi-block';
 
 export interface BlockProps extends CompBlockProps, TokensComponent {
   /** Padding from theme */
-  padding?: spacingTokensProp;
+  padding?: spacingSuomifiTokens;
   /** Margin from theme */
-  margin?: spacingTokensProp;
+  margin?: spacingSuomifiTokens;
 }
 
 const StyledBlock = styled(

--- a/src/core/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/core/Block/__snapshots__/Block.test.tsx.snap
@@ -27,10 +27,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -40,6 +36,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 .c0.fi-block--margin-xxs {

--- a/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -1,9 +1,9 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { nav, list, listItem, font } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
   ${nav({ theme })}
   ${font({ theme })('bodyText')}
   background-color: ${theme.colors.whiteBase};

--- a/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -1,32 +1,33 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../theme';
-import { BreadcrumbProps } from './Breadcrumb';
-import { nav, list, listItem, fonts } from '../theme/reset';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { nav, list, listItem } from '../theme/reset';
 
-export const baseStyles = ({ theme = suomifiTheme }: BreadcrumbProps) => css`
-  ${nav(theme)}
-  ${fonts(theme).body}
+export const baseStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
+  ${nav({ theme })}
+  ${theme.typography.bodyText}
   background-color: ${theme.colors.whiteBase};
 
   & .fi-breadcrumb {
     &_list {
-      ${list(theme)}
-      ${fonts(theme).body}
+      ${list({ theme })}
+      ${theme.typography.bodyText}
       margin: 0;
       padding: 0;
     }
     &_item {
-      ${listItem(theme)}
-      ${fonts(theme).body}
+      ${listItem({ theme })}
+      ${theme.typography.bodyText}
       float: left;
     }
     &_item,
     &_link,
     &_icon {
-      font-size: ${theme.typography.fontSize.body};
+      font-size: ${theme.values.typography.bodyText.fontSize};
     }
     &_icon {
       transform: translateY(.2em);
     }
   }
-`;
+`,
+);

--- a/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -1,23 +1,23 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
-import { nav, list, listItem } from '../theme/reset';
+import { nav, list, listItem, font } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: SuomifiThemeComponent) => css`
   ${nav({ theme })}
-  ${theme.typography.bodyText}
+  ${font({ theme })('bodyText')}
   background-color: ${theme.colors.whiteBase};
 
   & .fi-breadcrumb {
     &_list {
       ${list({ theme })}
-      ${theme.typography.bodyText}
+      ${font({ theme })('bodyText')}
       margin: 0;
       padding: 0;
     }
     &_item {
       ${listItem({ theme })}
-      ${theme.typography.bodyText}
+      ${font({ theme })('bodyText')}
       float: left;
     }
     &_item,

--- a/src/core/Breadcrumb/Breadcrumb.tsx
+++ b/src/core/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import { baseStyles } from './Breadcrumb.baseStyles';
 import {
   Breadcrumb as CompBreadcrumb,
@@ -12,7 +12,7 @@ import { BreadcrumbLink, BreadcrumbLinkProps } from './BreadcrumbLink';
 
 type BreadcrumbVariant = 'default' | 'link';
 
-export interface BreadcrumbProps extends CompBreadcrumbProps, TokensComponent {
+export interface BreadcrumbProps extends CompBreadcrumbProps, TokensProp {
   /**
    * 'default' | 'expansion'
    * @default default

--- a/src/core/Breadcrumb/Breadcrumb.tsx
+++ b/src/core/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import { baseStyles } from './Breadcrumb.baseStyles';
 import {
   Breadcrumb as CompBreadcrumb,
@@ -12,7 +12,7 @@ import { BreadcrumbLink, BreadcrumbLinkProps } from './BreadcrumbLink';
 
 type BreadcrumbVariant = 'default' | 'link';
 
-export interface BreadcrumbProps extends CompBreadcrumbProps, ThemeComponent {
+export interface BreadcrumbProps extends CompBreadcrumbProps, TokensComponent {
   /**
    * 'default' | 'expansion'
    * @default default
@@ -20,7 +20,7 @@ export interface BreadcrumbProps extends CompBreadcrumbProps, ThemeComponent {
   variant?: BreadcrumbVariant;
 }
 
-const StyledBreadcrumb = styled(({ theme, ...passProps }: BreadcrumbProps) => (
+const StyledBreadcrumb = styled(({ tokens, ...passProps }: BreadcrumbProps) => (
   <CompBreadcrumb {...passProps} />
 ))`
   ${props => baseStyles(props)};
@@ -36,20 +36,22 @@ type VariantBreadcrumbProps =
  */
 export class Breadcrumb extends Component<VariantBreadcrumbProps> {
   static link = (props: BreadcrumbLinkProps) => {
-    return <BreadcrumbLink {...withDefaultTheme(props)} />;
+    return <BreadcrumbLink {...withSuomifiDefaults(props)} />;
   };
 
   render() {
-    const { variant, 'aria-label': ariaLabel, ...passProps } = withDefaultTheme(
-      this.props,
-    );
+    const {
+      variant,
+      'aria-label': ariaLabel,
+      ...passProps
+    } = withSuomifiDefaults(this.props);
     if (variant === 'link') {
       return <BreadcrumbLink {...passProps as BreadcrumbLinkProps} />;
     }
     return (
       <StyledBreadcrumb
         {...passProps}
-        aria-label={!!ariaLabel ? ariaLabel : 'breadcrumb'}
+        aria-label={!!ariaLabel ? ariaLabel : 'Breadcrumb'}
       />
     );
   }

--- a/src/core/Breadcrumb/Breadcrumb.tsx
+++ b/src/core/Breadcrumb/Breadcrumb.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import { baseStyles } from './Breadcrumb.baseStyles';
 import {
@@ -36,7 +36,7 @@ type VariantBreadcrumbProps =
  */
 export class Breadcrumb extends Component<VariantBreadcrumbProps> {
   static link = (props: BreadcrumbLinkProps) => {
-    return <BreadcrumbLink {...withSuomifiDefaults(props)} />;
+    return <BreadcrumbLink {...withSuomifiDefaultProps(props)} />;
   };
 
   render() {
@@ -44,7 +44,7 @@ export class Breadcrumb extends Component<VariantBreadcrumbProps> {
       variant,
       'aria-label': ariaLabel,
       ...passProps
-    } = withSuomifiDefaults(this.props);
+    } = withSuomifiDefaultProps(this.props);
     if (variant === 'link') {
       return <BreadcrumbLink {...passProps as BreadcrumbLinkProps} />;
     }

--- a/src/core/Breadcrumb/BreadcrumbLink.tsx
+++ b/src/core/Breadcrumb/BreadcrumbLink.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import { withSuomifiDefaultProps } from '../theme/utils';
 import { baseClassName } from '../../components/Breadcrumb/Breadcrumb';
 import { Link, LinkProps } from '../Link/Link';
@@ -13,7 +13,7 @@ const iconClassName = `${baseClassName}_icon`;
 
 export interface BreadcrumbLinkProps
   extends Omit<LinkProps, 'href'>,
-    TokensComponent {
+    TokensProp {
   /** Indicating the link is the current page */
   current?: boolean;
   /** url for the link */

--- a/src/core/Breadcrumb/BreadcrumbLink.tsx
+++ b/src/core/Breadcrumb/BreadcrumbLink.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
-import { ThemeProp, suomifiTheme } from '../theme';
+import { TokensComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
 import { baseClassName } from '../../components/Breadcrumb/Breadcrumb';
 import { Link, LinkProps } from '../Link/Link';
 import { Icon } from '../Icon/Icon';
@@ -10,12 +11,13 @@ import { Omit } from '../../utils/typescript';
 const linkClassName = `${baseClassName}_link`;
 const iconClassName = `${baseClassName}_icon`;
 
-export interface BreadcrumbLinkProps extends Omit<LinkProps, 'href'> {
+export interface BreadcrumbLinkProps
+  extends Omit<LinkProps, 'href'>,
+    TokensComponent {
   /** Indicating the link is the current page */
   current?: boolean;
   /** url for the link */
   href?: string;
-  theme?: ThemeProp;
 }
 
 export const BreadcrumbLink = ({
@@ -41,11 +43,7 @@ export const BreadcrumbLink = ({
       <Icon
         icon="linkBreadcrumb"
         className={iconClassName}
-        color={
-          !!passProps.theme
-            ? passProps.theme.colors.blackBase
-            : suomifiTheme.colors.blackBase // TODO
-        }
+        color={withSuomifiDefaults(passProps).tokens.colors.blackBase}
       />
     </Fragment>
   );

--- a/src/core/Breadcrumb/BreadcrumbLink.tsx
+++ b/src/core/Breadcrumb/BreadcrumbLink.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { TokensComponent } from '../theme';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { baseClassName } from '../../components/Breadcrumb/Breadcrumb';
 import { Link, LinkProps } from '../Link/Link';
 import { Icon } from '../Icon/Icon';
@@ -43,7 +43,7 @@ export const BreadcrumbLink = ({
       <Icon
         icon="linkBreadcrumb"
         className={iconClassName}
-        color={withSuomifiDefaults(passProps).tokens.colors.blackBase}
+        color={withSuomifiDefaultProps(passProps).tokens.colors.blackBase}
       />
     </Fragment>
   );

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -132,10 +132,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c4 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -145,6 +141,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -196,10 +196,6 @@ exports[`calling render with the same component on the same container does not r
 .c0 {
   color: hsl(0,0%,16%);
   display: block;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -209,16 +205,16 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   background-color: hsl(0,0%,100%);
 }
 
 .c0 .fi-breadcrumb_list {
   color: hsl(0,0%,16%);
   list-style: none;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -228,6 +224,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   margin: 0;
   padding: 0;
 }
@@ -235,10 +235,6 @@ exports[`calling render with the same component on the same container does not r
 .c0 .fi-breadcrumb_item {
   color: hsl(0,0%,16%);
   list-style: none;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -248,6 +244,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   float: left;
 }
 

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -1,5 +1,5 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { ButtonProps } from './Button';
 import { element, focus, button } from '../theme/reset';
 
@@ -8,7 +8,7 @@ const fullWidthStyles = css`
   width: 100%;
 `;
 
-const negativeStyles = ({ theme }: SuomifiThemeComponent) => css`
+const negativeStyles = ({ theme }: SuomifiThemeProp) => css`
   &.fi-button--negative {
     background: none;
     background-color: ${theme.colors.highlightBase};
@@ -33,7 +33,7 @@ const negativeStyles = ({ theme }: SuomifiThemeComponent) => css`
   }
 `;
 
-const secondary = ({ theme }: SuomifiThemeComponent) => css`
+const secondary = ({ theme }: SuomifiThemeProp) => css`
   color: ${theme.colors.highlightBase};
   background: none;
   background-color: ${theme.colors.whiteBase};
@@ -60,20 +60,20 @@ const secondary = ({ theme }: SuomifiThemeComponent) => css`
   }
 `;
 
-const secondaryStyles = ({ theme }: SuomifiThemeComponent) => css`
+const secondaryStyles = ({ theme }: SuomifiThemeProp) => css`
   &.fi-button--secondary {
     ${secondary({ theme })}
   }
 `;
 
-const secondaryNoBorderStyles = ({ theme }: SuomifiThemeComponent) => css`
+const secondaryNoBorderStyles = ({ theme }: SuomifiThemeProp) => css`
   &.fi-button--secondary-noborder {
     ${secondary({ theme })}
     border: none;
   }
 `;
 
-const tertiaryStyles = ({ theme }: SuomifiThemeComponent) => css`
+const tertiaryStyles = ({ theme }: SuomifiThemeProp) => css`
   &.fi-button--tertiary {
     ${secondary({ theme })}
     background: ${theme.colors.highlightLight50};
@@ -93,7 +93,7 @@ export const baseStyles = withSuomifiTheme(
   ({
     theme,
     fullWidth = false,
-  }: SuomifiThemeComponent & Partial<ButtonProps>) => css`
+  }: SuomifiThemeProp & Partial<ButtonProps>) => css`
   ${button({ theme })}
   padding: ${theme.spacing.s} ${theme.spacing.m};
   min-height: 40px;
@@ -142,7 +142,7 @@ export const baseStyles = withSuomifiTheme(
 );
 
 export const unStyled = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
   ${element({ theme })}
   ${focus({ theme })}
   border-radius: ${theme.radius.basic};

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -1,5 +1,5 @@
 import { css } from 'styled-components';
-import { suomifiTheme, ThemeProp } from '../theme';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
 import { ButtonProps } from './Button';
 import { element, focus, button } from '../theme/reset';
 
@@ -8,7 +8,7 @@ const fullWidthStyles = css`
   width: 100%;
 `;
 
-const negativeStyles = (theme: ThemeProp) => css`
+const negativeStyles = ({ theme }: SuomifiThemeComponent) => css`
   &.fi-button--negative {
     background: none;
     background-color: ${theme.colors.highlightBase};
@@ -33,7 +33,7 @@ const negativeStyles = (theme: ThemeProp) => css`
   }
 `;
 
-const secondary = (theme: ThemeProp) => css`
+const secondary = ({ theme }: SuomifiThemeComponent) => css`
   color: ${theme.colors.highlightBase};
   background: none;
   background-color: ${theme.colors.whiteBase};
@@ -60,22 +60,22 @@ const secondary = (theme: ThemeProp) => css`
   }
 `;
 
-const secondaryStyles = (theme: ThemeProp) => css`
+const secondaryStyles = ({ theme }: SuomifiThemeComponent) => css`
   &.fi-button--secondary {
-    ${secondary(theme)}
+    ${secondary({ theme })}
   }
 `;
 
-const secondaryNoBorderStyles = (theme: ThemeProp) => css`
+const secondaryNoBorderStyles = ({ theme }: SuomifiThemeComponent) => css`
   &.fi-button--secondary-noborder {
-    ${secondary(theme)}
+    ${secondary({ theme })}
     border: none;
   }
 `;
 
-const tertiaryStyles = (theme: ThemeProp) => css`
+const tertiaryStyles = ({ theme }: SuomifiThemeComponent) => css`
   &.fi-button--tertiary {
-    ${secondary(theme)}
+    ${secondary({ theme })}
     background: ${theme.colors.highlightLight50};
     border: none;
 
@@ -89,11 +89,12 @@ const tertiaryStyles = (theme: ThemeProp) => css`
   }
 `;
 
-export const baseStyles = ({
-  theme = suomifiTheme,
-  fullWidth = false,
-}: ButtonProps) => css`
-  ${button(theme)}
+export const baseStyles = withSuomifiTheme(
+  ({
+    theme,
+    fullWidth = false,
+  }: SuomifiThemeComponent & Partial<ButtonProps>) => css`
+  ${button({ theme })}
   padding: ${theme.spacing.s} ${theme.spacing.m};
   min-height: 40px;
   color: ${theme.colors.whiteBase};
@@ -121,10 +122,10 @@ export const baseStyles = ({
   }
 
   ${fullWidth && fullWidthStyles}
-  ${negativeStyles(theme)}
-  ${secondaryStyles(theme)}
-  ${secondaryNoBorderStyles(theme)}
-  ${tertiaryStyles(theme)}
+  ${negativeStyles({ theme })}
+  ${secondaryStyles({ theme })}
+  ${secondaryNoBorderStyles({ theme })}
+  ${tertiaryStyles({ theme })}
 
   & > .fi-button_icon {
     width: 16px;
@@ -137,11 +138,14 @@ export const baseStyles = ({
       margin-left: ${theme.spacing.s};
     }
   }
-`;
+`,
+);
 
-export const unStyled = ({ theme = suomifiTheme }) => css`
-  ${element(theme)}
-  ${focus(theme)}
+export const unStyled = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
+  ${element({ theme })}
+  ${focus({ theme })}
   border-radius: ${theme.radius.basic};
   cursor: pointer;
-`;
+`,
+);

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { ThemeComponent, ThemeProp } from '../theme';
-import { withDefaultTheme } from '../theme/utils';
+import { TokensComponent, TokensProp } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
 import { baseStyles } from './Button.baseStyles';
 import {
   Button as CompButton,
@@ -19,7 +19,7 @@ type ButtonVariant =
   | 'tertiary'
   | 'unstyled';
 
-export interface ButtonProps extends CompButtonProps, ThemeComponent {
+export interface ButtonProps extends CompButtonProps, TokensComponent {
   /**
    * Set width to grow all available space
    */
@@ -49,7 +49,7 @@ const iconRightClassName = `${baseClassName}_icon--right`;
 
 const StyledButton = styled(
   ({
-    theme,
+    tokens,
     fullWidth,
     variant = 'default',
     className,
@@ -67,30 +67,27 @@ const StyledButton = styled(
 `;
 
 const iconColor = ({
-  theme,
+  tokens,
   invert,
   disabled,
 }: {
-  theme?: ThemeProp;
+  tokens: TokensProp;
   invert?: boolean;
   disabled?: boolean;
 }) => {
-  if (!!theme) {
-    const defaultColor = !!disabled
-      ? theme.colors.depthBase
-      : theme.colors.whiteBase;
-    const secondaryColor = !!disabled
-      ? theme.colors.depthBase
-      : theme.colors.highlightBase;
-    return !!invert ? secondaryColor : defaultColor;
-  }
-  return undefined;
+  const defaultColor = !!disabled
+    ? tokens.colors.depthBase
+    : tokens.colors.whiteBase;
+  const secondaryColor = !!disabled
+    ? tokens.colors.depthBase
+    : tokens.colors.highlightBase;
+  return !!invert ? secondaryColor : defaultColor;
 };
 
-class ButtonWithIcon extends Component<ButtonProps> {
+class ButtonWithIcon extends Component<ButtonProps & { tokens: TokensProp }> {
   render() {
     const { icon, iconRight, iconProps = {}, ...passProps } = this.props;
-    const { theme, disabled, variant } = passProps;
+    const { tokens, disabled, variant } = passProps;
     const { className: iconPropsClassName, ...passIconProps } = iconProps;
 
     if (variant === 'unstyled') {
@@ -108,7 +105,7 @@ class ButtonWithIcon extends Component<ButtonProps> {
           <Icon
             mousePointer={true}
             icon={icon}
-            color={iconColor({ theme, disabled, invert: secondaryOrTertiary })}
+            color={iconColor({ tokens, disabled, invert: secondaryOrTertiary })}
             className={classnames(iconClassName, iconPropsClassName)}
             {...passIconProps}
           />
@@ -118,7 +115,7 @@ class ButtonWithIcon extends Component<ButtonProps> {
           <Icon
             mousePointer={true}
             icon={iconRight}
-            color={iconColor({ theme, disabled, invert: secondaryOrTertiary })}
+            color={iconColor({ tokens, disabled, invert: secondaryOrTertiary })}
             className={classnames(
               iconClassName,
               iconRightClassName,
@@ -142,31 +139,37 @@ class ButtonWithIcon extends Component<ButtonProps> {
  */
 export class Button extends Component<ButtonProps> {
   static negative = (props: ButtonProps) => {
-    return <ButtonWithIcon {...withDefaultTheme(props)} variant="negative" />;
+    return (
+      <ButtonWithIcon {...withSuomifiDefaults(props)} variant="negative" />
+    );
   };
 
   static secondary = (props: ButtonProps) => {
-    return <ButtonWithIcon {...withDefaultTheme(props)} variant="secondary" />;
+    return (
+      <ButtonWithIcon {...withSuomifiDefaults(props)} variant="secondary" />
+    );
   };
 
   static secondaryNoborder = (props: ButtonProps) => {
     return (
       <ButtonWithIcon
-        {...withDefaultTheme(props)}
+        {...withSuomifiDefaults(props)}
         variant="secondary-noborder"
       />
     );
   };
 
   static tertiary = (props: ButtonProps) => {
-    return <ButtonWithIcon {...withDefaultTheme(props)} variant="tertiary" />;
+    return (
+      <ButtonWithIcon {...withSuomifiDefaults(props)} variant="tertiary" />
+    );
   };
 
   static unstyled = (props: ButtonProps) => {
-    return <UnstyledButton {...withDefaultTheme(props)} />;
+    return <UnstyledButton {...withSuomifiDefaults(props)} />;
   };
 
   render() {
-    return <ButtonWithIcon {...withDefaultTheme(this.props)} />;
+    return <ButtonWithIcon {...withSuomifiDefaults(this.props)} />;
   }
 }

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { TokensComponent, SuomifiTokens } from '../theme';
+import { TokensProp, SuomifiTokens } from '../theme';
 import { withSuomifiDefaultProps } from '../theme/utils';
 import { baseStyles } from './Button.baseStyles';
 import {
@@ -19,7 +19,7 @@ type ButtonVariant =
   | 'tertiary'
   | 'unstyled';
 
-export interface ButtonProps extends CompButtonProps, TokensComponent {
+export interface ButtonProps extends CompButtonProps, TokensProp {
   /**
    * Set width to grow all available space
    */

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { TokensComponent, TokensProp } from '../theme';
+import { TokensComponent, SuomifiTokens } from '../theme';
 import { withSuomifiDefaultProps } from '../theme/utils';
 import { baseStyles } from './Button.baseStyles';
 import {
@@ -71,7 +71,7 @@ const iconColor = ({
   invert,
   disabled,
 }: {
-  tokens: TokensProp;
+  tokens: SuomifiTokens;
   invert?: boolean;
   disabled?: boolean;
 }) => {
@@ -84,7 +84,9 @@ const iconColor = ({
   return !!invert ? secondaryColor : defaultColor;
 };
 
-class ButtonWithIcon extends Component<ButtonProps & { tokens: TokensProp }> {
+class ButtonWithIcon extends Component<
+  ButtonProps & { tokens: SuomifiTokens }
+> {
   render() {
     const { icon, iconRight, iconProps = {}, ...passProps } = this.props;
     const { tokens, disabled, variant } = passProps;

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { TokensComponent, TokensProp } from '../theme';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { baseStyles } from './Button.baseStyles';
 import {
   Button as CompButton,
@@ -140,20 +140,20 @@ class ButtonWithIcon extends Component<ButtonProps & { tokens: TokensProp }> {
 export class Button extends Component<ButtonProps> {
   static negative = (props: ButtonProps) => {
     return (
-      <ButtonWithIcon {...withSuomifiDefaults(props)} variant="negative" />
+      <ButtonWithIcon {...withSuomifiDefaultProps(props)} variant="negative" />
     );
   };
 
   static secondary = (props: ButtonProps) => {
     return (
-      <ButtonWithIcon {...withSuomifiDefaults(props)} variant="secondary" />
+      <ButtonWithIcon {...withSuomifiDefaultProps(props)} variant="secondary" />
     );
   };
 
   static secondaryNoborder = (props: ButtonProps) => {
     return (
       <ButtonWithIcon
-        {...withSuomifiDefaults(props)}
+        {...withSuomifiDefaultProps(props)}
         variant="secondary-noborder"
       />
     );
@@ -161,15 +161,15 @@ export class Button extends Component<ButtonProps> {
 
   static tertiary = (props: ButtonProps) => {
     return (
-      <ButtonWithIcon {...withSuomifiDefaults(props)} variant="tertiary" />
+      <ButtonWithIcon {...withSuomifiDefaultProps(props)} variant="tertiary" />
     );
   };
 
   static unstyled = (props: ButtonProps) => {
-    return <UnstyledButton {...withSuomifiDefaults(props)} />;
+    return <UnstyledButton {...withSuomifiDefaultProps(props)} />;
   };
 
   render() {
-    return <ButtonWithIcon {...withSuomifiDefaults(this.props)} />;
+    return <ButtonWithIcon {...withSuomifiDefaultProps(this.props)} />;
   }
 }

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -51,10 +51,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -64,6 +60,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
   line-height: 1;
   padding: 8px 16px;
   min-height: 40px;

--- a/src/core/Colors/Colors.baseStyles.tsx
+++ b/src/core/Colors/Colors.baseStyles.tsx
@@ -1,14 +1,11 @@
 import { css } from 'styled-components';
 import { readableColor } from 'polished';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { clearfix } from '../../utils/css/utils';
 import { ColorProps } from './Colors';
 
 export const baseStyles = withSuomifiTheme(
-  ({
-    theme,
-    color: colorProp,
-  }: SuomifiThemeComponent & Partial<ColorProps>) => {
+  ({ theme, color: colorProp }: SuomifiThemeProp & Partial<ColorProps>) => {
     const color = !!colorProp ? colorProp : theme.colors.blackBase;
     return css`
       ${theme.typography.bodyText}

--- a/src/core/Colors/Colors.baseStyles.tsx
+++ b/src/core/Colors/Colors.baseStyles.tsx
@@ -1,52 +1,59 @@
 import { css } from 'styled-components';
 import { readableColor } from 'polished';
-import { suomifiTheme } from '../theme';
-import { font } from '../theme/reset';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
 import { clearfix } from '../../utils/css/utils';
 import { ColorProps } from './Colors';
 
-export const baseStyles = ({ color, theme = suomifiTheme }: ColorProps) => css`
-  ${font(theme).bodyText}
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  float: left;
-  width: 192px;
-  height: 180px;
-  max-width: 100%;
-  padding: ${theme.spacing.s};
-  color: ${readableColor(color)};
-  background-color: ${color};
-  border-bottom: 4px solid ${color};
-  cursor: pointer;
-  z-index: 2;
+export const baseStyles = withSuomifiTheme(
+  ({
+    theme,
+    color: colorProp,
+  }: SuomifiThemeComponent & Partial<ColorProps>) => {
+    const color = !!colorProp ? colorProp : theme.colors.blackBase;
+    return css`
+      ${theme.typography.bodyText}
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      float: left;
+      width: 192px;
+      height: 180px;
+      max-width: 100%;
+      padding: ${theme.spacing.s};
+      color: ${readableColor(color)};
+      background-color: ${color};
+      border-bottom: 4px solid ${color};
+      cursor: pointer;
+      z-index: 2;
 
-  &:hover {
-    border-bottom-color: ${readableColor(color)};
-  }
+      &:hover {
+        border-bottom-color: ${readableColor(color)};
+      }
 
-  .fi-color__name {
-    position: relative;
-    width: 100%;
-    text-align: right;
-    overflow-wrap: break-word;
-    z-index: 3;
-    pointer-events: none;
+      .fi-color__name {
+        position: relative;
+        width: 100%;
+        text-align: right;
+        overflow-wrap: break-word;
+        z-index: 3;
+        pointer-events: none;
 
-    &--hex {
-      ${font(theme).bodyTextSmallScreen}
-      opacity: .4;
-    }
+        &--hex {
+          ${theme.typography.bodyTextSmallScreen}
+          opacity: .4;
+        }
 
-    &--key {
-      ${font(theme).bodySemiBold}
-    }
-  }
+        &--key {
+          ${theme.typography.bodySemiBold}
+        }
+      }
 
-  &:hover .fi-color__name--key {
-    text-decoration: underline;
-  }
-`;
+      &:hover .fi-color__name--key {
+        text-decoration: underline;
+      }
+    `;
+  },
+);
 
 export const containerStyles = css`
   ${clearfix}

--- a/src/core/Colors/Colors.tsx
+++ b/src/core/Colors/Colors.tsx
@@ -2,17 +2,17 @@ import React, { Component, ReactNode } from 'react';
 import { withSuomifiDefaultProps } from '../theme/utils';
 import { hslaToHex } from '../../utils/css/colors';
 import { default as styled } from 'styled-components';
-import { TokensComponent, SuomifiThemeProp } from '../theme';
+import { TokensProp, SuomifiThemeProp } from '../theme';
 import { baseStyles, containerStyles } from './Colors.baseStyles';
 import clipboardCopy from 'clipboard-copy';
 
-export interface ColorsProps extends TokensComponent {
+export interface ColorsProps extends TokensProp {
   colors?: {
     [key: string]: string;
   };
 }
 
-export interface ColorProps extends TokensComponent {
+export interface ColorProps extends TokensProp {
   keyName: string;
   color: string;
   children?: ReactNode;

--- a/src/core/Colors/Colors.tsx
+++ b/src/core/Colors/Colors.tsx
@@ -2,7 +2,7 @@ import React, { Component, ReactNode } from 'react';
 import { withSuomifiDefaultProps } from '../theme/utils';
 import { hslaToHex } from '../../utils/css/colors';
 import { default as styled } from 'styled-components';
-import { TokensComponent, SuomifiThemeComponent } from '../theme';
+import { TokensComponent, SuomifiThemeProp } from '../theme';
 import { baseStyles, containerStyles } from './Colors.baseStyles';
 import clipboardCopy from 'clipboard-copy';
 
@@ -19,7 +19,7 @@ export interface ColorProps extends TokensComponent {
 }
 
 const Color = styled.div`
-  ${(props: ColorProps & SuomifiThemeComponent) => baseStyles(props)};
+  ${(props: ColorProps & SuomifiThemeProp) => baseStyles(props)};
 `;
 
 const ColorsContainer = styled.div`

--- a/src/core/Colors/Colors.tsx
+++ b/src/core/Colors/Colors.tsx
@@ -1,25 +1,25 @@
 import React, { Component, ReactNode } from 'react';
-import { withDefaultTheme } from '../theme/utils';
+import { withSuomifiDefaults } from '../theme/utils';
 import { hslaToHex } from '../../utils/css/colors';
 import { default as styled } from 'styled-components';
-import { ThemeComponent } from '../theme';
+import { TokensComponent, SuomifiThemeComponent } from '../theme';
 import { baseStyles, containerStyles } from './Colors.baseStyles';
 import clipboardCopy from 'clipboard-copy';
 
-export interface ColorsProps extends ThemeComponent {
+export interface ColorsProps extends TokensComponent {
   colors?: {
     [key: string]: string;
   };
 }
 
-export interface ColorProps extends ThemeComponent {
+export interface ColorProps extends TokensComponent {
   keyName: string;
   color: string;
   children?: ReactNode;
 }
 
 const Color = styled.div`
-  ${(props: ColorProps) => baseStyles(props)};
+  ${(props: ColorProps & SuomifiThemeComponent) => baseStyles(props)};
 `;
 
 const ColorsContainer = styled.div`
@@ -31,35 +31,34 @@ const copyKey = (key: string) => () => clipboardCopy(key);
 export class Colors extends Component<ColorsProps> {
   render() {
     const { colors } = this.props;
-    const { theme } = withDefaultTheme(this.props);
+    const props = withSuomifiDefaults(this.props);
     return (
       <ColorsContainer>
-        {Object.entries(!!colors ? colors : theme.colors).reduce<JSX.Element[]>(
-          (arr, [key, value]) => {
-            const hslaAsHex = hslaToHex(value.toString());
-            const item = (
-              <Color
-                keyName={key.toString()}
-                color={value.toString()}
-                key={key.toString()}
-                theme={theme}
-                onClick={copyKey(key.toString())}
-              >
-                <div className="fi-color__name">{value.toString()}</div>
-                {!!hslaAsHex && (
-                  <div className="fi-color__name fi-color__name--hex">
-                    {hslaAsHex}
-                  </div>
-                )}
-                <div className="fi-color__name fi-color__name--key">
-                  {key.toString()}
+        {Object.entries(!!colors ? colors : props.tokens.colors).reduce<
+          JSX.Element[]
+        >((arr, [key, value]) => {
+          const hslaAsHex = hslaToHex(value.toString());
+          const item = (
+            <Color
+              keyName={key.toString()}
+              color={value.toString()}
+              key={key.toString()}
+              onClick={copyKey(key.toString())}
+              {...props}
+            >
+              <div className="fi-color__name">{value.toString()}</div>
+              {!!hslaAsHex && (
+                <div className="fi-color__name fi-color__name--hex">
+                  {hslaAsHex}
                 </div>
-              </Color>
-            );
-            return [...arr, item];
-          },
-          [],
-        )}
+              )}
+              <div className="fi-color__name fi-color__name--key">
+                {key.toString()}
+              </div>
+            </Color>
+          );
+          return [...arr, item];
+        }, [])}
       </ColorsContainer>
     );
   }

--- a/src/core/Colors/Colors.tsx
+++ b/src/core/Colors/Colors.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ReactNode } from 'react';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { hslaToHex } from '../../utils/css/colors';
 import { default as styled } from 'styled-components';
 import { TokensComponent, SuomifiThemeComponent } from '../theme';
@@ -31,7 +31,7 @@ const copyKey = (key: string) => () => clipboardCopy(key);
 export class Colors extends Component<ColorsProps> {
   render() {
     const { colors } = this.props;
-    const props = withSuomifiDefaults(this.props);
+    const props = withSuomifiDefaultProps(this.props);
     return (
       <ColorsContainer>
         {Object.entries(!!colors ? colors : props.tokens.colors).reduce<

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -1,9 +1,9 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { element, inputButton } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
     & > [data-reach-menu-button].fi-dropdown_button {
       ${inputButton({ theme })}
       position: relative;
@@ -31,7 +31,7 @@ export const baseStyles = withSuomifiTheme(
 );
 
 export const menuListStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
   &[data-reach-menu-list].fi-dropdown_list {
     ${element({ theme })}
     ${theme.typography.input}

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -1,45 +1,40 @@
 import { css } from 'styled-components';
-import { suomifiTheme, ThemeProp } from '../theme';
-import { DropdownProps } from './Dropdown';
-import { element, inputButton, fonts } from '../theme/reset';
-import { Omit } from '../../utils/typescript';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { element, inputButton } from '../theme/reset';
 
-export const baseStyles = ({
-  theme = suomifiTheme,
-}: Omit<DropdownProps, 'name'>) => css`
-  & > [data-reach-menu-button].fi-dropdown_button {
-    ${inputButton(theme)}
-    position: relative;
-    padding-right: 30px;
-    text-align: left;
-    cursor: pointer;
-    &:before {
-      content: '';
-      position: absolute;
-      top: 50%;
-      right: 10px;
-      margin-top: -3px;
-      border-style: solid;
-      border-color: ${theme.colors.depthDark27} transparent transparent
-        transparent;
-      border-width: 6px 4px 0 4px;
+export const baseStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
+    & > [data-reach-menu-button].fi-dropdown_button {
+      ${inputButton({ theme })}
+      position: relative;
+      padding-right: 30px;
+      text-align: left;
+      cursor: pointer;
+      &:before {
+        content: '';
+        position: absolute;
+        top: 50%;
+        right: 10px;
+        margin-top: -3px;
+        border-style: solid;
+        border-color: ${theme.colors.depthDark27} transparent transparent
+          transparent;
+        border-width: 6px 4px 0 4px;
+      }
+      &[aria-expanded='true']:before {
+        border-color: transparent transparent ${theme.colors.depthDark27}
+          transparent;
+        border-width: 0 4px 6px 4px;
+      }
     }
-    &[aria-expanded='true']:before {
-      border-color: transparent transparent ${theme.colors.depthDark27}
-        transparent;
-      border-width: 0 4px 6px 4px;
-    }
-  }
-`;
+  `,
+);
 
-export const menuListStyles = ({
-  theme = suomifiTheme,
-}: {
-  theme: ThemeProp;
-}) => css`
+export const menuListStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
   &[data-reach-menu-list].fi-dropdown_list {
-    ${element(theme)}
-    ${fonts(theme).input}
+    ${element({ theme })}
+    ${theme.typography.input}
     margin-top: -1px;
     padding: 0;
     font-size: 100%;
@@ -53,16 +48,17 @@ export const menuListStyles = ({
   }
 
   & [data-reach-menu-item].fi-dropdown_item {
-    ${element(theme)}
-    ${fonts(theme).input}
+    ${element({ theme })}
+    ${theme.typography.input}
     padding: ${theme.spacing.s} ${theme.spacing.m};
     border: 0;
     &[data-selected] {
-      ${fonts(theme).input}
+      ${theme.typography.input}
       color: ${theme.colors.blackBase};
       background-image: none;
       background-color: ${theme.colors.highlightLight50};
       border: 0;
     }
   }
-`;
+`,
+);

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-// import { cssFromBaseStyles } from '../utils';
-// import { baseStyles } from './Dropdown.baseStyles';
 import { axeTest } from '../../utils/test/axe';
 
 import { Dropdown } from './Dropdown';
@@ -13,10 +11,5 @@ const TestDropdown = (
     <Dropdown.item onSelect={doNothing}>Item 2</Dropdown.item>
   </Dropdown>
 );
-
-// test('CSS export', () => {
-//   const css = cssFromBaseStyles(baseStyles);
-//   expect(css).toEqual(expect.stringContaining('position'));
-// });
 
 test('should not have basic accessibility issues', axeTest(TestDropdown));

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { cssFromBaseStyles } from '../utils';
-import { baseStyles } from './Dropdown.baseStyles';
+// import { cssFromBaseStyles } from '../utils';
+// import { baseStyles } from './Dropdown.baseStyles';
 import { axeTest } from '../../utils/test/axe';
 
 import { Dropdown } from './Dropdown';
@@ -14,9 +14,9 @@ const TestDropdown = (
   </Dropdown>
 );
 
-test('CSS export', () => {
-  const css = cssFromBaseStyles(baseStyles);
-  expect(css).toEqual(expect.stringContaining('position'));
-});
+// test('CSS export', () => {
+//   const css = cssFromBaseStyles(baseStyles);
+//   expect(css).toEqual(expect.stringContaining('position'));
+// });
 
 test('should not have basic accessibility issues', axeTest(TestDropdown));

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import { baseStyles, menuListStyles } from './Dropdown.baseStyles';
 import {
   MenuList as CompMenuList,
@@ -13,7 +13,7 @@ import {
 } from '../../components/Dropdown/Dropdown';
 import { DropdownItem, DropdownItemProps } from './DropdownItem';
 
-export interface DropdownProps extends CompDropdownProps, TokensComponent {}
+export interface DropdownProps extends CompDropdownProps, TokensProp {}
 
 const StyledDropdown = styled(({ tokens, ...passProps }: DropdownProps) => (
   <CompDropdown
@@ -24,7 +24,7 @@ const StyledDropdown = styled(({ tokens, ...passProps }: DropdownProps) => (
   ${props => baseStyles(props)}
 `;
 
-interface MenuListProps extends CompMenuListProps, TokensComponent {}
+interface MenuListProps extends CompMenuListProps, TokensProp {}
 
 const StyledMenuList = styled(({ tokens, ...passProps }: MenuListProps) => (
   <CompMenuList {...passProps} />

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import { baseStyles, menuListStyles } from './Dropdown.baseStyles';
 import {
@@ -40,7 +40,7 @@ export class Dropdown extends Component<DropdownProps> {
   static item = (props: DropdownItemProps) => <DropdownItem {...props} />;
 
   render() {
-    const props = withSuomifiDefaults(this.props);
+    const props = withSuomifiDefaultProps(this.props);
     return (
       <Fragment>
         <StyledDropdown {...props} menuListComponent={StyledMenuList} />

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import { baseStyles, menuListStyles } from './Dropdown.baseStyles';
 import {
   MenuList as CompMenuList,
@@ -13,9 +13,9 @@ import {
 } from '../../components/Dropdown/Dropdown';
 import { DropdownItem, DropdownItemProps } from './DropdownItem';
 
-export interface DropdownProps extends CompDropdownProps, ThemeComponent {}
+export interface DropdownProps extends CompDropdownProps, TokensComponent {}
 
-const StyledDropdown = styled(({ theme, ...passProps }: DropdownProps) => (
+const StyledDropdown = styled(({ tokens, ...passProps }: DropdownProps) => (
   <CompDropdown
     {...passProps}
     dropdownItemProps={{ className: 'fi-dropdown-item' }}
@@ -24,9 +24,9 @@ const StyledDropdown = styled(({ theme, ...passProps }: DropdownProps) => (
   ${props => baseStyles(props)}
 `;
 
-interface MenuListProps extends CompMenuListProps, ThemeComponent {}
+interface MenuListProps extends CompMenuListProps, TokensComponent {}
 
-const StyledMenuList = styled(({ theme, ...passProps }: MenuListProps) => (
+const StyledMenuList = styled(({ tokens, ...passProps }: MenuListProps) => (
   <CompMenuList {...passProps} />
 ))`
   ${props => menuListStyles(props.theme)}
@@ -40,7 +40,7 @@ export class Dropdown extends Component<DropdownProps> {
   static item = (props: DropdownItemProps) => <DropdownItem {...props} />;
 
   render() {
-    const props = withDefaultTheme(this.props);
+    const props = withSuomifiDefaults(this.props);
     return (
       <Fragment>
         <StyledDropdown {...props} menuListComponent={StyledMenuList} />

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -1,9 +1,9 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../../theme';
 import { math } from 'polished';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
     & .fi-search-input {
       &_input-container {
         position: relative;

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -1,21 +1,22 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../../theme';
-import { SearchInputProps } from './SearchInput';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../../theme';
 import { math } from 'polished';
 
-export const baseStyles = ({ theme = suomifiTheme }: SearchInputProps) => css`
-  & .fi-search-input {
-    &_input-container {
-      position: relative;
+export const baseStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
+    & .fi-search-input {
+      &_input-container {
+        position: relative;
+      }
+      &_input {
+        padding-right: ${math(`${theme.spacing.m} * 2 + ${theme.spacing.s}`)};
+      }
+      &_icon {
+        position: absolute;
+        top: 50%;
+        right: ${theme.spacing.m};
+        margin-top: -0.5em;
+      }
     }
-    &_input {
-      padding-right: ${math(`${theme.spacing.m} * 2 + ${theme.spacing.s}`)};
-    }
-    &_icon {
-      position: absolute;
-      top: 50%;
-      right: ${theme.spacing.m};
-      margin-top: -0.5em;
-    }
-  }
-`;
+  `,
+);

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../../theme/utils';
+import { withSuomifiDefaultProps } from '../../theme/utils';
 import { baseStyles } from './SearchInput.baseStyles';
 import { TextInput, TextInputProps } from '../TextInput/TextInput';
 import { Icon } from '../../Icon/Icon';
@@ -36,7 +36,7 @@ export class SearchInput extends Component<TextInputProps> {
     return (
       <StyledTextInput
         labelMode="screenreader"
-        {...withSuomifiDefaults(this.props)}
+        {...withSuomifiDefaultProps(this.props)}
       >
         <Icon icon="search" className={iconBaseClassName} />
       </StyledTextInput>

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../../theme/utils';
+import { withSuomifiDefaults } from '../../theme/utils';
 import { baseStyles } from './SearchInput.baseStyles';
 import { TextInput, TextInputProps } from '../TextInput/TextInput';
 import { Icon } from '../../Icon/Icon';
@@ -15,7 +15,7 @@ const iconBaseClassName = `${baseClassName}_icon`;
 export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {}
 
 const StyledTextInput = styled(
-  ({ theme, className, inputClassName, ...passProps }: TextInputProps) => (
+  ({ tokens, className, inputClassName, ...passProps }: TextInputProps) => (
     <TextInput
       {...passProps}
       className={classnames(className, baseClassName)}
@@ -36,7 +36,7 @@ export class SearchInput extends Component<TextInputProps> {
     return (
       <StyledTextInput
         labelMode="screenreader"
-        {...withDefaultTheme(this.props)}
+        {...withSuomifiDefaults(this.props)}
       >
         <Icon icon="search" className={iconBaseClassName} />
       </StyledTextInput>

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -149,10 +149,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c1 .fi-text-input_input {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -162,6 +158,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   min-width: 245px;
   max-width: 100%;
   padding: 8px 16px;

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -1,19 +1,19 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../../theme';
-import { TextInputProps } from './TextInput';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../../theme';
 import { input, inputContainer } from '../../theme/reset';
 
-export const baseStyles = ({ theme = suomifiTheme }: TextInputProps) => css`
+export const baseStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
   & .fi-text-input_label-p {
     margin-bottom: ${theme.spacing.m};
   }
 
   & .fi-text-input_container {
-    ${inputContainer(theme)}
+    ${inputContainer({ theme })}
   }
 
   & .fi-text-input_input {
-    ${input(theme)}
+    ${input({ theme })}
     background-color: ${theme.colors.whiteBase};
   }
 
@@ -29,4 +29,5 @@ export const baseStyles = ({ theme = suomifiTheme }: TextInputProps) => css`
       border-color: ${theme.colors.successBase};
     }
   }
-`;
+`,
+);

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -1,9 +1,9 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../../theme';
 import { input, inputContainer } from '../../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
   & .fi-text-input_label-p {
     margin-bottom: ${theme.spacing.m};
   }

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../../theme/utils';
+import { withSuomifiDefaultProps } from '../../theme/utils';
 import { TokensComponent } from '../../theme';
 import { baseStyles } from './TextInput.baseStyles';
 import {
@@ -63,15 +63,15 @@ const StyledTextInput = styled(
  */
 export class TextInput extends Component<TextInputProps> {
   static error = (props: TextInputProps) => (
-    <StyledTextInput {...withSuomifiDefaults(props)} variant="error" />
+    <StyledTextInput {...withSuomifiDefaultProps(props)} variant="error" />
   );
 
   static success = (props: TextInputProps) => (
-    <StyledTextInput {...withSuomifiDefaults(props)} variant="success" />
+    <StyledTextInput {...withSuomifiDefaultProps(props)} variant="success" />
   );
 
   render() {
-    const { ...passProps } = withSuomifiDefaults(this.props);
+    const { ...passProps } = withSuomifiDefaultProps(this.props);
 
     return <StyledTextInput {...passProps} />;
   }

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../../theme/utils';
-import { TokensComponent } from '../../theme';
+import { TokensProp } from '../../theme';
 import { baseStyles } from './TextInput.baseStyles';
 import {
   TextInput as CompTextInput,
@@ -16,7 +16,7 @@ const errorClassName = `${baseClassName}--error`;
 const successClassName = `${baseClassName}--success`;
 
 type TextInputVariant = 'default' | 'error' | 'success';
-export interface TextInputProps extends CompTextInputProps, TokensComponent {
+export interface TextInputProps extends CompTextInputProps, TokensProp {
   variant?: TextInputVariant;
 }
 

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../../theme/utils';
-import { ThemeComponent } from '../../theme';
+import { withSuomifiDefaults } from '../../theme/utils';
+import { TokensComponent } from '../../theme';
 import { baseStyles } from './TextInput.baseStyles';
 import {
   TextInput as CompTextInput,
@@ -16,13 +16,13 @@ const errorClassName = `${baseClassName}--error`;
 const successClassName = `${baseClassName}--success`;
 
 type TextInputVariant = 'default' | 'error' | 'success';
-export interface TextInputProps extends CompTextInputProps, ThemeComponent {
+export interface TextInputProps extends CompTextInputProps, TokensComponent {
   variant?: TextInputVariant;
 }
 
 const StyledTextInput = styled(
   ({
-    theme,
+    tokens,
     variant,
     className,
     labelTextProps = { className: undefined },
@@ -63,15 +63,15 @@ const StyledTextInput = styled(
  */
 export class TextInput extends Component<TextInputProps> {
   static error = (props: TextInputProps) => (
-    <StyledTextInput {...withDefaultTheme(props)} variant="error" />
+    <StyledTextInput {...withSuomifiDefaults(props)} variant="error" />
   );
 
   static success = (props: TextInputProps) => (
-    <StyledTextInput {...withDefaultTheme(props)} variant="success" />
+    <StyledTextInput {...withSuomifiDefaults(props)} variant="success" />
   );
 
   render() {
-    const { ...passProps } = withDefaultTheme(this.props);
+    const { ...passProps } = withSuomifiDefaults(this.props);
 
     return <StyledTextInput {...passProps} />;
   }

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -137,10 +137,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 .fi-text-input_input {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -150,6 +146,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   min-width: 245px;
   max-width: 100%;
   padding: 8px 16px;

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -1,21 +1,21 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../../theme';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../../theme';
 import { focus } from '../../theme/utils';
-import { ToggleProps } from './Toggle';
-import { element, fonts } from '../../theme/reset';
+import { element, font } from '../../theme/reset';
 
 const svgPrefix = 'icon-toggle_svg__';
 
-export const baseStyles = ({ theme = suomifiTheme }: ToggleProps) => css`
-  ${element(theme)}
-  ${fonts(theme).body}
+export const baseStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
+  ${element({ theme })}
+  ${font({ theme })('bodyText')}
   background-color: ${theme.colors.whiteBase};
   & > .fi-toggle_label {
     cursor: pointer;
   }
   & > .fi-toggle_input {
-    ${element(theme)}
-    ${fonts(theme).body}
+    ${element({ theme })}
+    ${font({ theme })('bodyText')}
     width: 0;
     height: 0;
     opacity: 0;
@@ -64,4 +64,5 @@ export const baseStyles = ({ theme = suomifiTheme }: ToggleProps) => css`
       }
     }
   }
-`;
+`,
+);

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../../theme';
 import { focus } from '../../theme/utils';
 import { element, font } from '../../theme/reset';
 
 const svgPrefix = 'icon-toggle_svg__';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
   ${element({ theme })}
   ${font({ theme })('bodyText')}
   background-color: ${theme.colors.whiteBase};

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { withDefaultTheme } from '../../theme/utils';
-import { ThemeComponent } from '../../theme';
+import { withSuomifiDefaults } from '../../theme/utils';
+import { TokensComponent } from '../../theme';
 import { baseStyles } from './Toggle.baseStyles';
 import {
   Toggle as CompToggle,
@@ -12,16 +12,16 @@ import {
 } from '../../../components/Form/Toggle';
 import { Icon } from '../../Icon/Icon';
 
-export interface ToggleProps extends CompToggleProps, ThemeComponent {}
+export interface ToggleProps extends CompToggleProps, TokensComponent {}
 export interface ToggleInputProps
   extends CompToggleInputProps,
-    ThemeComponent {}
+    TokensComponent {}
 
 const iconBaseClassName = 'fi-toggle_icon';
 const iconDisabledClassName = `${iconBaseClassName}--disabled`;
 const iconCheckedClassName = `${iconBaseClassName}--checked`;
 
-const StyledToggle = styled(({ theme, ...passProps }: ToggleProps) => (
+const StyledToggle = styled(({ tokens, ...passProps }: ToggleProps) => (
   <CompToggle {...passProps} />
 ))`
   ${props => baseStyles(props)}
@@ -50,7 +50,7 @@ export class Toggle extends Component<ToggleProps> {
       checked: dissMissChecked,
       onClick,
       ...passProps
-    } = withDefaultTheme(this.props);
+    } = withSuomifiDefaults(this.props);
     const { toggleStatus } = this.state;
 
     return (

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { withSuomifiDefaultProps } from '../../theme/utils';
-import { TokensComponent } from '../../theme';
+import { TokensProp } from '../../theme';
 import { baseStyles } from './Toggle.baseStyles';
 import {
   Toggle as CompToggle,
@@ -12,10 +12,8 @@ import {
 } from '../../../components/Form/Toggle';
 import { Icon } from '../../Icon/Icon';
 
-export interface ToggleProps extends CompToggleProps, TokensComponent {}
-export interface ToggleInputProps
-  extends CompToggleInputProps,
-    TokensComponent {}
+export interface ToggleProps extends CompToggleProps, TokensProp {}
+export interface ToggleInputProps extends CompToggleInputProps, TokensProp {}
 
 const iconBaseClassName = 'fi-toggle_icon';
 const iconDisabledClassName = `${iconBaseClassName}--disabled`;

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { withSuomifiDefaults } from '../../theme/utils';
+import { withSuomifiDefaultProps } from '../../theme/utils';
 import { TokensComponent } from '../../theme';
 import { baseStyles } from './Toggle.baseStyles';
 import {
@@ -50,7 +50,7 @@ export class Toggle extends Component<ToggleProps> {
       checked: dissMissChecked,
       onClick,
       ...passProps
-    } = withSuomifiDefaults(this.props);
+    } = withSuomifiDefaultProps(this.props);
     const { toggleStatus } = this.state;
 
     return (

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -85,10 +85,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -98,6 +94,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   background-color: hsl(0,0%,100%);
 }
 
@@ -107,10 +107,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 > .fi-toggle_input {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -120,6 +116,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   width: 0;
   height: 0;
   opacity: 0;

--- a/src/core/Heading/Heading.baseStyles.ts
+++ b/src/core/Heading/Heading.baseStyles.ts
@@ -1,64 +1,63 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../theme';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
 import { HeadingProps } from './Heading';
-import { element, fonts } from '../theme/reset';
+import { element, font } from '../theme/reset';
 import { objValue } from '../../utils/typescript';
 
-export const baseStyles = ({
-  theme = suomifiTheme,
-  color,
-}: HeadingProps) => css`
-  ${element(theme)}
-  ${fonts(theme).body}
+export const baseStyles = withSuomifiTheme(
+  ({ theme, color }: SuomifiThemeComponent & Partial<HeadingProps>) => css`
+  ${element({ theme })}
+  ${font({ theme })('bodyText')}
   color: ${!!color ? objValue(theme.colors, color) : theme.colors.blackBase};
 
   &.fi-heading {
     &--h1hero {
-      ${fonts(theme).h1hero}
+      ${font({ theme })('heading1Hero')}
     }
     &--h1 {
-      ${fonts(theme).h1}
+      ${font({ theme })('heading1')}
     }
     &--h2 {
-      ${fonts(theme).h2}
+      ${font({ theme })('heading2')}
     }
     &--h3 {
-      ${fonts(theme).h3}
+      ${font({ theme })('heading3')}
     }
     &--h4 {
-      ${fonts(theme).h4}
+      ${font({ theme })('heading4')}
     }
     &--h5 {
-      ${fonts(theme).h5}
+      ${font({ theme })('heading5')}
     }
     &--h6 {
-      ${fonts(theme).h5}
+      ${font({ theme })('heading5')}
     }
     &--small-screen {
-      ${fonts(theme).smRes.h1}
+      ${font({ theme })('heading1SmallScreen')}
       &.fi-heading {
         &--h1hero {
-          ${fonts(theme).smRes.h1hero}
+          ${font({ theme })('heading1HeroSmallScreen')}
         }
         &--h1 {
-          ${fonts(theme).smRes.h1}
+          ${font({ theme })('heading1SmallScreen')}
         }
         &--h2 {
-          ${fonts(theme).smRes.h2}
+          ${font({ theme })('heading2SmallScreen')}
         }
         &--h3 {
-          ${fonts(theme).smRes.h3}
+          ${font({ theme })('heading3SmallScreen')}
         }
         &--h4 {
-          ${fonts(theme).smRes.h4}
+          ${font({ theme })('heading4SmallScreen')}
         }
         &--h5 {
-          ${fonts(theme).smRes.h5}
+          ${font({ theme })('heading5SmallScreen')}
         }
         &--h6 {
-          ${fonts(theme).smRes.h5}
+          ${font({ theme })('heading5SmallScreen')}
         }
       }
     }
   }
-`;
+`,
+);

--- a/src/core/Heading/Heading.baseStyles.ts
+++ b/src/core/Heading/Heading.baseStyles.ts
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { HeadingProps } from './Heading';
 import { element, font } from '../theme/reset';
 import { objValue } from '../../utils/typescript';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme, color }: SuomifiThemeComponent & Partial<HeadingProps>) => css`
+  ({ theme, color }: SuomifiThemeProp & Partial<HeadingProps>) => css`
   ${element({ theme })}
   ${font({ theme })('bodyText')}
   color: ${!!color ? objValue(theme.colors, color) : theme.colors.blackBase};

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent, ColorProp } from '../theme';
 import {
   Heading as CompHeading,
@@ -59,35 +59,35 @@ const StyledHeading = styled(
  */
 export class Heading extends Component<HeadingProps> {
   static h1hero = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withSuomifiDefaults(props)} variant="h1hero" />
+    <StyledHeading {...withSuomifiDefaultProps(props)} variant="h1hero" />
   );
 
   static h1 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withSuomifiDefaults(props)} variant="h1" />
+    <StyledHeading {...withSuomifiDefaultProps(props)} variant="h1" />
   );
 
   static h2 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withSuomifiDefaults(props)} variant="h2" />
+    <StyledHeading {...withSuomifiDefaultProps(props)} variant="h2" />
   );
 
   static h3 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withSuomifiDefaults(props)} variant="h3" />
+    <StyledHeading {...withSuomifiDefaultProps(props)} variant="h3" />
   );
 
   static h4 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withSuomifiDefaults(props)} variant="h4" />
+    <StyledHeading {...withSuomifiDefaultProps(props)} variant="h4" />
   );
 
   static h5 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withSuomifiDefaults(props)} variant="h5" />
+    <StyledHeading {...withSuomifiDefaultProps(props)} variant="h5" />
   );
 
   static h6 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withSuomifiDefaults(props)} variant="h6" />
+    <StyledHeading {...withSuomifiDefaultProps(props)} variant="h6" />
   );
 
   render() {
-    const { variant, ...passProps } = withSuomifiDefaults(this.props);
+    const { variant, ...passProps } = withSuomifiDefaultProps(this.props);
     if (!variant) {
       logger.warn(
         `Does not contain heading level (variant): ${passProps.children}`,

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent, ColorProp } from '../theme';
+import { TokensProp, ColorProp } from '../theme';
 import {
   Heading as CompHeading,
   HeadingProps as CompHeadingProps,
@@ -17,7 +17,7 @@ const smallScreenClassName = `${baseClassName}--small-screen`;
 
 export interface HeadingProps
   extends Omit<CompHeadingProps, 'variant'>,
-    TokensComponent {
+    TokensProp {
   /**
    * Heading level
    * @default h1

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent, ColorProp } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent, ColorProp } from '../theme';
 import {
   Heading as CompHeading,
   HeadingProps as CompHeadingProps,
@@ -17,7 +17,7 @@ const smallScreenClassName = `${baseClassName}--small-screen`;
 
 export interface HeadingProps
   extends Omit<CompHeadingProps, 'variant'>,
-    ThemeComponent {
+    TokensComponent {
   /**
    * Heading level
    * @default h1
@@ -32,7 +32,7 @@ export interface HeadingProps
 
 const StyledHeading = styled(
   ({
-    theme,
+    tokens,
     color,
     smallScreen,
     className,
@@ -59,35 +59,35 @@ const StyledHeading = styled(
  */
 export class Heading extends Component<HeadingProps> {
   static h1hero = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withDefaultTheme(props)} variant="h1hero" />
+    <StyledHeading {...withSuomifiDefaults(props)} variant="h1hero" />
   );
 
   static h1 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withDefaultTheme(props)} variant="h1" />
+    <StyledHeading {...withSuomifiDefaults(props)} variant="h1" />
   );
 
   static h2 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withDefaultTheme(props)} variant="h2" />
+    <StyledHeading {...withSuomifiDefaults(props)} variant="h2" />
   );
 
   static h3 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withDefaultTheme(props)} variant="h3" />
+    <StyledHeading {...withSuomifiDefaults(props)} variant="h3" />
   );
 
   static h4 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withDefaultTheme(props)} variant="h4" />
+    <StyledHeading {...withSuomifiDefaults(props)} variant="h4" />
   );
 
   static h5 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withDefaultTheme(props)} variant="h5" />
+    <StyledHeading {...withSuomifiDefaults(props)} variant="h5" />
   );
 
   static h6 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withDefaultTheme(props)} variant="h6" />
+    <StyledHeading {...withSuomifiDefaults(props)} variant="h6" />
   );
 
   render() {
-    const { variant, ...passProps } = withDefaultTheme(this.props);
+    const { variant, ...passProps } = withSuomifiDefaults(this.props);
     if (!variant) {
       logger.warn(
         `Does not contain heading level (variant): ${passProps.children}`,

--- a/src/core/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/core/Heading/__snapshots__/Heading.test.tsx.snap
@@ -27,10 +27,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -40,14 +36,14 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   color: hsl(0,0%,16%);
 }
 
 .c0.fi-heading--h1hero {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 40px;
-  font-weight: 600;
-  line-height: 48px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -57,13 +53,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 40px;
+  line-height: 48px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--h1 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 40px;
-  font-weight: 300;
-  line-height: 48px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -73,13 +69,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 40px;
+  line-height: 48px;
+  font-weight: 300;
 }
 
 .c0.fi-heading--h2 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 28px;
-  font-weight: 600;
-  line-height: 34px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -89,13 +85,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 28px;
+  line-height: 34px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--h3 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 22px;
-  font-weight: 600;
-  line-height: 28px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -105,13 +101,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 22px;
+  line-height: 28px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--h4 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 24px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -121,13 +117,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--h5 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 20px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -137,13 +133,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--h6 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 20px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -153,13 +149,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--small-screen {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 32px;
-  font-weight: 300;
-  line-height: 38px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -169,13 +165,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 32px;
+  line-height: 38px;
+  font-weight: 300;
 }
 
 .c0.fi-heading--small-screen.fi-heading--h1hero {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 32px;
-  font-weight: 600;
-  line-height: 38px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -185,13 +181,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 32px;
+  line-height: 38px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--small-screen.fi-heading--h1 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 32px;
-  font-weight: 300;
-  line-height: 38px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -201,13 +197,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 32px;
+  line-height: 38px;
+  font-weight: 300;
 }
 
 .c0.fi-heading--small-screen.fi-heading--h2 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 26px;
-  font-weight: 600;
-  line-height: 32px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -217,13 +213,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 26px;
+  line-height: 32px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--small-screen.fi-heading--h3 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 20px;
-  font-weight: 600;
-  line-height: 26px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -233,13 +229,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--small-screen.fi-heading--h4 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 20px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -249,13 +245,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--small-screen.fi-heading--h5 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 20px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -265,13 +261,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 600;
 }
 
 .c0.fi-heading--small-screen.fi-heading--h6 {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 20px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -281,6 +277,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 16px;
+  line-height: 20px;
+  font-weight: 600;
 }
 
 <div

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { iconBaseStyles } from './Icon.baseStyles';
-import { ThemeComponent } from '../theme';
-import { withDefaultTheme } from '../theme/utils';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import {
   ariaLabelOrHidden,
   ariaFocusableNoLabel,
@@ -21,7 +21,7 @@ import {
 export { IconKeys, StaticIconKeys } from 'suomifi-icons';
 import { logger } from '../../utils/logger';
 
-export interface IconProps extends Omit<CompIconProps, 'src'>, ThemeComponent {
+export interface IconProps extends Omit<CompIconProps, 'src'>, TokensComponent {
   /** Icon-name from suomifi-icons */
   icon?: IconKeys | StaticIconKeys;
   /** Image file */
@@ -79,11 +79,11 @@ export class Icon extends Component<IconProps> {
       src,
       color,
       icon = 'login',
-      theme,
+      tokens,
       ...passProps
-    } = withDefaultTheme(this.props);
+    } = withSuomifiDefaults(this.props);
     const { className, ariaLabel } = this.props;
-    const iconColor = color !== undefined ? color : theme.colors.depthDark27;
+    const iconColor = color !== undefined ? color : tokens.colors.depthDark27;
 
     if (!!src) {
       return <StyledIcon src={src} {...passProps} color={iconColor} />;

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { iconBaseStyles } from './Icon.baseStyles';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import {
   ariaLabelOrHidden,
@@ -81,7 +81,7 @@ export class Icon extends Component<IconProps> {
       icon = 'login',
       tokens,
       ...passProps
-    } = withSuomifiDefaults(this.props);
+    } = withSuomifiDefaultProps(this.props);
     const { className, ariaLabel } = this.props;
     const iconColor = color !== undefined ? color : tokens.colors.depthDark27;
 

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { iconBaseStyles } from './Icon.baseStyles';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import {
   ariaLabelOrHidden,
   ariaFocusableNoLabel,
@@ -21,7 +21,7 @@ import {
 export { IconKeys, StaticIconKeys } from 'suomifi-icons';
 import { logger } from '../../utils/logger';
 
-export interface IconProps extends Omit<CompIconProps, 'src'>, TokensComponent {
+export interface IconProps extends Omit<CompIconProps, 'src'>, TokensProp {
   /** Icon-name from suomifi-icons */
   icon?: IconKeys | StaticIconKeys;
   /** Image file */

--- a/src/core/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link.baseStyles.ts
@@ -1,13 +1,13 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../theme';
-import { LinkProps } from './Link';
-import { element, fonts, focus } from '../theme/reset';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { element, font, focus } from '../theme/reset';
 import { allStates } from '../../utils/css/pseudo';
 
-export const baseStyles = ({ theme = suomifiTheme }: LinkProps) => css`
-  ${element(theme)}
-  ${fonts(theme).body}
-  ${focus(theme)}
+export const baseStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
+  ${element({ theme })}
+  ${font({ theme })('bodyText')}
+  ${focus({ theme })}
   ${allStates(`color: ${theme.colors.highlightBase};`)};
   color: ${theme.colors.highlightBase};
   text-decoration: none;
@@ -20,11 +20,14 @@ export const baseStyles = ({ theme = suomifiTheme }: LinkProps) => css`
   &:visited {
     color: ${theme.colors.accentTertiaryDark9};
   }
-`;
+`,
+);
 
-export const externalStyles = ({ theme = suomifiTheme }: LinkProps) => css`
-  & .fi-link_icon {
-    padding-left: ${theme.spacing.xs};
-    transform: translateY(0.1em);
-  }
-`;
+export const externalStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
+    & .fi-link_icon {
+      padding-left: ${theme.spacing.xs};
+      transform: translateY(0.1em);
+    }
+  `,
+);

--- a/src/core/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link.baseStyles.ts
@@ -1,10 +1,10 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { element, font, focus } from '../theme/reset';
 import { allStates } from '../../utils/css/pseudo';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
   ${element({ theme })}
   ${font({ theme })('bodyText')}
   ${focus({ theme })}
@@ -24,7 +24,7 @@ export const baseStyles = withSuomifiTheme(
 );
 
 export const externalStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
     & .fi-link_icon {
       padding-left: ${theme.spacing.xs};
       transform: translateY(0.1em);

--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import {
   Link as CompLink,
@@ -31,7 +31,7 @@ export class Link extends Component<LinkProps | LinkExternalProps> {
   static external = (props: LinkExternalProps) => <LinkExternal {...props} />;
 
   render() {
-    const { variant, ...passProps } = withSuomifiDefaults(this.props);
+    const { variant, ...passProps } = withSuomifiDefaultProps(this.props);
 
     if (variant === 'external')
       return <LinkExternal {...passProps as LinkExternalProps} />;

--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import {
   Link as CompLink,
   LinkProps as CompLinkProps,
@@ -12,13 +12,12 @@ import { baseStyles } from './Link.baseStyles';
 export { LinkExternal, LinkExternalProps };
 
 type LinkVariant = 'default' | 'external';
-export interface LinkProps extends CompLinkProps, ThemeComponent {
+export interface LinkProps extends CompLinkProps, TokensComponent {
   variant?: LinkVariant;
   asProp?: asPropType;
 }
 
-const StyledLink = styled(({ theme, asProp, ...passProps }: LinkProps) => (
-  // as-property is defined internally as asProp and need to be implemented back if used
+const StyledLink = styled(({ tokens, asProp, ...passProps }: LinkProps) => (
   <CompLink {...passProps} as={asProp} />
 ))`
   ${props => baseStyles(props)};
@@ -32,7 +31,7 @@ export class Link extends Component<LinkProps | LinkExternalProps> {
   static external = (props: LinkExternalProps) => <LinkExternal {...props} />;
 
   render() {
-    const { variant, ...passProps } = withDefaultTheme(this.props);
+    const { variant, ...passProps } = withSuomifiDefaults(this.props);
 
     if (variant === 'external')
       return <LinkExternal {...passProps as LinkExternalProps} />;

--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import {
   Link as CompLink,
   LinkProps as CompLinkProps,
@@ -12,7 +12,7 @@ import { baseStyles } from './Link.baseStyles';
 export { LinkExternal, LinkExternalProps };
 
 type LinkVariant = 'default' | 'external';
-export interface LinkProps extends CompLinkProps, TokensComponent {
+export interface LinkProps extends CompLinkProps, TokensProp {
   variant?: LinkVariant;
   asProp?: asPropType;
 }

--- a/src/core/Link/LinkExternal.tsx
+++ b/src/core/Link/LinkExternal.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import { Link, LinkProps } from './Link';
 import {
@@ -47,7 +47,7 @@ export class LinkExternal extends Component<LinkExternalProps> {
       labelNewWindow,
       hideIcon,
       ...passProps
-    } = withSuomifiDefaults(this.props);
+    } = withSuomifiDefaultProps(this.props);
     if (!labelNewWindow) {
       logger.warn(
         'External link needs a translated description of link opening to a new window',

--- a/src/core/Link/LinkExternal.tsx
+++ b/src/core/Link/LinkExternal.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import { Link, LinkProps } from './Link';
 import {
   LinkExternal as CompLinkExternal,
@@ -18,7 +18,7 @@ const iconClassName = 'fi-link_icon';
 export interface LinkExternalProps
   extends CompLinkExternalProps,
     LinkProps,
-    TokensComponent {
+    TokensProp {
   /** Translated explanation of 'opens to a new window' */
   labelNewWindow: string;
   /** Hide the icon */

--- a/src/core/Link/LinkExternal.tsx
+++ b/src/core/Link/LinkExternal.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import { Link, LinkProps } from './Link';
 import {
   LinkExternal as CompLinkExternal,
@@ -18,7 +18,7 @@ const iconClassName = 'fi-link_icon';
 export interface LinkExternalProps
   extends CompLinkExternalProps,
     LinkProps,
-    ThemeComponent {
+    TokensComponent {
   /** Translated explanation of 'opens to a new window' */
   labelNewWindow: string;
   /** Hide the icon */
@@ -27,7 +27,7 @@ export interface LinkExternalProps
 
 const StyledLinkExternal = styled(
   ({
-    theme,
+    tokens,
     ...passProps
   }: Omit<LinkExternalProps, 'labelNewWindow' | 'hideIcon'>) => (
     <Link {...passProps} asProp={CompLinkExternal} />
@@ -47,7 +47,7 @@ export class LinkExternal extends Component<LinkExternalProps> {
       labelNewWindow,
       hideIcon,
       ...passProps
-    } = withDefaultTheme(this.props);
+    } = withSuomifiDefaults(this.props);
     if (!labelNewWindow) {
       logger.warn(
         'External link needs a translated description of link opening to a new window',

--- a/src/core/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/__snapshots__/Link.test.tsx.snap
@@ -36,10 +36,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -49,6 +45,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -84,10 +84,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c1 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -97,6 +93,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/core/Menu/Menu.baseStyles.tsx
+++ b/src/core/Menu/Menu.baseStyles.tsx
@@ -1,22 +1,20 @@
 import { css } from 'styled-components';
-import { suomifiTheme, ThemeProp } from '../theme';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
 import { MenuProps } from './Menu';
-import { element, fonts, focus } from '../theme/reset';
-import { Omit } from '../../utils/typescript';
+import { element, focus } from '../theme/reset';
 import { padding } from '../theme/utils';
 
-export const baseStyles = ({
-  theme = suomifiTheme,
-}: Omit<MenuProps, 'name'>) => css`
+export const baseStyles = withSuomifiTheme(
+  ({ theme, tokens }: SuomifiThemeComponent & Partial<MenuProps>) => css`
   & > [data-reach-menu-button].fi-menu_button {
-    ${element(theme)}
-    ${fonts(theme).body}
-    ${focus(theme)}
+    ${element({ theme })}
+    ${theme.typography.bodyText}
+    ${focus({ theme })}
     cursor: pointer;
     &.fi-menu-language_button {
-      ${element(theme)}
-      ${fonts(theme).inputSemibold}
-      ${padding(theme)('s', 'xs', 's', 's')}
+      ${element({ theme })}
+      ${theme.typography.inputSemibold}
+      ${padding(tokens)('s', 'xs', 's', 's')}
       background-color: ${theme.colors.whiteBase};
       border: 1px solid ${theme.colors.depthBase};
       border-radius: ${theme.radius.basic};
@@ -26,31 +24,30 @@ export const baseStyles = ({
         width: 1.2em;
         transform: translateY(0.3em); 
         margin-left: ${theme.spacing.xs};
+
       }
     }
   }
-`;
+`,
+);
 
-export const menuListStyles = ({
-  theme = suomifiTheme,
-}: {
-  theme: ThemeProp;
-}) => css`
+export const menuListStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
   &[data-reach-menu-list].fi-menu_list {
-    ${element(theme)}
-    ${fonts(theme).body}
+    ${element({ theme })}
+    ${theme.typography.bodyText}
     margin-top: -2px;
     background-color: ${theme.colors.whiteBase};
     border: none;
     box-shadow: ${theme.shadows.menuShadow};
     &.fi-menu-language_list {
-      ${fonts(theme).input}
+      ${theme.typography.input}
       position: absolute;
       right: 0;
       top: 0;
       margin-top: 12px;
       padding: 10px 0;
-      border: 1px solid ${suomifiTheme.colors.depthBase};
+      border: 1px solid ${theme.colors.depthBase};
       border-radius: ${theme.radius.basic};
       &:before,
       &:after {
@@ -64,12 +61,12 @@ export const menuListStyles = ({
         pointer-events: none;
       }
       &:before {
-        border-bottom-color: ${suomifiTheme.colors.depthBase};
+        border-bottom-color: ${theme.colors.depthBase};
         border-width: 8px;
         margin-right: -8px;
       }
       &:after {
-        border-bottom-color: ${suomifiTheme.colors.whiteBase};
+        border-bottom-color: ${theme.colors.whiteBase};
         border-width: 7px;
         margin-right: -7px;
       }
@@ -77,25 +74,26 @@ export const menuListStyles = ({
   }
 
   & [data-reach-menu-item].fi-menu_item {
-    ${element(theme)}
-    ${fonts(theme).body}
+    ${element({ theme })}
+    ${theme.typography.bodyText}
     &[data-selected] {
-      ${fonts(theme).body}
+      ${theme.typography.bodyText}
       color: ${theme.colors.blackBase};
       background-color: ${theme.colors.highlightLight50};
     }
     &.fi-menu-language_item,
     &[data-selected].fi-menu-language_item {
-      ${fonts(theme).input}
+      ${theme.typography.input}
       padding: 6px 20px 6px 14px;
       border-left: 6px solid transparent;
       background-color: transparent;
       &.fi-menu-lang-item-selected {
-        ${fonts(theme).inputSemibold};
+        ${theme.typography.inputSemibold};
       }
     }
     &[data-selected].fi-menu-language_item {
       border-left-color: ${theme.colors.highlightBase};
     }
   }
-`;
+`,
+);

--- a/src/core/Menu/Menu.baseStyles.tsx
+++ b/src/core/Menu/Menu.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { MenuProps } from './Menu';
 import { element, focus } from '../theme/reset';
 import { padding } from '../theme/utils';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme, tokens }: SuomifiThemeComponent & Partial<MenuProps>) => css`
+  ({ theme, tokens }: SuomifiThemeProp & Partial<MenuProps>) => css`
   & > [data-reach-menu-button].fi-menu_button {
     ${element({ theme })}
     ${theme.typography.bodyText}
@@ -32,7 +32,7 @@ export const baseStyles = withSuomifiTheme(
 );
 
 export const menuListStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
   &[data-reach-menu-list].fi-menu_list {
     ${element({ theme })}
     ${theme.typography.bodyText}

--- a/src/core/Menu/Menu.test.tsx
+++ b/src/core/Menu/Menu.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { axeTest } from '../../utils/test/axe';
-// import { cssFromBaseStyles } from '../utils';
 
 import { Menu } from './Menu';
 import { MenuItem, MenuLink } from './MenuItem';
-// import { baseStyles } from './Menu.baseStyles';
 
 const doNothing = () => ({});
 
@@ -16,10 +14,5 @@ const TestMenuLanguage = (
     <MenuLink.language href="/sv">På svenska (SV)</MenuLink.language>
   </Menu.language>
 );
-
-// test('CSS export', () => {
-//   const css = cssFromBaseStyles(baseStyles);
-//   expect(css).toEqual(expect.stringContaining('data-reach-menu-button'));
-// });
 
 test('should not have basic accessibility issues', axeTest(TestMenuLanguage));

--- a/src/core/Menu/Menu.test.tsx
+++ b/src/core/Menu/Menu.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { axeTest } from '../../utils/test/axe';
-import { cssFromBaseStyles } from '../utils';
+// import { cssFromBaseStyles } from '../utils';
 
 import { Menu } from './Menu';
 import { MenuItem, MenuLink } from './MenuItem';
-import { baseStyles } from './Menu.baseStyles';
+// import { baseStyles } from './Menu.baseStyles';
 
 const doNothing = () => ({});
 
@@ -17,9 +17,9 @@ const TestMenuLanguage = (
   </Menu.language>
 );
 
-test('CSS export', () => {
-  const css = cssFromBaseStyles(baseStyles);
-  expect(css).toEqual(expect.stringContaining('data-reach-menu-button'));
-});
+// test('CSS export', () => {
+//   const css = cssFromBaseStyles(baseStyles);
+//   expect(css).toEqual(expect.stringContaining('data-reach-menu-button'));
+// });
 
 test('should not have basic accessibility issues', axeTest(TestMenuLanguage));

--- a/src/core/Menu/Menu.tsx
+++ b/src/core/Menu/Menu.tsx
@@ -2,7 +2,7 @@ import React, { Component, ReactNode, Fragment } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { classnamesValue } from '../../utils/typescript';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import { baseStyles, menuListStyles } from './Menu.baseStyles';
 import {
@@ -84,7 +84,7 @@ class MenuVariation extends Component<MenuProps> {
       className,
       menuListComponent: MenuListComponentProp,
       ...passProps
-    } = withSuomifiDefaults(this.props);
+    } = withSuomifiDefaultProps(this.props);
     const ifMenuLanguage = variant === 'language';
     const menuButtonClassName = classnames(
       buttonClassName,

--- a/src/core/Menu/Menu.tsx
+++ b/src/core/Menu/Menu.tsx
@@ -2,8 +2,8 @@ import React, { Component, ReactNode, Fragment } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { classnamesValue } from '../../utils/typescript';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import { baseStyles, menuListStyles } from './Menu.baseStyles';
 import {
   Menu as CompMenu,
@@ -31,7 +31,7 @@ const iconLangClassName = 'fi-menu-language_icon';
 
 type ButtonVariant = 'default' | 'language';
 
-export interface MenuProps extends CompMenuProps, ThemeComponent {
+export interface MenuProps extends CompMenuProps, TokensComponent {
   /**
    * 'default' | 'language'
    * @default default
@@ -39,7 +39,7 @@ export interface MenuProps extends CompMenuProps, ThemeComponent {
   variant?: ButtonVariant;
 }
 
-const StyledMenu = styled(({ theme, ...passProps }: MenuProps) => (
+const StyledMenu = styled(({ tokens, ...passProps }: MenuProps) => (
   <CompMenu {...passProps} />
 ))`
   ${props => baseStyles(props)}
@@ -67,9 +67,9 @@ const languageName = (name: ReactNode) => (
   </Fragment>
 );
 
-interface MenuListProps extends CompMenuListProps, ThemeComponent {}
+interface MenuListProps extends CompMenuListProps, TokensComponent {}
 
-const StyledMenuList = styled(({ theme, ...passProps }: MenuListProps) => (
+const StyledMenuList = styled(({ tokens, ...passProps }: MenuListProps) => (
   <CompMenuList {...passProps} />
 ))`
   ${props => menuListStyles(props.theme)}
@@ -84,7 +84,7 @@ class MenuVariation extends Component<MenuProps> {
       className,
       menuListComponent: MenuListComponentProp,
       ...passProps
-    } = withDefaultTheme(this.props);
+    } = withSuomifiDefaults(this.props);
     const ifMenuLanguage = variant === 'language';
     const menuButtonClassName = classnames(
       buttonClassName,

--- a/src/core/Menu/Menu.tsx
+++ b/src/core/Menu/Menu.tsx
@@ -3,7 +3,7 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { classnamesValue } from '../../utils/typescript';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import { baseStyles, menuListStyles } from './Menu.baseStyles';
 import {
   Menu as CompMenu,
@@ -31,7 +31,7 @@ const iconLangClassName = 'fi-menu-language_icon';
 
 type ButtonVariant = 'default' | 'language';
 
-export interface MenuProps extends CompMenuProps, TokensComponent {
+export interface MenuProps extends CompMenuProps, TokensProp {
   /**
    * 'default' | 'language'
    * @default default
@@ -67,7 +67,7 @@ const languageName = (name: ReactNode) => (
   </Fragment>
 );
 
-interface MenuListProps extends CompMenuListProps, TokensComponent {}
+interface MenuListProps extends CompMenuListProps, TokensProp {}
 
 const StyledMenuList = styled(({ tokens, ...passProps }: MenuListProps) => (
   <CompMenuList {...passProps} />

--- a/src/core/Panel/Panel.baseStyles.tsx
+++ b/src/core/Panel/Panel.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
-import { element } from '../theme/reset';
+import { element, font } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: SuomifiThemeComponent) => css`
   ${element({ theme })}
-  ${theme.typography.bodyText}
+  ${font({ theme })('bodyText')}
   padding: ${theme.spacing.m};
   background-color: ${theme.colors.whiteBase};
 `,

--- a/src/core/Panel/Panel.baseStyles.tsx
+++ b/src/core/Panel/Panel.baseStyles.tsx
@@ -1,11 +1,12 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../theme';
-import { PanelProps } from './Panel';
-import { element, fonts } from '../theme/reset';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { element } from '../theme/reset';
 
-export const baseStyles = ({ theme = suomifiTheme }: PanelProps) => css`
-  ${element(theme)}
-  ${fonts(theme).body}
+export const baseStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
+  ${element({ theme })}
+  ${theme.typography.bodyText}
   padding: ${theme.spacing.m};
   background-color: ${theme.colors.whiteBase};
-`;
+`,
+);

--- a/src/core/Panel/Panel.baseStyles.tsx
+++ b/src/core/Panel/Panel.baseStyles.tsx
@@ -1,9 +1,9 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { element, font } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
   ${element({ theme })}
   ${font({ theme })('bodyText')}
   padding: ${theme.spacing.m};

--- a/src/core/Panel/Panel.tsx
+++ b/src/core/Panel/Panel.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import { baseStyles } from './Panel.baseStyles';
 import {
   Panel as CompPanel,
@@ -15,7 +15,7 @@ import {
 
 type PanelVariant = 'default' | 'expansion' | 'expansionGroup';
 
-export interface PanelProps extends CompPanelProps, TokensComponent {
+export interface PanelProps extends CompPanelProps, TokensProp {
   /**
    * 'default' | 'expansion'
    * @default default

--- a/src/core/Panel/Panel.tsx
+++ b/src/core/Panel/Panel.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import { baseStyles } from './Panel.baseStyles';
 import {
   Panel as CompPanel,
@@ -15,7 +15,7 @@ import {
 
 type PanelVariant = 'default' | 'expansion' | 'expansionGroup';
 
-export interface PanelProps extends CompPanelProps, ThemeComponent {
+export interface PanelProps extends CompPanelProps, TokensComponent {
   /**
    * 'default' | 'expansion'
    * @default default
@@ -23,7 +23,7 @@ export interface PanelProps extends CompPanelProps, ThemeComponent {
   variant?: PanelVariant;
 }
 
-const StyledPanel = styled(({ theme, ...passProps }: PanelProps) => (
+const StyledPanel = styled(({ tokens, ...passProps }: PanelProps) => (
   <CompPanel {...passProps} />
 ))`
   ${props => baseStyles(props)};
@@ -39,15 +39,15 @@ type VariantPanelProps =
  */
 export class Panel extends Component<VariantPanelProps> {
   static expansion = (props: PanelExpansionProps) => {
-    return <PanelExpansion {...withDefaultTheme(props)} />;
+    return <PanelExpansion {...withSuomifiDefaults(props)} />;
   };
 
   static expansionGroup = (props: PanelExpansionGroupProps) => {
-    return <PanelExpansionGroup {...withDefaultTheme(props)} />;
+    return <PanelExpansionGroup {...withSuomifiDefaults(props)} />;
   };
 
   render() {
-    const { variant, ...passProps } = withDefaultTheme(this.props);
+    const { variant, ...passProps } = withSuomifiDefaults(this.props);
     if (variant === 'expansion') {
       return <PanelExpansion {...passProps as PanelExpansionProps} />;
     }

--- a/src/core/Panel/Panel.tsx
+++ b/src/core/Panel/Panel.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import { baseStyles } from './Panel.baseStyles';
 import {
@@ -39,15 +39,15 @@ type VariantPanelProps =
  */
 export class Panel extends Component<VariantPanelProps> {
   static expansion = (props: PanelExpansionProps) => {
-    return <PanelExpansion {...withSuomifiDefaults(props)} />;
+    return <PanelExpansion {...withSuomifiDefaultProps(props)} />;
   };
 
   static expansionGroup = (props: PanelExpansionGroupProps) => {
-    return <PanelExpansionGroup {...withSuomifiDefaults(props)} />;
+    return <PanelExpansionGroup {...withSuomifiDefaultProps(props)} />;
   };
 
   render() {
-    const { variant, ...passProps } = withSuomifiDefaults(this.props);
+    const { variant, ...passProps } = withSuomifiDefaultProps(this.props);
     if (variant === 'expansion') {
       return <PanelExpansion {...passProps as PanelExpansionProps} />;
     }

--- a/src/core/Panel/PanelExpansion.baseStyles.tsx
+++ b/src/core/Panel/PanelExpansion.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { button } from '../theme/reset';
 import { absolute } from '../../utils/css/pseudo';
 import { padding } from '../theme/utils';
 import { PanelExpansionProps } from './PanelExpansion';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme, tokens }: SuomifiThemeComponent & Partial<PanelExpansionProps>) => {
+  ({ theme, tokens }: SuomifiThemeProp & Partial<PanelExpansionProps>) => {
     return css`
   ${absolute('before')}
   position: relative;

--- a/src/core/Panel/PanelExpansion.baseStyles.tsx
+++ b/src/core/Panel/PanelExpansion.baseStyles.tsx
@@ -1,13 +1,13 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../theme';
-import { PanelExpansionProps } from './PanelExpansion';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
 import { button } from '../theme/reset';
 import { absolute } from '../../utils/css/pseudo';
 import { padding } from '../theme/utils';
+import { PanelExpansionProps } from './PanelExpansion';
 
-export const baseStyles = ({
-  theme = suomifiTheme,
-}: PanelExpansionProps) => css`
+export const baseStyles = withSuomifiTheme(
+  ({ theme, tokens }: SuomifiThemeComponent & Partial<PanelExpansionProps>) => {
+    return css`
   ${absolute('before')}
   position: relative;
   padding: 0;
@@ -26,12 +26,12 @@ export const baseStyles = ({
   }
 
   & .fi-panel-expansion_title {
-    ${button(theme)}
+    ${button({ theme })}
     position: relative;
     display: block;
     width: 100%;
     &--no-tag {
-      ${padding(theme)('m', 'xl', 'm', 'm')}
+      ${padding(tokens)('m', 'xl', 'm', 'm')}
       color: ${theme.colors.highlightBase};
     }
   }
@@ -66,7 +66,7 @@ export const baseStyles = ({
       animation: fi-panel-expansion_content-anim ${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction} 1 forwards;
       &:not(.fi-panel-expansion_content--no-padding) {
-        ${padding(theme)('0', 'm', 'm', 'm')}
+        ${padding(tokens)('0', 'm', 'm', 'm')}
       }
     }
     @keyframes fi-panel-expansion_content-anim {
@@ -80,3 +80,5 @@ export const baseStyles = ({
     }
   }
 `;
+  },
+);

--- a/src/core/Panel/PanelExpansion.tsx
+++ b/src/core/Panel/PanelExpansion.tsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import { baseStyles as panelBaseStyles } from './Panel.baseStyles';
 import { baseStyles } from './PanelExpansion.baseStyles';
 import {
@@ -17,7 +17,7 @@ const noPaddingClassName = `fi-panel-expansion_content--no-padding`;
 
 export interface PanelExpansionProps
   extends CompPanelExpansionProps,
-    ThemeComponent {
+    TokensComponent {
   /** Remove padding from expandable content area (for background usage with padding in given container etc.) */
   noPadding?: boolean;
 }
@@ -66,7 +66,7 @@ export class PanelExpansion extends Component<PanelExpansionProps> {
   };
 
   render() {
-    const { open, title, titleTag, ...passProps } = withDefaultTheme(
+    const { open, title, titleTag, ...passProps } = withSuomifiDefaults(
       this.props,
     );
     const notControlled = open === undefined;
@@ -86,7 +86,7 @@ export class PanelExpansion extends Component<PanelExpansionProps> {
                 className={classnames(iconClassName, {
                   [iconOpenClassName]: openState,
                 })}
-                color={passProps.theme.colors.highlightBase}
+                color={passProps.tokens.colors.highlightBase}
               />
             )}
           </Fragment>

--- a/src/core/Panel/PanelExpansion.tsx
+++ b/src/core/Panel/PanelExpansion.tsx
@@ -23,7 +23,7 @@ export interface PanelExpansionProps
 }
 
 const StyledPanelExpansion = styled(
-  ({ noPadding, ...passProps }: PanelExpansionProps) => {
+  ({ tokens, noPadding, ...passProps }: PanelExpansionProps) => {
     return (
       <CompPanelExpansion
         {...passProps}

--- a/src/core/Panel/PanelExpansion.tsx
+++ b/src/core/Panel/PanelExpansion.tsx
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import { baseStyles as panelBaseStyles } from './Panel.baseStyles';
 import { baseStyles } from './PanelExpansion.baseStyles';
@@ -66,7 +66,7 @@ export class PanelExpansion extends Component<PanelExpansionProps> {
   };
 
   render() {
-    const { open, title, titleTag, ...passProps } = withSuomifiDefaults(
+    const { open, title, titleTag, ...passProps } = withSuomifiDefaultProps(
       this.props,
     );
     const notControlled = open === undefined;

--- a/src/core/Panel/PanelExpansion.tsx
+++ b/src/core/Panel/PanelExpansion.tsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import { baseStyles as panelBaseStyles } from './Panel.baseStyles';
 import { baseStyles } from './PanelExpansion.baseStyles';
 import {
@@ -17,7 +17,7 @@ const noPaddingClassName = `fi-panel-expansion_content--no-padding`;
 
 export interface PanelExpansionProps
   extends CompPanelExpansionProps,
-    TokensComponent {
+    TokensProp {
   /** Remove padding from expandable content area (for background usage with padding in given container etc.) */
   noPadding?: boolean;
 }

--- a/src/core/Panel/PanelExpansionGroup.baseStyles.tsx
+++ b/src/core/Panel/PanelExpansionGroup.baseStyles.tsx
@@ -1,12 +1,10 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../theme';
-import { PanelExpansionGroupProps } from './PanelExpansionGroup';
-import { element, fonts, focus } from '../theme/reset';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { element, font, focus } from '../theme/reset';
 
-export const baseStyles = ({
-  theme = suomifiTheme,
-}: PanelExpansionGroupProps) => css`
-  ${element(theme)}
+export const baseStyles = withSuomifiTheme(
+  ({ theme }: SuomifiThemeComponent) => css`
+  ${element({ theme })}
   display: flex;
   flex-direction: column;
   & > .fi-panel-expansion-group_panels {
@@ -29,9 +27,9 @@ export const baseStyles = ({
   }
 
   & > .fi-panel-expansion-group_all-button {
-    ${element(theme)}
-    ${fonts(theme).semiBold}
-    ${focus(theme)}
+    ${element({ theme })}
+    ${font({ theme })('bodySemiBold')}
+    ${focus({ theme })}
     flex: 1;
     margin-left: auto;
     margin-bottom: ${theme.spacing.s};
@@ -39,4 +37,5 @@ export const baseStyles = ({
     color: ${theme.colors.highlightBase};
     cursor: pointer;
   }
-`;
+`,
+);

--- a/src/core/Panel/PanelExpansionGroup.baseStyles.tsx
+++ b/src/core/Panel/PanelExpansionGroup.baseStyles.tsx
@@ -1,9 +1,9 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { element, font, focus } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: SuomifiThemeComponent) => css`
+  ({ theme }: SuomifiThemeProp) => css`
   ${element({ theme })}
   display: flex;
   flex-direction: column;

--- a/src/core/Panel/PanelExpansionGroup.tsx
+++ b/src/core/Panel/PanelExpansionGroup.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent } from '../theme';
+import { TokensProp } from '../theme';
 import {
   PanelExpansionGroup as CompPanelExpansionGroup,
   PanelExpansionGroupProps as CompPanelExpansionGroupProps,
@@ -13,11 +13,9 @@ const openAllButtonClassName = 'fi-panel-expansion-group_all-button';
 
 export interface PanelExpansionGroupProps
   extends CompPanelExpansionGroupProps,
-    TokensComponent {}
+    TokensProp {}
 
-interface PanelExpansionOpenAllButtonProps
-  extends ButtonProps,
-    TokensComponent {}
+interface PanelExpansionOpenAllButtonProps extends ButtonProps, TokensProp {}
 
 const StyledPanelExpansionGroup = styled(
   ({ tokens, ...passProps }: PanelExpansionGroupProps) => (

--- a/src/core/Panel/PanelExpansionGroup.tsx
+++ b/src/core/Panel/PanelExpansionGroup.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent } from '../theme';
 import {
   PanelExpansionGroup as CompPanelExpansionGroup,
   PanelExpansionGroupProps as CompPanelExpansionGroupProps,
@@ -13,14 +13,14 @@ const openAllButtonClassName = 'fi-panel-expansion-group_all-button';
 
 export interface PanelExpansionGroupProps
   extends CompPanelExpansionGroupProps,
-    ThemeComponent {}
+    TokensComponent {}
 
 interface PanelExpansionOpenAllButtonProps
   extends ButtonProps,
-    ThemeComponent {}
+    TokensComponent {}
 
 const StyledPanelExpansionGroup = styled(
-  ({ theme, ...passProps }: PanelExpansionGroupProps) => (
+  ({ tokens, ...passProps }: PanelExpansionGroupProps) => (
     <CompPanelExpansionGroup {...passProps} />
   ),
 )`
@@ -29,14 +29,9 @@ const StyledPanelExpansionGroup = styled(
 
 const OpenAllButton = ({
   children,
-  theme,
   ...passProps
 }: PanelExpansionOpenAllButtonProps) => (
-  <Button.unstyled
-    {...passProps}
-    theme={theme}
-    className={openAllButtonClassName}
-  >
+  <Button.unstyled {...passProps} className={openAllButtonClassName}>
     {children}
   </Button.unstyled>
 );
@@ -47,15 +42,15 @@ const OpenAllButton = ({
  */
 export class PanelExpansionGroup extends Component<PanelExpansionGroupProps> {
   render() {
-    const { OpenAll, CloseAll, ...passProps } = withDefaultTheme(this.props);
+    const { OpenAll, CloseAll, ...passProps } = withSuomifiDefaults(this.props);
     return (
       <StyledPanelExpansionGroup
         {...passProps}
         OpenAll={
-          <OpenAllButton theme={passProps.theme}>{OpenAll}</OpenAllButton>
+          <OpenAllButton tokens={passProps.tokens}>{OpenAll}</OpenAllButton>
         }
         CloseAll={
-          <OpenAllButton theme={passProps.theme}>{CloseAll}</OpenAllButton>
+          <OpenAllButton tokens={passProps.tokens}>{CloseAll}</OpenAllButton>
         }
       />
     );

--- a/src/core/Panel/PanelExpansionGroup.tsx
+++ b/src/core/Panel/PanelExpansionGroup.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent } from '../theme';
 import {
   PanelExpansionGroup as CompPanelExpansionGroup,
@@ -42,7 +42,9 @@ const OpenAllButton = ({
  */
 export class PanelExpansionGroup extends Component<PanelExpansionGroupProps> {
   render() {
-    const { OpenAll, CloseAll, ...passProps } = withSuomifiDefaults(this.props);
+    const { OpenAll, CloseAll, ...passProps } = withSuomifiDefaultProps(
+      this.props,
+    );
     return (
       <StyledPanelExpansionGroup
         {...passProps}

--- a/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
+++ b/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
@@ -102,10 +102,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -115,6 +111,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   padding: 16px;
   background-color: hsl(0,0%,100%);
   position: relative;
@@ -148,10 +148,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 .fi-panel-expansion_title {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -161,6 +157,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
   line-height: 1;
   position: relative;
   display: block;
@@ -249,7 +249,6 @@ exports[`calling render with the same component on the same container does not r
 
 <div
   class="panel-expansion-test c0 fi-panel-expansion c1 c2"
-  theme="[object Object]"
 >
   <button
     aria-disabled="false"

--- a/src/core/Paragraph/Paragraph.baseStyles.ts
+++ b/src/core/Paragraph/Paragraph.baseStyles.ts
@@ -1,17 +1,20 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../theme';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
 import { ParagraphProps } from './Paragraph';
-import { element, fonts } from '../theme/reset';
+import { element } from '../theme/reset';
 import { objValue } from '../../utils/typescript';
 import { margin } from '../theme/utils/spacing';
 
-export const baseStyles = ({
-  theme = suomifiTheme,
-  color,
-  marginBottomSpacing = '0',
-}: ParagraphProps) => css`
-  ${element(theme)}
-  ${fonts(theme).body}
-  ${margin(theme)('0', '0', marginBottomSpacing, '0')};
+export const baseStyles = withSuomifiTheme(
+  ({
+    theme,
+    tokens,
+    color,
+    marginBottomSpacing = '0',
+  }: ParagraphProps & SuomifiThemeComponent) => css`
+  ${element({ theme })}
+  ${theme.typography.bodyText}
+  ${margin(tokens)('0', '0', marginBottomSpacing, '0')};
   color: ${!!color ? objValue(theme.colors, color) : theme.colors.blackBase};
-`;
+`,
+);

--- a/src/core/Paragraph/Paragraph.baseStyles.ts
+++ b/src/core/Paragraph/Paragraph.baseStyles.ts
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
 import { ParagraphProps } from './Paragraph';
-import { element } from '../theme/reset';
+import { element, font } from '../theme/reset';
 import { objValue } from '../../utils/typescript';
 import { margin } from '../theme/utils/spacing';
 
@@ -13,7 +13,7 @@ export const baseStyles = withSuomifiTheme(
     marginBottomSpacing = '0',
   }: ParagraphProps & SuomifiThemeComponent) => css`
   ${element({ theme })}
-  ${theme.typography.bodyText}
+  ${font({ theme })('bodyText')}
   ${margin(tokens)('0', '0', marginBottomSpacing, '0')};
   color: ${!!color ? objValue(theme.colors, color) : theme.colors.blackBase};
 `,

--- a/src/core/Paragraph/Paragraph.baseStyles.ts
+++ b/src/core/Paragraph/Paragraph.baseStyles.ts
@@ -1,5 +1,5 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { ParagraphProps } from './Paragraph';
 import { element, font } from '../theme/reset';
 import { objValue } from '../../utils/typescript';
@@ -11,7 +11,7 @@ export const baseStyles = withSuomifiTheme(
     tokens,
     color,
     marginBottomSpacing = '0',
-  }: ParagraphProps & SuomifiThemeComponent) => css`
+  }: ParagraphProps & SuomifiThemeProp) => css`
   ${element({ theme })}
   ${font({ theme })('bodyText')}
   ${margin(tokens)('0', '0', marginBottomSpacing, '0')};

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent, ColorProp } from '../theme';
+import { TokensProp, ColorProp } from '../theme';
 import {
   Paragraph as CompParagraph,
   ParagraphProps as CompParagraphProps,
@@ -9,7 +9,7 @@ import {
 import { baseStyles } from './Paragraph.baseStyles';
 import { SpaceProp } from '../theme/utils/spacing';
 
-export interface ParagraphProps extends CompParagraphProps, TokensComponent {
+export interface ParagraphProps extends CompParagraphProps, TokensProp {
   /** Change color */
   color?: ColorProp;
   /** Spacing token for bottom margin */

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent, ColorProp } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent, ColorProp } from '../theme';
 import {
   Paragraph as CompParagraph,
   ParagraphProps as CompParagraphProps,
@@ -9,7 +9,7 @@ import {
 import { baseStyles } from './Paragraph.baseStyles';
 import { SpaceProp } from '../theme/utils/spacing';
 
-export interface ParagraphProps extends CompParagraphProps, ThemeComponent {
+export interface ParagraphProps extends CompParagraphProps, TokensComponent {
   /** Change color */
   color?: ColorProp;
   /** Spacing token for bottom margin */
@@ -17,7 +17,7 @@ export interface ParagraphProps extends CompParagraphProps, ThemeComponent {
 }
 
 const StyledParagraph = styled(
-  ({ theme, color, marginBottomSpacing, ...passProps }: ParagraphProps) => (
+  ({ tokens, color, marginBottomSpacing, ...passProps }: ParagraphProps) => (
     <CompParagraph {...passProps} />
   ),
 )`
@@ -29,6 +29,6 @@ const StyledParagraph = styled(
  */
 export class Paragraph extends Component<ParagraphProps> {
   render() {
-    return <StyledParagraph {...withDefaultTheme(this.props)} />;
+    return <StyledParagraph {...withSuomifiDefaults(this.props)} />;
   }
 }

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent, ColorProp } from '../theme';
 import {
   Paragraph as CompParagraph,
@@ -29,6 +29,6 @@ const StyledParagraph = styled(
  */
 export class Paragraph extends Component<ParagraphProps> {
   render() {
-    return <StyledParagraph {...withSuomifiDefaults(this.props)} />;
+    return <StyledParagraph {...withSuomifiDefaultProps(this.props)} />;
   }
 }

--- a/src/core/Paragraph/__snapshots__/Paragraph.test.tsx.snap
+++ b/src/core/Paragraph/__snapshots__/Paragraph.test.tsx.snap
@@ -27,10 +27,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -40,6 +36,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   margin-top: 0;
   margin-right: 0;
   margin-bottom: 0;

--- a/src/core/Text/Text.baseStyles.ts
+++ b/src/core/Text/Text.baseStyles.ts
@@ -1,29 +1,31 @@
 import { css } from 'styled-components';
-import { suomifiTheme } from '../theme';
+import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
 import { TextProps } from './Text';
-import { element, fonts } from '../theme/reset';
+import { element } from '../theme/reset';
 import { objValue } from '../../utils/typescript';
 
-export const baseStyles = ({ theme = suomifiTheme, color }: TextProps) => css`
-  ${element(theme)}
-  ${fonts(theme).body}
+export const baseStyles = withSuomifiTheme(
+  ({ theme, color }: SuomifiThemeComponent & TextProps) => css`
+  ${element({ theme })}
+  ${theme.typography.bodyText}
   color: ${!!color ? objValue(theme.colors, color) : theme.colors.blackBase};
 
   &.fi-text {
     &--bold {
-      ${fonts(theme).semiBold}
+      ${theme.typography.bodySemiBold}
     }
     &--lead {
-      ${fonts(theme).lead}
+      ${theme.typography.leadText}
     }
     &--small-screen {
-      ${fonts(theme).smRes.body}
+      ${theme.typography.bodyTextSmallScreen}
       &.fi-text--bold {
-        ${fonts(theme).smRes.semiBold}
+        ${theme.typography.bodySemiBoldSmallScreen}
       }
       &.fi-text--lead {
-        ${fonts(theme).smRes.lead}
+        ${theme.typography.leadTextSmallScreen}
       }
     }
   } 
-`;
+`,
+);

--- a/src/core/Text/Text.baseStyles.ts
+++ b/src/core/Text/Text.baseStyles.ts
@@ -12,18 +12,18 @@ export const baseStyles = withSuomifiTheme(
 
   &.fi-text {
     &--bold {
-      ${theme.typography.bodySemiBold}
+      ${font({ theme })('bodySemiBold')}
     }
     &--lead {
-      ${theme.typography.leadText}
+      ${font({ theme })('leadText')}
     }
     &--small-screen {
-      ${theme.typography.bodyTextSmallScreen}
+      ${font({ theme })('bodyTextSmallScreen')}
       &.fi-text--bold {
-        ${theme.typography.bodySemiBoldSmallScreen}
+        ${font({ theme })('bodySemiBoldSmallScreen')}
       }
       &.fi-text--lead {
-        ${theme.typography.leadTextSmallScreen}
+        ${font({ theme })('leadTextSmallScreen')}
       }
     }
   } 

--- a/src/core/Text/Text.baseStyles.ts
+++ b/src/core/Text/Text.baseStyles.ts
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
-import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
+import { withSuomifiTheme, SuomifiThemeProp } from '../theme';
 import { TextProps } from './Text';
 import { element, font } from '../theme/reset';
 import { objValue } from '../../utils/typescript';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme, color }: SuomifiThemeComponent & TextProps) => css`
+  ({ theme, color }: SuomifiThemeProp & TextProps) => css`
   ${element({ theme })}
   ${font({ theme })('bodyText')}
   color: ${!!color ? objValue(theme.colors, color) : theme.colors.blackBase};

--- a/src/core/Text/Text.baseStyles.ts
+++ b/src/core/Text/Text.baseStyles.ts
@@ -1,13 +1,13 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, SuomifiThemeComponent } from '../theme';
 import { TextProps } from './Text';
-import { element } from '../theme/reset';
+import { element, font } from '../theme/reset';
 import { objValue } from '../../utils/typescript';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme, color }: SuomifiThemeComponent & TextProps) => css`
   ${element({ theme })}
-  ${theme.typography.bodyText}
+  ${font({ theme })('bodyText')}
   color: ${!!color ? objValue(theme.colors, color) : theme.colors.blackBase};
 
   &.fi-text {

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withDefaultTheme } from '../theme/utils';
-import { ThemeComponent, ColorProp } from '../theme';
+import { withSuomifiDefaults } from '../theme/utils';
+import { TokensComponent, ColorProp } from '../theme';
 import {
   Text as CompText,
   TextProps as CompTextProps,
@@ -12,7 +12,7 @@ import classnames from 'classnames';
 const baseClassName = 'fi-text';
 const smallScreenClassName = `${baseClassName}--small-screen`;
 
-export interface TextProps extends CompTextProps, ThemeComponent {
+export interface TextProps extends CompTextProps, TokensComponent {
   /** Change font to smaller screen size and style */
   smallScreen?: boolean;
   /** Change color for text from theme colors */
@@ -26,7 +26,7 @@ export interface TextProps extends CompTextProps, ThemeComponent {
 
 const StyledText = styled(
   ({
-    theme,
+    tokens,
     color,
     variant = 'body',
     smallScreen,
@@ -49,15 +49,14 @@ const StyledText = styled(
  */
 export class Text extends Component<TextProps> {
   static lead = (props: TextProps) => (
-    <StyledText {...withDefaultTheme(props)} variant="lead" />
+    <StyledText {...withSuomifiDefaults(props)} variant="lead" />
   );
 
   static bold = (props: TextProps) => (
-    <StyledText {...withDefaultTheme(props)} variant="bold" />
+    <StyledText {...withSuomifiDefaults(props)} variant="bold" />
   );
 
   render() {
-    const passProps = withDefaultTheme(this.props);
-    return <StyledText {...passProps} />;
+    return <StyledText {...withSuomifiDefaults(this.props)} />;
   }
 }

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
-import { TokensComponent, ColorProp } from '../theme';
+import { TokensProp, ColorProp } from '../theme';
 import {
   Text as CompText,
   TextProps as CompTextProps,
@@ -12,7 +12,7 @@ import classnames from 'classnames';
 const baseClassName = 'fi-text';
 const smallScreenClassName = `${baseClassName}--small-screen`;
 
-export interface TextProps extends CompTextProps, TokensComponent {
+export interface TextProps extends CompTextProps, TokensProp {
   /** Change font to smaller screen size and style */
   smallScreen?: boolean;
   /** Change color for text from theme colors */

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { withSuomifiDefaults } from '../theme/utils';
+import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensComponent, ColorProp } from '../theme';
 import {
   Text as CompText,
@@ -49,14 +49,14 @@ const StyledText = styled(
  */
 export class Text extends Component<TextProps> {
   static lead = (props: TextProps) => (
-    <StyledText {...withSuomifiDefaults(props)} variant="lead" />
+    <StyledText {...withSuomifiDefaultProps(props)} variant="lead" />
   );
 
   static bold = (props: TextProps) => (
-    <StyledText {...withSuomifiDefaults(props)} variant="bold" />
+    <StyledText {...withSuomifiDefaultProps(props)} variant="bold" />
   );
 
   render() {
-    return <StyledText {...withSuomifiDefaults(this.props)} />;
+    return <StyledText {...withSuomifiDefaultProps(this.props)} />;
   }
 }

--- a/src/core/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/core/Text/__snapshots__/Text.test.tsx.snap
@@ -27,10 +27,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 {
   color: hsl(0,0%,16%);
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -40,14 +36,14 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
   color: hsl(0,0%,16%);
 }
 
 .c0.fi-text--bold {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -57,13 +53,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
 }
 
 .c0.fi-text--lead {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 22px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -73,13 +69,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 22px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 .c0.fi-text--small-screen {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -89,13 +85,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 .c0.fi-text--small-screen.fi-text--bold {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -105,13 +101,13 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
 }
 
 .c0.fi-text--small-screen.fi-text--lead {
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 20px;
-  font-weight: 400;
-  line-height: 1.5;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -121,6 +117,10 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 20px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 <div

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -7,15 +7,15 @@ import { zindexes } from './zindexes';
 import { transitions } from './transitions';
 import { radius } from './radius';
 
-export type TokensProp = typeof importedTokens;
-export type DefaultTokensProp = typeof defaultTokens;
+export type SuomifiTokens = typeof importedTokens;
+export type DefaultSuomifiTokens = typeof defaultTokens;
 export type TypographyProp = keyof typeof importedTokens.typography;
 export type ColorProp = keyof typeof importedTokens.colors;
 export type SpacingProp = keyof typeof importedTokens.spacing;
 export type SuomifiTheme = ReturnType<typeof suomifiTheme>;
 
 export interface TokensComponent {
-  tokens?: TokensProp;
+  tokens?: SuomifiTokens;
 }
 
 export interface SuomifiThemeComponent {
@@ -44,13 +44,13 @@ export const defaultTokens = {
 
 /**
  *  Theme tokens and tokens as CSS
- * @param tokens TokensProp, defaults to suomifi-tokens
+ * @param tokens SuomifiTokens, defaults to suomifi-tokens
  */
 export const suomifiTheme = ({
   colors,
   spacing,
   typography,
-}: TokensProp = defaultTokens) => ({
+}: SuomifiTokens = defaultTokens) => ({
   ...internalTokens,
   colors,
   spacing,

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -7,21 +7,39 @@ import { zindexes } from './zindexes';
 import { transitions } from './transitions';
 import { radius } from './radius';
 
-export type TokensProp = typeof tokens;
-export type TypographyProp = keyof typeof tokens.typography;
-export type ColorProp = keyof typeof tokens.colors;
-export type SpacingProp = keyof typeof tokens.spacing;
+export type TokensProp = typeof importedTokens;
+export type DefaultTokensProp = typeof defaultTokens;
+export type TypographyProp = keyof typeof importedTokens.typography;
+export type ColorProp = keyof typeof importedTokens.colors;
+export type SpacingProp = keyof typeof importedTokens.spacing;
 export type SuomifiThemeProp = ReturnType<typeof suomifiTheme>;
 
 export interface TokensComponent {
-  /** Default as suomifiTheme */
   tokens?: TokensProp;
 }
 
-const tokens = {
+export interface SuomifiThemeComponent {
+  theme: SuomifiThemeProp;
+}
+
+const internalTokens = {
+  shadows,
+  gradients,
+  outlines,
+  zindexes,
+  transitions,
+  radius,
+};
+
+const importedTokens = {
   colors,
   spacing,
   typography: typographyTokens,
+};
+
+export const defaultTokens = {
+  ...importedTokens,
+  ...internalTokens,
 };
 
 /**
@@ -32,15 +50,8 @@ export const suomifiTheme = ({
   colors,
   spacing,
   typography,
-}: TokensProp = tokens) => ({
-  // Internals
-  shadows,
-  gradients,
-  outlines,
-  zindexes,
-  transitions,
-  radius,
-  // Tokens
+}: TokensProp = defaultTokens) => ({
+  ...internalTokens,
   colors,
   spacing,
   typography: typographyUtils(typography),
@@ -48,8 +59,10 @@ export const suomifiTheme = ({
 });
 
 export const withSuomifiTheme = (
-  baseStyles: <T>(props: T) => FlattenSimpleInterpolation,
-) => <T extends TokensComponent>({
+  baseStyles: <K>(
+    props: K & SuomifiThemeComponent,
+  ) => FlattenSimpleInterpolation,
+) => <T extends SuomifiThemeComponent>({
   tokens,
   ...passProps
 }: TokensComponent & T) =>

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -18,7 +18,7 @@ export interface TokensComponent {
   tokens?: SuomifiTokens;
 }
 
-export interface SuomifiThemeComponent {
+export interface SuomifiThemeProp {
   theme: SuomifiTheme;
 }
 
@@ -63,10 +63,8 @@ export const suomifiTheme = ({
  * @param {function} baseStyles Function that will get components' props including tokens-prop and return CSS-styles
  */
 export const withSuomifiTheme = (
-  baseStyles: <K>(
-    props: K & SuomifiThemeComponent,
-  ) => FlattenSimpleInterpolation,
-) => <T extends SuomifiThemeComponent>({
+  baseStyles: <K>(props: K & SuomifiThemeProp) => FlattenSimpleInterpolation,
+) => <T extends SuomifiThemeProp>({
   tokens,
   ...passProps
 }: TokensComponent & T) =>

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -58,6 +58,10 @@ export const suomifiTheme = ({
   values: { colors, spacing, typography },
 });
 
+/**
+ * Function that will add theme to baseStyles-function using tokens
+ * @param {function} baseStyles Function that will get components' props including tokens-prop and return CSS-styles
+ */
 export const withSuomifiTheme = (
   baseStyles: <K>(
     props: K & SuomifiThemeComponent,

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -14,7 +14,7 @@ export type ColorProp = keyof typeof importedTokens.colors;
 export type SpacingProp = keyof typeof importedTokens.spacing;
 export type SuomifiTheme = ReturnType<typeof suomifiTheme>;
 
-export interface TokensComponent {
+export interface TokensProp {
   tokens?: SuomifiTokens;
 }
 
@@ -64,8 +64,5 @@ export const suomifiTheme = ({
  */
 export const withSuomifiTheme = (
   baseStyles: <K>(props: K & SuomifiThemeProp) => FlattenSimpleInterpolation,
-) => <T extends SuomifiThemeProp>({
-  tokens,
-  ...passProps
-}: TokensComponent & T) =>
+) => <T extends SuomifiThemeProp>({ tokens, ...passProps }: TokensProp & T) =>
   baseStyles({ ...passProps, theme: suomifiTheme(tokens) });

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -12,14 +12,14 @@ export type DefaultTokensProp = typeof defaultTokens;
 export type TypographyProp = keyof typeof importedTokens.typography;
 export type ColorProp = keyof typeof importedTokens.colors;
 export type SpacingProp = keyof typeof importedTokens.spacing;
-export type SuomifiThemeProp = ReturnType<typeof suomifiTheme>;
+export type SuomifiTheme = ReturnType<typeof suomifiTheme>;
 
 export interface TokensComponent {
   tokens?: TokensProp;
 }
 
 export interface SuomifiThemeComponent {
-  theme: SuomifiThemeProp;
+  theme: SuomifiTheme;
 }
 
 const internalTokens = {

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -1,62 +1,80 @@
 import { css } from 'styled-components';
-import { TokenProp, suomifiTheme } from '../';
-import { focus as focusUtil } from '../utils';
+import { TypographyProp } from '../';
+import {
+  focus as focusUtil,
+  themeOrTokens,
+  TokensOrThemeProps,
+} from '../utils';
 
-export const focus = (tokens: TokenProp) => focusUtil({ tokens });
+export const focus = (props: TokensOrThemeProps) => focusUtil(props);
 
-export const element = (tokens: TokenProp) => css`
-  color: ${suomifiTheme(tokens).colors.blackBase};
+export const element = (props: TokensOrThemeProps) => css`
+  color: ${themeOrTokens(props).colors.blackBase};
 `;
 
-export const input = (tokens: TokenProp) => css`
-  ${element(tokens)}
-  ${suomifiTheme(tokens).typography.input}
+export const font = (props: TokensOrThemeProps) => (
+  typographyToken: TypographyProp,
+) => css`
+  letter-spacing: 0;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  ${themeOrTokens(props).typography[typographyToken]}
+`;
+
+export const input = (props: TokensOrThemeProps) => {
+  const theme = themeOrTokens(props);
+  return css`
+    ${element(props)}
+    ${theme.typography.input}
   min-width: 245px;
-  max-width: 100%;
-  padding: ${suomifiTheme(tokens).spacing.s} ${suomifiTheme(tokens).spacing.m};
-  border: 1px solid ${suomifiTheme(tokens).colors.depthBase};
-  border-radius: ${suomifiTheme(tokens).radius.basic};
-  line-height: 1;
-`;
+    max-width: 100%;
+    padding: ${theme.spacing.s} ${theme.spacing.m};
+    border: 1px solid ${theme.colors.depthBase};
+    border-radius: ${theme.radius.basic};
+    line-height: 1;
+  `;
+};
 
-export const inputContainer = (tokens: TokenProp) => css`
+export const inputContainer = (props: TokensOrThemeProps) => css`
   > input:focus {
     /* For IE/Edge */
-    outline-color: ${suomifiTheme(tokens).colors.accentBase};
+    outline-color: ${themeOrTokens(props).colors.accentBase};
     outline-width: 4px;
     outline-offset: 2px;
   }
   &:focus-within {
-    ${focusUtil({ tokens, noPseudo: true })}
+    ${focusUtil({ ...props, noPseudo: true })}
     > input:focus {
       outline: none;
     }
   }
 `;
 
-export const inputButton = (tokens: TokenProp) => css`
-  ${input(tokens)}
-  ${focus(tokens)}
+export const inputButton = (props: TokensOrThemeProps) => css`
+  ${input(props)}
+  ${focus(props)}
 `;
 
-export const button = (tokens: TokenProp) => css`
-  ${element(tokens)}
-  ${suomifiTheme(tokens).typography.inputSemibold}
-  ${focus(tokens)}
+export const button = (props: TokensOrThemeProps) => css`
+  ${element(props)}
+  ${themeOrTokens(props).typography.inputSemibold}
+  ${focus(props)}
   line-height: 1;
 `;
 
-export const nav = (tokens: TokenProp) => css`
-  ${element(tokens)}
+export const nav = (props: TokensOrThemeProps) => css`
+  ${element(props)}
   display: block;
 `;
 
-export const list = (tokens: TokenProp) => css`
-  ${element(tokens)}
+export const list = (props: TokensOrThemeProps) => css`
+  ${element(props)}
   list-style: none;
 `;
 
-export const listItem = (tokens: TokenProp) => css`
-  ${element(tokens)}
+export const listItem = (props: TokensOrThemeProps) => css`
+  ${element(props)}
   list-style: none;
 `;

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -27,7 +27,7 @@ export const input = (props: TokensOrThemeProps) => {
   const theme = themeOrTokens(props);
   return css`
     ${element(props)}
-    ${theme.typography.input}
+    ${font(props)('input')}
   min-width: 245px;
     max-width: 100%;
     padding: ${theme.spacing.s} ${theme.spacing.m};
@@ -59,7 +59,7 @@ export const inputButton = (props: TokensOrThemeProps) => css`
 
 export const button = (props: TokensOrThemeProps) => css`
   ${element(props)}
-  ${themeOrTokens(props).typography.inputSemibold}
+  ${font(props)('inputSemibold')}
   ${focus(props)}
   line-height: 1;
 `;

--- a/src/core/theme/spacing.ts
+++ b/src/core/theme/spacing.ts
@@ -1,4 +1,4 @@
-export type spacingTokensProp = keyof typeof spacingTokens;
+export type spacingSuomifiTokens = keyof typeof spacingTokens;
 
 export const spacingTokens = {
   xxs: '2px',
@@ -11,6 +11,6 @@ export const spacingTokens = {
 
 export const spacingTokensKeys = Object.keys(
   spacingTokens,
-) as spacingTokensProp[];
+) as spacingSuomifiTokens[];
 
 export const spacing = spacingTokens;

--- a/src/core/theme/utils/defaults.ts
+++ b/src/core/theme/utils/defaults.ts
@@ -15,7 +15,7 @@ const internalTokens = (tokens?: TokensProp) =>
  * - include internal tokens (THESE ARE NOT GEMERATED BY GIVEN TOKENS! but can be overridden by given tokens)
  * @param props All component's props
  */
-export const withSuomifiDefaults = <T extends { tokens: TokensProp }>({
+export const withSuomifiDefaultProps = <T extends { tokens: TokensProp }>({
   tokens,
   ...props
 }: Partial<T>): T =>

--- a/src/core/theme/utils/defaults.ts
+++ b/src/core/theme/utils/defaults.ts
@@ -5,6 +5,7 @@ import {
   SuomifiTokens,
   DefaultSuomifiTokens,
 } from '../';
+import { asPropType } from '../../../utils/typescript';
 
 const internalTokens = (tokens?: SuomifiTokens) =>
   !!tokens ? { ...defaultTokens, ...tokens } : defaultTokens;
@@ -13,15 +14,20 @@ const internalTokens = (tokens?: SuomifiTokens) =>
  * Check component props and do common defaulting
  * - Check if tokens are given or use default ones
  * - include internal tokens (THESE ARE NOT GEMERATED BY GIVEN TOKENS! but can be overridden by given tokens)
+ * - If as-prop (styled-components) set pass it as asProp
  * @param props All component's props
  */
-export const withSuomifiDefaultProps = <T extends { tokens: SuomifiTokens }>({
+export const withSuomifiDefaultProps = <
+  T extends { tokens: SuomifiTokens; asProp?: asPropType }
+>({
   tokens,
+  as,
   ...props
-}: Partial<T>): T =>
+}: Partial<T> & { as?: asPropType }): T =>
   ({
     ...props,
     tokens: internalTokens(tokens),
+    ...(!!as ? { asProp: as } : {}),
   } as T & { tokens: DefaultSuomifiTokens });
 
 export interface Tokens {

--- a/src/core/theme/utils/defaults.ts
+++ b/src/core/theme/utils/defaults.ts
@@ -1,6 +1,6 @@
 import {
   suomifiTheme,
-  SuomifiThemeProp,
+  SuomifiTheme,
   defaultTokens,
   TokensProp,
   DefaultTokensProp,
@@ -29,7 +29,7 @@ export interface Tokens {
 }
 
 export interface Theme {
-  theme: SuomifiThemeProp;
+  theme: SuomifiTheme;
 }
 export type TokensOrThemeProps = Tokens | Theme;
 

--- a/src/core/theme/utils/defaults.ts
+++ b/src/core/theme/utils/defaults.ts
@@ -2,11 +2,11 @@ import {
   suomifiTheme,
   SuomifiTheme,
   defaultTokens,
-  TokensProp,
-  DefaultTokensProp,
+  SuomifiTokens,
+  DefaultSuomifiTokens,
 } from '../';
 
-const internalTokens = (tokens?: TokensProp) =>
+const internalTokens = (tokens?: SuomifiTokens) =>
   !!tokens ? { ...defaultTokens, ...tokens } : defaultTokens;
 
 /**
@@ -15,17 +15,17 @@ const internalTokens = (tokens?: TokensProp) =>
  * - include internal tokens (THESE ARE NOT GEMERATED BY GIVEN TOKENS! but can be overridden by given tokens)
  * @param props All component's props
  */
-export const withSuomifiDefaultProps = <T extends { tokens: TokensProp }>({
+export const withSuomifiDefaultProps = <T extends { tokens: SuomifiTokens }>({
   tokens,
   ...props
 }: Partial<T>): T =>
   ({
     ...props,
     tokens: internalTokens(tokens),
-  } as T & { tokens: DefaultTokensProp });
+  } as T & { tokens: DefaultSuomifiTokens });
 
 export interface Tokens {
-  tokens: TokensProp;
+  tokens: SuomifiTokens;
 }
 
 export interface Theme {

--- a/src/core/theme/utils/defaults.ts
+++ b/src/core/theme/utils/defaults.ts
@@ -1,4 +1,10 @@
-import { defaultTokens, TokensProp, DefaultTokensProp } from '../';
+import {
+  suomifiTheme,
+  SuomifiThemeProp,
+  defaultTokens,
+  TokensProp,
+  DefaultTokensProp,
+} from '../';
 
 const internalTokens = (tokens?: TokensProp) =>
   !!tokens ? { ...defaultTokens, ...tokens } : defaultTokens;
@@ -17,3 +23,20 @@ export const withSuomifiDefaults = <T extends { tokens: TokensProp }>({
     ...props,
     tokens: internalTokens(tokens),
   } as T & { tokens: DefaultTokensProp });
+
+export interface Tokens {
+  tokens: TokensProp;
+}
+
+export interface Theme {
+  theme: SuomifiThemeProp;
+}
+export type TokensOrThemeProps = Tokens | Theme;
+
+/**
+ * Return theme if defined or theme based on tokens
+ * @param {Object} prop.theme Theme if defined
+ * @param {Object} prop.tokens Tokens
+ */
+export const themeOrTokens = (props: TokensOrThemeProps) =>
+  'theme' in props ? props.theme : suomifiTheme(props.tokens);

--- a/src/core/theme/utils/focus.ts
+++ b/src/core/theme/utils/focus.ts
@@ -1,14 +1,16 @@
-import { suomifiTheme, TokensComponent } from '../';
+import { themeOrTokens, TokensOrThemeProps } from '../utils';
 
 export const focus = ({
   outline,
   noPseudo,
-  tokens,
-}: TokensComponent & {
+  ...tokensOrTheme
+}: TokensOrThemeProps & {
   outline?: string;
   noPseudo?: boolean;
 }) => {
-  const style = !!outline ? outline : suomifiTheme(tokens).outlines.basic;
+  const style = !!outline
+    ? outline
+    : themeOrTokens(tokensOrTheme).outlines.basic;
   return !!noPseudo
     ? style
     : `&:focus {

--- a/src/core/theme/utils/focus.ts
+++ b/src/core/theme/utils/focus.ts
@@ -1,3 +1,4 @@
+import { css } from 'styled-components';
 import { themeOrTokens, TokensOrThemeProps } from '../utils';
 
 export const focus = ({
@@ -13,7 +14,9 @@ export const focus = ({
     : themeOrTokens(tokensOrTheme).outlines.basic;
   return !!noPseudo
     ? style
-    : `&:focus {
-    ${style}
-  }`;
+    : css`
+        &:focus {
+          ${style}
+        }
+      `;
 };

--- a/src/core/theme/utils/index.ts
+++ b/src/core/theme/utils/index.ts
@@ -1,5 +1,5 @@
 export {
-  withSuomifiDefaults,
+  withSuomifiDefaultProps,
   themeOrTokens,
   TokensOrThemeProps,
 } from './defaults';

--- a/src/core/theme/utils/index.ts
+++ b/src/core/theme/utils/index.ts
@@ -1,4 +1,8 @@
-export { withSuomifiDefaults } from './defaultTokens';
+export {
+  withSuomifiDefaults,
+  themeOrTokens,
+  TokensOrThemeProps,
+} from './defaults';
 export { focus } from './focus';
 export { boxshadowOutline } from './outline';
 export { margin, padding, spacingModifiers } from './spacing';

--- a/src/core/theme/utils/outline.ts
+++ b/src/core/theme/utils/outline.ts
@@ -1,3 +1,4 @@
+import { css } from 'styled-components';
 import { colors } from '../colors';
 import { radius } from '../radius';
 
@@ -9,7 +10,7 @@ const boxshadow = ({
   borderRadius: string;
   border: string;
   color: string;
-}) => `
+}) => css`
   border-radius: ${borderRadius};
   border: ${border} solid ${color};
   box-sizing: border-box;
@@ -28,7 +29,7 @@ const afterBoxshadow = ({
   border: string;
   color: string;
   zIndex: number;
-}) => `
+}) => css`
   position: relative;
   &:after {
     content: '';
@@ -42,8 +43,10 @@ const afterBoxshadow = ({
     border: ${border} solid ${color};
     box-sizing: border-box;
     box-shadow: 0 0 10px 0 ${color};
-    ${!!zIndex && `z-index: ${zIndex};}`}`;
+    ${!!zIndex && `z-index: ${zIndex};`}
+  }`;
 
+// TODO Refactor, create interfaces (and extend with Partial<>), add JSDOC for functions
 export const boxshadowOutline = ({
   color = colors.accentBase,
   offset = '0',
@@ -58,15 +61,15 @@ export const boxshadowOutline = ({
   borderRadius?: string;
   zIndex?: number;
   afterPseudo?: boolean;
-} = {}) => {
+}) => {
   const focusVisible = !!afterPseudo
     ? '&:not(:focus-visible):after { content: none; }'
     : '&:not(:focus-visible) { box-shadow: none; }';
-  return `outline: 0;
-    ${
-      !!afterPseudo
-        ? afterBoxshadow({ offset, borderRadius, border, color, zIndex })
-        : boxshadow({ borderRadius, border, color })
-    }
-    ${focusVisible}`;
+  return css`
+    outline: 0;
+    ${!!afterPseudo
+      ? afterBoxshadow({ offset, borderRadius, border, color, zIndex })
+      : boxshadow({ borderRadius, border, color })}
+    ${focusVisible}
+  `;
 };

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -1,15 +1,15 @@
 // TODO make this whole util again to work with suomifiTheme-util
 
 import {
-  spacingTokensProp,
+  spacingSuomifiTokens,
   spacingTokensKeys,
   spacingTokens,
 } from '../spacing';
-import { TokensProp } from '../';
+import { SuomifiTokens } from '../';
 
-export type SpaceProp = spacingTokensProp | '0';
+export type SpaceProp = spacingSuomifiTokens | '0';
 
-const spaceVal = (tokens?: TokensProp) => (val?: SpaceProp) => {
+const spaceVal = (tokens?: SuomifiTokens) => (val?: SpaceProp) => {
   if (val === '0') return '0';
   const useTokens =
     !!tokens && !!tokens.spacing ? tokens.spacing : spacingTokens;
@@ -34,7 +34,7 @@ const spaceVal = (tokens?: TokensProp) => (val?: SpaceProp) => {
  * @param {Object} theme suomifiTheme
  * @return {(spacingType) => (spacingTokens) => String}
  */
-const space = (tokens?: TokensProp) => (type: 'padding' | 'margin') => (
+const space = (tokens?: SuomifiTokens) => (type: 'padding' | 'margin') => (
   t?: SpaceProp,
   r?: SpaceProp,
   b?: SpaceProp,
@@ -51,12 +51,12 @@ const space = (tokens?: TokensProp) => (type: 'padding' | 'margin') => (
  * Set margin based on tokens
  * @param {Object} tokens
  */
-export const margin = (tokens?: TokensProp) => space(tokens)('margin');
+export const margin = (tokens?: SuomifiTokens) => space(tokens)('margin');
 /**
  * Set padding based on tokens
  * @param {Object} tokens
  */
-export const padding = (tokens?: TokensProp) => space(tokens)('padding');
+export const padding = (tokens?: SuomifiTokens) => space(tokens)('padding');
 
 /**
  * Create spacing styles for CSS-selector (-xxs, -xs, -s...)
@@ -64,7 +64,7 @@ export const padding = (tokens?: TokensProp) => space(tokens)('padding');
  * @param {Object} tokens Design tokens
  * @return {(spacingType) => (selector: String) => String}
  */
-export const spacingModifiers = (tokens?: TokensProp) => (
+export const spacingModifiers = (tokens?: SuomifiTokens) => (
   spacing: 'padding' | 'margin',
 ) => (selector: string) =>
   spacingTokensKeys.reduce(

--- a/src/core/theme/utils/typography.ts
+++ b/src/core/theme/utils/typography.ts
@@ -15,7 +15,7 @@ export interface TypographyUtil extends TypographyTokensAsCssProp {}
 export class TypographyUtil {
   static instance: any;
   constructor(tokens: TypographyTokens) {
-    // If instance not created, does not take on account if theme is different!
+    // If instance not created, does not take on account if tokens is different!
     if (!TypographyUtil.instance) {
       // Assing typographyTokens as CSS FlattenSimpleInterpolation to this object
       Object.assign(this, cssObjectsToCss(tokens));

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,8 +1,8 @@
 import { FlattenSimpleInterpolation } from 'styled-components';
-import { suomifiTheme, ThemeProp } from '../theme';
+import { suomifiTheme, SuomifiThemeProp } from '../theme';
 
 interface BaseStylesInterface {
-  theme: ThemeProp;
+  theme: SuomifiThemeProp;
   [key: string]: any;
 }
 
@@ -14,4 +14,4 @@ interface BaseStylesInterface {
 export const cssFromBaseStyles = (
   baseStyles: ({ theme }: BaseStylesInterface) => FlattenSimpleInterpolation,
   props = {},
-) => baseStyles({ ...props, theme: suomifiTheme }).join('');
+) => baseStyles({ ...props, theme: suomifiTheme() }).join('');

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,8 +1,8 @@
 import { FlattenSimpleInterpolation } from 'styled-components';
-import { suomifiTheme, SuomifiThemeProp } from '../theme';
+import { suomifiTheme, SuomifiTheme } from '../theme';
 
 interface BaseStylesInterface {
-  theme: SuomifiThemeProp;
+  theme: SuomifiTheme;
   [key: string]: any;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,5 +45,5 @@ export {
   suomifiTheme,
   SuomifiThemeProp,
   defaultTokens,
-  TokensComponent,
+  TokensProp,
 } from './core/theme';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,4 +41,9 @@ export {
 export { Panel, PanelProps } from './core/Panel/Panel';
 export { Paragraph, ParagraphProps } from './core/Paragraph/Paragraph';
 export { Text, TextProps } from './core/Text/Text';
-export { suomifiTheme, ThemeComponent } from './core/theme';
+export {
+  suomifiTheme,
+  SuomifiThemeComponent,
+  defaultTokens,
+  TokensComponent,
+} from './core/theme';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,7 @@ export { Paragraph, ParagraphProps } from './core/Paragraph/Paragraph';
 export { Text, TextProps } from './core/Text/Text';
 export {
   suomifiTheme,
-  SuomifiThemeComponent,
+  SuomifiThemeProp,
   defaultTokens,
   TokensComponent,
 } from './core/theme';


### PR DESCRIPTION
- Now `theme`-object is for our internal usage - but can be given to component.
  - Later we will implement `suomifiThemeProvider` to handle via context (like Styled Components ThemeProvider)
- Components can now have properties:
  - `tokens` - defaults to suomifi-design-tokens
  - `theme` - defaults to theme created from tokens

Those implementations are at the `core`-level (suomifi-specific).

There are limitations that you can give another component a tokens-prop and another a theme (or different theme to different components), but cannot give different tokens-prop to different components.