### PR TITLE
Bugfix/do not try to export suomifi theme function

### DIFF
--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -22,6 +22,7 @@ export interface SuomifiThemeProp {
   theme: SuomifiTheme;
 }
 
+type DefaultInternalTokens = typeof internalTokens;
 const internalTokens = {
   shadows,
   gradients,
@@ -47,11 +48,13 @@ export const defaultTokens = {
  * @param tokens SuomifiTokens, defaults to suomifi-tokens
  */
 export const suomifiTheme = ({
-  colors,
-  spacing,
-  typography,
-}: SuomifiTokens = defaultTokens) => ({
+  colors = defaultTokens.colors,
+  spacing = defaultTokens.spacing,
+  typography = defaultTokens.typography,
+  ...internalTokensProp
+}: Partial<SuomifiTokens & DefaultInternalTokens> = defaultTokens) => ({
   ...internalTokens,
+  ...internalTokensProp,
   colors,
   spacing,
   typography: typographyUtils(typography),

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -45,9 +45,14 @@ export const defaultTokens = {
 
 /**
  *  Theme tokens and tokens as CSS
- * @param tokens SuomifiTokens, defaults to suomifi-tokens
+ * @param tokens SuomifiTokens with libraryTokenOverrides, defaults to suomifi-design-tokens
+ * @param tokens.colors color tokens, defaults to suomifi-design-tokens colors
+ * @param tokens.spacing spacing tokens, defaults to suomifi-design-tokens spacing
+ * @param tokens.typography typography tokens, defaults to suomifi-design-tokens typography
  */
 export const suomifiTheme = ({
+  // If one object property is set function parameter default (defaultTokens) will not be used
+  // Then need to set individually
   colors = defaultTokens.colors,
   spacing = defaultTokens.spacing,
   typography = defaultTokens.typography,

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -51,10 +51,13 @@ export const suomifiTheme = ({
   colors = defaultTokens.colors,
   spacing = defaultTokens.spacing,
   typography = defaultTokens.typography,
-  ...internalTokensProp
+  // Rest of the properties are overrides for internalTokens
+  ...libraryTokenOverrides
 }: Partial<SuomifiTokens & DefaultInternalTokens> = defaultTokens) => ({
+  // Get all internalTokens
   ...internalTokens,
-  ...internalTokensProp,
+  // Override if any defined
+  ...(!!libraryTokenOverrides ? libraryTokenOverrides : {}),
   colors,
   spacing,
   typography: typographyUtils(typography),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,9 +41,4 @@ export {
 export { Panel, PanelProps } from './core/Panel/Panel';
 export { Paragraph, ParagraphProps } from './core/Paragraph/Paragraph';
 export { Text, TextProps } from './core/Text/Text';
-export {
-  suomifiTheme,
-  SuomifiThemeProp,
-  defaultTokens,
-  TokensProp,
-} from './core/theme';
+export { defaultTokens, TokensProp } from './core/theme';


### PR DESCRIPTION
Do not try to export suomifiTheme function outside the library as it uses singleton to get theme from tokens. Exported defaultTokens contains also internal tokens so everything is still available.

Fix so that suomifiTheme function understands also given customized internalTokens.

Closes #194