### PR TITLE
[Bugfix] Added the missing background-color for the Dropdown's baseStyle

### DIFF
--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -9,6 +9,7 @@ export const baseStyles = withSuomifiTheme(
       position: relative;
       padding-right: 30px;
       text-align: left;
+      background-color: ${theme.colors.whiteBase};
       cursor: pointer;
       &:before {
         content: '';

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -19,7 +19,7 @@ const StyledDropdown = styled(
   ({ tokens, ...passProps }: DropdownProps & InternalTokensProp) => (
     <CompDropdown
       {...passProps}
-      dropdownItemProps={{ className: 'fi-dropdown-item' }}
+      dropdownItemProps={{ className: 'fi-dropdown_item' }}
     />
   ),
 )`


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

Dropdown component had gray background when it should be white.

### Was able to reproduce the problem 
**Versions:** 0.2.4, 0.2.5. 0.2.6
**Operating system:** macOS Catalina 10.15
**Browsers:** Firefox, Safari

### Was **not** able to reproduce the problem with
**Versions:** 0.2.4, 0.2.5. 0.2.6
**Operating system:** macOS Catalina 10.15
**Browsers:** Chrome, Opera

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #178 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
To look consistent with all applicable browsers and with intended colors.

## How Has This Been Tested?

Manually tested after the change with 
**Operating system:** macOS Catalina 10.15
**Browsers:** Chrome, Firefox, Safari, Opera

And seemed to work with all these browsers now.

And ran the validations
`yarn validate`
