### PR TITLE
Bugfix/create token for wrong text sizes

### DIFF
--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`calling render with the same component on the same container does not r
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
   line-height: 1;

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -35,7 +35,7 @@ export const menuListStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
   &[data-reach-menu-list].fi-dropdown_list {
     ${element({ theme })}
-    ${theme.typography.input}
+    ${theme.typography.actionElementInnerText}
     margin-top: -1px;
     padding: 0;
     font-size: 100%;
@@ -50,11 +50,11 @@ export const menuListStyles = withSuomifiTheme(
 
   & [data-reach-menu-item].fi-dropdown_item {
     ${element({ theme })}
-    ${theme.typography.input}
+    ${theme.typography.actionElementInnerText}
     padding: ${theme.spacing.s} ${theme.spacing.m};
     border: 0;
     &[data-selected] {
-      ${theme.typography.input}
+      ${theme.typography.actionElementInnerText}
       color: ${theme.colors.blackBase};
       background-image: none;
       background-color: ${theme.colors.highlightLight50};

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`calling render with the same component on the same container does not r
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
   min-width: 245px;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`calling render with the same component on the same container does not r
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
   min-width: 245px;

--- a/src/core/Menu/Menu.baseStyles.tsx
+++ b/src/core/Menu/Menu.baseStyles.tsx
@@ -13,7 +13,7 @@ export const baseStyles = withSuomifiTheme(
     cursor: pointer;
     &.fi-menu-language_button {
       ${element({ theme })}
-      ${theme.typography.inputSemibold}
+      ${theme.typography.actionElementInnerTextBold}
       ${padding(tokens)('s', 'xs', 's', 's')}
       background-color: ${theme.colors.whiteBase};
       border: 1px solid ${theme.colors.depthBase};
@@ -41,7 +41,7 @@ export const menuListStyles = withSuomifiTheme(
     border: none;
     box-shadow: ${theme.shadows.menuShadow};
     &.fi-menu-language_list {
-      ${theme.typography.input}
+      ${theme.typography.actionElementInnerText}
       position: absolute;
       right: 0;
       top: 0;
@@ -83,12 +83,12 @@ export const menuListStyles = withSuomifiTheme(
     }
     &.fi-menu-language_item,
     &[data-selected].fi-menu-language_item {
-      ${theme.typography.input}
+      ${theme.typography.actionElementInnerText}
       padding: 6px 20px 6px 14px;
       border-left: 6px solid transparent;
       background-color: transparent;
       &.fi-menu-lang-item-selected {
-        ${theme.typography.inputSemibold};
+        ${theme.typography.actionElementInnerTextBold};
       }
     }
     &[data-selected].fi-menu-language_item {

--- a/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
+++ b/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
@@ -158,7 +158,7 @@ exports[`calling render with the same component on the same container does not r
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
   line-height: 1;

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`snapshot testing 1`] = `
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
   line-height: 1;

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -27,7 +27,7 @@ export const input = (props: TokensOrThemeProps) => {
   const theme = themeOrTokens(props);
   return css`
     ${element(props)}
-    ${font(props)('input')}
+    ${font(props)('actionElementInnerText')}
   min-width: 245px;
     max-width: 100%;
     padding: ${theme.spacing.s} ${theme.spacing.m};
@@ -59,7 +59,7 @@ export const inputButton = (props: TokensOrThemeProps) => css`
 
 export const button = (props: TokensOrThemeProps) => css`
   ${element(props)}
-  ${font(props)('inputSemibold')}
+  ${font(props)('actionElementInnerTextBold')}
   ${focus(props)}
   line-height: 1;
 `;

--- a/src/core/theme/typography.ts
+++ b/src/core/theme/typography.ts
@@ -1,6 +1,6 @@
 const fontSize = {
   default: {
-    input: '16px',
+    actionElementInnerText: '16px',
     body: '18px',
     lead: '22px',
     h1: '40px',
@@ -10,7 +10,7 @@ const fontSize = {
     h5: '16px',
   },
   smRes: {
-    input: '16px',
+    actionElementInnerText: '16px',
     body: '16px',
     lead: '20px',
     h1: '32px',
@@ -23,7 +23,7 @@ const fontSize = {
 
 const lineHeight = {
   default: {
-    input: '1.5',
+    actionElementInnerText: '1.5',
     lead: '1.5',
     body: '1.5',
     h1: '48px',
@@ -33,7 +33,7 @@ const lineHeight = {
     h5: '20px',
   },
   smRes: {
-    input: '1.5',
+    actionElementInnerText: '1.5',
     lead: '1.5',
     body: '1.5',
     h1: '38px',
@@ -55,13 +55,19 @@ const fontWeights = {
 
 const tokenMap = {
   // TODO Define as variations from imported typography token
-  input: ['default', 'body'],
-  inputSemibold: ['default', 'body', 'semiBold'],
   bodySemiBold: ['default', 'body', 'semiBold'],
   bodySemiBoldSmallScreen: ['smRes', 'body', 'semiBold'],
   // Regression fallbacks (TODO Create linter to have this ruled as deprecated)
   body: ['default', 'body'],
   // TODO remove when tokens from suomifi-design-tokens
+  actionElementInnerText: ['default', 'actionElementInnerText'],
+  actionElementInnerTextSmallScreen: ['default', 'actionElementInnerText'],
+  actionElementInnerTextBold: ['default', 'actionElementInnerText', 'semiBold'],
+  actionElementInnerTextBoldSmallScreen: [
+    'default',
+    'actionElementInnerText',
+    'semiBold',
+  ],
   bodyText: ['default', 'body'],
   bodyTextSmallScreen: ['smRes', 'body'],
   leadText: ['default', 'lead'],


### PR DESCRIPTION
## Description

Add tokens:
- actionElementInnerText
- actionElementInnerTextSmallScreen
- actionElementInnerTextBold
- actionElementInnerTextBoldSmallScreen

## Motivation and Context

Tokens are missing text size for Button and input-elements

## How Has This Been Tested?

`yarn start`
`yarn validate`
snapshots