### PR TITLE
[Bugfix] Removed the open-prop from documentation

### DIFF
--- a/src/components/Panel/PanelExpansion.tsx
+++ b/src/components/Panel/PanelExpansion.tsx
@@ -57,13 +57,11 @@ export interface PanelExpansionProps extends PanelProps {
    * @default none
    */
   titleTag?: string;
-  /** Controlled open-state, use onClick to change  */
-  open?: boolean;
   /** Properties for title-Button */
   titleProps?: ButtonProps & { open?: boolean };
   /** Properties for the content div */
   contentProps?: PanelProps;
-  /** Default status of panel open when not using controlled 'open' state
+  /** Default status of panel open
    * @default false
    */
   defaultOpen?: boolean;
@@ -99,7 +97,6 @@ export class PanelExpansionItem extends Component<PanelExpansionProps> {
 
   handleClick = () => {
     const {
-      open,
       onClick,
       consumer: { onClick: consumerOnClick } = { onClick: undefined },
       index,
@@ -109,19 +106,15 @@ export class PanelExpansionItem extends Component<PanelExpansionProps> {
       consumerOnClick(index);
     } else {
       const openState = !this.state.openState;
-      const notControlled = open === undefined;
-      if (notControlled) {
-        this.setState({ openState });
-      }
+      this.setState({ openState });
       if (!!onClick) {
-        onClick({ openState: notControlled ? openState : !!open });
+        onClick({ openState });
       }
     }
   };
 
   render() {
     const {
-      open,
       defaultOpen,
       onClick,
       className,
@@ -137,8 +130,7 @@ export class PanelExpansionItem extends Component<PanelExpansionProps> {
       },
       ...passProps
     } = this.props;
-    const localOpenState = () =>
-      open !== undefined ? !!open : this.state.openState;
+    const localOpenState = () => this.state.openState;
     const openState =
       index !== undefined && !!openPanels
         ? openPanels.includes(index)

--- a/src/core/Panel/Panel.md
+++ b/src/core/Panel/Panel.md
@@ -31,20 +31,18 @@ import { Panel } from 'suomifi-ui-components';
 </Panel.expansionGroup>;
 ```
 
-### Example with controlled open-prop:
+### Example of panel open by default
 
 ```jsx
 import { Panel } from 'suomifi-ui-components';
 initialState = { open: true };
 
 <Panel.expansion
-  title="Test expansion bgr"
-  noPadding
-  open={state.open}
+  title="Test expansion"
+  className="panel-expansion-test"
   onClick={() => setState({ open: !state.open })}
+  defaultOpen={true}
 >
-  <div style={{ backgroundColor: 'green', padding: '20px' }}>
-    Test expansion content
-  </div>
+  Test expansion content
 </Panel.expansion>;
 ```

--- a/src/core/Panel/PanelExpansion.tsx
+++ b/src/core/Panel/PanelExpansion.tsx
@@ -58,28 +58,23 @@ export class PanelExpansion extends Component<PanelExpansionProps> {
   };
 
   handleClick = () => {
-    const { open, onClick } = this.props;
+    const { onClick } = this.props;
     const { openState } = this.state;
-    const notControlled = open === undefined;
-    if (notControlled) {
-      this.setState({ openState: !openState });
-    }
+    this.setState({ openState: !openState });
     if (!!onClick) {
-      onClick({ openState: notControlled ? !openState : !!open });
+      onClick({ openState: !openState });
     }
   };
 
   render() {
-    const { open, title, titleTag, ...passProps } = withSuomifiDefaultProps(
+    const { title, titleTag, ...passProps } = withSuomifiDefaultProps(
       this.props,
     );
-    const notControlled = open === undefined;
-    const openState = !notControlled ? open : this.state.openState;
+    const openState = this.state.openState;
     return (
       <StyledPanelExpansion
         {...passProps}
         onClick={this.handleClick}
-        open={open}
         titleTag={titleTag}
         title={
           <Fragment>


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Removes the `open`-prop from the documentation because it is handled by `onClick`.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #203 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
The open-state is handled by `onClick`.

## How Has This Been Tested?

- manually checked in the browser
- `yarn validate`
