### PR TITLE
[Bugfix] PanelExpansion: Removed the JSDoc of the open-prop & example

### DIFF
--- a/src/components/Panel/PanelExpansion.tsx
+++ b/src/components/Panel/PanelExpansion.tsx
@@ -57,13 +57,12 @@ export interface PanelExpansionProps extends PanelProps {
    * @default none
    */
   titleTag?: string;
-  /** Controlled open-state, use onClick to change  */
   open?: boolean;
   /** Properties for title-Button */
   titleProps?: ButtonProps & { open?: boolean };
   /** Properties for the content div */
   contentProps?: PanelProps;
-  /** Default status of panel open when not using controlled 'open' state
+  /** Default status of panel open
    * @default false
    */
   defaultOpen?: boolean;

--- a/src/core/Panel/Panel.md
+++ b/src/core/Panel/Panel.md
@@ -30,21 +30,3 @@ import { Panel } from 'suomifi-ui-components';
   </Panel.expansion>
 </Panel.expansionGroup>;
 ```
-
-### Example with controlled open-prop:
-
-```jsx
-import { Panel } from 'suomifi-ui-components';
-initialState = { open: true };
-
-<Panel.expansion
-  title="Test expansion bgr"
-  noPadding
-  open={state.open}
-  onClick={() => setState({ open: !state.open })}
->
-  <div style={{ backgroundColor: 'green', padding: '20px' }}>
-    Test expansion content
-  </div>
-</Panel.expansion>;
-```


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Removes the JSDoc of the open-prop from PanelExpansion. Therefore also got rid of the example of using the prop.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #203 

## Motivation and Context

> PanelExpansion should not have described open-prop because it is handled by onClick

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- manually checked in the browser
- `yarn validate`