### PR TITLE
Panel expansion disabled attribute

### DIFF
--- a/src/components/Panel/PanelExpansion.tsx
+++ b/src/components/Panel/PanelExpansion.tsx
@@ -20,6 +20,7 @@ const contentOpenClassName = `${contentBaseClassName}--open`;
 
 interface StyledPanelExpansionContentProps extends PanelProps {
   openState: boolean;
+  hidden: boolean;
 }
 
 export const StyledPanelExpansionContent = styled(
@@ -169,7 +170,7 @@ export class PanelExpansionItem extends Component<PanelExpansionProps> {
           className={classnames(contentBaseClassName, contentClassName, {
             [contentOpenClassName]: !!openState,
           })}
-          aria-hidden={!openState}
+          hidden={!openState}
         >
           {children}
         </StyledPanelExpansionContent>

--- a/src/components/Panel/PanelExpansion.tsx
+++ b/src/components/Panel/PanelExpansion.tsx
@@ -171,6 +171,8 @@ export class PanelExpansionItem extends Component<PanelExpansionProps> {
             [contentOpenClassName]: !!openState,
           })}
           hidden={!openState}
+          key={String(openState)}
+          aria-hidden={!openState}
         >
           {children}
         </StyledPanelExpansionContent>

--- a/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
+++ b/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
@@ -274,6 +274,7 @@ exports[`calling render with the same component on the same container does not r
     </svg>
   </button>
   <div
+    aria-hidden="true"
     class="fi-panel-expansion_content c6 fi-panel c1 c2"
     hidden=""
   >

--- a/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
+++ b/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
@@ -274,8 +274,8 @@ exports[`calling render with the same component on the same container does not r
     </svg>
   </button>
   <div
-    aria-hidden="true"
     class="fi-panel-expansion_content c6 fi-panel c1 c2"
+    hidden=""
   >
     Test expansion content
   </div>

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -408,8 +408,8 @@ exports[`snapshot testing 1`] = `
         </svg>
       </button>
       <div
-        aria-hidden="true"
         class="fi-panel-expansion_content c9 fi-panel c6 c2"
+        hidden=""
       >
         Test expansion content 1
       </div>
@@ -440,8 +440,8 @@ exports[`snapshot testing 1`] = `
         </svg>
       </button>
       <div
-        aria-hidden="true"
         class="fi-panel-expansion_content c9 fi-panel c6 c2"
+        hidden=""
       >
         Test expansion content 2
       </div>
@@ -472,8 +472,8 @@ exports[`snapshot testing 1`] = `
         </svg>
       </button>
       <div
-        aria-hidden="true"
         class="fi-panel-expansion_content c9 fi-panel c6 c2"
+        hidden=""
       >
         Test expansion content 3
       </div>

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -408,6 +408,7 @@ exports[`snapshot testing 1`] = `
         </svg>
       </button>
       <div
+        aria-hidden="true"
         class="fi-panel-expansion_content c9 fi-panel c6 c2"
         hidden=""
       >
@@ -440,6 +441,7 @@ exports[`snapshot testing 1`] = `
         </svg>
       </button>
       <div
+        aria-hidden="true"
         class="fi-panel-expansion_content c9 fi-panel c6 c2"
         hidden=""
       >
@@ -472,6 +474,7 @@ exports[`snapshot testing 1`] = `
         </svg>
       </button>
       <div
+        aria-hidden="true"
         class="fi-panel-expansion_content c9 fi-panel c6 c2"
         hidden=""
       >


### PR DESCRIPTION
## Description
PanelExpansion now uses hidden attribute in addition to aria-hidden. The hidden attribute is conditionally removed when the panel is expanded while aria-hidden is always present and only it's value is derived from expanded state. Hidden content is force rendered by changing the element key when panel is either collapsed or expanded. The hidden prop is handled internally and cannot be provided as prop externally, so there should be no need for any existence checks etc.

## Related Issue

Closes #199 

## Motivation and Context

PanelExpansion was using only aria-hidden for expansion content, but to be accessible and semantically correct, hidden attribute should be used instead. Aria-hidden was left in place as a fallback for browsers that do not implement accessibility features for hidden attribute correctly.

## How Has This Been Tested?

Changes were tested locally with chrome browser and with Edge via BrowserStack using the the build and included styleguide. In addition, both bare accessible component and Suomifi styled component were tested using create react app project. 

The resulting html now also contains the properties provided in #199.

![Screenshot 2019-10-23 at 13 56 23](https://user-images.githubusercontent.com/53744258/67386185-2622db80-f59d-11e9-882e-8537f24daf9c.png)
![Screenshot 2019-10-23 at 13 56 40](https://user-images.githubusercontent.com/53744258/67386199-2ae78f80-f59d-11e9-8919-0fe65ea3830d.png)

![Screenshot 2019-10-23 at 13 55 47](https://user-images.githubusercontent.com/53744258/67386215-2fac4380-f59d-11e9-8916-d74fc38a7f59.png)
![Screenshot 2019-10-23 at 13 56 07](https://user-images.githubusercontent.com/53744258/67386222-35098e00-f59d-11e9-990a-de084f8fc95b.png)
