### PR TITLE
Install suomifi design tokens 0.2.1

### DIFF
--- a/.styleguidist/typography.md
+++ b/.styleguidist/typography.md
@@ -4,11 +4,11 @@ Suomifi-styleguide typography
 import { default as styled } from 'styled-components';
 import { Text } from '../src/core/Text/Text';
 import { Heading } from '../src/core/Heading/Heading';
-import {
-  typographyTokens,
-  fontFamily
-} from '../src/core/theme/typography';
+import { suomifiTheme } from '../src/core/theme';
 import clipboardCopy from 'clipboard-copy';
+
+const fontFamily = 'Source Sans Pro';
+const typographyTokens = suomifiTheme().typography;
 
 const Row = styled(({ mb, code, ...passProps }) => (
   <div

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "polished": "3.4.0",
     "react-svg": "7.2.2",
     "styled-components": "4.3.2",
-    "suomifi-design-tokens": "0.1.0",
+    "suomifi-design-tokens": "0.2.1",
     "suomifi-icons": "0.0.8",
     "uuid": "3.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "polished": "3.4.0",
     "react-svg": "7.2.2",
     "styled-components": "4.3.2",
+    "suomifi-design-tokens": "0.1.0",
     "suomifi-icons": "0.0.8",
     "uuid": "3.3.2"
   },

--- a/src/core/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/core/Block/__snapshots__/Block.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../theme';
 import { nav, list, listItem, font } from '../theme/reset';
+import { fontSize } from '../theme/utils';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
@@ -23,7 +24,7 @@ export const baseStyles = withSuomifiTheme(
     &_item,
     &_link,
     &_icon {
-      font-size: ${theme.values.typography.bodyText.fontSize};
+      font-size: ${fontSize({ theme })('bodyText')};
     }
     &_icon {
       transform: translateY(.2em);

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -205,7 +205,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -224,7 +224,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -244,7 +244,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;

--- a/src/core/Colors/Colors.baseStyles.tsx
+++ b/src/core/Colors/Colors.baseStyles.tsx
@@ -1,6 +1,10 @@
 import { css } from 'styled-components';
 import { readableColor } from 'polished';
-import { withSuomifiTheme, TokensAndTheme } from '../theme';
+import {
+  withSuomifiTheme,
+  TokensAndTheme,
+  internalTypographyTokens,
+} from '../theme';
 import { clearfix } from '../../utils/css/utils';
 import { ColorProps } from './Colors';
 
@@ -41,7 +45,7 @@ export const baseStyles = withSuomifiTheme(
         }
 
         &--key {
-          ${theme.typography.bodySemiBold}
+          ${internalTypographyTokens.bodySemiBold}
         }
       }
 

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -158,7 +158,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -146,7 +146,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -116,7 +116,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/core/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/core/Heading/__snapshots__/Heading.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -53,7 +53,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 40px;
   line-height: 48px;
   font-weight: 600;
@@ -69,7 +69,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 40px;
   line-height: 48px;
   font-weight: 300;
@@ -85,7 +85,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 28px;
   line-height: 34px;
   font-weight: 600;
@@ -101,7 +101,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 22px;
   line-height: 28px;
   font-weight: 600;
@@ -117,7 +117,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 24px;
   font-weight: 600;
@@ -133,7 +133,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 20px;
   font-weight: 600;
@@ -149,7 +149,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 20px;
   font-weight: 600;
@@ -165,7 +165,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 32px;
   line-height: 38px;
   font-weight: 300;
@@ -181,7 +181,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 32px;
   line-height: 38px;
   font-weight: 600;
@@ -197,7 +197,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 32px;
   line-height: 38px;
   font-weight: 300;
@@ -213,7 +213,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 26px;
   line-height: 32px;
   font-weight: 600;
@@ -229,7 +229,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 20px;
   line-height: 26px;
   font-weight: 600;
@@ -245,7 +245,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 20px;
   font-weight: 600;
@@ -261,7 +261,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 20px;
   font-weight: 600;
@@ -277,7 +277,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 20px;
   font-weight: 600;

--- a/src/core/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/__snapshots__/Link.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/core/Panel/PanelExpansionGroup.baseStyles.tsx
+++ b/src/core/Panel/PanelExpansionGroup.baseStyles.tsx
@@ -28,7 +28,7 @@ export const baseStyles = withSuomifiTheme(
 
   & > .fi-panel-expansion-group_all-button {
     ${element({ theme })}
-    ${font({ theme })('bodySemiBold')}
+    ${font({ theme })('actionElementInnerTextBold')}
     ${focus({ theme })}
     flex: 1;
     margin-left: auto;

--- a/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
+++ b/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -157,7 +157,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;

--- a/src/core/Paragraph/__snapshots__/Paragraph.test.tsx.snap
+++ b/src/core/Paragraph/__snapshots__/Paragraph.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/core/Text/Text.baseStyles.ts
+++ b/src/core/Text/Text.baseStyles.ts
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../theme';
 import { TextProps } from './Text';
-import { element, font } from '../theme/reset';
+import { element, font, internalTokenFont } from '../theme/reset';
 import { objValue } from '../../utils/typescript';
 
 export const baseStyles = withSuomifiTheme(
@@ -12,7 +12,7 @@ export const baseStyles = withSuomifiTheme(
 
   &.fi-text {
     &--bold {
-      ${font({ theme })('bodySemiBold')}
+      ${internalTokenFont('bodySemiBold')}
     }
     &--lead {
       ${font({ theme })('leadText')}
@@ -20,7 +20,7 @@ export const baseStyles = withSuomifiTheme(
     &--small-screen {
       ${font({ theme })('bodyTextSmallScreen')}
       &.fi-text--bold {
-        ${font({ theme })('bodySemiBoldSmallScreen')}
+        ${internalTokenFont('bodySemiBoldSmallScreen')}
       }
       &.fi-text--lead {
         ${font({ theme })('leadTextSmallScreen')}

--- a/src/core/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/core/Text/__snapshots__/Text.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -58,7 +58,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -104,7 +104,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -121,7 +121,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
@@ -137,7 +137,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 22px;
   line-height: 1.5;
   font-weight: 400;
@@ -153,7 +153,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -169,7 +169,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
@@ -185,7 +185,7 @@ exports[`calling render with the same component on the same container does not r
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 20px;
   line-height: 1.5;
   font-weight: 400;

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`snapshot testing 1`] = `
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
@@ -193,7 +193,7 @@ exports[`snapshot testing 1`] = `
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
@@ -326,8 +326,8 @@ exports[`snapshot testing 1`] = `
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
-  font-size: 18px;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
   -webkit-flex: 1;

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -1,15 +1,24 @@
 import { FlattenSimpleInterpolation } from 'styled-components';
-import { typographyTokens } from './typography';
+import {
+  typography,
+  TypographyProp,
+  internalTypographyTokens,
+  internalTypographyTokensProp,
+} from './typography';
 import { typographyUtils } from './utils';
 import { colors, shadows, gradients, outlines } from './colors';
 import { spacing } from './spacing';
 import { zindexes } from './zindexes';
 import { transitions } from './transitions';
 import { radius } from './radius';
+export {
+  TypographyProp,
+  internalTypographyTokens,
+  internalTypographyTokensProp,
+};
 
 export type SuomifiTokens = typeof importedTokens;
 export type DefaultSuomifiTokens = typeof defaultTokens;
-export type TypographyProp = keyof typeof importedTokens.typography;
 export type ColorProp = keyof typeof importedTokens.colors;
 export type SpacingProp = keyof typeof importedTokens.spacing;
 export type SuomifiTheme = ReturnType<typeof suomifiTheme>;
@@ -44,7 +53,7 @@ const internalTokens = {
 const importedTokens = {
   colors,
   spacing,
-  typography: typographyTokens,
+  typography,
 };
 
 export const defaultTokens = {

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -1,5 +1,9 @@
 import { css } from 'styled-components';
-import { TypographyProp } from '../';
+import {
+  TypographyProp,
+  internalTypographyTokens,
+  internalTypographyTokensProp,
+} from '../';
 import {
   focus as focusUtil,
   themeOrTokens,
@@ -12,15 +16,26 @@ export const element = (props: TokensOrThemeProps) => css`
   color: ${themeOrTokens(props).colors.blackBase};
 `;
 
-export const font = (props: TokensOrThemeProps) => (
-  typographyToken: TypographyProp,
-) => css`
+const fontBase = css`
   letter-spacing: 0;
   text-decoration: none;
   word-break: break-word;
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
+`;
+
+export const font = (props: TokensOrThemeProps) => (
+  typographyToken: TypographyProp,
+) => css`
+  ${fontBase}
   ${themeOrTokens(props).typography[typographyToken]}
+`;
+
+export const internalTokenFont = (
+  typographyToken: keyof internalTypographyTokensProp,
+) => css`
+  ${fontBase}
+  ${internalTypographyTokens[typographyToken]}
 `;
 
 export const input = (props: TokensOrThemeProps) => {
@@ -28,7 +43,7 @@ export const input = (props: TokensOrThemeProps) => {
   return css`
     ${element(props)}
     ${font(props)('actionElementInnerText')}
-  min-width: 245px;
+    min-width: 245px;
     max-width: 100%;
     padding: ${theme.spacing.s} ${theme.spacing.m};
     border: 1px solid ${theme.colors.depthBase};

--- a/src/core/theme/typography.ts
+++ b/src/core/theme/typography.ts
@@ -1,118 +1,15 @@
-const fontSize = {
-  default: {
-    actionElementInnerText: '16px',
-    body: '18px',
-    lead: '22px',
-    h1: '40px',
-    h2: '28px',
-    h3: '22px',
-    h4: '18px',
-    h5: '16px',
-  },
-  smRes: {
-    actionElementInnerText: '16px',
-    body: '16px',
-    lead: '20px',
-    h1: '32px',
-    h2: '26px',
-    h3: '20px',
-    h4: '16px',
-    h5: '16px',
-  },
-};
+import { tokens } from 'suomifi-design-tokens';
+export type TypographyProp = keyof typeof tokens.typography;
+import { cssObjectToCss } from '../../utils/css';
 
-const lineHeight = {
-  default: {
-    actionElementInnerText: '1.5',
-    lead: '1.5',
-    body: '1.5',
-    h1: '48px',
-    h2: '34px',
-    h3: '28px',
-    h4: '24px',
-    h5: '20px',
-  },
-  smRes: {
-    actionElementInnerText: '1.5',
-    lead: '1.5',
-    body: '1.5',
-    h1: '38px',
-    h2: '32px',
-    h3: '26px',
-    h4: '20px',
-    h5: '20px',
-  },
-};
+export const typography = tokens.typography;
 
-export const fontFamily = 'Source Sans Pro';
-const fontFamilyWithFallbacks = `'${fontFamily}','Helvetica Neue', Arial, sans-serif`;
-
-const fontWeights = {
-  light: 300,
-  normal: 400,
-  semiBold: 600,
-};
-
-const tokenMap = {
-  // TODO Define as variations from imported typography token
-  bodySemiBold: ['default', 'body', 'semiBold'],
-  bodySemiBoldSmallScreen: ['smRes', 'body', 'semiBold'],
-  // Regression fallbacks (TODO Create linter to have this ruled as deprecated)
-  body: ['default', 'body'],
-  // TODO remove when tokens from suomifi-design-tokens
-  actionElementInnerText: ['default', 'actionElementInnerText'],
-  actionElementInnerTextSmallScreen: ['default', 'actionElementInnerText'],
-  actionElementInnerTextBold: ['default', 'actionElementInnerText', 'semiBold'],
-  actionElementInnerTextBoldSmallScreen: [
-    'default',
-    'actionElementInnerText',
-    'semiBold',
-  ],
-  bodyText: ['default', 'body'],
-  bodyTextSmallScreen: ['smRes', 'body'],
-  leadText: ['default', 'lead'],
-  leadTextSmallScreen: ['smRes', 'lead'],
-  heading1Hero: ['default', 'h1', 'semiBold'],
-  heading1HeroSmallScreen: ['smRes', 'h1', 'semiBold'],
-  heading1: ['default', 'h1', 'light'],
-  heading1SmallScreen: ['smRes', 'h1', 'light'],
-  heading2: ['default', 'h2', 'semiBold'],
-  heading2SmallScreen: ['smRes', 'h2', 'semiBold'],
-  heading3: ['default', 'h3', 'semiBold'],
-  heading3SmallScreen: ['smRes', 'h3', 'semiBold'],
-  heading4: ['default', 'h4', 'semiBold'],
-  heading4SmallScreen: ['smRes', 'h4', 'semiBold'],
-  heading5: ['default', 'h5', 'semiBold'],
-  heading5SmallScreen: ['smRes', 'h5', 'semiBold'],
-  heading6: ['default', 'h6', 'semiBold'],
-  heading6SmallScreen: ['smRes', 'h6', 'semiBold'],
-};
-
-type tokenConversionProp = [
-  keyof typeof tokenMap,
-  [
-    keyof typeof fontSize,
-    keyof typeof fontSize.default,
-    keyof typeof fontWeights
-  ]
-];
-export type TypographyTokens = {
-  [key in keyof typeof tokenMap]: {
-    fontFamily: string;
-    fontSize: string;
-    lineHeight: number | string;
-    fontWeight: number | string;
-  }
-};
-export const typographyTokens = Object.entries(tokenMap).reduce(
-  (retObj, [key, [size, oldToken, fontWeight]]: tokenConversionProp) => ({
-    ...retObj,
-    [key]: {
-      fontFamily: fontFamilyWithFallbacks,
-      fontSize: fontSize[size][oldToken],
-      lineHeight: lineHeight[size][oldToken],
-      fontWeight: fontWeights[!!fontWeight ? fontWeight : 'normal'],
-    },
+export const internalTypographyTokens = {
+  bodySemiBold: cssObjectToCss({ ...typography.bodyText, fontWeight: 600 }),
+  bodySemiBoldSmallScreen: cssObjectToCss({
+    ...typography.bodyTextSmallScreen,
+    fontWeight: 600,
   }),
-  {} as TypographyTokens,
-);
+};
+
+export type internalTypographyTokensProp = typeof internalTypographyTokens;

--- a/src/core/theme/utils/index.ts
+++ b/src/core/theme/utils/index.ts
@@ -6,4 +6,4 @@ export {
 export { focus } from './focus';
 export { boxshadowOutline } from './outline';
 export { margin, padding, spacingModifiers } from './spacing';
-export { typographyUtils } from './typography';
+export { typographyUtils, fontSize } from './typography';

--- a/src/core/theme/utils/typography.ts
+++ b/src/core/theme/utils/typography.ts
@@ -1,20 +1,22 @@
 import {
   cssObjectsToCss,
   FlattenSimpleInterpolation,
+  cssValueToString,
 } from '../../../utils/css';
-import { typographyTokens, TypographyTokens } from '../typography';
+import { tokens, TypograhpyDesingTokens } from 'suomifi-design-tokens';
+import { SuomifiTheme } from '../';
 
 export type TypographyTokensAsCss = {
-  [key in keyof typeof typographyTokens]: string
+  [key in keyof typeof tokens.typography]: string
 };
 
 type TypographyTokensAsCssProp = {
-  [key in keyof TypographyTokens]: FlattenSimpleInterpolation
+  [key in keyof TypograhpyDesingTokens]: FlattenSimpleInterpolation
 };
 export interface TypographyUtil extends TypographyTokensAsCssProp {}
 export class TypographyUtil {
   static instance: TypographyUtil;
-  constructor(tokens: TypographyTokens) {
+  constructor(tokens: TypograhpyDesingTokens) {
     // If instance not created, does not take on account if tokens is different!
     if (!TypographyUtil.instance) {
       // Assing typographyTokens as CSS FlattenSimpleInterpolation to this object
@@ -30,8 +32,18 @@ export class TypographyUtil {
  * @param typography Typography-tokens
  * @return typographyWithUtils Typography-tokens and typography-tokens as CSS strings
  */
-export const typographyUtils = (typography: TypographyTokens) => {
+export const typographyUtils = (typography: TypograhpyDesingTokens) => {
   const instance = new TypographyUtil(typography);
   Object.freeze(instance);
   return instance;
+};
+
+type ValueTypographyTokenProp = keyof typeof tokens.typography;
+export const fontSize = (props: {
+  theme: SuomifiTheme;
+  [key: string]: any | any[];
+}) => (typographyToken: ValueTypographyTokenProp) => {
+  return cssValueToString(
+    props.theme.values.typography[typographyToken].fontSize,
+  );
 };

--- a/src/utils/css/index.ts
+++ b/src/utils/css/index.ts
@@ -5,4 +5,5 @@ export {
   cssObjectToCss,
   cssObjectsToCss,
   FlattenSimpleInterpolation,
+  cssValueToString,
 } from './utils';

--- a/src/utils/css/utils.ts
+++ b/src/utils/css/utils.ts
@@ -9,6 +9,22 @@ export const clearfix = css`
   }
 `;
 
+interface ValueAndUnit {
+  value: number | string;
+  unit: string;
+}
+/**
+ * Return FlattenSimpleInterpolation compatible string or number
+ * @param cssValue compatible value or {value, unit} pair-object
+ */
+const cssValueToString = (cssValue: number | string | ValueAndUnit) => {
+  if (!!cssValue && typeof cssValue === 'object' && 'value' in cssValue) {
+    const { value, unit } = cssValue;
+    return !!unit ? `${value}${unit}` : value;
+  }
+  return cssValue;
+};
+
 const camelToSnake = (string: string) =>
   string.replace(/[\w]([A-Z])/g, m => `${m[0]}-${m[1]}`).toLowerCase();
 /**
@@ -17,7 +33,7 @@ const camelToSnake = (string: string) =>
  */
 export const cssObjectToCss = <T>(value: T) => css`
   ${Object.entries(value)
-    .map(([key, value]) => `${camelToSnake(key)}: ${value};`)
+    .map(([key, value]) => `${camelToSnake(key)}: ${cssValueToString(value)};`)
     .join('')}
 `;
 

--- a/src/utils/css/utils.ts
+++ b/src/utils/css/utils.ts
@@ -1,4 +1,5 @@
 import { css, FlattenSimpleInterpolation } from 'styled-components';
+import { ValueUnit } from 'suomifi-design-tokens';
 export { FlattenSimpleInterpolation };
 
 export const clearfix = css`
@@ -9,10 +10,6 @@ export const clearfix = css`
   }
 `;
 
-interface ValueAndUnit {
-  value: number | string;
-  unit: string;
-}
 /**
  * Return FlattenSimpleInterpolation compatible string or number
  * @param cssValue compatible value or {value, unit} pair-object

--- a/src/utils/css/utils.ts
+++ b/src/utils/css/utils.ts
@@ -14,7 +14,7 @@ export const clearfix = css`
  * Return FlattenSimpleInterpolation compatible string or number
  * @param cssValue compatible value or {value, unit} pair-object
  */
-const cssValueToString = (cssValue: number | string | ValueAndUnit) => {
+export const cssValueToString = (cssValue: number | string | ValueUnit) => {
   if (!!cssValue && typeof cssValue === 'object' && 'value' in cssValue) {
     const { value, unit } = cssValue;
     return !!unit ? `${value}${unit}` : value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10541,6 +10541,11 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
+suomifi-design-tokens@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.1.0.tgz#c84ee20440cef543c9f3c95ad0989ddfd19dde28"
+  integrity sha512-JUGah/dM2MTVFhiIuoblHT/DcelOJYBiPBbOFEMwSOHxoNTDC/B+Rq2bO7zk6dVZnDFCxV9U76apjzWxDzRb4w==
+
 suomifi-icons@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.0.8.tgz#2a25de59b9e945321d504c0c393f8371d8213bbb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10541,10 +10541,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-suomifi-design-tokens@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.1.0.tgz#c84ee20440cef543c9f3c95ad0989ddfd19dde28"
-  integrity sha512-JUGah/dM2MTVFhiIuoblHT/DcelOJYBiPBbOFEMwSOHxoNTDC/B+Rq2bO7zk6dVZnDFCxV9U76apjzWxDzRb4w==
+suomifi-design-tokens@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.2.1.tgz#adfa14df6617ab26b96884b7071789a398bcf1e7"
+  integrity sha512-C8pkDmi9A8hradqiVfKxtfqfNIGl9ky8T5RoCa7oQRORTzxFu1RudJ83SDkm4/iLR64mCLByeMtwZFvKCveCDw==
 
 suomifi-icons@0.0.8:
   version "0.0.8"


### PR DESCRIPTION
## Description

- Install `suomifi-design-tokens`
- Fix CSS-values to be `string | number | ValueUnit`
- Create utils for using `suomifi-design-tokens` typography format
- Implement BodyTextBold-token internally

## Motivation and Context

Design tokens where separated to `suomifi-design-tokens`-package

## How Has This Been Tested?

`yarn validate`
Styleguidist selected pages
