### PR TITLE
Expansion panel alignment in IE and Edge

### DIFF
--- a/src/core/Panel/PanelExpansionGroup.baseStyles.tsx
+++ b/src/core/Panel/PanelExpansionGroup.baseStyles.tsx
@@ -30,7 +30,8 @@ export const baseStyles = withSuomifiTheme(
     ${element({ theme })}
     ${font({ theme })('bodySemiBold')}
     ${focus({ theme })}
-    flex: 1;
+    flex: 1 1 auto;
+    align-self: flex-end; 
     margin-left: auto;
     margin-bottom: ${theme.spacing.s};
     padding: ${theme.spacing.xs} 0;

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -330,9 +330,12 @@ exports[`snapshot testing 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
   margin-left: auto;
   margin-bottom: 8px;
   padding: 4px 0;


### PR DESCRIPTION
## Description

This PR improves the styles for PanelExpansionGroup open/close all button for IE and Edge. Button is now correctly aligned to the right and not hiding under the expansion panels.

## Related Issue

Closes #191 

## How Has This Been Tested?

The fix has been tested using Chrome locally and with IE11 and Edge using BrowserStack. The fix has also been tested using the styleguidist build and by creating a package using verdaccio and importing it to a local create react app typescript project.

![Screenshot 2019-10-24 at 13 52 22](https://user-images.githubusercontent.com/53744258/67478855-8d0bc780-f665-11e9-86f1-2bf5802fe700.png)