### PR TITLE
[Feature] Differentiating input and button versions of Toggle

### DIFF
--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -5,14 +5,13 @@ import React, {
   ComponentClass,
   FunctionComponent,
 } from 'react';
-import { HtmlLabel, HtmlInput, HtmlSpan } from '../../reset';
 import { idGenerator } from '../../utils/uuid';
-import classnames from 'classnames';
+import { ToggleInput } from './ToggleInput';
+import { ToggleButton } from './ToggleButton';
+export { ToggleButton, ToggleInput };
 
-const baseClassName = 'fi-toggle';
-const toggleDisabledClassName = `${baseClassName}--disabled`;
-const toggleInputClassName = `${baseClassName}_input`;
-const toggleLabelClassName = `${baseClassName}_label`;
+export const baseClassName = 'fi-toggle';
+// const toggleDisabledClassName = `${baseClassName}--disabled`;
 
 export interface ToggleInputProps {
   /** State of input checkbox */
@@ -24,20 +23,6 @@ export interface ToggleInputProps {
   controlled?: boolean;
   'aria-label'?: string;
   'aria-labelledby'?: string;
-}
-
-export class ToggleInput extends Component<ToggleInputProps> {
-  render() {
-    const { disabled = false, controlled, checked, ...passProps } = this.props;
-    return (
-      <HtmlInput
-        disabled={disabled}
-        {...passProps}
-        type="checkbox"
-        checked={!!checked}
-      />
-    );
-  }
 }
 
 export interface ToggleProps {
@@ -57,6 +42,8 @@ export interface ToggleProps {
    * Label element content
    */
   children?: ReactNode;
+  /** Use input instead of button */
+  withInput?: boolean;
   /** Pass custom props to Toggle's input component/element */
   toggleInputProps?: ToggleInputProps;
   /** Customized ToggleInput-component */
@@ -76,97 +63,52 @@ export interface ToggleProps {
   id?: string;
 }
 
-interface ToggleState {
+export interface ToggleState {
   toggleState: boolean;
 }
 
-const componentOrElementWithProps = (
-  component: ReactElement<any> | FunctionComponent<any> | ComponentClass<any>,
-  props: object,
-) => {
-  if (!!component) {
-    if (React.isValidElement(component)) {
-      return React.cloneElement(component, props); // element
-    }
-    return React.createElement(
-      component as FunctionComponent<any> | ComponentClass<any>,
-      props,
-    ); // component
-  }
-  return;
-};
-
 export class Toggle extends Component<ToggleProps> {
-  state: ToggleState = {
-    toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
-  };
+  // state: ToggleState = {
+  //   toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
+  // };
 
-  componentWillReceiveProps(nextProps: ToggleProps) {
-    const { checked } = nextProps;
-    if (!!checked) {
-      this.setState({ toggleState: !!checked });
-    }
-  }
+  // componentWillReceiveProps(nextProps: ToggleProps) {
+  //   const { checked } = nextProps;
+  //   if (!!checked) {
+  //     this.setState({ toggleState: !!checked });
+  //   }
+  // }
 
-  handleClick = () => {
-    const { checked, onClick } = this.props;
-    const { toggleState } = this.state;
-    if (checked === undefined) {
-      this.setState({ toggleState: !toggleState });
-    }
-    if (!!onClick) {
-      onClick({ toggleState: !toggleState });
-    }
-  };
+  // handleClick = () => {
+  //   const { checked, onClick } = this.props;
+  //   const { toggleState } = this.state;
+  //   if (checked === undefined) {
+  //     this.setState({ toggleState: !toggleState });
+  //   }
+  //   if (!!onClick) {
+  //     onClick({ toggleState: !toggleState });
+  //   }
+  // };
 
   render() {
-    const {
-      disabled,
-      className,
-      children,
-      toggleInputProps,
-      toggleInputComponent,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      checked: dissMissChecked,
-      defaultChecked: dissMissDefaultChecked,
-      onClick: dissMissOnClick,
-      id: propId,
-      ...passProps
-    } = this.props;
-    const { toggleState } = this.state;
+    const { withInput, id: propId, ...passProps } = this.props;
+
     const id = idGenerator(propId);
-    const newToggleInputProps = {
-      disabled,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      checked: !!toggleState,
-      className: toggleInputClassName,
-      onChange: this.handleClick,
-      ...toggleInputProps,
+
+    // TODO: passaa kaikki propsit, lisää mahdollisesti jotain; esim. id ja ..?
+    const newToggleProps = {
       id,
+      ...passProps,
     };
 
     return (
-      <HtmlSpan
-        className={classnames(className, baseClassName, {
-          [toggleDisabledClassName]: !!disabled,
-        })}
-      >
-        {!!toggleInputComponent ? (
-          componentOrElementWithProps(toggleInputComponent, newToggleInputProps) // element
+      <React.Fragment>
+        {!!withInput ? (
+          <ToggleInput {...newToggleProps} />
         ) : (
-          <ToggleInput {...newToggleInputProps} />
+          <ToggleButton {...newToggleProps} />
         )}
-        <HtmlLabel
-          {...passProps}
-          className={toggleLabelClassName}
-          onClick={this.handleClick}
-          htmlFor={id}
-        >
-          {children}
-        </HtmlLabel>
-      </HtmlSpan>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -74,14 +74,10 @@ export class Toggle extends Component<ToggleProps> {
       ...passProps,
     };
 
-    return (
-      <React.Fragment>
-        {!!withInput ? (
-          <ToggleInput {...newToggleProps} />
-        ) : (
-          <ToggleButton {...newToggleProps} />
-        )}
-      </React.Fragment>
+    return !!withInput ? (
+      <ToggleInput {...newToggleProps} />
+    ) : (
+      <ToggleButton {...newToggleProps} />
     );
   }
 }

--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -24,7 +24,7 @@ export interface ToggleInputProps {
 }
 
 export interface ToggleProps {
-  /** Controlled toggle-state, use onClick to change  */
+  /** Controlled toggle-state - user actions use onClick to change  */
   checked?: boolean;
   /** Default status of toggle when not using controlled 'checked' state
    * @default false

--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -19,7 +19,6 @@ export interface ToggleInputProps {
   className?: string;
   /** Disable Button usage */
   disabled?: boolean;
-  controlled?: boolean;
   'aria-label'?: string;
   'aria-labelledby'?: string;
 }

--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -10,7 +10,6 @@ import { ToggleInput } from './ToggleInput';
 import { ToggleButton } from './ToggleButton';
 
 export { ToggleInput };
-export const baseClassName = 'fi-toggle';
 
 type ToggleVariant = 'default' | 'withInput';
 

--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -33,7 +33,7 @@ export interface ToggleProps {
   defaultChecked?: boolean;
   /** Custom classname to extend or customize */
   className?: string;
-  /** Disable Button usage */
+  /** Disable usage */
   disabled?: boolean;
   /** Event handler to execute when clicked */
   onClick?: ({ toggleState }: { toggleState: boolean }) => void;

--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -9,7 +9,7 @@ import { idGenerator } from '../../utils/uuid';
 import { ToggleInput } from './ToggleInput';
 import { ToggleButton } from './ToggleButton';
 
-export { ToggleButton, ToggleInput };
+export { ToggleInput };
 export const baseClassName = 'fi-toggle';
 
 export interface ToggleInputProps {

--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -12,6 +12,8 @@ import { ToggleButton } from './ToggleButton';
 export { ToggleInput };
 export const baseClassName = 'fi-toggle';
 
+type ToggleVariant = 'default' | 'withInput';
+
 export interface ToggleInputProps {
   /** State of input checkbox */
   checked?: boolean;
@@ -40,8 +42,11 @@ export interface ToggleProps {
    * Label element content
    */
   children?: ReactNode;
-  /** Use input instead of button */
-  withInput?: boolean;
+  /**
+   * 'default' | 'withInput'
+   * @default default
+   */
+  variant?: ToggleVariant;
   /** Pass custom props to Toggle's input component/element */
   toggleInputProps?: ToggleInputProps;
   /** Customized ToggleInput-component */
@@ -67,14 +72,14 @@ export interface ToggleState {
 
 export class Toggle extends Component<ToggleProps> {
   render() {
-    const { withInput, id: propId, ...passProps } = this.props;
+    const { variant = 'default', id: propId, ...passProps } = this.props;
     const id = idGenerator(propId);
     const newToggleProps = {
       id,
       ...passProps,
     };
 
-    return !!withInput ? (
+    return variant === 'withInput' ? (
       <ToggleInput {...newToggleProps} />
     ) : (
       <ToggleButton {...newToggleProps} />

--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -8,10 +8,9 @@ import React, {
 import { idGenerator } from '../../utils/uuid';
 import { ToggleInput } from './ToggleInput';
 import { ToggleButton } from './ToggleButton';
-export { ToggleButton, ToggleInput };
 
+export { ToggleButton, ToggleInput };
 export const baseClassName = 'fi-toggle';
-// const toggleDisabledClassName = `${baseClassName}--disabled`;
 
 export interface ToggleInputProps {
   /** State of input checkbox */
@@ -68,34 +67,9 @@ export interface ToggleState {
 }
 
 export class Toggle extends Component<ToggleProps> {
-  // state: ToggleState = {
-  //   toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
-  // };
-
-  // componentWillReceiveProps(nextProps: ToggleProps) {
-  //   const { checked } = nextProps;
-  //   if (!!checked) {
-  //     this.setState({ toggleState: !!checked });
-  //   }
-  // }
-
-  // handleClick = () => {
-  //   const { checked, onClick } = this.props;
-  //   const { toggleState } = this.state;
-  //   if (checked === undefined) {
-  //     this.setState({ toggleState: !toggleState });
-  //   }
-  //   if (!!onClick) {
-  //     onClick({ toggleState: !toggleState });
-  //   }
-  // };
-
   render() {
     const { withInput, id: propId, ...passProps } = this.props;
-
     const id = idGenerator(propId);
-
-    // TODO: passaa kaikki propsit, lisää mahdollisesti jotain; esim. id ja ..?
     const newToggleProps = {
       id,
       ...passProps,

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -1,8 +1,11 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { HtmlButton } from '../../reset';
-import { ToggleProps, baseClassName, ToggleState } from './Toggle';
+import { ToggleProps, ToggleState } from './Toggle';
 import { logger } from '../../utils/logger';
+
+const baseClassName = 'fi-toggle';
+const toggleDisabledClassName = `${baseClassName}--disabled`;
 
 export class ToggleButton extends Component<ToggleProps> {
   state: ToggleState = {
@@ -50,7 +53,9 @@ export class ToggleButton extends Component<ToggleProps> {
 
     return (
       <HtmlButton
-        className={classnames(toggleClassName, className, baseClassName)}
+        className={classnames(toggleClassName, className, baseClassName, {
+          [toggleDisabledClassName]: !!disabled,
+        })}
         aria-disabled={disabled}
         disabled={disabled}
         tabIndex={0}

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -33,7 +33,7 @@ export class ToggleButton extends Component<ToggleProps> {
     const { toggleState } = this.state;
     const toggleButtonClassName = `${baseClassName}_button`;
 
-    if (toggleInputProps || toggleInputComponent) {
+    if (!!toggleInputProps || !!toggleInputComponent) {
       logger.error(
         `ToggleButton does not utilize 'toggleInputProps' and 'toggleInputComponent' props.`,
       );

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import { HtmlButton } from '../../reset';
+import { ToggleProps, baseClassName, ToggleState } from './Toggle';
+
+export class ToggleButton extends Component<ToggleProps> {
+  state: ToggleState = {
+    toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
+  };
+
+  handleClick = () => {
+    const { checked, onClick } = this.props;
+    const { toggleState } = this.state;
+    if (checked === undefined) {
+      this.setState({ toggleState: !toggleState });
+    }
+    if (!!onClick) {
+      onClick({ toggleState: !toggleState });
+    }
+  };
+
+  render() {
+    const {
+      disabled = false,
+      children,
+      checked: dissMissChecked,
+      defaultChecked: dissMissDefaultChecked,
+      onClick: dissMissOnClick,
+      ...passProps
+    } = this.props;
+    const { toggleState } = this.state;
+    const toggleButtonClassName = `${baseClassName}_button`;
+
+    return (
+      <HtmlButton
+        className={toggleButtonClassName}
+        {...passProps}
+        aria-disabled={disabled}
+        tabIndex={0}
+        onClick={this.handleClick}
+        checked={!!toggleState}
+      >
+        {children}
+      </HtmlButton>
+    );
+  }
+}

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -35,7 +35,7 @@ export class ToggleButton extends Component<ToggleProps> {
 
     if (toggleInputProps || toggleInputComponent) {
       logger.error(
-        "ToggleButton does not utilize 'toggleInputProps' and 'toggleInputComponent' props.",
+        `ToggleButton does not utilize 'toggleInputProps' and 'toggleInputComponent' props.`,
       );
       return false;
     }
@@ -43,12 +43,12 @@ export class ToggleButton extends Component<ToggleProps> {
     return (
       <HtmlButton
         className={toggleButtonClassName}
-        {...passProps}
         aria-disabled={disabled}
+        disabled={disabled}
         tabIndex={0}
         onClick={this.handleClick}
-        checked={!!toggleState}
         aria-pressed={!!toggleState}
+        {...passProps}
       >
         {children}
       </HtmlButton>

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -43,7 +43,7 @@ export class ToggleButton extends Component<ToggleProps> {
       ...passProps
     } = this.props;
     const { toggleState } = this.state;
-    const toggleClassName = `${baseClassName}--button`;
+    const toggleClassName = `${baseClassName}--with-button`;
 
     if (!!toggleInputProps || !!toggleInputComponent) {
       logger.error(

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import { HtmlButton } from '../../reset';
 import { ToggleProps, baseClassName, ToggleState } from './Toggle';
 import { logger } from '../../utils/logger';
@@ -28,6 +29,7 @@ export class ToggleButton extends Component<ToggleProps> {
 
   render() {
     const {
+      className,
       disabled = false,
       children,
       checked: dissMissChecked,
@@ -38,7 +40,7 @@ export class ToggleButton extends Component<ToggleProps> {
       ...passProps
     } = this.props;
     const { toggleState } = this.state;
-    const toggleButtonClassName = `${baseClassName}_button`;
+    const toggleClassName = `${baseClassName}--button`;
 
     if (!!toggleInputProps || !!toggleInputComponent) {
       logger.error(
@@ -48,7 +50,7 @@ export class ToggleButton extends Component<ToggleProps> {
 
     return (
       <HtmlButton
-        className={toggleButtonClassName}
+        className={classnames(toggleClassName, className, baseClassName)}
         aria-disabled={disabled}
         disabled={disabled}
         tabIndex={0}

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { HtmlButton } from '../../reset';
 import { ToggleProps, baseClassName, ToggleState } from './Toggle';
+import { logger } from '../../utils/logger';
 
 export class ToggleButton extends Component<ToggleProps> {
   state: ToggleState = {
@@ -25,10 +26,19 @@ export class ToggleButton extends Component<ToggleProps> {
       checked: dissMissChecked,
       defaultChecked: dissMissDefaultChecked,
       onClick: dissMissOnClick,
+      toggleInputProps,
+      toggleInputComponent,
       ...passProps
     } = this.props;
     const { toggleState } = this.state;
     const toggleButtonClassName = `${baseClassName}_button`;
+
+    if (toggleInputProps || toggleInputComponent) {
+      logger.error(
+        "ToggleButton does not utilize 'toggleInputProps' and 'toggleInputComponent' props.",
+      );
+      return false;
+    }
 
     return (
       <HtmlButton

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -37,7 +37,6 @@ export class ToggleButton extends Component<ToggleProps> {
       logger.error(
         `ToggleButton does not utilize 'toggleInputProps' and 'toggleInputComponent' props.`,
       );
-      return false;
     }
 
     return (

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -8,6 +8,13 @@ export class ToggleButton extends Component<ToggleProps> {
     toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
   };
 
+  componentWillReceiveProps(nextProps: ToggleProps) {
+    const { checked } = nextProps;
+    if (!!checked) {
+      this.setState({ toggleState: !!checked });
+    }
+  }
+
   handleClick = () => {
     const { checked, onClick } = this.props;
     const { toggleState } = this.state;

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -38,6 +38,7 @@ export class ToggleButton extends Component<ToggleProps> {
         tabIndex={0}
         onClick={this.handleClick}
         checked={!!toggleState}
+        aria-pressed={!!toggleState}
       >
         {children}
       </HtmlButton>

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -75,6 +75,7 @@ export class ToggleInput extends Component<ToggleProps> {
           componentOrElementWithProps(toggleInputComponent, this.props)
         ) : (
           <HtmlInput
+            id={id}
             className={toggleInputClassName}
             disabled={disabled}
             {...passProps}

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -54,7 +54,10 @@ export class ToggleInput extends Component<ToggleProps> {
       id,
       className,
       disabled = false,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
       children,
+      toggleInputProps,
       toggleInputComponent,
       checked: dissMissChecked,
       defaultChecked: dissMissDefaultChecked,
@@ -65,6 +68,17 @@ export class ToggleInput extends Component<ToggleProps> {
     const toggleInputClassName = `${baseClassName}_input`;
     const toggleLabelClassName = `${baseClassName}_label`;
 
+    const newToggleInputProps = {
+      disabled,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      checked: !!toggleState,
+      className: toggleInputClassName,
+      onChange: this.handleClick,
+      ...toggleInputProps,
+      id,
+    };
+
     return (
       <HtmlSpan
         className={classnames(className, baseClassName, {
@@ -72,17 +86,9 @@ export class ToggleInput extends Component<ToggleProps> {
         })}
       >
         {!!toggleInputComponent ? (
-          componentOrElementWithProps(toggleInputComponent, this.props)
+          componentOrElementWithProps(toggleInputComponent, newToggleInputProps)
         ) : (
-          <HtmlInput
-            id={id}
-            className={toggleInputClassName}
-            disabled={disabled}
-            {...passProps}
-            type="checkbox"
-            checked={!!toggleState}
-            onChange={this.handleClick}
-          />
+          <HtmlInput {...newToggleInputProps} type="checkbox" />
         )}
         <HtmlLabel
           {...passProps}

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -65,6 +65,7 @@ export class ToggleInput extends Component<ToggleProps> {
       ...passProps
     } = this.props;
     const { toggleState } = this.state;
+    const toggleClassName = `${baseClassName}--input`;
     const toggleInputClassName = `${baseClassName}_input`;
     const toggleLabelClassName = `${baseClassName}_label`;
 
@@ -81,7 +82,7 @@ export class ToggleInput extends Component<ToggleProps> {
 
     return (
       <HtmlSpan
-        className={classnames(className, baseClassName, {
+        className={classnames(toggleClassName, className, baseClassName, {
           [toggleDisabledClassName]: !!disabled,
         })}
       >

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -81,6 +81,7 @@ export class ToggleInput extends Component<ToggleProps> {
             {...passProps}
             type="checkbox"
             checked={!!toggleState}
+            onChange={this.handleClick}
           />
         )}
         <HtmlLabel

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -6,8 +6,9 @@ import React, {
 } from 'react';
 import classnames from 'classnames';
 import { HtmlInput, HtmlLabel, HtmlSpan } from '../../reset';
-import { ToggleProps, baseClassName, ToggleState } from './Toggle';
+import { ToggleProps, ToggleState } from './Toggle';
 
+const baseClassName = 'fi-toggle';
 const toggleDisabledClassName = `${baseClassName}--disabled`;
 
 const componentOrElementWithProps = (

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -66,7 +66,7 @@ export class ToggleInput extends Component<ToggleProps> {
       ...passProps
     } = this.props;
     const { toggleState } = this.state;
-    const toggleClassName = `${baseClassName}--input`;
+    const toggleClassName = `${baseClassName}--with-input`;
     const toggleInputClassName = `${baseClassName}_input`;
     const toggleLabelClassName = `${baseClassName}_label`;
 

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -1,0 +1,96 @@
+import React, {
+  Component,
+  ReactElement,
+  ComponentClass,
+  FunctionComponent,
+} from 'react';
+import classnames from 'classnames';
+import { HtmlInput, HtmlLabel, HtmlSpan } from '../../reset';
+import { ToggleProps, baseClassName, ToggleState } from './Toggle';
+
+const toggleDisabledClassName = `${baseClassName}--disabled`;
+
+const componentOrElementWithProps = (
+  component: ReactElement<any> | FunctionComponent<any> | ComponentClass<any>,
+  props: object,
+) => {
+  if (!!component) {
+    if (React.isValidElement(component)) {
+      return React.cloneElement(component, props); // element
+    }
+    return React.createElement(
+      component as FunctionComponent<any> | ComponentClass<any>,
+      props,
+    ); // component
+  }
+  return;
+};
+
+export class ToggleInput extends Component<ToggleProps> {
+  state: ToggleState = {
+    toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
+  };
+
+  componentWillReceiveProps(nextProps: ToggleProps) {
+    const { checked } = nextProps;
+    if (!!checked) {
+      this.setState({ toggleState: !!checked });
+    }
+  }
+
+  handleClick = () => {
+    const { checked, onClick } = this.props;
+    const { toggleState } = this.state;
+    if (checked === undefined) {
+      this.setState({ toggleState: !toggleState });
+    }
+    if (!!onClick) {
+      onClick({ toggleState: !toggleState });
+    }
+  };
+
+  render() {
+    const {
+      id,
+      className,
+      disabled = false,
+      children,
+      toggleInputComponent,
+      checked: dissMissChecked,
+      defaultChecked: dissMissDefaultChecked,
+      onClick: dissMissOnClick,
+      ...passProps
+    } = this.props;
+    const { toggleState } = this.state;
+    const toggleInputClassName = `${baseClassName}_input`;
+    const toggleLabelClassName = `${baseClassName}_label`;
+
+    return (
+      <HtmlSpan
+        className={classnames(className, baseClassName, {
+          [toggleDisabledClassName]: !!disabled,
+        })}
+      >
+        {!!toggleInputComponent ? (
+          componentOrElementWithProps(toggleInputComponent, this.props)
+        ) : (
+          <HtmlInput
+            className={toggleInputClassName}
+            disabled={disabled}
+            {...passProps}
+            type="checkbox"
+            checked={!!toggleState}
+          />
+        )}
+        <HtmlLabel
+          {...passProps}
+          className={toggleLabelClassName}
+          onClick={this.handleClick}
+          htmlFor={id}
+        >
+          {children}
+        </HtmlLabel>
+      </HtmlSpan>
+    );
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,7 +13,6 @@ export {
   Toggle,
   ToggleProps,
   ToggleInputProps,
-  ToggleButton,
   ToggleInput,
 } from './Form/Toggle';
 export { Heading, HeadingProps } from './Heading/Heading';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,8 +12,9 @@ export { TextInput, TextInputProps } from './Form/TextInput';
 export {
   Toggle,
   ToggleProps,
-  ToggleInput,
   ToggleInputProps,
+  ToggleButton,
+  ToggleInput,
 } from './Form/Toggle';
 export { Heading, HeadingProps } from './Heading/Heading';
 export { Icon, IconProps } from './Icon/Icon';

--- a/src/core/Form/Toggle/Toggle.md
+++ b/src/core/Form/Toggle/Toggle.md
@@ -1,7 +1,14 @@
 ```js
 import { Toggle } from 'suomifi-ui-components';
-
-<Toggle onClick={({ toggleState }) => console.log(toggleState)}>
-  Test
-</Toggle>;
+<>
+  <Toggle onClick={({ toggleState }) => console.log(toggleState)}>
+    Toggle button
+  </Toggle>
+  <Toggle
+    withInput={true}
+    onClick={({ toggleState }) => console.log(toggleState)}
+  >
+    Toggle input
+  </Toggle>
+</>;
 ```

--- a/src/core/Form/Toggle/Toggle.md
+++ b/src/core/Form/Toggle/Toggle.md
@@ -4,11 +4,10 @@ import { Toggle } from 'suomifi-ui-components';
   <Toggle onClick={({ toggleState }) => console.log(toggleState)}>
     Toggle button
   </Toggle>
-  <Toggle
-    withInput={true}
+  <Toggle.withInput
     onClick={({ toggleState }) => console.log(toggleState)}
   >
     Toggle input
-  </Toggle>
+  </Toggle.withInput>
 </>;
 ```

--- a/src/core/Form/Toggle/Toggle.test.tsx
+++ b/src/core/Form/Toggle/Toggle.test.tsx
@@ -17,6 +17,12 @@ const TestToggleWithInput = (
   </Toggle>
 );
 
+const TestToggleWithButton = (
+  <Toggle onClick={doNothing} data-testid="toggle" id="test-toggle">
+    Test
+  </Toggle>
+);
+
 test('Input: calling render with the same component on the same container does not remount', () => {
   const toggleInputRendered = render(TestToggleWithInput);
   const { getByTestId, container, rerender } = toggleInputRendered;
@@ -32,7 +38,27 @@ test('Input: calling render with the same component on the same container does n
   expect(getByTestId('elggot').textContent).toBe('Test two');
 });
 
+test('Button: calling render with the same component on the same container does not remount', () => {
+  const toggleButtonRendered = render(TestToggleWithButton);
+  const { getByTestId, container, rerender } = toggleButtonRendered;
+  expect(container.firstChild).toMatchSnapshot();
+  expect(getByTestId('toggle').textContent).toBe('Test');
+
+  // re-render the same component with different props
+  rerender(
+    <Toggle onClick={doNothing} data-testid="elggot">
+      Test two
+    </Toggle>,
+  );
+  expect(getByTestId('elggot').textContent).toBe('Test two');
+});
+
 test(
-  'should not have basic accessibility issues',
+  'Input: should not have basic accessibility issues',
   axeTest(TestToggleWithInput),
+);
+
+test(
+  'Button: should not have basic accessibility issues',
+  axeTest(TestToggleWithButton),
 );

--- a/src/core/Form/Toggle/Toggle.test.tsx
+++ b/src/core/Form/Toggle/Toggle.test.tsx
@@ -6,25 +6,33 @@ import { Toggle } from './Toggle';
 
 const doNothing = () => ({});
 
-const TestToggle = (
-  <Toggle onClick={doNothing} data-testid="toggle" id="test-toggle">
+const TestToggleWithInput = (
+  <Toggle
+    onClick={doNothing}
+    data-testid="toggle"
+    id="test-toggle"
+    withInput={true}
+  >
     Test
   </Toggle>
 );
 
 test('calling render with the same component on the same container does not remount', () => {
-  const buttonRendered = render(TestToggle);
+  const buttonRendered = render(TestToggleWithInput);
   const { getByTestId, container, rerender } = buttonRendered;
   expect(container.firstChild).toMatchSnapshot();
   expect(getByTestId('toggle').textContent).toBe('Test');
 
   // re-render the same component with different props
   rerender(
-    <Toggle onClick={doNothing} data-testid="elggot">
+    <Toggle onClick={doNothing} data-testid="elggot" withInput={true}>
       Test two
     </Toggle>,
   );
   expect(getByTestId('elggot').textContent).toBe('Test two');
 });
 
-test('should not have basic accessibility issues', axeTest(TestToggle));
+test(
+  'should not have basic accessibility issues',
+  axeTest(TestToggleWithInput),
+);

--- a/src/core/Form/Toggle/Toggle.test.tsx
+++ b/src/core/Form/Toggle/Toggle.test.tsx
@@ -15,7 +15,7 @@ const CreateTestToggle = (
     onClick={doNothing}
     data-testid={dataTestId}
     id="test-toggle"
-    withInput={withInput}
+    variant={withInput ? 'withInput' : 'default'}
   >
     {text}
   </Toggle>

--- a/src/core/Form/Toggle/Toggle.test.tsx
+++ b/src/core/Form/Toggle/Toggle.test.tsx
@@ -17,9 +17,9 @@ const TestToggleWithInput = (
   </Toggle>
 );
 
-test('calling render with the same component on the same container does not remount', () => {
-  const buttonRendered = render(TestToggleWithInput);
-  const { getByTestId, container, rerender } = buttonRendered;
+test('Input: calling render with the same component on the same container does not remount', () => {
+  const toggleInputRendered = render(TestToggleWithInput);
+  const { getByTestId, container, rerender } = toggleInputRendered;
   expect(container.firstChild).toMatchSnapshot();
   expect(getByTestId('toggle').textContent).toBe('Test');
 

--- a/src/core/Form/Toggle/Toggle.test.tsx
+++ b/src/core/Form/Toggle/Toggle.test.tsx
@@ -6,22 +6,23 @@ import { Toggle } from './Toggle';
 
 const doNothing = () => ({});
 
-const TestToggleWithInput = (
+const CreateTestToggle = (
+  withInput: boolean,
+  text: string,
+  dataTestId: string,
+) => (
   <Toggle
     onClick={doNothing}
-    data-testid="toggle"
+    data-testid={dataTestId}
     id="test-toggle"
-    withInput={true}
+    withInput={withInput}
   >
-    Test
+    {text}
   </Toggle>
 );
 
-const TestToggleWithButton = (
-  <Toggle onClick={doNothing} data-testid="toggle" id="test-toggle">
-    Test
-  </Toggle>
-);
+const TestToggleWithInput = CreateTestToggle(true, 'Test', 'toggle');
+const TestToggleWithButton = CreateTestToggle(false, 'Test', 'toggle');
 
 test('Input: calling render with the same component on the same container does not remount', () => {
   const toggleInputRendered = render(TestToggleWithInput);
@@ -30,11 +31,7 @@ test('Input: calling render with the same component on the same container does n
   expect(getByTestId('toggle').textContent).toBe('Test');
 
   // re-render the same component with different props
-  rerender(
-    <Toggle onClick={doNothing} data-testid="elggot" withInput={true}>
-      Test two
-    </Toggle>,
-  );
+  rerender(CreateTestToggle(true, 'Test two', 'elggot'));
   expect(getByTestId('elggot').textContent).toBe('Test two');
 });
 
@@ -45,11 +42,7 @@ test('Button: calling render with the same component on the same container does 
   expect(getByTestId('toggle').textContent).toBe('Test');
 
   // re-render the same component with different props
-  rerender(
-    <Toggle onClick={doNothing} data-testid="elggot">
-      Test two
-    </Toggle>,
-  );
+  rerender(CreateTestToggle(false, 'Test two', 'elggot'));
   expect(getByTestId('elggot').textContent).toBe('Test two');
 });
 

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -54,7 +54,11 @@ export class Toggle extends Component<ToggleProps> {
     const { toggleStatus } = this.state;
 
     return (
-      <StyledToggle {...passProps} onClick={this.handleToggle}>
+      <StyledToggle
+        disabled={disabled}
+        {...passProps}
+        onClick={this.handleToggle}
+      >
         <Icon
           icon="toggle"
           className={classnames(iconBaseClassName, {

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -75,11 +75,13 @@ class ToggleWithIcon extends Component<ToggleProps> {
 
 export class Toggle extends Component<ToggleProps> {
   static withInput = (props: ToggleProps) => {
-    return <ToggleWithIcon {...props} variant="withInput" />;
+    return (
+      <ToggleWithIcon {...withSuomifiDefaultProps(props)} variant="withInput" />
+    );
   };
 
   render() {
-    return <ToggleWithIcon {...this.props} />;
+    return <ToggleWithIcon {...withSuomifiDefaultProps(this.props)} />;
   }
 }
 

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -31,7 +31,7 @@ const StyledToggle = styled(
  * <i class="semantics" />
  * Use for toggling form selection or application state
  */
-export class Toggle extends Component<ToggleProps> {
+class ToggleWithIcon extends Component<ToggleProps> {
   state = { toggleStatus: !!this.props.checked };
 
   handleToggle = () => {
@@ -70,6 +70,16 @@ export class Toggle extends Component<ToggleProps> {
         {children}
       </StyledToggle>
     );
+  }
+}
+
+export class Toggle extends Component<ToggleProps> {
+  static withInput = (props: ToggleProps) => {
+    return <ToggleWithIcon {...props} variant="withInput" />;
+  };
+
+  render() {
+    return <ToggleWithIcon {...this.props} />;
   }
 }
 

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`Button: calling render with the same component on the same container do
 <button
   aria-disabled="false"
   aria-pressed="false"
-  class="fi-toggle--button c0 fi-toggle c1"
+  class="fi-toggle--with-button c0 fi-toggle c1"
   data-testid="toggle"
   id="test-toggle"
   tabindex="0"
@@ -554,7 +554,7 @@ exports[`Input: calling render with the same component on the same container doe
 }
 
 <span
-  class="fi-toggle--input c0 fi-toggle c1"
+  class="fi-toggle--with-input c0 fi-toggle c1"
 >
   <input
     class="fi-toggle_input c2"

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -1,59 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Input: calling render with the same component on the same container does not remount 1`] = `
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  overflow: visible;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline-block;
-  max-width: 100%;
-}
-
-.c2::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
+exports[`Button: calling render with the same component on the same container does not remount 1`] = `
 .c1 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   margin: 0;
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  margin: 0;
   padding: 0;
   border: 0;
   box-sizing: border-box;
@@ -66,20 +22,40 @@ exports[`Input: calling render with the same component on the same container doe
   color: inherit;
   background: none;
   cursor: inherit;
-  display: inline;
+  display: inline-block;
   max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
+  cursor: pointer;
 }
 
-.c4 {
+.c1:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c1::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c1::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c1::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c1::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.c2 {
   display: inline-block;
   vertical-align: baseline;
   cursor: pointer;
 }
 
-.c4 * {
+.c2 * {
   cursor: inherit;
 }
 
@@ -204,181 +180,176 @@ exports[`Input: calling render with the same component on the same container doe
   fill: hsl(166,90%,36%);
 }
 
-<span
-  class="c0 fi-toggle c1"
+<button
+  aria-disabled="false"
+  aria-pressed="false"
+  class="c0 c1"
+  data-testid="toggle"
+  id="test-toggle"
+  tabindex="0"
+  type="button"
 >
-  <input
-    class="fi-toggle_input c2"
-    id="test-toggle"
-    type="checkbox"
-  />
-  <label
-    class="fi-toggle_label c3"
-    data-testid="toggle"
-    for="test-toggle"
+  <svg
+    aria-hidden="true"
+    class="fi-toggle_icon c2"
+    focusable="false"
+    height="1em"
+    viewBox="0 0 38 23"
+    width="1em"
   >
-    <svg
-      aria-hidden="true"
-      class="fi-toggle_icon c4"
-      focusable="false"
-      height="1em"
-      viewBox="0 0 38 23"
-      width="1em"
+    <defs>
+      <lineargradient
+        id="icon-toggle_svg__c"
+        x1="50%"
+        x2="50%"
+        y1="0%"
+        y2="99.021%"
+      >
+        <stop
+          offset="0%"
+          stop-opacity="0"
+        />
+        <stop
+          offset="80%"
+          stop-opacity="0.02"
+        />
+        <stop
+          offset="100%"
+          stop-opacity="0.04"
+        />
+      </lineargradient>
+      <lineargradient
+        id="icon-toggle_svg__d"
+        x1="50%"
+        x2="50%"
+        y1="0%"
+        y2="100%"
+      >
+        <stop
+          offset="0%"
+          stop-color="#FFF"
+          stop-opacity="0.12"
+        />
+        <stop
+          offset="20%"
+          stop-color="#FFF"
+          stop-opacity="0.06"
+        />
+        <stop
+          offset="100%"
+          stop-color="#FFF"
+          stop-opacity="0"
+        />
+      </lineargradient>
+      <filter
+        filterUnits="objectBoundingBox"
+        height="120%"
+        id="icon-toggle_svg__a"
+        width="117.5%"
+        x="-8.8%"
+        y="-8.8%"
+      >
+        <feoffset
+          dy="1"
+          in="SourceAlpha"
+          result="shadowOffsetOuter1"
+        />
+        <fegaussianblur
+          in="shadowOffsetOuter1"
+          result="shadowBlurOuter1"
+          stdDeviation="0.25"
+        />
+        <fecomposite
+          in="shadowBlurOuter1"
+          in2="SourceAlpha"
+          operator="out"
+          result="shadowBlurOuter1"
+        />
+        <fecolormatrix
+          in="shadowBlurOuter1"
+          result="shadowMatrixOuter1"
+          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"
+        />
+        <feoffset
+          in="SourceAlpha"
+          result="shadowOffsetOuter2"
+        />
+        <fegaussianblur
+          in="shadowOffsetOuter2"
+          result="shadowBlurOuter2"
+          stdDeviation="0.5"
+        />
+        <fecomposite
+          in="shadowBlurOuter2"
+          in2="SourceAlpha"
+          operator="out"
+          result="shadowBlurOuter2"
+        />
+        <fecolormatrix
+          in="shadowBlurOuter2"
+          result="shadowMatrixOuter2"
+          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+        />
+        <femerge>
+          <femergenode
+            in="shadowMatrixOuter1"
+          />
+          <femergenode
+            in="shadowMatrixOuter2"
+          />
+        </femerge>
+      </filter>
+      <circle
+        cx="10"
+        cy="12"
+        id="icon-toggle_svg__b"
+        r="10"
+      />
+    </defs>
+    <g
+      fill="none"
+      fill-rule="evenodd"
     >
-      <defs>
-        <lineargradient
-          id="icon-toggle_svg__c"
-          x1="50%"
-          x2="50%"
-          y1="0%"
-          y2="99.021%"
-        >
-          <stop
-            offset="0%"
-            stop-opacity="0"
-          />
-          <stop
-            offset="80%"
-            stop-opacity="0.02"
-          />
-          <stop
-            offset="100%"
-            stop-opacity="0.04"
-          />
-        </lineargradient>
-        <lineargradient
-          id="icon-toggle_svg__d"
-          x1="50%"
-          x2="50%"
-          y1="0%"
-          y2="100%"
-        >
-          <stop
-            offset="0%"
-            stop-color="#FFF"
-            stop-opacity="0.12"
-          />
-          <stop
-            offset="20%"
-            stop-color="#FFF"
-            stop-opacity="0.06"
-          />
-          <stop
-            offset="100%"
-            stop-color="#FFF"
-            stop-opacity="0"
-          />
-        </lineargradient>
-        <filter
-          filterUnits="objectBoundingBox"
-          height="120%"
-          id="icon-toggle_svg__a"
-          width="117.5%"
-          x="-8.8%"
-          y="-8.8%"
-        >
-          <feoffset
-            dy="1"
-            in="SourceAlpha"
-            result="shadowOffsetOuter1"
-          />
-          <fegaussianblur
-            in="shadowOffsetOuter1"
-            result="shadowBlurOuter1"
-            stdDeviation="0.25"
-          />
-          <fecomposite
-            in="shadowBlurOuter1"
-            in2="SourceAlpha"
-            operator="out"
-            result="shadowBlurOuter1"
-          />
-          <fecolormatrix
-            in="shadowBlurOuter1"
-            result="shadowMatrixOuter1"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"
-          />
-          <feoffset
-            in="SourceAlpha"
-            result="shadowOffsetOuter2"
-          />
-          <fegaussianblur
-            in="shadowOffsetOuter2"
-            result="shadowBlurOuter2"
-            stdDeviation="0.5"
-          />
-          <fecomposite
-            in="shadowBlurOuter2"
-            in2="SourceAlpha"
-            operator="out"
-            result="shadowBlurOuter2"
-          />
-          <fecolormatrix
-            in="shadowBlurOuter2"
-            result="shadowMatrixOuter2"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
-          />
-          <femerge>
-            <femergenode
-              in="shadowMatrixOuter1"
-            />
-            <femergenode
-              in="shadowMatrixOuter2"
-            />
-          </femerge>
-        </filter>
+      <path
+        class="icon-toggle_svg__fi-toggle-icon-slide"
+        d="M38 11c0 3.9-3.1 7-7 7H11c-3.9 0-7-3.1-7-7s3.1-7 7-7h20c3.9 0 7 3.1 7 7z"
+        fill="#C9CDCF"
+      />
+      <g
+        class="icon-toggle_svg__fi-toggle-icon-knob"
+        transform="translate(1 -1)"
+      >
+        <use
+          fill="#000"
+          filter="url(#icon-toggle_svg__a)"
+          xlink:href="#icon-toggle_svg__b"
+        />
+        <circle
+          class="icon-toggle_svg__fi-toggle-icon-circle"
+          cx="10"
+          cy="12"
+          fill="#F6F6F7"
+          r="9.75"
+          stroke="url(#icon-toggle_svg__c)"
+          stroke-linejoin="square"
+          stroke-width="0.5"
+        />
         <circle
           cx="10"
           cy="12"
-          id="icon-toggle_svg__b"
-          r="10"
+          r="9.75"
+          stroke="url(#icon-toggle_svg__d)"
+          stroke-linejoin="square"
+          stroke-width="0.5"
         />
-      </defs>
-      <g
-        fill="none"
-        fill-rule="evenodd"
-      >
-        <path
-          class="icon-toggle_svg__fi-toggle-icon-slide"
-          d="M38 11c0 3.9-3.1 7-7 7H11c-3.9 0-7-3.1-7-7s3.1-7 7-7h20c3.9 0 7 3.1 7 7z"
-          fill="#C9CDCF"
-        />
-        <g
-          class="icon-toggle_svg__fi-toggle-icon-knob"
-          transform="translate(1 -1)"
-        >
-          <use
-            fill="#000"
-            filter="url(#icon-toggle_svg__a)"
-            xlink:href="#icon-toggle_svg__b"
-          />
-          <circle
-            class="icon-toggle_svg__fi-toggle-icon-circle"
-            cx="10"
-            cy="12"
-            fill="#F6F6F7"
-            r="9.75"
-            stroke="url(#icon-toggle_svg__c)"
-            stroke-linejoin="square"
-            stroke-width="0.5"
-          />
-          <circle
-            cx="10"
-            cy="12"
-            r="9.75"
-            stroke="url(#icon-toggle_svg__d)"
-            stroke-linejoin="square"
-            stroke-width="0.5"
-          />
-        </g>
       </g>
-    </svg>
-    Test
-  </label>
-</span>
+    </g>
+  </svg>
+  Test
+</button>
 `;
 
-exports[`withInput=true: calling render with the same component on the same container does not remount 1`] = `
+exports[`Input: calling render with the same component on the same container does not remount 1`] = `
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`Button: calling render with the same component on the same container do
 <button
   aria-disabled="false"
   aria-pressed="false"
-  class="c0 c1"
+  class="fi-toggle--button c0 fi-toggle c1"
   data-testid="toggle"
   id="test-toggle"
   tabindex="0"
@@ -554,7 +554,7 @@ exports[`Input: calling render with the same component on the same container doe
 }
 
 <span
-  class="c0 fi-toggle c1"
+  class="fi-toggle--input c0 fi-toggle c1"
 >
   <input
     class="fi-toggle_input c2"

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -1,6 +1,384 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calling render with the same component on the same container does not remount 1`] = `
+exports[`Input: calling render with the same component on the same container does not remount 1`] = `
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c2::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c1 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4 {
+  display: inline-block;
+  vertical-align: baseline;
+  cursor: pointer;
+}
+
+.c4 * {
+  cursor: inherit;
+}
+
+.c0 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: hsl(0,0%,100%);
+}
+
+.c0 > .fi-toggle_label {
+  cursor: pointer;
+}
+
+.c0 > .fi-toggle_input {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue',Arial,sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  z-index: -9999;
+  background-color: hsl(0,0%,100%);
+}
+
+.c0 > .fi-toggle_input:focus {
+  outline: 0;
+}
+
+.c0 > .fi-toggle_input:focus + .fi-toggle_label {
+  outline: 0;
+  position: relative;
+}
+
+.c0 > .fi-toggle_input:focus + .fi-toggle_label:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c0 > .fi-toggle_input:focus + .fi-toggle_label:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 > .fi-toggle_input:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.c0 > .fi-toggle_input:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 .fi-toggle_icon {
+  width: 40px;
+  height: 24px;
+  margin-right: 8px;
+  vertical-align: bottom;
+  overflow: visible;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+}
+
+.c0 .fi-toggle_icon * {
+  cursor: pointer;
+}
+
+.c0 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-knob {
+  -webkit-transform: translateX(0%);
+  -ms-transform: translateX(0%);
+  transform: translateX(0%);
+}
+
+.c0 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-slide {
+  -webkit-transform: translateY(1px);
+  -ms-transform: translateY(1px);
+  transform: translateY(1px);
+}
+
+.c0 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-knob {
+  -webkit-transform: translateX(50%);
+  -ms-transform: translateX(50%);
+  transform: translateX(50%);
+}
+
+.c0 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-slide {
+  fill: hsl(166,54%,80%);
+}
+
+.c0 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-circle {
+  fill: hsl(166,90%,36%);
+}
+
+<span
+  class="c0 fi-toggle c1"
+>
+  <input
+    class="fi-toggle_input c2"
+    id="test-toggle"
+    type="checkbox"
+  />
+  <label
+    class="fi-toggle_label c3"
+    data-testid="toggle"
+    for="test-toggle"
+  >
+    <svg
+      aria-hidden="true"
+      class="fi-toggle_icon c4"
+      focusable="false"
+      height="1em"
+      viewBox="0 0 38 23"
+      width="1em"
+    >
+      <defs>
+        <lineargradient
+          id="icon-toggle_svg__c"
+          x1="50%"
+          x2="50%"
+          y1="0%"
+          y2="99.021%"
+        >
+          <stop
+            offset="0%"
+            stop-opacity="0"
+          />
+          <stop
+            offset="80%"
+            stop-opacity="0.02"
+          />
+          <stop
+            offset="100%"
+            stop-opacity="0.04"
+          />
+        </lineargradient>
+        <lineargradient
+          id="icon-toggle_svg__d"
+          x1="50%"
+          x2="50%"
+          y1="0%"
+          y2="100%"
+        >
+          <stop
+            offset="0%"
+            stop-color="#FFF"
+            stop-opacity="0.12"
+          />
+          <stop
+            offset="20%"
+            stop-color="#FFF"
+            stop-opacity="0.06"
+          />
+          <stop
+            offset="100%"
+            stop-color="#FFF"
+            stop-opacity="0"
+          />
+        </lineargradient>
+        <filter
+          filterUnits="objectBoundingBox"
+          height="120%"
+          id="icon-toggle_svg__a"
+          width="117.5%"
+          x="-8.8%"
+          y="-8.8%"
+        >
+          <feoffset
+            dy="1"
+            in="SourceAlpha"
+            result="shadowOffsetOuter1"
+          />
+          <fegaussianblur
+            in="shadowOffsetOuter1"
+            result="shadowBlurOuter1"
+            stdDeviation="0.25"
+          />
+          <fecomposite
+            in="shadowBlurOuter1"
+            in2="SourceAlpha"
+            operator="out"
+            result="shadowBlurOuter1"
+          />
+          <fecolormatrix
+            in="shadowBlurOuter1"
+            result="shadowMatrixOuter1"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"
+          />
+          <feoffset
+            in="SourceAlpha"
+            result="shadowOffsetOuter2"
+          />
+          <fegaussianblur
+            in="shadowOffsetOuter2"
+            result="shadowBlurOuter2"
+            stdDeviation="0.5"
+          />
+          <fecomposite
+            in="shadowBlurOuter2"
+            in2="SourceAlpha"
+            operator="out"
+            result="shadowBlurOuter2"
+          />
+          <fecolormatrix
+            in="shadowBlurOuter2"
+            result="shadowMatrixOuter2"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+          />
+          <femerge>
+            <femergenode
+              in="shadowMatrixOuter1"
+            />
+            <femergenode
+              in="shadowMatrixOuter2"
+            />
+          </femerge>
+        </filter>
+        <circle
+          cx="10"
+          cy="12"
+          id="icon-toggle_svg__b"
+          r="10"
+        />
+      </defs>
+      <g
+        fill="none"
+        fill-rule="evenodd"
+      >
+        <path
+          class="icon-toggle_svg__fi-toggle-icon-slide"
+          d="M38 11c0 3.9-3.1 7-7 7H11c-3.9 0-7-3.1-7-7s3.1-7 7-7h20c3.9 0 7 3.1 7 7z"
+          fill="#C9CDCF"
+        />
+        <g
+          class="icon-toggle_svg__fi-toggle-icon-knob"
+          transform="translate(1 -1)"
+        >
+          <use
+            fill="#000"
+            filter="url(#icon-toggle_svg__a)"
+            xlink:href="#icon-toggle_svg__b"
+          />
+          <circle
+            class="icon-toggle_svg__fi-toggle-icon-circle"
+            cx="10"
+            cy="12"
+            fill="#F6F6F7"
+            r="9.75"
+            stroke="url(#icon-toggle_svg__c)"
+            stroke-linejoin="square"
+            stroke-width="0.5"
+          />
+          <circle
+            cx="10"
+            cy="12"
+            r="9.75"
+            stroke="url(#icon-toggle_svg__d)"
+            stroke-linejoin="square"
+            stroke-width="0.5"
+          />
+        </g>
+      </g>
+    </svg>
+    Test
+  </label>
+</span>
+`;
+
+exports[`withInput=true: calling render with the same component on the same container does not remount 1`] = `
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Toggle will now have button-component by default and with the `withInput` attribute you can get the input-component version.

`toggleInputProps` and `toggleInputComponent` attributes will only work for the input-version.

Different versions are in separate files: `ToggleInput` and `ToggleButton`

```
suomifi-ui-components/src/components/Form
├── Toggle.tsx
├── ToggleButton.tsx
└── ToggleInput.tsx
```

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

This PR closes #136 and is related to the #154 changes (toggle functionality fixes incoming in later PR).

## How Has This Been Tested?
- manually in the browser
- `yarn validate`