### PR TITLE
[Bugfix] Only allow placeholder for search input

### DIFF
--- a/src/components/Form/SearchInput.tsx
+++ b/src/components/Form/SearchInput.tsx
@@ -1,0 +1,21 @@
+import React, { Component } from 'react';
+import { BaseTextInput, TextInputProps } from './TextInput';
+import { logger } from '../../utils/logger';
+
+export class SearchInput extends Component<TextInputProps> {
+  render() {
+    const { placeholder, ...passProps } = this.props;
+
+    if (!!placeholder) {
+      logger.warn(
+        'Manually set placeholder attribute is not supported, use labelText instead',
+      );
+    }
+    const labelAsPlaceholder = this.props.labelMode === 'hidden';
+    const props = {
+      placeholder: labelAsPlaceholder ? this.props.labelText : undefined,
+    };
+
+    return <BaseTextInput {...passProps} {...props} />;
+  }
+}

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -86,7 +86,7 @@ export class BaseTextInput extends Component<TextInputProps> {
             {...passProps}
             className={classnames(inputBaseClassName, inputClassName)}
             type="text"
-            placeholder={hideLabel ? labelText : ''} // halutaanko että on sauma muutenkin käyttää labeltextiä tässä
+            placeholder={hideLabel ? labelText : ''}
           />
           {children}
         </HtmlDiv>
@@ -97,13 +97,48 @@ export class BaseTextInput extends Component<TextInputProps> {
 
 export class TextInput extends BaseTextInput {
   render() {
-    const { placeholder, ...passProps } = this.props;
+    const {
+      className,
+      inputClassName,
+      labelText,
+      labelMode,
+      placeholder,
+      labelProps,
+      labelTextProps,
+      inputContainerProps,
+      children,
+      ...passProps
+    } = this.props;
 
     if (!!placeholder) {
       logger.error(
         'Using placeholder in text inputs is not accessible and it is ignored. Use labelText instead',
       );
     }
-    return <BaseTextInput {...passProps} />;
+
+    const hideLabel = labelMode === 'hidden';
+
+    return (
+      <HtmlLabel
+        {...labelProps}
+        className={classnames(labelBaseClassName, className, {
+          [disabledClassName]: !!passProps.disabled,
+        })}
+      >
+        {hideLabel ? (
+          <VisuallyHidden>{labelText}</VisuallyHidden>
+        ) : (
+          <Paragraph {...labelTextProps}>{labelText}</Paragraph>
+        )}
+        <HtmlDiv {...inputContainerProps}>
+          <HtmlInput
+            {...passProps}
+            className={classnames(inputBaseClassName, inputClassName)}
+            type="text"
+          />
+          {children}
+        </HtmlDiv>
+      </HtmlLabel>
+    );
   }
 }

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -60,7 +60,6 @@ export class BaseTextInput extends Component<TextInputProps> {
       inputClassName,
       labelText,
       labelMode,
-      placeholder,
       labelProps,
       labelTextProps,
       inputContainerProps,
@@ -69,7 +68,6 @@ export class BaseTextInput extends Component<TextInputProps> {
     } = this.props;
 
     const hideLabel = labelMode === 'hidden';
-    const labelAsPlaceholder = hideLabel || !!placeholder;
 
     return (
       <HtmlLabel
@@ -88,7 +86,6 @@ export class BaseTextInput extends Component<TextInputProps> {
             {...passProps}
             className={classnames(inputBaseClassName, inputClassName)}
             type="text"
-            placeholder={labelAsPlaceholder ? labelText : undefined}
           />
           {children}
         </HtmlDiv>
@@ -97,20 +94,9 @@ export class BaseTextInput extends Component<TextInputProps> {
   }
 }
 
-export class TextInput extends BaseTextInput {
+export class TextInput extends Component<TextInputProps> {
   render() {
-    const {
-      className,
-      inputClassName,
-      labelText,
-      labelMode,
-      placeholder,
-      labelProps,
-      labelTextProps,
-      inputContainerProps,
-      children,
-      ...passProps
-    } = this.props;
+    const { placeholder, ...passProps } = this.props;
 
     if (!!placeholder) {
       logger.error(
@@ -118,29 +104,11 @@ export class TextInput extends BaseTextInput {
       );
     }
 
-    const hideLabel = labelMode === 'hidden';
+    const showPlaceholder = this.props.labelMode === 'hidden';
+    const props = {
+      placeholder: showPlaceholder ? this.props.labelText : undefined,
+    };
 
-    return (
-      <HtmlLabel
-        {...labelProps}
-        className={classnames(labelBaseClassName, className, {
-          [disabledClassName]: !!passProps.disabled,
-        })}
-      >
-        {hideLabel ? (
-          <VisuallyHidden>{labelText}</VisuallyHidden>
-        ) : (
-          <Paragraph {...labelTextProps}>{labelText}</Paragraph>
-        )}
-        <HtmlDiv {...inputContainerProps}>
-          <HtmlInput
-            {...passProps}
-            className={classnames(inputBaseClassName, inputClassName)}
-            type="text"
-          />
-          {children}
-        </HtmlDiv>
-      </HtmlLabel>
-    );
+    return <BaseTextInput {...passProps} {...props} />;
   }
 }

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -86,7 +86,9 @@ export class BaseTextInput extends Component<TextInputProps> {
             {...passProps}
             className={classnames(inputBaseClassName, inputClassName)}
             type="text"
-            placeholder={hideLabel ? labelText : ''}
+            placeholder={
+              hideLabel ? labelText : placeholder === labelText ? labelText : ''
+            }
           />
           {children}
         </HtmlDiv>

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -41,8 +41,9 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
   /** Label */
   labelText: string;
-  /** Label displaymode
+  /** Label displaymode -
    * visible: show above, hidden: show as placeholder
+   * @default visible
    */
   labelMode?: Label;
 
@@ -68,6 +69,7 @@ export class BaseTextInput extends Component<TextInputProps> {
     } = this.props;
 
     const hideLabel = labelMode === 'hidden';
+    const labelAsPlaceholder = hideLabel || !!placeholder;
 
     return (
       <HtmlLabel
@@ -86,7 +88,7 @@ export class BaseTextInput extends Component<TextInputProps> {
             {...passProps}
             className={classnames(inputBaseClassName, inputClassName)}
             type="text"
-            placeholder={hideLabel ? labelText : !!placeholder ? labelText : ''}
+            placeholder={labelAsPlaceholder ? labelText : undefined}
           />
           {children}
         </HtmlDiv>

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -10,8 +10,8 @@ import {
 } from '../../reset';
 import { VisuallyHidden } from '../Visually-hidden/Visually-hidden';
 import { Paragraph, ParagraphProps } from '../Paragraph/Paragraph';
-import classnames from 'classnames';
 import { logger } from '../../utils/logger';
+import classnames from 'classnames';
 
 const baseClassName = 'fi-text-input';
 const disabledClassName = `${baseClassName}--disabled`;
@@ -86,9 +86,7 @@ export class BaseTextInput extends Component<TextInputProps> {
             {...passProps}
             className={classnames(inputBaseClassName, inputClassName)}
             type="text"
-            placeholder={
-              hideLabel ? labelText : placeholder === labelText ? labelText : ''
-            }
+            placeholder={hideLabel ? labelText : !!placeholder ? labelText : ''}
           />
           {children}
         </HtmlDiv>

--- a/src/core/Form/SearchInput/SearchInput.md
+++ b/src/core/Form/SearchInput/SearchInput.md
@@ -1,5 +1,6 @@
 ```js
 import { SearchInput } from 'suomifi-ui-components';
+
 <SearchInput
   onBlur={event => console.log(event.target.value)}
   labelText="Search..."

--- a/src/core/Form/SearchInput/SearchInput.md
+++ b/src/core/Form/SearchInput/SearchInput.md
@@ -1,9 +1,17 @@
 ```js
 import { SearchInput } from 'suomifi-ui-components';
+<>
+  <SearchInput
+    onBlur={event => console.log(event.target.value)}
+    labelText="Search..."
+    labelMode="hidden"
+  />
 
-<SearchInput
-  onBlur={event => console.log(event.target.value)}
-  labelText="Search..."
-  labelMode="hidden"
-/>;
+  <SearchInput
+    onBlur={event => console.log(event.target.value)}
+    labelText="Search..."
+    labelMode="visible"
+    placeholder="Any value (see console)"
+  />
+</>;
 ```

--- a/src/core/Form/SearchInput/SearchInput.md
+++ b/src/core/Form/SearchInput/SearchInput.md
@@ -1,8 +1,8 @@
 ```js
 import { SearchInput } from 'suomifi-ui-components';
-
 <SearchInput
   onBlur={event => console.log(event.target.value)}
   labelText="Search..."
+  labelMode="hidden"
 />;
 ```

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -16,10 +16,7 @@ const inputContainerBaseClassName = `${baseClassName}_input-container`;
 const inputBaseClassName = `${baseClassName}_input`;
 const iconBaseClassName = `${baseClassName}_icon`;
 
-export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {
-  /** Input placeholder-text if not using screenreader-labelmode */
-  placeholder?: string;
-}
+export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {}
 
 const StyledTextInput = styled(
   ({
@@ -71,10 +68,7 @@ export class SearchInput extends Component<SearchInputProps> {
     }
 
     return (
-      <StyledTextInput
-        {...withSuomifiDefaultProps(this.props)}
-        placeholder={labelText}
-      >
+      <StyledTextInput {...withSuomifiDefaultProps(this.props)}>
         <Icon icon="search" className={iconBaseClassName} />
       </StyledTextInput>
     );

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -7,13 +7,22 @@ import { TextInput, TextInputProps } from '../TextInput/TextInput';
 import { Icon } from '../../Icon/Icon';
 import classnames from 'classnames';
 import { Omit } from '../../../utils/typescript';
+import { logger } from '../../../utils/logger';
 
 const baseClassName = 'fi-search-input';
 const inputContainerBaseClassName = `${baseClassName}_input-container`;
 const inputBaseClassName = `${baseClassName}_input`;
 const iconBaseClassName = `${baseClassName}_icon`;
+type Label = 'default' | 'screenreader';
 
-export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {}
+export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {
+  /** Input placeholder-text if not using screenreader-labelmode */
+  placeholder?: string;
+  /** Label displaymode
+   * default: show above, screenreader: show as placeholder
+   */
+  labelMode?: Label;
+}
 
 const StyledTextInput = styled(
   ({
@@ -37,12 +46,20 @@ const StyledTextInput = styled(
  * <i class="semantics" />
  * Use for user inputting search text
  */
-export class SearchInput extends Component<TextInputProps> {
+export class SearchInput extends Component<SearchInputProps> {
   render() {
+    const { labelMode, labelText, placeholder } = this.props;
+
+    const ifScreenreader = labelMode === 'screenreader';
+    if (ifScreenreader && placeholder) {
+      logger.warn(
+        'Placeholder not used as label is hidden and using label instead',
+      );
+    }
     return (
       <StyledTextInput
-        labelMode="screenreader"
         {...withSuomifiDefaultProps(this.props)}
+        placeholder={ifScreenreader ? labelText : placeholder}
       >
         <Icon icon="search" className={iconBaseClassName} />
       </StyledTextInput>

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -4,22 +4,18 @@ import { InternalTokensProp } from '../../theme';
 import { withSuomifiDefaultProps } from '../../theme/utils';
 import { baseStyles } from './SearchInput.baseStyles';
 import { baseStyles as inputBaseStyles } from '../TextInput/TextInput.baseStyles';
-import { BaseTextInput } from '../../../components/Form/TextInput';
+import { SearchInput as CompSearchInput } from '../../../components/Form/SearchInput';
 import { TextInputProps, textInputClassNames } from '../TextInput/TextInput';
 import { Icon } from '../../Icon/Icon';
 import classnames from 'classnames';
 import { Omit } from '../../../utils/typescript';
-import { logger } from '../../../utils/logger';
 
 const baseClassName = 'fi-search-input';
 const inputContainerBaseClassName = `${baseClassName}_input-container`;
 const inputBaseClassName = `${baseClassName}_input`;
 const iconBaseClassName = `${baseClassName}_icon`;
 
-export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {
-  /** Placeholder text for search field. Must match labelText */
-  placeholder?: string;
-}
+export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {}
 
 const StyledTextInput = styled(
   ({
@@ -30,7 +26,7 @@ const StyledTextInput = styled(
     inputClassName,
     ...passProps
   }: TextInputProps & InternalTokensProp) => (
-    <BaseTextInput
+    <CompSearchInput
       {...passProps}
       labelTextProps={{
         ...labelTextProps,
@@ -52,8 +48,8 @@ const StyledTextInput = styled(
     />
   ),
 )`
-  ${props => baseStyles(props)}
   ${props => inputBaseStyles(props)}
+  ${props => baseStyles(props)}
 `;
 
 /**
@@ -62,14 +58,6 @@ const StyledTextInput = styled(
  */
 export class SearchInput extends Component<SearchInputProps> {
   render() {
-    const { labelText, placeholder } = this.props;
-
-    if (!!placeholder && labelText !== placeholder) {
-      logger.warn(
-        'Placeholder different than label is not supported, using labelText instead',
-      );
-    }
-
     return (
       <StyledTextInput {...withSuomifiDefaultProps(this.props)}>
         <Icon icon="search" className={iconBaseClassName} />

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -16,7 +16,10 @@ const inputContainerBaseClassName = `${baseClassName}_input-container`;
 const inputBaseClassName = `${baseClassName}_input`;
 const iconBaseClassName = `${baseClassName}_icon`;
 
-export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {}
+export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {
+  /** Placeholder text for search field. Must match labelText */
+  placeholder?: string;
+}
 
 const StyledTextInput = styled(
   ({

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -3,7 +3,9 @@ import { default as styled } from 'styled-components';
 import { InternalTokensProp } from '../../theme';
 import { withSuomifiDefaultProps } from '../../theme/utils';
 import { baseStyles } from './SearchInput.baseStyles';
-import { TextInput, TextInputProps } from '../TextInput/TextInput';
+import { baseStyles as inputBaseStyles } from '../TextInput/TextInput.baseStyles';
+import { BaseTextInput } from '../../../components/Form/TextInput';
+import { TextInputProps, textInputClassNames } from '../TextInput/TextInput';
 import { Icon } from '../../Icon/Icon';
 import classnames from 'classnames';
 import { Omit } from '../../../utils/typescript';
@@ -13,33 +15,45 @@ const baseClassName = 'fi-search-input';
 const inputContainerBaseClassName = `${baseClassName}_input-container`;
 const inputBaseClassName = `${baseClassName}_input`;
 const iconBaseClassName = `${baseClassName}_icon`;
-type Label = 'default' | 'screenreader';
 
 export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {
   /** Input placeholder-text if not using screenreader-labelmode */
   placeholder?: string;
-  /** Label displaymode
-   * default: show above, screenreader: show as placeholder
-   */
-  labelMode?: Label;
 }
 
 const StyledTextInput = styled(
   ({
     tokens,
     className,
+    labelTextProps = { className: undefined },
+    inputContainerProps = { className: inputContainerBaseClassName },
     inputClassName,
     ...passProps
   }: TextInputProps & InternalTokensProp) => (
-    <TextInput
+    <BaseTextInput
+      {...passProps}
+      labelTextProps={{
+        ...labelTextProps,
+        className: classnames(
+          labelTextProps.className,
+          textInputClassNames.labelParagraph,
+        ),
+      }}
+      inputContainerProps={{
+        ...inputContainerProps,
+        className: classnames(
+          inputContainerProps.className,
+          textInputClassNames.inputContainer,
+        ),
+      }}
       {...passProps}
       className={classnames(className, baseClassName)}
       inputClassName={classnames(inputClassName, inputBaseClassName)}
-      inputContainerProps={{ className: inputContainerBaseClassName }}
     />
   ),
 )`
   ${props => baseStyles(props)}
+  ${props => inputBaseStyles(props)}
 `;
 
 /**
@@ -48,18 +62,18 @@ const StyledTextInput = styled(
  */
 export class SearchInput extends Component<SearchInputProps> {
   render() {
-    const { labelMode, labelText, placeholder } = this.props;
+    const { labelText, placeholder } = this.props;
 
-    const ifScreenreader = labelMode === 'screenreader';
-    if (ifScreenreader && placeholder) {
+    if (!!placeholder && labelText !== placeholder) {
       logger.warn(
-        'Placeholder not used as label is hidden and using label instead',
+        'Placeholder different than label is not supported, using labelText instead',
       );
     }
+
     return (
       <StyledTextInput
         {...withSuomifiDefaultProps(this.props)}
-        placeholder={ifScreenreader ? labelText : placeholder}
+        placeholder={labelText}
       >
         <Icon icon="search" className={iconBaseClassName} />
       </StyledTextInput>

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -102,21 +102,6 @@ exports[`calling render with the same component on the same container does not r
   vertical-align: baseline;
 }
 
-.c0 .fi-search-input_input-container {
-  position: relative;
-}
-
-.c0 .fi-search-input_input {
-  padding-right: 40px;
-}
-
-.c0 .fi-search-input_icon {
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -0.5em;
-}
-
 .c0 .fi-text-input_label-p {
   margin-bottom: 16px;
 }
@@ -189,6 +174,21 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(166,90%,36%);
 }
 
+.c0 .fi-search-input_input-container {
+  position: relative;
+}
+
+.c0 .fi-search-input_input {
+  padding-right: 40px;
+}
+
+.c0 .fi-search-input_icon {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -0.5em;
+}
+
 <label
   class="fi-text-input_label c0 fi-search-input c1"
 >
@@ -203,7 +203,6 @@ exports[`calling render with the same component on the same container does not r
     <input
       class="fi-text-input_input fi-search-input_input c4"
       data-testid="textinput"
-      placeholder=""
       type="text"
     />
     <svg

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`calling render with the same component on the same container does not remount 1`] = `
-.c5 {
+.c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -25,7 +25,7 @@ exports[`calling render with the same component on the same container does not r
   white-space: normal;
 }
 
-.c6 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -48,9 +48,29 @@ exports[`calling render with the same component on the same container does not r
   max-width: 100%;
 }
 
-.c6::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
+}
+
+.c1 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
 }
 
 .c2 {
@@ -70,61 +90,49 @@ exports[`calling render with the same component on the same container does not r
   color: inherit;
   background: none;
   cursor: inherit;
-  max-width: 100%;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
+  display: block;
   max-width: 100%;
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
 }
 
-.c3 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
+.c5 {
+  display: inline-block;
+  vertical-align: baseline;
 }
 
-.c1 .fi-text-input_label-p {
+.c0 .fi-search-input_input-container {
+  position: relative;
+}
+
+.c0 .fi-search-input_input {
+  padding-right: 40px;
+}
+
+.c0 .fi-search-input_icon {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -0.5em;
+}
+
+.c0 .fi-text-input_label-p {
   margin-bottom: 16px;
 }
 
-.c1 .fi-text-input_container > input:focus {
+.c0 .fi-text-input_container > input:focus {
   outline-color: hsl(23,82%,53%);
   outline-width: 4px;
   outline-offset: 2px;
 }
 
-.c1 .fi-text-input_container:focus-within {
+.c0 .fi-text-input_container:focus-within {
   outline: 0;
   position: relative;
 }
 
-.c1 .fi-text-input_container:focus-within:after {
+.c0 .fi-text-input_container:focus-within:after {
   content: '';
   position: absolute;
   top: -4px;
@@ -139,15 +147,15 @@ exports[`calling render with the same component on the same container does not r
   z-index: 9999;
 }
 
-.c1 .fi-text-input_container:focus-within:not(:focus-visible):after {
+.c0 .fi-text-input_container:focus-within:not(:focus-visible):after {
   content: none;
 }
 
-.c1 .fi-text-input_container:focus-within > input:focus {
+.c0 .fi-text-input_container:focus-within > input:focus {
   outline: none;
 }
 
-.c1 .fi-text-input_input {
+.c0 .fi-text-input_input {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -171,56 +179,36 @@ exports[`calling render with the same component on the same container does not r
   background-color: hsl(0,0%,100%);
 }
 
-.c1.fi-text-input--error .fi-text-input_input {
+.c0.fi-text-input--error .fi-text-input_input {
   color: hsl(3,59%,48%);
   border-color: hsl(3,59%,48%);
 }
 
-.c1.fi-text-input--success .fi-text-input_input {
+.c0.fi-text-input--success .fi-text-input_input {
   color: hsl(166,90%,36%);
   border-color: hsl(166,90%,36%);
 }
 
-.c7 {
-  display: inline-block;
-  vertical-align: baseline;
-}
-
-.c0 .fi-search-input_input-container {
-  position: relative;
-}
-
-.c0 .fi-search-input_input {
-  padding-right: 40px;
-}
-
-.c0 .fi-search-input_icon {
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -0.5em;
-}
-
 <label
-  class="fi-text-input_label c0 fi-search-input c1 c2"
+  class="fi-text-input_label c0 fi-search-input c1"
 >
-  <span
-    class="fi-visually-hidden c3 c4"
+  <p
+    class="fi-paragraph fi-text-input_label-p c2"
   >
     Test search input
-  </span>
+  </p>
   <div
-    class="fi-search-input_input-container fi-text-input_container c5"
+    class="fi-search-input_input-container fi-text-input_container c3"
   >
     <input
-      class="fi-text-input_input fi-search-input_input c6"
+      class="fi-text-input_input fi-search-input_input c4"
       data-testid="textinput"
-      placeholder="Test search input"
+      placeholder=""
       type="text"
     />
     <svg
       aria-hidden="true"
-      class="fi-search-input_icon c7"
+      class="fi-search-input_icon c5"
       focusable="false"
       height="1em"
       style="fill: hsl(202, 7%, 40%);"

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -13,18 +13,19 @@ import { TextInput } from 'suomifi-ui-components';
 <>
   <TextInput
     onBlur={event => console.log(event.target.value)}
-    labelMode="screenreader"
+    labelMode="hidden"
     labelText="Test with hidden label"
+    defaultValue="Test with hidden label"
   />
   <TextInput.error
-    labelMode="screenreader"
+    labelMode="hidden"
     labelText="Error with hidden label"
-    value="Error with hidden label"
+    defaultValue="Error with hidden label"
   />
   <TextInput.success
-    labelMode="screenreader"
+    labelMode="hidden"
     labelText="Success with hidden label"
-    value="Success with hidden label"
+    defaultValue="Success with hidden label"
   />
 </>;
 ```

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -78,5 +78,3 @@ export class TextInput extends Component<TextInputProps> {
     return <StyledTextInput {...passProps} />;
   }
 }
-
-export class SearchInput extends Component<TextInputProps> {}

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -8,14 +8,17 @@ import {
   TextInputProps as CompTextInputProps,
 } from '../../../components/Form/TextInput';
 import classnames from 'classnames';
-
 const baseClassName = 'fi-text-input';
-const labelParagraphClassName = `${baseClassName}_label-p`;
-const inputContainerClassName = `${baseClassName}_container`;
-const errorClassName = `${baseClassName}--error`;
-const successClassName = `${baseClassName}--success`;
 
+export const textInputClassNames = {
+  baseClassName,
+  labelParagraph: `${baseClassName}_label-p`,
+  inputContainer: `${baseClassName}_container`,
+  error: `${baseClassName}--error`,
+  success: `${baseClassName}--success`,
+};
 type TextInputVariant = 'default' | 'error' | 'success';
+
 export interface TextInputProps extends CompTextInputProps, TokensProp {
   variant?: TextInputVariant;
 }
@@ -36,19 +39,19 @@ const StyledTextInput = styled(
           ...labelTextProps,
           className: classnames(
             labelTextProps.className,
-            labelParagraphClassName,
+            textInputClassNames.labelParagraph,
           ),
         }}
         inputContainerProps={{
           ...inputContainerProps,
           className: classnames(
             inputContainerProps.className,
-            inputContainerClassName,
+            textInputClassNames.inputContainer,
           ),
         }}
         className={classnames(className, {
-          [errorClassName]: variant === 'error',
-          [successClassName]: variant === 'success',
+          [textInputClassNames.error]: variant === 'error',
+          [textInputClassNames.success]: variant === 'success',
         })}
       />
     );
@@ -72,7 +75,8 @@ export class TextInput extends Component<TextInputProps> {
 
   render() {
     const { ...passProps } = withSuomifiDefaultProps(this.props);
-
     return <StyledTextInput {...passProps} />;
   }
 }
+
+export class SearchInput extends Component<TextInputProps> {}

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -75,6 +75,7 @@ export class TextInput extends Component<TextInputProps> {
 
   render() {
     const { ...passProps } = withSuomifiDefaultProps(this.props);
+
     return <StyledTextInput {...passProps} />;
   }
 }


### PR DESCRIPTION
## Description

Adjusted TextInput and SearchInput components to the following standard:

1. Placeholder is not allowed in TextInput, and the user gets an error in console if one is used.
2. Placeholder is allowed in SearchInput, but only it is forced to match labelText. User gets warning in console if different placeholder is used.
3. Label can be made hidden or visible in both TextInput and SearchInput

Had to make some bigger adjustments since SearchInput uses TextInput. Need to make some changes to the way these work. Did it as follows:

1. Made a new class of BaseTextInput which essentially is the old TextInput without the required error when using placeholder.
2. Exported another class by the name of TextInput, which extends BaseTextInput and adds the error message and a slightly different logic regarding the label and placeholder.
3. Set the SearchInput to extend the BaseTextInput class to allow the use of placeholder

The BaseTextInput is not listed in the Index.ts.

## Related Issue

https://github.com/vrk-kpa/suomifi-ui-components/issues/185

Closes #185 

Placeholder is not accessible in many cases and it shouldn't be used instead of label. Now it can only be used in SearchInput and even there only when the placeholder matches the label.

## How Has This Been Tested?

yarn validate and manual testing.
