### PR TITLE
[BreakingChange] Update suomifi-design-tokens to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "polished": "3.4.0",
     "react-svg": "7.2.2",
     "styled-components": "4.3.2",
-    "suomifi-design-tokens": "0.2.1",
+    "suomifi-design-tokens": "0.3.0",
     "suomifi-icons": "0.0.8",
     "uuid": "3.3.2"
   },

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -4,7 +4,7 @@ import { alphaHex } from '../../utils/css';
 import { boxshadowOutline } from './utils/outline';
 import { zindexes } from './zindexes';
 
-export { ColorDesingTokens } from 'suomifi-design-tokens';
+export { ColorDesignTokens } from 'suomifi-design-tokens';
 
 export const { colors } = tokens;
 

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -4,7 +4,7 @@ import {
   TypographyProp,
   internalTypographyTokens,
   internalTypographyTokensProp,
-  TypograhpyDesingTokens,
+  TypographyDesignTokens,
 } from './typography';
 import { typographyUtils, spacingUtils, colorsUtils } from './utils';
 import {
@@ -12,9 +12,9 @@ import {
   shadows,
   gradients,
   outlines,
-  ColorDesingTokens,
+  ColorDesignTokens,
 } from './colors';
-import { spacing, SpacingProp, SpacingDesingTokens } from './spacing';
+import { spacing, SpacingProp, SpacingDesignTokens } from './spacing';
 import { zindexes } from './zindexes';
 import { transitions } from './transitions';
 import { radius } from './radius';
@@ -31,9 +31,9 @@ export type ColorProp = keyof typeof importedTokens.colors;
 export type SuomifiTheme = ReturnType<typeof suomifiTheme>;
 
 export interface PartialTokens {
-  colors?: Partial<ColorDesingTokens>;
-  spacing?: Partial<SpacingDesingTokens>;
-  typography?: Partial<TypograhpyDesingTokens>;
+  colors?: Partial<ColorDesignTokens>;
+  spacing?: Partial<SpacingDesignTokens>;
+  typography?: Partial<TypographyDesignTokens>;
 }
 export interface TokensProp {
   /** Custom  Design-tokens or one category of tokens customized, clone defaultTokens for base */

--- a/src/core/theme/spacing.ts
+++ b/src/core/theme/spacing.ts
@@ -1,12 +1,12 @@
-import { tokens, SpacingDesingTokens } from 'suomifi-design-tokens';
-export { SpacingDesingTokens };
+import { tokens, SpacingDesignTokens } from 'suomifi-design-tokens';
+export { SpacingDesignTokens };
 
-export type SpacingProp = keyof SpacingDesingTokens;
+export type SpacingProp = keyof SpacingDesignTokens;
 
-type SpacingDesingTokensKeys = keyof SpacingDesingTokens;
+type SpacingDesignTokensKeys = keyof SpacingDesignTokens;
 
 export const spacing = tokens.spacing;
 
 export const spacingTokensKeys = Object.keys(
   spacing,
-) as SpacingDesingTokensKeys[];
+) as SpacingDesignTokensKeys[];

--- a/src/core/theme/typography.ts
+++ b/src/core/theme/typography.ts
@@ -2,7 +2,7 @@ import { tokens } from 'suomifi-design-tokens';
 export type TypographyProp = keyof typeof tokens.typography;
 import { cssObjectToCss } from '../../utils/css';
 
-export { TypograhpyDesingTokens } from 'suomifi-design-tokens';
+export { TypographyDesignTokens } from 'suomifi-design-tokens';
 
 export const typography = tokens.typography;
 

--- a/src/core/theme/utils/colors.ts
+++ b/src/core/theme/utils/colors.ts
@@ -1,15 +1,15 @@
-import { ColorDesingTokens } from 'suomifi-design-tokens';
+import { ColorDesignTokens } from 'suomifi-design-tokens';
 import { InternalTokensProp } from '../';
 
 export const colorValue = (props: InternalTokensProp) => (
-  colorToken: keyof ColorDesingTokens,
+  colorToken: keyof ColorDesignTokens,
 ) => props.tokens.colors[colorToken].hsl;
 
-export const colorsUtils = (colors: ColorDesingTokens) =>
+export const colorsUtils = (colors: ColorDesignTokens) =>
   Object.entries(colors).reduce(
     (retObj, [key, value]) => ({
       ...retObj,
       [key]: value.hsl,
     }),
-    {} as { [key in keyof ColorDesingTokens]: string },
+    {} as { [key in keyof ColorDesignTokens]: string },
   );

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -2,17 +2,17 @@ import { FlattenSimpleInterpolation } from 'styled-components';
 import {
   SpacingProp,
   spacingTokensKeys,
-  SpacingDesingTokens,
+  SpacingDesignTokens,
 } from '../spacing';
 import { cssValueToString } from '../../../utils/css';
 
-export const spacingUtils = (spacing: SpacingDesingTokens) =>
+export const spacingUtils = (spacing: SpacingDesignTokens) =>
   Object.entries(spacing).reduce(
     (retObj, [key, value]) => ({
       ...retObj,
       [key]: cssValueToString(value),
     }),
-    {} as { [key in keyof SpacingDesingTokens]: FlattenSimpleInterpolation },
+    {} as { [key in keyof SpacingDesignTokens]: FlattenSimpleInterpolation },
   );
 
 // TODO make this whole util again to work with suomifiTheme-util

--- a/src/core/theme/utils/typography/fontsize.ts
+++ b/src/core/theme/utils/typography/fontsize.ts
@@ -1,8 +1,8 @@
-import { TypograhpyDesingTokens } from 'suomifi-design-tokens';
+import { TypographyDesignTokens } from 'suomifi-design-tokens';
 import { SuomifiTheme } from '../../';
 import { cssValueToString } from '../../../../utils/css';
 
-type ValueTypographyTokenProp = keyof TypograhpyDesingTokens;
+type ValueTypographyTokenProp = keyof TypographyDesignTokens;
 export interface FontSizeProps {
   theme: SuomifiTheme;
   [key: string]: any;

--- a/src/core/theme/utils/typography/typographyutil.ts
+++ b/src/core/theme/utils/typography/typographyutil.ts
@@ -1,18 +1,18 @@
 import { FlattenSimpleInterpolation } from 'styled-components';
 import { cssObjectsToCss } from '../../../../utils/css';
-import { tokens, TypograhpyDesingTokens } from 'suomifi-design-tokens';
+import { tokens, TypographyDesignTokens } from 'suomifi-design-tokens';
 
 export type TypographyTokensAsCss = {
   [key in keyof typeof tokens.typography]: string
 };
 
 type TypographyTokensAsCssProp = {
-  [key in keyof TypograhpyDesingTokens]: FlattenSimpleInterpolation
+  [key in keyof TypographyDesignTokens]: FlattenSimpleInterpolation
 };
 export interface TypographyUtil extends TypographyTokensAsCssProp {}
 export class TypographyUtil {
   static instance: TypographyUtil;
-  constructor(tokens: TypograhpyDesingTokens) {
+  constructor(tokens: TypographyDesignTokens) {
     // If instance not created, does not take on account if tokens is different!
     if (!TypographyUtil.instance) {
       // Assing typographyTokens as CSS FlattenSimpleInterpolation to this object
@@ -28,7 +28,7 @@ export class TypographyUtil {
  * @param typography Typography-tokens
  * @return typographyWithUtils Typography-tokens and typography-tokens as CSS strings
  */
-export const typographyUtils = (typography: TypograhpyDesingTokens) => {
+export const typographyUtils = (typography: TypographyDesignTokens) => {
   const instance = new TypographyUtil(typography);
   Object.freeze(instance);
   return instance;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10543,10 +10543,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-suomifi-design-tokens@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.2.1.tgz#adfa14df6617ab26b96884b7071789a398bcf1e7"
-  integrity sha512-C8pkDmi9A8hradqiVfKxtfqfNIGl9ky8T5RoCa7oQRORTzxFu1RudJ83SDkm4/iLR64mCLByeMtwZFvKCveCDw==
+suomifi-design-tokens@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.3.0.tgz#694660b5038e1a652ad64d2a8e727f0561392588"
+  integrity sha512-brxPbFjpJUNm17SF/d174UhZtZGZJPL8OhRApBVi30eCm9BFptiqD18SLy1k58dlloVfqGjhALNnHiwhEcFftA==
 
 suomifi-icons@0.0.8:
   version "0.0.8"


### PR DESCRIPTION
## Description

Update to suomifi-design-tokens to 0.3.0. This update includes only fixes for typos in typings, especially interface names.

Introduces a breaking change as some of the interfaces from suomifi-design-tokens are exported indirectly. Names of these interfaces have changed. For further details see https://github.com/vrk-kpa/suomifi-design-tokens/releases/tag/0.3.0 

## How Has This Been Tested?

Tested using yarn build and yarn test and locally using Verdaccio and create-react-app TypeScript project.