### PR TITLE
[Feature] Icon component custom props

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "react-svg": "7.2.2",
     "styled-components": "4.3.2",
     "suomifi-design-tokens": "0.3.0",
-    "suomifi-icons": "0.0.8",
+    "suomifi-icons": "0.0.10",
     "uuid": "3.3.2"
   },
   "peerDependencies": {

--- a/src/components/Svg/Svg.tsx
+++ b/src/components/Svg/Svg.tsx
@@ -19,6 +19,8 @@ export interface SvgProps {
   /** Show mouse cursor as hand-pointer */
   mousePointer?: boolean;
   testId?: string;
+  /** Allow passing custom attributes */
+  [key: string]: any;
 }
 
 export const Svg = styled(

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -283,9 +283,9 @@ exports[`calling render with the same component on the same container does not r
       <svg
         aria-hidden="true"
         class="fi-breadcrumb_icon c6"
+        fill="hsl(0, 0%, 16%)"
         focusable="false"
         height="1em"
-        style="fill: hsl(202, 7%, 40%);"
         viewBox="0 0 24 24"
         width="1em"
       >
@@ -306,9 +306,9 @@ exports[`calling render with the same component on the same container does not r
       <svg
         aria-hidden="true"
         class="fi-breadcrumb_icon c6"
+        fill="hsl(0, 0%, 16%)"
         focusable="false"
         height="1em"
-        style="fill: hsl(202, 7%, 40%);"
         viewBox="0 0 24 24"
         width="1em"
       >

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`calling render with the same component on the same container does not r
     />
     <svg
       aria-hidden="true"
-      class="fi-search-input_icon c5"
+      class="fi-search-input_icon c6"
       fill="hsl(202, 7%, 40%)"
       focusable="false"
       height="1em"

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -211,10 +211,10 @@ exports[`calling render with the same component on the same container does not r
     />
     <svg
       aria-hidden="true"
-      class="fi-search-input_icon c6"
+      class="fi-search-input_icon c5"
+      fill="hsl(202, 7%, 40%)"
       focusable="false"
       height="1em"
-      style="fill: hsl(202, 7%, 40%);"
       viewBox="0 0 24 24"
       width="1em"
     >

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -84,24 +84,15 @@ export class Icon extends Component<IconProps> {
     } = withSuomifiDefaultProps(this.props);
     const { className, ariaLabel } = this.props;
 
+    const iconColor =
+      color !== undefined ? color : colorValue({ tokens })('depthDark27');
+
     if (!!src) {
-      return (
-        <StyledIcon
-          src={src}
-          {...passProps}
-          color={colorValue({ tokens })('depthDark27')}
-        />
-      );
+      return <StyledIcon src={src} {...passProps} color={iconColor} />;
     }
 
     if (icon !== undefined) {
-      return (
-        <StyledSuomifiIcon
-          {...passProps}
-          icon={icon}
-          color={colorValue({ tokens })('depthDark27')}
-        />
-      );
+      return <StyledSuomifiIcon {...passProps} icon={icon} color={iconColor} />;
     }
 
     logger.warn(

--- a/src/core/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/core/Icon/__snapshots__/Icon.test.tsx.snap
@@ -11,9 +11,9 @@ exports[`calling render with the same component on the same container does not r
     aria-label="Test label"
     class="my-icon--test c0"
     data-testid="icon"
+    fill="hsl(202, 7%, 40%)"
     height="1em"
     role="img"
-    style="fill: hsl(202, 7%, 40%);"
     viewBox="0 0 24 24"
     width="1em"
   >
@@ -24,9 +24,9 @@ exports[`calling render with the same component on the same container does not r
   <svg
     aria-hidden="true"
     class="c0"
+    fill="hsl(202, 7%, 40%)"
     focusable="false"
     height="1em"
-    style="fill: hsl(202, 7%, 40%);"
     viewBox="0 0 24 24"
     width="1em"
   >

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -161,9 +161,9 @@ exports[`calling render with the same component on the same container does not r
   <svg
     aria-hidden="true"
     class="fi-link_icon c5"
+    fill="currentColor"
     focusable="false"
     height="1em"
-    style="fill: hsl(202, 7%, 40%);"
     viewBox="0 0 24 24"
     width="1em"
   >

--- a/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
+++ b/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
@@ -265,10 +265,10 @@ exports[`calling render with the same component on the same container does not r
     Test expansion
     <svg
       aria-hidden="true"
-      class="fi-panel-expansion_title-icon c6"
+      class="fi-panel-expansion_title-icon c5"
+      fill="hsl(212, 63%, 45%)"
       focusable="false"
       height="1em"
-      style="fill: hsl(202, 7%, 40%);"
       viewBox="0 0 24 24"
       width="1em"
     >

--- a/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
+++ b/src/core/Panel/__snapshots__/PanelExpansion.test.tsx.snap
@@ -265,7 +265,7 @@ exports[`calling render with the same component on the same container does not r
     Test expansion
     <svg
       aria-hidden="true"
-      class="fi-panel-expansion_title-icon c5"
+      class="fi-panel-expansion_title-icon c6"
       fill="hsl(212, 63%, 45%)"
       focusable="false"
       height="1em"

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -399,7 +399,7 @@ exports[`snapshot testing 1`] = `
         Test expansion 1
         <svg
           aria-hidden="true"
-          class="fi-panel-expansion_title-icon c8"
+          class="fi-panel-expansion_title-icon c9"
           fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"
@@ -432,7 +432,7 @@ exports[`snapshot testing 1`] = `
         Test expansion 2
         <svg
           aria-hidden="true"
-          class="fi-panel-expansion_title-icon c8"
+          class="fi-panel-expansion_title-icon c9"
           fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"
@@ -465,7 +465,7 @@ exports[`snapshot testing 1`] = `
         Test expansion 3
         <svg
           aria-hidden="true"
-          class="fi-panel-expansion_title-icon c8"
+          class="fi-panel-expansion_title-icon c9"
           fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -399,10 +399,10 @@ exports[`snapshot testing 1`] = `
         Test expansion 1
         <svg
           aria-hidden="true"
-          class="fi-panel-expansion_title-icon c9"
+          class="fi-panel-expansion_title-icon c8"
+          fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"
-          style="fill: hsl(202, 7%, 40%);"
           viewBox="0 0 24 24"
           width="1em"
         >
@@ -432,10 +432,10 @@ exports[`snapshot testing 1`] = `
         Test expansion 2
         <svg
           aria-hidden="true"
-          class="fi-panel-expansion_title-icon c9"
+          class="fi-panel-expansion_title-icon c8"
+          fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"
-          style="fill: hsl(202, 7%, 40%);"
           viewBox="0 0 24 24"
           width="1em"
         >
@@ -465,10 +465,10 @@ exports[`snapshot testing 1`] = `
         Test expansion 3
         <svg
           aria-hidden="true"
-          class="fi-panel-expansion_title-icon c9"
+          class="fi-panel-expansion_title-icon c8"
+          fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"
-          style="fill: hsl(202, 7%, 40%);"
           viewBox="0 0 24 24"
           width="1em"
         >

--- a/yarn.lock
+++ b/yarn.lock
@@ -10548,10 +10548,10 @@ suomifi-design-tokens@0.3.0:
   resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.3.0.tgz#694660b5038e1a652ad64d2a8e727f0561392588"
   integrity sha512-brxPbFjpJUNm17SF/d174UhZtZGZJPL8OhRApBVi30eCm9BFptiqD18SLy1k58dlloVfqGjhALNnHiwhEcFftA==
 
-suomifi-icons@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.0.8.tgz#2a25de59b9e945321d504c0c393f8371d8213bbb"
-  integrity sha512-C/qsOpERN73eyAMjpOMtGPw2NkS1R57VVk/cjsxM7mmlDMiBYjCdXM8XYa3HPsGxlznEHxNmCxWqMf4z/QF1WA==
+suomifi-icons@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.0.10.tgz#d2e32f7e03c53b86d1efeeada037a0f420a01804"
+  integrity sha512-tPh7CFBOGyyK0qaBU7dlOsHn9c8hLi0qpNHXz2xhHbVOkPD6bGLDlrtkQVdvni5nRi9zYJ2xeiaSZ7azADTeLQ==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

This PR update suomifi-icons to version 0.0.10 and introduces support for Icon component custom props. The custom props are now passed forward to underlying svg.

In addition, includes a fix to restore support for custom icon colors.

## Related Issue

Closes #156 
Relates to #250 

## Motivation and Context

This update adds support for strict CSP when using Icons and setting the colors.

## How Has This Been Tested?

Tested by creating a new local package using Verdaccio and with create react app typescript application with strict CSP.
