### PR TITLE
[Bugfix] Fix Toggle's 'defaultChecked' property

### DIFF
--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -98,7 +98,11 @@ export class ToggleInput extends Component<ToggleProps> {
         {!!toggleInputComponent ? (
           componentOrElementWithProps(toggleInputComponent, newToggleInputProps)
         ) : (
-          <HtmlInput {...newToggleInputProps} type="checkbox" />
+          <HtmlInput
+            {...newToggleInputProps}
+            type="checkbox"
+            key={String(toggleState)}
+          />
         )}
         {children}
       </HtmlLabel>

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -33,7 +33,7 @@ const StyledToggle = styled(
  * Use for toggling form selection or application state
  */
 class ToggleWithIcon extends Component<ToggleProps> {
-  state = { toggleStatus: !!this.props.checked };
+  state = { toggleStatus: !!this.props.checked || !!this.props.defaultChecked };
 
   handleToggle = () => {
     const { onClick } = this.props;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Toggle's `defaultChecked` prop was not showing visible change in the Toggle component. 

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #154 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
`defaultChecked` prop only added the `checked` attribute for the input (previously there was only input-version available of the Toggle).

## How Has This Been Tested?
- `yarn validate`
- manually testing in the browser
