### PR TITLE
[BreakingChange] Remove heading 6 variant

### DIFF
--- a/.styleguidist/typography.md
+++ b/.styleguidist/typography.md
@@ -106,12 +106,12 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
     code="<Heading.h1hero smallScreen></Heading.h1hero>"
   />
 
-  {[1, 2, 3, 4, 5, 6].map(n => (
+  {[1, 2, 3, 4, 5].map(n => (
     <React.Fragment key={n}>
       <HeadingSet
         variant={`h${n}`}
         name={`Heading ${n}`}
-        size={typographyTokens[`heading${n !== 6 ? n : 5}`].fontSize}
+        size={typographyTokens[`heading${n}`].fontSize}
         code={`<Heading.h${n}></Heading.h${n}>`}
       />
       <HeadingSet
@@ -119,10 +119,7 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
         smallScreen
         variant={`h${n}`}
         name={`Heading ${n}`}
-        size={
-          typographyTokens[`heading${n !== 6 ? n : 5}SmallScreen`]
-            .fontSize
-        }
+        size={typographyTokens[`heading${n}SmallScreen`].fontSize}
         code={`<Heading.h${n} smallScreen></Heading.h${n}>`}
       />
     </React.Fragment>

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "polished": "3.4.0",
     "react-svg": "7.2.2",
     "styled-components": "4.3.2",
-    "suomifi-design-tokens": "0.3.0",
+    "suomifi-design-tokens": "0.4.0",
     "suomifi-icons": "0.0.8",
     "uuid": "3.3.2"
   },

--- a/src/core/Heading/Heading.md
+++ b/src/core/Heading/Heading.md
@@ -8,7 +8,6 @@ import { Heading } from 'suomifi-ui-components';
   <Heading.h3>h3 text</Heading.h3>
   <Heading.h4>h4 text</Heading.h4>
   <Heading.h5>h5 text</Heading.h5>
-  <Heading.h6>h6 text</Heading.h6>
   <Heading.h1hero>h1 text with hero styling</Heading.h1hero>
   <Heading.h1 smallScreen>
     h1 text for small screen resolution

--- a/src/core/Heading/Heading.test.tsx
+++ b/src/core/Heading/Heading.test.tsx
@@ -13,7 +13,6 @@ const TestHeadings = (
     <Heading.h3>Test Heading</Heading.h3>
     <Heading.h4>Test Heading</Heading.h4>
     <Heading.h5>Test Heading</Heading.h5>
-    <Heading.h6>Test Heading</Heading.h6>
   </div>
 );
 

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -82,10 +82,6 @@ export class Heading extends Component<HeadingProps> {
     <StyledHeading {...withSuomifiDefaultProps(props)} variant="h5" />
   );
 
-  static h6 = (props: Omit<HeadingProps, 'variant'>) => (
-    <StyledHeading {...withSuomifiDefaultProps(props)} variant="h6" />
-  );
-
   render() {
     const { variant, ...passProps } = withSuomifiDefaultProps(this.props);
     if (!variant) {

--- a/src/core/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/core/Heading/__snapshots__/Heading.test.tsx.snap
@@ -321,10 +321,5 @@ exports[`calling render with the same component on the same container does not r
   >
     Test Heading
   </h5>
-  <h6
-    class="fi-heading c0 fi-heading--h6 c1"
-  >
-    Test Heading
-  </h6>
 </div>
 `;

--- a/src/reset/HtmlH/HtmlH.tsx
+++ b/src/reset/HtmlH/HtmlH.tsx
@@ -3,7 +3,7 @@ import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
 import { Omit, asPropType } from '../../utils/typescript';
 
-export type hLevels = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+export type hLevels = 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
 
 export interface HtmlHProps
   extends Omit<HTMLProps<HTMLHeadingElement>, 'ref' | 'as'> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6715,12 +6715,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.13:
+lodash@4.17.15, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -10543,10 +10538,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-suomifi-design-tokens@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.3.0.tgz#694660b5038e1a652ad64d2a8e727f0561392588"
-  integrity sha512-brxPbFjpJUNm17SF/d174UhZtZGZJPL8OhRApBVi30eCm9BFptiqD18SLy1k58dlloVfqGjhALNnHiwhEcFftA==
+suomifi-design-tokens@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/suomifi-design-tokens/-/suomifi-design-tokens-0.4.0.tgz#5b8e4d0bc60b2274287c8d1bbb6990bb74d0e52f"
+  integrity sha512-R1O4Uq3RoW5NWloix+nrFfgd+4XntW2gU4l6qaBKkGmP65rIUeOPwpiGA7UyGc24Oy3EId0p3+dt17EdWlb9Kw==
 
 suomifi-icons@0.0.8:
   version "0.0.8"


### PR DESCRIPTION

## Description

Removed the heading level 6 variant and references to it in tests and examples. Also updated suomifi-design-tokens to 0.4.0, which removes the tokens from there as well.

## How Has This Been Tested?

yarn test and manually in local branch
