### PR TITLE
Release 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "react-svg": "7.2.2",
     "styled-components": "4.3.2",
     "suomifi-design-tokens": "0.6.0",
-    "suomifi-icons": "0.0.10",
+    "suomifi-icons": "0.0.12",
     "uuid": "3.3.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Suomi.fi UI component library",
   "main": "dist/umd/index.js",
   "module": "dist/esm/index.js",

--- a/src/core/Icon/Icon.md
+++ b/src/core/Icon/Icon.md
@@ -19,7 +19,11 @@ import { Icon } from 'suomifi-ui-components';
 ```jsx noeditor
 import { Icon } from 'suomifi-ui-components';
 import { default as styled } from 'styled-components';
-import { allIcons, allStaticIcons } from 'suomifi-icons';
+import {
+  allIcons,
+  allStaticIcons,
+  allDoctypeIcons
+} from 'suomifi-icons';
 import clipboardCopy from 'clipboard-copy';
 const StyledIcon = styled(props => <Icon {...props} />)({
   height: '50px',
@@ -40,6 +44,16 @@ const StyledIcon = styled(props => <Icon {...props} />)({
   </div>
   <div>
     {allStaticIcons.map(icon => (
+      <StyledIcon
+        mousePointer
+        icon={icon}
+        key={icon}
+        onClick={() => clipboardCopy(icon)}
+      />
+    ))}
+  </div>
+  <div>
+    {allDoctypeIcons.map(icon => (
       <StyledIcon
         mousePointer
         icon={icon}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10543,10 +10543,10 @@ suomifi-design-tokens@0.6.0:
   resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.6.0.tgz#a849e6a1115df18beff82b74c7835586fcf19814"
   integrity sha512-1His7iGBynkEzUI9uhMDGHCYQeFUh+kfbOsqdn4rMz8v9Vqpx/5QngTs3UstK85mjJzaZrN0Q7bdTcRtVCkrWA==
 
-suomifi-icons@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.0.10.tgz#d2e32f7e03c53b86d1efeeada037a0f420a01804"
-  integrity sha512-tPh7CFBOGyyK0qaBU7dlOsHn9c8hLi0qpNHXz2xhHbVOkPD6bGLDlrtkQVdvni5nRi9zYJ2xeiaSZ7azADTeLQ==
+suomifi-icons@0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.0.12.tgz#4437cc0a2097907c8b03bab2e10e60e4a67c1179"
+  integrity sha512-g+MpKqghgr9per4KJbmnrL+M1JPVUuT96Igk99xxLZ+QVNo/YNIDOgCW31L7P5hjqpXcZV0ECmXAjRi1kmSnQw==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Release 0.4.1

- Updated to use `suomifi-icons`  0.0.12
- Showing the new docType icons in the styleguidist