### PR TITLE
[Feature]Add styles for toggle component disabled variants

### DIFF
--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -46,6 +46,9 @@ export const baseStyles = withSuomifiTheme(
     & .${svgPrefix}fi-toggle-icon-knob {
       transform: translateX(0%);
     }
+    .${svgPrefix}fi-toggle-icon-circle {
+        fill: ${theme.colors.whiteBase};
+      }
     & .${svgPrefix}fi-toggle-icon-slide {
       transform: translateY(1px);
     }

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -76,5 +76,6 @@ export const baseStyles = withSuomifiTheme(
       }
     }
   }
+  }
 `,
 );

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -49,6 +49,14 @@ export const baseStyles = withSuomifiTheme(
     & .${svgPrefix}fi-toggle-icon-slide {
       transform: translateY(1px);
     }
+    &.fi-toggle_icon--disabled {
+      .${svgPrefix}fi-toggle-icon-circle {
+        fill: ${theme.colors.depthLight30};
+      }
+      & .${svgPrefix}fi-toggle-icon-slide {
+        fill: ${theme.colors.depthLight26};
+    }
+    }
     &.fi-toggle_icon--checked {
       .${svgPrefix}fi-toggle-icon-knob {
         transform: translateX(50%);
@@ -58,6 +66,10 @@ export const baseStyles = withSuomifiTheme(
       }
       .${svgPrefix}fi-toggle-icon-circle {
         fill: ${theme.colors.successBase};
+      }
+      &.fi-toggle_icon--disabled {
+      .${svgPrefix}fi-toggle-icon-circle {
+        fill: ${theme.colors.successSecondary};
       }
     }
   }

--- a/src/core/Form/Toggle/Toggle.md
+++ b/src/core/Form/Toggle/Toggle.md
@@ -13,7 +13,7 @@ import { Toggle } from 'suomifi-ui-components';
     defaultChecked
     onClick={({ toggleState }) => console.log(toggleState)}
   >
-    Checked enabled
+    Checked enabled using input
   </Toggle.withInput>
 
   <Toggle.withInput
@@ -24,7 +24,7 @@ import { Toggle } from 'suomifi-ui-components';
   </Toggle.withInput>
 
   <Toggle onClick={({ toggleState }) => console.log(toggleState)}>
-    Unchecked enabled
+    Unchecked enabled using button
   </Toggle>
 </>;
 ```

--- a/src/core/Form/Toggle/Toggle.md
+++ b/src/core/Form/Toggle/Toggle.md
@@ -1,13 +1,30 @@
 ```js
 import { Toggle } from 'suomifi-ui-components';
 <>
-  <Toggle onClick={({ toggleState }) => console.log(toggleState)}>
-    Toggle button
-  </Toggle>
-  <Toggle.withInput
+  <Toggle
+    defaultChecked
+    disabled
     onClick={({ toggleState }) => console.log(toggleState)}
   >
-    Toggle input
+    Checked disabled using button
+  </Toggle>
+
+  <Toggle.withInput
+    defaultChecked
+    onClick={({ toggleState }) => console.log(toggleState)}
+  >
+    Checked enabled
   </Toggle.withInput>
+
+  <Toggle.withInput
+    disabled
+    onClick={({ toggleState }) => console.log(toggleState)}
+  >
+    Unchecked disabled using input
+  </Toggle.withInput>
+
+  <Toggle onClick={({ toggleState }) => console.log(toggleState)}>
+    Unchecked enabled
+  </Toggle>
 </>;
 ```

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -67,7 +67,7 @@ class ToggleWithIcon extends Component<ToggleProps> {
             [iconCheckedClassName]: !!toggleStatus,
           })}
         />
-        <Text>{children}</Text>
+        <Text color={!!disabled ? 'depthBase' : 'blackBase'}>{children}</Text>
       </StyledToggle>
     );
   }

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -277,10 +277,22 @@ exports[`Button: calling render with the same component on the same container do
   transform: translateX(0%);
 }
 
+.c0 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-circle {
+  fill: hsl(0,0%,100%);
+}
+
 .c0 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-slide {
   -webkit-transform: translateY(1px);
   -ms-transform: translateY(1px);
   transform: translateY(1px);
+}
+
+.c0 .fi-toggle_icon.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-circle {
+  fill: hsl(202,7%,97%);
+}
+
+.c0 .fi-toggle_icon.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-slide {
+  fill: hsl(202,7%,93%);
 }
 
 .c0 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-knob {
@@ -295,6 +307,10 @@ exports[`Button: calling render with the same component on the same container do
 
 .c0 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-circle {
   fill: hsl(166,90%,36%);
+}
+
+.c0 .fi-toggle_icon.fi-toggle_icon--checked.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-circle {
+  fill: hsl(166,54%,80%);
 }
 
 <button
@@ -748,10 +764,22 @@ exports[`Input: calling render with the same component on the same container doe
   transform: translateX(0%);
 }
 
+.c0 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-circle {
+  fill: hsl(0,0%,100%);
+}
+
 .c0 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-slide {
   -webkit-transform: translateY(1px);
   -ms-transform: translateY(1px);
   transform: translateY(1px);
+}
+
+.c0 .fi-toggle_icon.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-circle {
+  fill: hsl(202,7%,97%);
+}
+
+.c0 .fi-toggle_icon.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-slide {
+  fill: hsl(202,7%,93%);
 }
 
 .c0 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-knob {
@@ -766,6 +794,10 @@ exports[`Input: calling render with the same component on the same container doe
 
 .c0 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-circle {
   fill: hsl(166,90%,36%);
+}
+
+.c0 .fi-toggle_icon.fi-toggle_icon--checked.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-circle {
+  fill: hsl(166,54%,80%);
 }
 
 <label


### PR DESCRIPTION
## Description

Added styling to match the implementation to the updated designs at https://app.goabstract.com/share/92d4527a-036e-4f0f-89b2-f8d841a6ef9c

This was done mostly in the toggle basestyles, but the label color is changed by a conditional color prop in the text component inside the toggle component.

## Motivation and Context

There was no clear visual cue for when a toggle component is disabled. Now the toggle component has a visually distinctive style for all combinations of checked/disabled.

## How Has This Been Tested?

By testing manually in local environment and yarn test.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/54316341/71964338-08f9c280-3206-11ea-9d0b-2418ba226833.png)
