### PR TITLE
[BreakingChange] Button variant 'negative' changed to 'inverted'

### DIFF
--- a/.styleguidist/styleguidist.styles.js
+++ b/.styleguidist/styleguidist.styles.js
@@ -95,7 +95,7 @@ module.exports = {
     preview: {
       '&:not([data-preview="Text"]) > div': {
         ...grid440px24px,
-        '& [example="negative"]': {
+        '& [example="inverted"]': {
           ...grid440px24px,
           padding: '24px',
           backgroundColor: '#2A6EBB',

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -3,8 +3,8 @@ import { withSuomifiTheme, TokensAndTheme, SuomifiThemeProp } from '../theme';
 import { ButtonProps } from './Button';
 import { element, focus, button } from '../theme/reset';
 
-const negativeStyles = ({ theme }: SuomifiThemeProp) => css`
-  &.fi-button--negative {
+const invertedStyles = ({ theme }: SuomifiThemeProp) => css`
+  &.fi-button--inverted {
     background: none;
     background-color: ${theme.colors.highlightBase};
     border: 1px solid ${theme.colors.whiteBase};
@@ -122,7 +122,7 @@ export const baseStyles = withSuomifiTheme(
     width: 100%;
   }
 
-  ${negativeStyles({ theme })}
+  ${invertedStyles({ theme })}
   ${secondaryStyles({ theme })}
   ${secondaryNoBorderStyles({ theme })}
   ${tertiaryStyles({ theme })}

--- a/src/core/Button/Button.md
+++ b/src/core/Button/Button.md
@@ -36,11 +36,11 @@ import { Button } from 'suomifi-ui-components';
 
 <>
   <div example="negative">
-    <Button.negative>Button.negative</Button.negative>
+    <Button.inverted>Button.inverted</Button.inverted>
 
-    <Button.negative disabled fullWidth icon="login">
-      Button.negative disabled fullWidth icon="login"
-    </Button.negative>
+    <Button.inverted disabled fullWidth icon="login">
+      Button.inverted disabled fullWidth icon="login"
+    </Button.inverted>
   </div>
 </>;
 ```

--- a/src/core/Button/Button.md
+++ b/src/core/Button/Button.md
@@ -35,7 +35,7 @@ import { Button } from 'suomifi-ui-components';
 import { Button } from 'suomifi-ui-components';
 
 <>
-  <div example="negative">
+  <div example="inverted">
     <Button.inverted>Button.inverted</Button.inverted>
 
     <Button.inverted disabled fullWidth icon="login">

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -13,7 +13,7 @@ import { UnstyledButton } from './UnstyledButton';
 
 type ButtonVariant =
   | 'default'
-  | 'negative'
+  | 'inverted'
   | 'secondary'
   | 'secondary-noborder'
   | 'tertiary'
@@ -25,7 +25,7 @@ export interface ButtonProps extends CompButtonProps, TokensProp {
    */
   fullWidth?: boolean;
   /**
-   * 'default' | 'negative' | 'secondary' | 'secondary-noborder' | 'tertiary'
+   * 'default' | 'inverted' | 'secondary' | 'secondary-noborder' | 'tertiary'
    * @default default
    */
   variant?: ButtonVariant;
@@ -152,9 +152,9 @@ class ButtonWithIcon extends Component<ButtonProps & InternalTokensProp> {
  * `import { UnstyledButton } from 'suomifi-ui-components';` or `<Button.unstyled />`.
  */
 export class Button extends Component<ButtonProps> {
-  static negative = (props: ButtonProps) => {
+  static inverted = (props: ButtonProps) => {
     return (
-      <ButtonWithIcon {...withSuomifiDefaultProps(props)} variant="negative" />
+      <ButtonWithIcon {...withSuomifiDefaultProps(props)} variant="inverted" />
     );
   };
 

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -132,25 +132,25 @@ exports[`calling render with the same component on the same container does not r
   width: 100%;
 }
 
-.c0.fi-button--negative {
+.c0.fi-button--inverted {
   background: none;
   background-color: hsl(212,63%,45%);
   border: 1px solid hsl(0,0%,100%);
   text-shadow: none;
 }
 
-.c0.fi-button--negative:hover {
+.c0.fi-button--inverted:hover {
   background: linear-gradient(-180deg,rgba(255,255,255,0.1) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c0.fi-button--negative:active {
+.c0.fi-button--inverted:active {
   background: none;
   background-color: hsl(212,63%,45%);
 }
 
-.c0.fi-button--negative.fi-button--disabled,
-.c0.fi-button--negative[disabled],
-.c0.fi-button--negative:disabled {
+.c0.fi-button--inverted.fi-button--disabled,
+.c0.fi-button--inverted[disabled],
+.c0.fi-button--inverted:disabled {
   opacity: 0.5;
   background-color: hsl(212,63%,45%);
 }


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Button variant 'negative' changed to 'inverted' to match design. 

This is a breaking change, so users should use 'inverted' instead of previous 'negative' after this change goes live.

**Before**: `<Button.negative>Button.negative</Button.negative>`
**Now**: ` <Button.inverted>Button.inverted</Button.inverted>`

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Naming of the variant changed to reflect the design to prevent any possibility of miscommunication or confusion.

## How Has This Been Tested?

- Run locally in the browser
- `yarn validate` 