### PR TITLE
[Bugfix] Make toggle input match icon size

### DIFF
--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -5,6 +5,8 @@ import { element, font } from '../../theme/reset';
 
 // Contains double underscore because it is written in the SVG-file
 const svgPrefix = 'icon-toggle_svg__';
+const iconWidth = '40px';
+const iconHeight = '24px';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
@@ -17,8 +19,9 @@ export const baseStyles = withSuomifiTheme(
   & > .fi-toggle_input {
     ${element({ theme })}
     ${font({ theme })('bodyText')}
-    width: 0;
-    height: 0;
+    position: absolute;
+    width: ${iconWidth};
+    height: ${iconHeight};
     opacity: 0;
     z-index: -9999;
     background-color: ${theme.colors.whiteBase};
@@ -36,8 +39,8 @@ export const baseStyles = withSuomifiTheme(
     }
   }
   & .fi-toggle_icon {
-    width: 40px;
-    height: 24px;
+    width: ${iconWidth};
+    height: ${iconHeight};
     margin-right: ${theme.spacing.s};
     vertical-align: bottom;
     overflow: visible;

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -217,8 +217,9 @@ exports[`Button: calling render with the same component on the same container do
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  width: 0;
-  height: 0;
+  position: absolute;
+  width: 40px;
+  height: 24px;
   opacity: 0;
   z-index: -9999;
   background-color: hsl(0,0%,100%);
@@ -704,8 +705,9 @@ exports[`Input: calling render with the same component on the same container doe
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  width: 0;
-  height: 0;
+  position: absolute;
+  width: 40px;
+  height: 24px;
   opacity: 0;
   z-index: -9999;
   background-color: hsl(0,0%,100%);


### PR DESCRIPTION

## Description

Gave the toggle input a size that matches the icon(s) used. This allows for the component to be found by mobile screen readers. Some issues regarding focus remain, but they will be addressed in another ticket.

## Related Issue

Closes #268 

## How Has This Been Tested?

Tested manually on a pc as well as a mobile phone (android) and snapshot tests.
