### PR TITLE
[Bugfix]Toggle focus

### DIFF
--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -107,11 +107,7 @@ export class ToggleInput extends Component<ToggleProps> {
         {!!toggleInputComponent ? (
           componentOrElementWithProps(toggleInputComponent, newToggleInputProps)
         ) : (
-          <HtmlInput
-            {...newToggleInputProps}
-            type="checkbox"
-            key={String(toggleState)}
-          />
+          <HtmlInput {...newToggleInputProps} type="checkbox" />
         )}
         {children}
       </StyledHtmlLabel>

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -25,9 +25,18 @@ export const baseStyles = withSuomifiTheme(
         }
       }
     }
-  & > .fi-toggle_label {
-    cursor: pointer;
-  }
+    & + .fi-toggle--with-input {
+      &:focus-within {
+        outline: 0;
+        ${focus({ theme, noPseudo: true })}
+      }
+      &:focus-within:not(:focus-visible) {
+        outline: 0;
+        &:after {
+          content: none;
+        }
+      }
+    }
   & > .fi-toggle_input {
     ${element({ theme })}
     ${font({ theme })('bodyText')}
@@ -37,18 +46,6 @@ export const baseStyles = withSuomifiTheme(
     opacity: 0;
     z-index: -9999;
     background-color: ${theme.colors.whiteBase};
-    &:focus {
-      outline: 0;
-      & + .fi-toggle_label {
-        ${focus({ theme, noPseudo: true })}
-      }
-    }
-    &:focus:not(:focus-visible) {
-      outline: 0;
-      &:after {
-        content: none;
-      }
-    }
   }
   & .fi-toggle_icon {
     width: ${iconWidth};

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -13,6 +13,18 @@ export const baseStyles = withSuomifiTheme(
   ${element({ theme })}
   ${font({ theme })('bodyText')}
   background-color: ${theme.colors.whiteBase};
+    & + .fi-toggle--with-button {
+      &:focus {
+        outline: 0;
+        ${focus({ theme, noPseudo: true })}
+      }
+      &:focus:not(:focus-visible) {
+        outline: 0;
+        &:after {
+          content: none;
+        }
+      }
+    }
   & > .fi-toggle_label {
     cursor: pointer;
   }

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -198,8 +198,70 @@ exports[`Button: calling render with the same component on the same container do
   background-color: hsl(0,0%,100%);
 }
 
-.c0 > .fi-toggle_label {
-  cursor: pointer;
+.c0 + .fi-toggle--with-button:focus {
+  outline: 0;
+  outline: 0;
+  position: relative;
+}
+
+.c0 + .fi-toggle--with-button:focus:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c0 + .fi-toggle--with-button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 + .fi-toggle--with-button:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.c0 + .fi-toggle--with-button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 + .fi-toggle--with-input:focus-within {
+  outline: 0;
+  outline: 0;
+  position: relative;
+}
+
+.c0 + .fi-toggle--with-input:focus-within:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c0 + .fi-toggle--with-input:focus-within:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 + .fi-toggle--with-input:focus-within:not(:focus-visible) {
+  outline: 0;
+}
+
+.c0 + .fi-toggle--with-input:focus-within:not(:focus-visible):after {
+  content: none;
 }
 
 .c0 > .fi-toggle_input {
@@ -223,42 +285,6 @@ exports[`Button: calling render with the same component on the same container do
   opacity: 0;
   z-index: -9999;
   background-color: hsl(0,0%,100%);
-}
-
-.c0 > .fi-toggle_input:focus {
-  outline: 0;
-}
-
-.c0 > .fi-toggle_input:focus + .fi-toggle_label {
-  outline: 0;
-  position: relative;
-}
-
-.c0 > .fi-toggle_input:focus + .fi-toggle_label:after {
-  content: '';
-  position: absolute;
-  top: -4px;
-  right: -4px;
-  bottom: -4px;
-  left: -4px;
-  border-radius: 4px;
-  background-color: transparent;
-  border: 1px solid hsl(23,82%,53%);
-  box-sizing: border-box;
-  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
-  z-index: 9999;
-}
-
-.c0 > .fi-toggle_input:focus + .fi-toggle_label:not(:focus-visible):after {
-  content: none;
-}
-
-.c0 > .fi-toggle_input:focus:not(:focus-visible) {
-  outline: 0;
-}
-
-.c0 > .fi-toggle_input:focus:not(:focus-visible):after {
-  content: none;
 }
 
 .c0 .fi-toggle_icon {
@@ -686,8 +712,70 @@ exports[`Input: calling render with the same component on the same container doe
   background-color: hsl(0,0%,100%);
 }
 
-.c0 > .fi-toggle_label {
-  cursor: pointer;
+.c0 + .fi-toggle--with-button:focus {
+  outline: 0;
+  outline: 0;
+  position: relative;
+}
+
+.c0 + .fi-toggle--with-button:focus:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c0 + .fi-toggle--with-button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 + .fi-toggle--with-button:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.c0 + .fi-toggle--with-button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 + .fi-toggle--with-input:focus-within {
+  outline: 0;
+  outline: 0;
+  position: relative;
+}
+
+.c0 + .fi-toggle--with-input:focus-within:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c0 + .fi-toggle--with-input:focus-within:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 + .fi-toggle--with-input:focus-within:not(:focus-visible) {
+  outline: 0;
+}
+
+.c0 + .fi-toggle--with-input:focus-within:not(:focus-visible):after {
+  content: none;
 }
 
 .c0 > .fi-toggle_input {
@@ -711,42 +799,6 @@ exports[`Input: calling render with the same component on the same container doe
   opacity: 0;
   z-index: -9999;
   background-color: hsl(0,0%,100%);
-}
-
-.c0 > .fi-toggle_input:focus {
-  outline: 0;
-}
-
-.c0 > .fi-toggle_input:focus + .fi-toggle_label {
-  outline: 0;
-  position: relative;
-}
-
-.c0 > .fi-toggle_input:focus + .fi-toggle_label:after {
-  content: '';
-  position: absolute;
-  top: -4px;
-  right: -4px;
-  bottom: -4px;
-  left: -4px;
-  border-radius: 4px;
-  background-color: transparent;
-  border: 1px solid hsl(23,82%,53%);
-  box-sizing: border-box;
-  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
-  z-index: 9999;
-}
-
-.c0 > .fi-toggle_input:focus + .fi-toggle_label:not(:focus-visible):after {
-  content: none;
-}
-
-.c0 > .fi-toggle_input:focus:not(:focus-visible) {
-  outline: 0;
-}
-
-.c0 > .fi-toggle_input:focus:not(:focus-visible):after {
-  content: none;
 }
 
 .c0 .fi-toggle_icon {


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

- Fixes the focus outline of Toggle for both, the input- and button-version
- Fixes the disappearing focus issue when toggling the state of input-version
- Updated snapshot test accordingly

## Background info
Here are some additional info to support the changes made.

### checked attribute

> If present on a checkbox type, it indicates that the checkbox is checked by default (when the page loads). It does not indicate whether this checkbox is currently checked: if the checkbox’s state is changed, this content attribute does not reflect the change.

Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefchecked

Therefore the `key={String(toggleState)}` was removed from the ToggleInput.

### Space/Enter will not read changed state

Using `Space` or `Enter` will not read the state on **Safari** when toggling the state of the ToggleButton. _(On Chrome, it will read the state also with Space and Enter)_
But as the VoiceOver guides, using `Ctrl+Opt+Space`, the state is read nicely when toggling. 

Here are two examples which also works like this with VoiceOver.
- [Toggle Button example (Mute Audio)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role)
- [Toggle Button (switch)](https://scottaohara.github.io/a11y_styled_form_controls/src/toggle-button-switch/)

So this should be okay as it currently is after this PR. Will be go through accessibility clinic, but might be not possible to change/force the VoiceOver action after all.

## How Has This Been Tested?
- `yarn validate`
- Tested with VoiceOver on macOS Safari
- Tested with VoiceOver on iOS Safari


**EDIT**: _Added information how this works different on Safari vs Chrome_