### PR TITLE
[Bugfix] Fix breadcrumb alignment

### DIFF
--- a/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -8,6 +8,7 @@ export const baseStyles = withSuomifiTheme(
   ${nav({ theme })}
   ${font({ theme })('bodyText')}
   background-color: ${theme.colors.whiteBase};
+  height: 1.5em;
 
   & .fi-breadcrumb {
     &_list {

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -210,6 +210,7 @@ exports[`calling render with the same component on the same container does not r
   line-height: 1.5;
   font-weight: 400;
   background-color: hsl(0,0%,100%);
+  height: 1.5em;
 }
 
 .c0 .fi-breadcrumb_list {


### PR DESCRIPTION
## Description
The breadcrumb component had no height and thus didn't position correctly (as a block-level element). Added height attribute to the nav element of the component to make it behave like a block-level element.

## Related Issue

The issue was risen by one of the project teams using the ui-library. No issue ticket on github though. 

## Motivation and Context

Now breadcrumb behaves like a block-level element. If in the future we want to support treating it as an inline element that will require some additional tweaking. Not many use cases for that though.

## How Has This Been Tested?

Yarn test and running locally in a CRA test project.