### PR TITLE
Feature/update reach

### DIFF
--- a/.styleguidist/styleguidist.require.js
+++ b/.styleguidist/styleguidist.require.js
@@ -1,1 +1,2 @@
 import '../src/core/theme/fontFaces.css';
+import '@reach/menu-button/styles.css';

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "typescript": "3.3.1"
   },
   "dependencies": {
-    "@reach/component-component": "0.1.3",
-    "@reach/menu-button": "0.1.7",
+    "@reach/component-component": "0.8.2",
+    "@reach/menu-button": "0.8.4",
     "classnames": "2.2.6",
     "normalize.cssinjs": "1.1.0",
     "polished": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "typescript": "3.3.1"
   },
   "dependencies": {
-    "@reach/component-component": "0.8.2",
-    "@reach/menu-button": "0.8.4",
+    "@reach/menu-button": "0.8.5",
+    "@reach/popover": "0.8.5",
     "classnames": "2.2.6",
     "normalize.cssinjs": "1.1.0",
     "polished": "3.4.0",

--- a/src/components/Component-component/Component-component.tsx
+++ b/src/components/Component-component/Component-component.tsx
@@ -1,2 +1,0 @@
-import { default as Component } from '@reach/component-component';
-export { Component };

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -5,11 +5,12 @@ import {
   Menu,
   MenuButton,
   MenuButtonProps,
-  MenuList,
-  MenuListProps,
+  MenuPopoverProps,
   MenuItem,
   MenuItemProps,
+  MenuPopover,
 } from '@reach/menu-button';
+import { positionMatchWidth } from '@reach/popover';
 import { logger } from '../../utils/logger';
 
 export { MenuItem as DropdownItem };
@@ -35,7 +36,9 @@ interface DropdownState {
 type OptionalMenuButtonProps = {
   [K in keyof MenuButtonProps]?: MenuButtonProps[K];
 };
-type OptionalMenuListProps = { [K in keyof MenuListProps]?: MenuListProps[K] };
+type OptionalMenuListProps = {
+  [K in keyof MenuPopoverProps]?: MenuPopoverProps[K];
+};
 type OptionalMenuItemProps = { [K in keyof MenuItemProps]?: MenuItemProps[K] };
 
 export interface DropdownProps {
@@ -137,13 +140,16 @@ export class Dropdown extends Component<DropdownProps> {
               )}
             </MenuListComponentReplace>
           ) : (
-            <MenuList {...passDropdownListProps}>
+            <MenuPopover
+              position={positionMatchWidth}
+              {...passDropdownListProps}
+            >
               {this.list(
                 children,
                 changeNameToSelection,
                 passDropdownItemProps,
               )}
-            </MenuList>
+            </MenuPopover>
           )}
         </Menu>
       </HtmlSpan>

--- a/src/components/LanguageMenu/LanguageMenu.tsx
+++ b/src/components/LanguageMenu/LanguageMenu.tsx
@@ -8,11 +8,20 @@ import {
   MenuListProps,
   MenuItem,
   MenuLink,
+  MenuPopover,
+  MenuPopoverProps,
 } from '@reach/menu-button';
 import { logger } from '../../utils/logger';
 import { Omit } from '../../utils/typescript';
 
-export { MenuList, MenuListProps, MenuItem, MenuLink };
+export {
+  MenuList,
+  MenuListProps,
+  MenuItem,
+  MenuLink,
+  MenuPopover,
+  MenuPopoverProps,
+};
 
 const baseClassName = 'fi-language-menu';
 export interface LanguageMenuItemProps {
@@ -31,7 +40,7 @@ interface LanguageMenuLinkPropsWithType {
   /** Item content */
   children: ReactNode;
   className?: string;
-  component?: SupportedMenuLinkComponent;
+  as?: SupportedMenuLinkComponent;
 }
 
 export interface LanguageMenuLinkProps

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,6 @@
 export { Breadcrumb, BreadcrumbProps } from './Breadcrumb/Breadcrumb';
 export { Block, BlockProps } from './Block/Block';
 export { Button, ButtonProps } from './Button/Button';
-export { Component } from './Component-component/Component-component';
 export {
   Dropdown,
   DropdownProps,

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../theme';
-import { element, inputButton } from '../theme/reset';
+import { element, inputButton, inputButtonList } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
@@ -34,7 +34,7 @@ export const baseStyles = withSuomifiTheme(
 export const menuListStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
   &[data-reach-menu-list].fi-dropdown_list {
-    ${element({ theme })}
+    ${inputButtonList({ theme })}
     ${theme.typography.actionElementInnerText}
     margin-top: -1px;
     padding: 0;

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../theme';
-import { element, inputButton, inputButtonList } from '../theme/reset';
+import { element, inputButton } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
@@ -33,11 +33,12 @@ export const baseStyles = withSuomifiTheme(
 
 export const menuListStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
-  &[data-reach-menu-list].fi-dropdown_list {
-    ${inputButtonList({ theme })}
+  &[data-reach-menu-popover].fi-dropdown_list {
+    ${element({ theme })}
     ${theme.typography.actionElementInnerText}
     margin-top: -1px;
     padding: 0;
+    box-sizing: border-box;
     font-size: 100%;
     border: 0;
     background-color: ${theme.colors.whiteBase};
@@ -59,6 +60,9 @@ export const menuListStyles = withSuomifiTheme(
       background-image: none;
       background-color: ${theme.colors.highlightLight50};
       border: 0;
+    }
+    &:focus {
+      outline: 0;
     }
   }
 `,

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -4,7 +4,7 @@ import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensProp, InternalTokensProp } from '../theme';
 import { baseStyles, menuListStyles } from './Dropdown.baseStyles';
 import {
-  MenuList as CompMenuList,
+  MenuPopover as CompMenuPopover,
   MenuListProps as CompMenuListProps,
 } from '../../components/LanguageMenu/LanguageMenu';
 import {
@@ -12,6 +12,7 @@ import {
   DropdownProps as CompDropdownProps,
 } from '../../components/Dropdown/Dropdown';
 import { DropdownItem, DropdownItemProps } from './DropdownItem';
+import { positionMatchWidth } from '@reach/popover';
 
 export interface DropdownProps extends CompDropdownProps, TokensProp {}
 
@@ -29,7 +30,7 @@ const StyledDropdown = styled(
 interface MenuListProps extends CompMenuListProps, TokensProp {}
 
 const StyledMenuList = styled(({ tokens, ...passProps }: MenuListProps) => (
-  <CompMenuList {...passProps} />
+  <CompMenuPopover position={positionMatchWidth} {...passProps} />
 ))`
   ${props => menuListStyles(props.theme)}
 `;

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -42,7 +42,8 @@ export const languageMenuListStyles = withSuomifiTheme(
     &.fi-language-menu-language_list {
       ${theme.typography.actionElementInnerText}
       position: absolute;
-      right: 0;
+      box-sizing: content-box;
+      right: -50px;
       top: 0;
       margin-top: 12px;
       padding: 10px 0;
@@ -92,6 +93,9 @@ export const languageMenuListStyles = withSuomifiTheme(
     }
     &[data-selected].fi-language-menu-language_item {
       border-left-color: ${theme.colors.highlightBase};
+    }
+    &:focus {
+      outline: 0;
     }
   }
 `,

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -49,7 +49,7 @@ const LanguageMenuListWithProps = (
       // Set defaul component-prop/type to be 'a' needed for links
       if (React.isValidElement(child)) {
         return React.cloneElement(child, {
-          component: 'a',
+          as: 'a',
           className: classnames(itemClassName, addClass),
         });
       }

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -27,16 +27,13 @@ export const font = (props: SuomifiThemeProp) => (
   ${props.theme.typography[typographyToken]}
 `;
 
-const inputWidthBase = css`
-  min-width: 245px;
-  max-width: 100%;
-`;
-
 export const input = (props: SuomifiThemeProp) => {
   return css`
     ${element(props)}
     ${font(props)('actionElementInnerText')}
-    ${inputWidthBase}
+    min-width: 245px;
+    max-width: 100%;
+    width: 245px;
     padding: ${props.theme.spacing.s} ${props.theme.spacing.m};
     border: 1px solid ${props.theme.colors.depthBase};
     border-radius: ${props.theme.radius.basic};
@@ -62,12 +59,6 @@ export const inputContainer = (props: TokensOrThemeProps) => css`
 export const inputButton = (props: SuomifiThemeProp) => css`
   ${input(props)}
   ${focus(props)}
-`;
-
-export const inputButtonList = (props: SuomifiThemeProp) => css`
-  ${element(props)}
-  ${inputWidthBase}
-  box-sizing: border-box;
 `;
 
 export const button = (props: SuomifiThemeProp) => css`

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -27,12 +27,16 @@ export const font = (props: SuomifiThemeProp) => (
   ${props.theme.typography[typographyToken]}
 `;
 
+const inputWidthBase = css`
+  min-width: 245px;
+  max-width: 100%;
+`;
+
 export const input = (props: SuomifiThemeProp) => {
   return css`
     ${element(props)}
     ${font(props)('actionElementInnerText')}
-    min-width: 245px;
-    max-width: 100%;
+    ${inputWidthBase}
     padding: ${props.theme.spacing.s} ${props.theme.spacing.m};
     border: 1px solid ${props.theme.colors.depthBase};
     border-radius: ${props.theme.radius.basic};
@@ -58,6 +62,12 @@ export const inputContainer = (props: TokensOrThemeProps) => css`
 export const inputButton = (props: SuomifiThemeProp) => css`
   ${input(props)}
   ${focus(props)}
+`;
+
+export const inputButtonList = (props: SuomifiThemeProp) => css`
+  ${element(props)}
+  ${inputWidthBase}
+  box-sizing: border-box;
 `;
 
 export const button = (props: SuomifiThemeProp) => css`

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -33,7 +33,6 @@ export const input = (props: SuomifiThemeProp) => {
     ${font(props)('actionElementInnerText')}
     min-width: 245px;
     max-width: 100%;
-    width: 245px;
     padding: ${props.theme.spacing.s} ${props.theme.spacing.m};
     border: 1px solid ${props.theme.colors.depthBase};
     border-radius: ${props.theme.radius.basic};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,6 +38,18 @@ declare module '@reach/menu-button' {
 
   export const MenuList: React.SFC<MenuListProps>;
 
+  export type Position = (
+    targetRect?: PRect | null,
+    popoverRect?: PRect | null,
+  ) => React.CSSProperties;
+
+  export type MenuPopoverProps = React.HTMLAttributes<HTMLDivElement> & {
+    children: React.ReactNode;
+    position?: Position;
+  };
+
+  export const MenuPopover: React.SFC<MenuPopoverProps>;
+
   type ResolvedMenuLinkProps<T> = T extends keyof JSX.IntrinsicElements
     ? JSX.IntrinsicElements[T]
     : T;
@@ -79,51 +91,6 @@ declare module '@reach/menu-button' {
   };
 
   export const MenuItem: React.SFC<MenuItemProps>;
-}
-
-declare module '@reach/component-component' {
-  type Args<P, S> = {
-    props: P;
-    state: S;
-    setState<K extends keyof S>(
-      state:
-        | ((prevState: Readonly<S>, props: P) => Pick<S, K> | S | null)
-        | (Pick<S, K> | S | null),
-      callback?: () => void,
-    ): void;
-    forceUpdate(callBack?: () => void): void;
-  };
-
-  type Refs = { [key: string]: React.RefObject<HTMLElement> };
-
-  type StateProps<P, S> = Pick<Args<P, S>, 'state' | 'props'>;
-
-  export type ComponentProps<P, S> = {
-    initialState?: S;
-    getInitialState?(): S;
-    refs?: Refs;
-    getRefs?(): Refs;
-    didMount?(args: Args<P, S> & Refs): void;
-    didUpdate?(args: Args<P, S> & Refs & { prevProps: P; prevState: S }): void;
-    willUnmount?(args: StateProps<P, S> & Refs): void;
-    getSnapshotBeforeUpdate?(
-      args: StateProps<P, S> & Refs & { prevProps: P; prevState: S },
-    ): any;
-    shouldUpdate?(
-      args: StateProps<P, S> & { nextProps: P; nextState: S },
-    ): boolean;
-    children?(
-      args: Args<P, S> & Refs,
-    ): Args<P, S> & Refs | React.ReactNode | null;
-    render?(args: Args<P, S>): void;
-  };
-
-  class Component<
-    P extends ComponentProps<P, S>,
-    S = any
-  > extends React.Component<ComponentProps<P, S>, {}> {}
-
-  export default Component;
 }
 
 declare module 'react-styleguidist/lib/client/rsg-components/ComponentsList/ComponentsList' {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,37 +1176,30 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@reach/auto-id@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.8.2.tgz#ea33a29dd08d186585650754f983129492cd86ce"
-  integrity sha512-yVsU0NZa1xjw9dM8+emYLxvpO7QCPnKqZDUNJl5djuAKantaGzTDIoozViI9FdIy965O1XDKHswuAi64utboMQ==
+"@reach/auto-id@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.8.5.tgz#940500d4c93624852efa5ecbed29c5d7015eb6e9"
+  integrity sha512-FmyoQ5Mvw+WXLd3JOlDmHDQKqhTiZ+BwtEq9HW6pgzYMztq1wr5itv4lrSDqOYa/hJfNrkBC8iCtaIKcykuYnQ==
   dependencies:
     tslib "^1.10.0"
 
-"@reach/component-component@0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.8.2.tgz#87590421b90ecf57cffcee61f1210ba63202fef8"
-  integrity sha512-3N9baC2t6jatMYuQj0sPWN/VcK6EH//ywSqbpLXZiRQZXLIQkuelOHRYzfufRbPCIJQipYBko4Q8jg4Jc4nF/w==
+"@reach/descendants@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.8.5.tgz#084b2410bd13be4a76ac663d5957a54325301df0"
+  integrity sha512-L1zGSeOtpK8m/SA/CyJsKBnk+z+kvraEJUq1u/apkw1n47j1Byu40nA7TwKvUxuZtEVaK1CdsGFRGeyHRfU/kg==
   dependencies:
-    prop-types "^15.7.2"
-
-"@reach/descendants@^0.8.4":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.8.4.tgz#b193129e653c474a42c289ba185fd1e1360ffa72"
-  integrity sha512-vCGiX5IX+qTwZUMDlE4cdsiAjdgxCyJxdNSeJrzu1d/+joJ089AEgDnKiVvynUwcNBYwzKC2CJSGQqRD3v4nzw==
-  dependencies:
-    "@reach/utils" "^0.8.4"
+    "@reach/utils" "^0.8.5"
     tslib "^1.10.0"
 
-"@reach/menu-button@0.8.4":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.8.4.tgz#5c87b389871d2d45471501068d3df039c5b6dfb2"
-  integrity sha512-R9swIBEHNR9AhoScfBdxU0Vih7hYuzY3JGmeXG7O9uvYMN3J6z0l/9CLh76Vdx0dxIYHKGdzJza9iVQH2QfsPA==
+"@reach/menu-button@0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.8.5.tgz#d37ea9f7a24fe1cb91daa57b6d036eeab25944e8"
+  integrity sha512-8fD4QOFiDORKhXzWWKGk6uDB1iojA7sgDmBwj21pS03crewmuzbAu/jJj31fbcRwm7xZjtm/UaGGjyaJOSJt/g==
   dependencies:
-    "@reach/auto-id" "^0.8.2"
-    "@reach/descendants" "^0.8.4"
-    "@reach/popover" "^0.8.4"
-    "@reach/utils" "^0.8.4"
+    "@reach/auto-id" "^0.8.5"
+    "@reach/descendants" "^0.8.5"
+    "@reach/popover" "^0.8.5"
+    "@reach/utils" "^0.8.5"
     prop-types "^15.7.2"
     tslib "^1.10.0"
     warning "^4.0.3"
@@ -1216,21 +1209,21 @@
   resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.0.5.tgz#28bf3c5c35da7fef72cd124af4ac32308d0c3f15"
   integrity sha512-EQLHhquzwAh2TFtMJU0PXJRmhpOrAhzApgoI4Lwn72J7ygrMk3Ys3a3i8KDnV0TetbwAxn4XSHi4pE8sPWUYLg==
 
-"@reach/popover@^0.8.4":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/@reach/popover/-/popover-0.8.4.tgz#dd5c6f7726bcc5f4771eb6d3d38cc6a641604bf1"
-  integrity sha512-13adZOZMPB2ZYe2e0NnbDz/Zy8493B/vTZUtRWm3YBW6HLVeq+f7OQvCqY0i8fvw81q0xCT1MIaAZ6UXrw81tg==
+"@reach/popover@0.8.5", "@reach/popover@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@reach/popover/-/popover-0.8.5.tgz#0e64b89585655d5e4290fc5a41f8e62f5f617889"
+  integrity sha512-6s+DJGvuK9ZimQQP9/JFhWSdQAIafte7kwIPeNmQUQNf51RYHYRX30xyhAqcuuogXjEr+tRDWVOfEBXEmtt4RA==
   dependencies:
-    "@reach/portal" "^0.8.2"
+    "@reach/portal" "^0.8.5"
     "@reach/rect" "^0.8.2"
-    "@reach/utils" "^0.8.4"
+    "@reach/utils" "^0.8.5"
     tabbable "^4.0.0"
     tslib "^1.10.0"
 
-"@reach/portal@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.8.2.tgz#7b00910eade9d17a7c141d7923e663a1a5ff8f95"
-  integrity sha512-IXOse/oHYoNQgDB2YqRSx4dKTWQv+JJNWTtGz9tGALF8ePbyNY3tq5zp5bsJIYTV1oL5j/m8PBaM2HSBU4mZRA==
+"@reach/portal@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.8.5.tgz#586e8686e9ba34368b1df3fc9a84c3ef923dd2d3"
+  integrity sha512-YRQgItjxw6DznndN4T3YS6Ikuq+FPZg8fekXeM1feuQSnMlAtEAyYVaMhpAKSD65+Yc9Zu0Utfxp5ji+wO+FLg==
   dependencies:
     tslib "^1.10.0"
 
@@ -1243,10 +1236,10 @@
     prop-types "^15.7.2"
     tslib "^1.10.0"
 
-"@reach/utils@^0.8.4":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.8.4.tgz#c5045637401beff8fa5e8e278fafc5af226c2fee"
-  integrity sha512-RZq5Y5K5+CakM5zzecNypP28U60/9sm3PraZznCsfcB/O3+3O0kgg5X+a7IHD3GnRqJVYTzAjA6sral6kPYLKQ==
+"@reach/utils@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.8.5.tgz#6675d6f81054c8dce1b9d535280b0e3c5174fe7d"
+  integrity sha512-nc84exIqBa+EohJPBFjePQP88dBAP4l+tChxwWszzZ+R6tTtSgOg40WyQ5EjPYJFbltnbZIbASHefcEBrFxqng==
   dependencies:
     tslib "^1.10.0"
     warning "^4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,65 +1176,80 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@reach/component-component@0.1.3", "@reach/component-component@^0.1.1", "@reach/component-component@^0.1.2", "@reach/component-component@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.1.3.tgz#5d156319572dc38995b246f81878bc2577c517e5"
-  integrity sha512-a1USH7L3bEfDdPN4iNZGvMEFuBfkdG+QNybeyDv8RloVFgZYRoM+KGXyy2KOfEnTUM8QWDRSROwaL3+ts5Angg==
-
-"@reach/menu-button@0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.1.7.tgz#48666636b5774066839a312e37cc03f0bd770bad"
-  integrity sha512-xPweR+luu5sgW8OeRHt8SN3dlV3d8S6fqABXAqfuI5Aebq0lOcSxZuL2gxlpH742OzrkjteBE/LV5Jt0vJUsOA==
+"@reach/auto-id@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.8.2.tgz#ea33a29dd08d186585650754f983129492cd86ce"
+  integrity sha512-yVsU0NZa1xjw9dM8+emYLxvpO7QCPnKqZDUNJl5djuAKantaGzTDIoozViI9FdIy965O1XDKHswuAi64utboMQ==
   dependencies:
-    "@reach/component-component" "^0.1.1"
-    "@reach/portal" "^0.1.1"
-    "@reach/rect" "^0.1.1"
-    "@reach/router" "^1.1.0"
-    "@reach/utils" "^0.1.2"
-    "@reach/window-size" "^0.1.1"
-    warning "^4.0.2"
+    tslib "^1.10.0"
 
-"@reach/observe-rect@^1.0.3":
+"@reach/component-component@0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.8.2.tgz#87590421b90ecf57cffcee61f1210ba63202fef8"
+  integrity sha512-3N9baC2t6jatMYuQj0sPWN/VcK6EH//ywSqbpLXZiRQZXLIQkuelOHRYzfufRbPCIJQipYBko4Q8jg4Jc4nF/w==
+  dependencies:
+    prop-types "^15.7.2"
+
+"@reach/descendants@^0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.8.4.tgz#b193129e653c474a42c289ba185fd1e1360ffa72"
+  integrity sha512-vCGiX5IX+qTwZUMDlE4cdsiAjdgxCyJxdNSeJrzu1d/+joJ089AEgDnKiVvynUwcNBYwzKC2CJSGQqRD3v4nzw==
+  dependencies:
+    "@reach/utils" "^0.8.4"
+    tslib "^1.10.0"
+
+"@reach/menu-button@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.8.4.tgz#5c87b389871d2d45471501068d3df039c5b6dfb2"
+  integrity sha512-R9swIBEHNR9AhoScfBdxU0Vih7hYuzY3JGmeXG7O9uvYMN3J6z0l/9CLh76Vdx0dxIYHKGdzJza9iVQH2QfsPA==
+  dependencies:
+    "@reach/auto-id" "^0.8.2"
+    "@reach/descendants" "^0.8.4"
+    "@reach/popover" "^0.8.4"
+    "@reach/utils" "^0.8.4"
+    prop-types "^15.7.2"
+    tslib "^1.10.0"
+    warning "^4.0.3"
+
+"@reach/observe-rect@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.0.5.tgz#28bf3c5c35da7fef72cd124af4ac32308d0c3f15"
   integrity sha512-EQLHhquzwAh2TFtMJU0PXJRmhpOrAhzApgoI4Lwn72J7ygrMk3Ys3a3i8KDnV0TetbwAxn4XSHi4pE8sPWUYLg==
 
-"@reach/portal@^0.1.1":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.1.3.tgz#31d820f31bbab73570d5b5a449e2b0fa6457802f"
-  integrity sha512-yDcu5XZWfWKmKvbOs/uS7vITPVFXmn+XY5V6YcGhlz20KgwG+aJX2c7yvYzO++Zr0qvmtQCmxA4EGEciqIys6g==
+"@reach/popover@^0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@reach/popover/-/popover-0.8.4.tgz#dd5c6f7726bcc5f4771eb6d3d38cc6a641604bf1"
+  integrity sha512-13adZOZMPB2ZYe2e0NnbDz/Zy8493B/vTZUtRWm3YBW6HLVeq+f7OQvCqY0i8fvw81q0xCT1MIaAZ6UXrw81tg==
   dependencies:
-    "@reach/component-component" "^0.1.3"
+    "@reach/portal" "^0.8.2"
+    "@reach/rect" "^0.8.2"
+    "@reach/utils" "^0.8.4"
+    tabbable "^4.0.0"
+    tslib "^1.10.0"
 
-"@reach/rect@^0.1.1":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.1.2.tgz#8f5dbd90152f8e865cc6c1622266403dcfe26691"
-  integrity sha512-2zgOdngtfAiykcVrjsgyjBhLItqc0TpuMCK0RrYydkhjKuHazjhtB5NEGuzp3TFDl3dlR++U28P55Gt4MkN3+g==
+"@reach/portal@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.8.2.tgz#7b00910eade9d17a7c141d7923e663a1a5ff8f95"
+  integrity sha512-IXOse/oHYoNQgDB2YqRSx4dKTWQv+JJNWTtGz9tGALF8ePbyNY3tq5zp5bsJIYTV1oL5j/m8PBaM2HSBU4mZRA==
   dependencies:
-    "@reach/component-component" "^0.1.2"
-    "@reach/observe-rect" "^1.0.3"
+    tslib "^1.10.0"
 
-"@reach/router@^1.1.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.1.tgz#0a49f75fa9621323d6e21c803447bcfcde1713b2"
-  integrity sha512-Ov1j1J+pSgXliJHFL7XWhjyREwc6GxeWfgBTa5MMH5eRmYtHbPhaovba4xKo7aTVCg8fxkt2yDMNSpvwfUP+pA==
+"@reach/rect@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.8.2.tgz#4e51ef1b734f26a42c3cdfa8d812a11b8017d3ef"
+  integrity sha512-6vrGm/9Cjw5ygbzccJdmrERqLxmaR2dATzkOvmsnTuR54BH/UgUjUYMxy/pVCmHZacNMTZRqOJwAyJQBOdCD4w==
   dependencies:
-    create-react-context "0.3.0"
-    invariant "^2.2.3"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
+    "@reach/observe-rect" "^1.0.5"
+    prop-types "^15.7.2"
+    tslib "^1.10.0"
 
-"@reach/utils@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.1.2.tgz#72f547b5c9b0401a56de303d9e508abf6d3fa56a"
-  integrity sha512-HpDR5BeCApr3HufQtpg0P5b9sl0S66zikZSMtC/2jZBvrDzjVaT9O8PbKTQqW0PdkMNrnBkX1UtlrrM1TN3/Og==
-
-"@reach/window-size@^0.1.1":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@reach/window-size/-/window-size-0.1.4.tgz#3257b646548f61c2708a661a683620fbe0a706cb"
-  integrity sha512-JZshEuGsLvi6fUIJ7Unx12yNeM5SmqWjber2MLr9tfwf1hpNv73EiPBOIJyV0DjW7GXzjcOEvwnqysm59s2s/A==
+"@reach/utils@^0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.8.4.tgz#c5045637401beff8fa5e8e278fafc5af226c2fee"
+  integrity sha512-RZq5Y5K5+CakM5zzecNypP28U60/9sm3PraZznCsfcB/O3+3O0kgg5X+a7IHD3GnRqJVYTzAjA6sral6kPYLKQ==
   dependencies:
-    "@reach/component-component" "^0.1.3"
+    tslib "^1.10.0"
+    warning "^4.0.3"
 
 "@rollup/plugin-commonjs@^11.0.0":
   version "11.0.2"
@@ -3673,14 +3688,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
-  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
-  dependencies:
-    gud "^1.0.0"
-    warning "^4.0.3"
-
 cross-env@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
@@ -5829,11 +5836,6 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
-
 gzip-size@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.0.0.tgz#a55ecd99222f4c48fd8c01c625ce3b349d0a0e80"
@@ -6393,7 +6395,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -10245,7 +10247,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@15.7.2, prop-types@^15.5.4, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.4, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -12384,6 +12386,11 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tabbable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
+  integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
@@ -12760,6 +12767,11 @@ tslib@1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^1.10.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.0.tgz#f1f3528301621a53220d58373ae510ff747a66bc"
+  integrity sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==
 
 tslint-webpack-plugin@2.1.0:
   version "2.1.0"
@@ -13223,7 +13235,7 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.2, warning@^4.0.3:
+warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
## Update reach menu-button version and remove component-component

This PR updates reach menu-button version to latest available and adjusts implementation to match the new API. In addition, this PR removes Reach component-component. Also adds Reach popover as dependency to support Dropdown width alignment with menu-button.

## Motivation and Context

Reach menu-button did not work properly after upgrading other dependencies and had to be updated. Component-component was no longer used and had to be removed.

## How Has This Been Tested?

These changes have been tested using styleguidist, Create React App with JS and TS and two separate React SSR templates.
