### PR TITLE
Release 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Suomi.fi UI component library",
   "main": "dist/index.js",
   "module": "dist/suomifi-ui-components.esm.js",


### PR DESCRIPTION
- **suomifi-icons updated to 0.0.14**
  - A temporary fix for a typing issue where the custom 'SvgrComponent' type couldn't be included in the build for some reason, which resulted in typing errors when using the library (vrk-kpa/suomifi-icons#24)