### PR TITLE
[Bugfix] Button's Assertive component

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -84,20 +84,17 @@ interface AssertiveProps {
 }
 
 export class Assertive extends Component<AssertiveProps> {
-  state = { unDisabled: false };
-
-  componentDidUpdate(prevProps: AssertiveProps) {
-    const { disabled } = this.props;
-    if (disabled !== prevProps.disabled) {
-      this.setState({ unDisabled: !disabled });
-    }
-  }
-
   render() {
-    const { ariaAssertiveDisabled, ariaAssertiveUnDisabled } = this.props;
-    const { unDisabled } = this.state;
-    if (!ariaAssertiveDisabled && !ariaAssertiveUnDisabled) return null;
-    const text = !!unDisabled ? ariaAssertiveUnDisabled : ariaAssertiveDisabled;
+    const {
+      ariaAssertiveDisabled,
+      ariaAssertiveUnDisabled,
+      disabled,
+    } = this.props;
+
+    if (!ariaAssertiveDisabled && !ariaAssertiveUnDisabled) {
+      return null;
+    }
+    const text = !!disabled ? ariaAssertiveDisabled : ariaAssertiveUnDisabled;
     return !!text ? (
       <VisuallyHidden aria-live="assertive">{text}</VisuallyHidden>
     ) : null;
@@ -145,6 +142,7 @@ export class Button extends Component<ButtonProps> {
             [disabledClassName]: !!disabled,
           })}
         />
+
         <Assertive
           disabled={disabled}
           ariaAssertiveDisabled={ariaAssertiveDisabled}


### PR DESCRIPTION
## Description

- Previously Button's Assertive component's text was based on the state
  - Now it is changed to be based on the `disabled`-prop instead
- Fix the wrong state of Assertive component's text at start

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Idea of this issue (#206) was originally to prevent unneeded render, but with the changes suggested and others solutions tried there was no benefit gained.

Because using the `this.setState` it will cause render, therefore using the `firstState` does not really help, as when toggling it to false it will render and the result is still same. 

> And here comes the caveat in a React application; we need to ensure that the live region is already rendered when we send our first message and that it stays rendered until we no longer require it.

Source: [ARIA live regions in React](https://almerosteyn.com/2017/09/aria-live-regions-in-react)

Closes #206

## How Has This Been Tested?
- `yarn validate`
- locally ran on separate test bench project (CRA +TS)