### PR TITLE
[Feature] TextInput state text & colors

### DIFF
--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -20,8 +20,8 @@ const baseClassName = 'fi-text-input';
 const disabledClassName = `${baseClassName}--disabled`;
 const labelBaseClassName = `${baseClassName}_label`;
 const inputBaseClassName = `${baseClassName}_input`;
-const stateTextClassName = `${baseClassName}_stateText`;
-const stateTextLabelClassName = `${stateTextClassName}_label`;
+const statusTextClassName = `${baseClassName}_statusText`;
+const statusTextLabelClassName = `${statusTextClassName}_label`;
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
 
@@ -56,8 +56,8 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   /** Input container div to define custom styling */
   inputContainerProps?: HtmlDivProps;
   children?: ReactNode;
-  /** Showing the state text; like validation error beneath the component */
-  stateText?: string;
+  /** Showing the status text; like validation error beneath the component */
+  statusText?: string;
 }
 
 class BaseTextInput extends Component<TextInputProps> {
@@ -71,13 +71,13 @@ class BaseTextInput extends Component<TextInputProps> {
       labelTextProps,
       inputContainerProps,
       children,
-      stateText,
+      statusText,
       id: propId,
       ...passProps
     } = this.props;
 
     const hideLabel = labelMode === 'hidden';
-    const generatedId = idGenerator(`${propId}-stateText`);
+    const generatedId = idGenerator(`${propId}-statusText`);
 
     return (
       <HtmlLabel
@@ -91,7 +91,7 @@ class BaseTextInput extends Component<TextInputProps> {
         ) : (
           <Paragraph {...labelTextProps}>{labelText}</Paragraph>
         )}
-        <HtmlDiv className={stateTextClassName}>
+        <HtmlDiv className={statusTextClassName}>
           <HtmlDiv {...inputContainerProps}>
             <HtmlInput
               id={propId}
@@ -102,8 +102,8 @@ class BaseTextInput extends Component<TextInputProps> {
             />
             {children}
           </HtmlDiv>
-          <HtmlLabel className={stateTextLabelClassName} id={generatedId}>
-            {stateText}
+          <HtmlLabel className={statusTextLabelClassName} id={generatedId}>
+            {statusText}
           </HtmlLabel>
         </HtmlDiv>
       </HtmlLabel>

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -7,6 +7,7 @@ import {
   HtmlInputProps,
   HtmlDiv,
   HtmlDivProps,
+  HtmlSpan,
 } from '../../reset';
 import { VisuallyHidden } from '../Visually-hidden/Visually-hidden';
 import { Paragraph, ParagraphProps } from '../Paragraph/Paragraph';
@@ -22,7 +23,6 @@ const labelBaseClassName = `${baseClassName}_label`;
 const inputBaseClassName = `${baseClassName}_input`;
 const statusTextClassName = `${baseClassName}_statusText`;
 const statusTextContainerClassName = `${statusTextClassName}_container`;
-const statusTextLabelClassName = `${statusTextClassName}_label`;
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
 
@@ -103,9 +103,9 @@ class BaseTextInput extends Component<TextInputProps> {
             />
             {children}
           </HtmlDiv>
-          <HtmlLabel className={statusTextLabelClassName} id={generatedId}>
+          <HtmlSpan className={statusTextClassName} id={generatedId}>
             {statusText}
-          </HtmlLabel>
+          </HtmlSpan>
         </HtmlDiv>
       </HtmlLabel>
     );

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -78,7 +78,7 @@ class BaseTextInput extends Component<TextInputProps> {
     } = this.props;
 
     const hideLabel = labelMode === 'hidden';
-    const generatedId = idGenerator(`${propId}-statusText`);
+    const generatedId = `${idGenerator(propId)}-statusText`;
 
     return (
       <HtmlLabel

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -14,11 +14,14 @@ import { logger } from '../../utils/logger';
 import classnames from 'classnames';
 import styled from 'styled-components';
 import { disabledCursor } from '../utils/css';
+import { idGenerator } from '../../utils/uuid';
 
 const baseClassName = 'fi-text-input';
 const disabledClassName = `${baseClassName}--disabled`;
 const labelBaseClassName = `${baseClassName}_label`;
 const inputBaseClassName = `${baseClassName}_input`;
+const stateTextClassName = `${baseClassName}_stateText`;
+const stateTextLabelClassName = `${stateTextClassName}_label`;
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
 
@@ -53,6 +56,8 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   /** Input container div to define custom styling */
   inputContainerProps?: HtmlDivProps;
   children?: ReactNode;
+  /** Showing the state text; like validation error beneath the component */
+  stateText?: string;
 }
 
 class BaseTextInput extends Component<TextInputProps> {
@@ -66,10 +71,13 @@ class BaseTextInput extends Component<TextInputProps> {
       labelTextProps,
       inputContainerProps,
       children,
+      stateText,
+      id: propId,
       ...passProps
     } = this.props;
 
     const hideLabel = labelMode === 'hidden';
+    const generatedId = idGenerator(propId);
 
     return (
       <HtmlLabel
@@ -83,13 +91,19 @@ class BaseTextInput extends Component<TextInputProps> {
         ) : (
           <Paragraph {...labelTextProps}>{labelText}</Paragraph>
         )}
-        <HtmlDiv {...inputContainerProps}>
-          <HtmlInput
-            {...passProps}
-            className={classnames(inputBaseClassName, inputClassName)}
-            type="text"
-          />
-          {children}
+        <HtmlDiv className={stateTextClassName}>
+          <HtmlDiv {...inputContainerProps}>
+            <HtmlInput
+              {...passProps}
+              className={classnames(inputBaseClassName, inputClassName)}
+              type="text"
+              aria-describedby={generatedId}
+            />
+            {children}
+          </HtmlDiv>
+          <HtmlLabel className={stateTextLabelClassName} id={generatedId}>
+            {stateText}
+          </HtmlLabel>
         </HtmlDiv>
       </HtmlLabel>
     );

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -77,7 +77,7 @@ class BaseTextInput extends Component<TextInputProps> {
     } = this.props;
 
     const hideLabel = labelMode === 'hidden';
-    const generatedId = idGenerator(propId);
+    const generatedId = idGenerator(`${propId}-stateText`);
 
     return (
       <HtmlLabel
@@ -94,6 +94,7 @@ class BaseTextInput extends Component<TextInputProps> {
         <HtmlDiv className={stateTextClassName}>
           <HtmlDiv {...inputContainerProps}>
             <HtmlInput
+              id={propId}
               {...passProps}
               className={classnames(inputBaseClassName, inputClassName)}
               type="text"

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -23,6 +23,7 @@ const labelBaseClassName = `${baseClassName}_label`;
 const inputBaseClassName = `${baseClassName}_input`;
 const statusTextClassName = `${baseClassName}_statusText`;
 const statusTextContainerClassName = `${statusTextClassName}_container`;
+const statusTextSpanClassName = `${baseClassName}_statusText_span`;
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
 
@@ -103,7 +104,7 @@ class BaseTextInput extends Component<TextInputProps> {
             />
             {children}
           </HtmlDiv>
-          <HtmlSpan className={statusTextClassName} id={generatedId}>
+          <HtmlSpan className={statusTextSpanClassName} id={generatedId}>
             {statusText}
           </HtmlSpan>
         </HtmlDiv>

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -21,6 +21,7 @@ const disabledClassName = `${baseClassName}--disabled`;
 const labelBaseClassName = `${baseClassName}_label`;
 const inputBaseClassName = `${baseClassName}_input`;
 const statusTextClassName = `${baseClassName}_statusText`;
+const statusTextContainerClassName = `${statusTextClassName}_container`;
 const statusTextLabelClassName = `${statusTextClassName}_label`;
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
@@ -91,7 +92,7 @@ class BaseTextInput extends Component<TextInputProps> {
         ) : (
           <Paragraph {...labelTextProps}>{labelText}</Paragraph>
         )}
-        <HtmlDiv className={statusTextClassName}>
+        <HtmlDiv className={statusTextContainerClassName}>
           <HtmlDiv {...inputContainerProps}>
             <HtmlInput
               id={propId}

--- a/src/core/Form/SearchInput/SearchInput.test.tsx
+++ b/src/core/Form/SearchInput/SearchInput.test.tsx
@@ -5,7 +5,11 @@ import { axeTest } from '../../../utils/test/axe';
 import { SearchInput } from './SearchInput';
 
 const TestSearchInput = (
-  <SearchInput labelText="Test search input" data-testid="textinput" />
+  <SearchInput
+    labelText="Test search input"
+    data-testid="textinput"
+    id="test-id"
+  />
 );
 
 test('calling render with the same component on the same container does not remount', () => {

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -15,7 +15,7 @@ const inputContainerBaseClassName = `${baseClassName}_input-container`;
 const inputBaseClassName = `${baseClassName}_input`;
 const iconBaseClassName = `${baseClassName}_icon`;
 
-export interface SearchInputProps extends Omit<TextInputProps, 'variant'> {}
+export interface SearchInputProps extends Omit<TextInputProps, 'status'> {}
 
 const StyledTextInput = styled(
   ({

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`calling render with the same component on the same container does not r
   outline: none;
 }
 
-.c0 .fi-text-input_stateText {
+.c0 .fi-text-input_statusText {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -154,8 +154,7 @@ exports[`calling render with the same component on the same container does not r
   flex-direction: column;
 }
 
-.c0 .fi-text-input_stateText .fi-text-input_stateText_label {
-  height: 0em;
+.c0 .fi-text-input_statusText .fi-text-input_statusText_label {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -191,7 +190,7 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(3,59%,48%);
 }
 
-.c0.fi-text-input--error .fi-text-input_stateText_label {
+.c0.fi-text-input--error .fi-text-input_statusText_label {
   color: hsl(3,59%,48%);
 }
 
@@ -228,13 +227,13 @@ exports[`calling render with the same component on the same container does not r
     Test search input
   </p>
   <div
-    class="fi-text-input_stateText c4"
+    class="fi-text-input_statusText c4"
   >
     <div
       class="fi-search-input_input-container fi-text-input_container c4"
     >
       <input
-        aria-describedby="test-id-stateText"
+        aria-describedby="test-id-statusText"
         class="fi-text-input_input fi-search-input_input c5"
         data-testid="textinput"
         id="test-id"
@@ -255,8 +254,8 @@ exports[`calling render with the same component on the same container does not r
       </svg>
     </div>
     <label
-      class="fi-text-input_stateText_label c2"
-      id="test-id-stateText"
+      class="fi-text-input_statusText_label c2"
+      id="test-id-statusText"
     />
   </div>
 </label>

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -73,6 +73,30 @@ exports[`calling render with the same component on the same container does not r
   max-width: 100%;
 }
 
+.c7 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -154,7 +178,7 @@ exports[`calling render with the same component on the same container does not r
   flex-direction: column;
 }
 
-.c0 .fi-text-input_statusText_container .fi-text-input_statusText_label {
+.c0 .fi-text-input_statusText_container .fi-text-input_statusText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -190,7 +214,7 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(3,59%,48%);
 }
 
-.c0.fi-text-input--error .fi-text-input_statusText_label {
+.c0.fi-text-input--error .fi-text-input_statusText {
   color: hsl(3,59%,48%);
 }
 
@@ -253,8 +277,8 @@ exports[`calling render with the same component on the same container does not r
         />
       </svg>
     </div>
-    <label
-      class="fi-text-input_statusText_label c2"
+    <span
+      class="fi-text-input_statusText c7"
       id="test-id-statusText"
     />
   </div>

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`calling render with the same component on the same container does not r
   flex-direction: column;
 }
 
-.c0 .fi-text-input_statusText_container .fi-text-input_statusText {
+.c0 .fi-text-input_statusText_container .fi-text-input_statusText_span {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -214,7 +214,7 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(3,59%,48%);
 }
 
-.c0.fi-text-input--error .fi-text-input_statusText {
+.c0.fi-text-input--error .fi-text-input_statusText_span {
   color: hsl(3,59%,48%);
 }
 
@@ -278,7 +278,7 @@ exports[`calling render with the same component on the same container does not r
       </svg>
     </div>
     <span
-      class="fi-text-input_statusText c7"
+      class="fi-text-input_statusText_span c7"
       id="test-id-statusText"
     />
   </div>

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -199,6 +199,11 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(166,90%,36%);
 }
 
+.c0.fi-text-input--disabled .fi-text-input_input {
+  color: hsl(202,7%,67%);
+  background-color: hsl(202,7%,97%);
+}
+
 .c0 .fi-search-input_input-container {
   position: relative;
 }

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -144,6 +144,24 @@ exports[`calling render with the same component on the same container does not r
   outline: none;
 }
 
+.c0 .fi-text-input_stateText {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 .fi-text-input_stateText .fi-text-input_stateText_label {
+  height: 0em;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
 .c0 .fi-text-input_input {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -170,12 +188,14 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c0.fi-text-input--error .fi-text-input_input {
-  color: hsl(3,59%,48%);
   border-color: hsl(3,59%,48%);
 }
 
+.c0.fi-text-input--error .fi-text-input_stateText_label {
+  color: hsl(3,59%,48%);
+}
+
 .c0.fi-text-input--success .fi-text-input_input {
-  color: hsl(166,90%,36%);
   border-color: hsl(166,90%,36%);
 }
 
@@ -203,26 +223,35 @@ exports[`calling render with the same component on the same container does not r
     Test search input
   </p>
   <div
-    class="fi-search-input_input-container fi-text-input_container c4"
+    class="fi-text-input_stateText c4"
   >
-    <input
-      class="fi-text-input_input fi-search-input_input c5"
-      data-testid="textinput"
-      type="text"
-    />
-    <svg
-      aria-hidden="true"
-      class="fi-search-input_icon c6"
-      fill="hsl(202, 7%, 40%)"
-      focusable="false"
-      height="1em"
-      viewBox="0 0 24 24"
-      width="1em"
+    <div
+      class="fi-search-input_input-container fi-text-input_container c4"
     >
-      <path
-        d="M9 2C5.14 2 2 5.141 2 9.001 2 12.86 5.14 16 9 16s7-3.14 7-6.999C16 5.141 12.86 2 9 2m7.029 12.615l7.678 7.678a.999.999 0 11-1.414 1.414l-7.678-7.678A8.957 8.957 0 019 18c-4.962 0-9-4.037-9-8.999C0 4.038 4.038 0 9 0s9 4.038 9 9.001a8.955 8.955 0 01-1.971 5.614z"
+      <input
+        aria-describedby="test-id"
+        class="fi-text-input_input fi-search-input_input c5"
+        data-testid="textinput"
+        type="text"
       />
-    </svg>
+      <svg
+        aria-hidden="true"
+        class="fi-search-input_icon c6"
+        fill="hsl(202, 7%, 40%)"
+        focusable="false"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+      >
+        <path
+          d="M9 2C5.14 2 2 5.141 2 9.001 2 12.86 5.14 16 9 16s7-3.14 7-6.999C16 5.141 12.86 2 9 2m7.029 12.615l7.678 7.678a.999.999 0 11-1.414 1.414l-7.678-7.678A8.957 8.957 0 019 18c-4.962 0-9-4.037-9-8.999C0 4.038 4.038 0 9 0s9 4.038 9 9.001a8.955 8.955 0 01-1.971 5.614z"
+        />
+      </svg>
+    </div>
+    <label
+      class="fi-text-input_stateText_label c2"
+      id="test-id"
+    />
   </div>
 </label>
 `;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -234,9 +234,10 @@ exports[`calling render with the same component on the same container does not r
       class="fi-search-input_input-container fi-text-input_container c4"
     >
       <input
-        aria-describedby="test-id"
+        aria-describedby="test-id-stateText"
         class="fi-text-input_input fi-search-input_input c5"
         data-testid="textinput"
+        id="test-id"
         type="text"
       />
       <svg
@@ -255,7 +256,7 @@ exports[`calling render with the same component on the same container does not r
     </div>
     <label
       class="fi-text-input_stateText_label c2"
-      id="test-id"
+      id="test-id-stateText"
     />
   </div>
 </label>

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -144,7 +144,7 @@ exports[`calling render with the same component on the same container does not r
   outline: none;
 }
 
-.c0 .fi-text-input_statusText {
+.c0 .fi-text-input_statusText_container {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -154,7 +154,7 @@ exports[`calling render with the same component on the same container does not r
   flex-direction: column;
 }
 
-.c0 .fi-text-input_statusText .fi-text-input_statusText_label {
+.c0 .fi-text-input_statusText_container .fi-text-input_statusText_label {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -227,7 +227,7 @@ exports[`calling render with the same component on the same container does not r
     Test search input
   </p>
   <div
-    class="fi-text-input_statusText c4"
+    class="fi-text-input_statusText_container c4"
   >
     <div
       class="fi-search-input_input-container fi-text-input_container c4"

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -43,7 +43,7 @@ export const baseStyles = withSuomifiTheme(
   &.fi-text-input--disabled {
     & .fi-text-input_input {
       color: ${theme.colors.depthBase};
-      background-color: ${theme.colors.depthLight30};
+      background-color: ${theme.colors.depthLight3};
     }
   }
 `,

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -1,16 +1,9 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../../theme';
 import { input, inputContainer } from '../../theme/reset';
-import { TextInputProps } from './TextInput';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme, ...passProps }: TokensAndTheme & Partial<TextInputProps>) => {
-    const hasStateText = Object.prototype.hasOwnProperty.call(
-      passProps,
-      'stateText',
-    );
-
-    return css`
+  ({ theme }: TokensAndTheme) => css`
   & .fi-text-input_label-p {
     margin-bottom: ${theme.spacing.m};
   }
@@ -24,11 +17,6 @@ export const baseStyles = withSuomifiTheme(
     flex-direction: column;
 
     & .fi-text-input_stateText_label {
-      height: ${
-        hasStateText
-          ? theme.values.typography.bodySemiBoldSmall.lineHeight.value
-          : 0
-      }em
       ${theme.typography.bodySemiBoldSmall}
     }
   }
@@ -58,6 +46,5 @@ export const baseStyles = withSuomifiTheme(
       background-color: ${theme.colors.depthLight30};
     }
   }
-`;
-  },
+`,
 );

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -16,7 +16,7 @@ export const baseStyles = withSuomifiTheme(
     display: flex;
     flex-direction: column;
 
-    & .fi-text-input_statusText_label {
+    & .fi-text-input_statusText {
       ${theme.typography.bodySemiBoldSmall}
     }
   }
@@ -31,7 +31,7 @@ export const baseStyles = withSuomifiTheme(
     & .fi-text-input_input {
       border-color: ${theme.colors.alertBase};
     }
-    & .fi-text-input_statusText_label {
+    & .fi-text-input_statusText {
       color: ${theme.colors.alertBase};
     }
   }

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -52,6 +52,12 @@ export const baseStyles = withSuomifiTheme(
       border-color: ${theme.colors.successBase};
     }
   }
+  &.fi-text-input--disabled {
+    & .fi-text-input_input {
+      color: ${theme.colors.depthBase};
+      background-color: ${theme.colors.depthLight30};
+    }
+  }
 `;
   },
 );

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -1,15 +1,36 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../../theme';
 import { input, inputContainer } from '../../theme/reset';
+import { TextInputProps } from './TextInput';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: TokensAndTheme) => css`
+  ({ theme, ...passProps }: TokensAndTheme & Partial<TextInputProps>) => {
+    const hasStateText = Object.prototype.hasOwnProperty.call(
+      passProps,
+      'stateText',
+    );
+
+    return css`
   & .fi-text-input_label-p {
     margin-bottom: ${theme.spacing.m};
   }
 
   & .fi-text-input_container {
     ${inputContainer({ theme })}
+  }
+
+  & .fi-text-input_stateText {
+    display: flex;
+    flex-direction: column;
+
+    & .fi-text-input_stateText_label {
+      height: ${
+        hasStateText
+          ? theme.values.typography.bodySemiBoldSmall.lineHeight.value
+          : 0
+      }em
+      ${theme.typography.bodySemiBoldSmall}
+    }
   }
 
   & .fi-text-input_input {
@@ -22,11 +43,15 @@ export const baseStyles = withSuomifiTheme(
     & .fi-text-input_input {
       border-color: ${theme.colors.alertBase};
     }
+    & .fi-text-input_stateText_label {
+      color: ${theme.colors.alertBase};
+    }
   }
   &.fi-text-input--success {
     & .fi-text-input_input {
       border-color: ${theme.colors.successBase};
     }
   }
-`,
+`;
+  },
 );

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -20,13 +20,11 @@ export const baseStyles = withSuomifiTheme(
 
   &.fi-text-input--error {
     & .fi-text-input_input {
-      color: ${theme.colors.alertBase};
       border-color: ${theme.colors.alertBase};
     }
   }
   &.fi-text-input--success {
     & .fi-text-input_input {
-      color: ${theme.colors.successBase};
       border-color: ${theme.colors.successBase};
     }
   }

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -16,7 +16,7 @@ export const baseStyles = withSuomifiTheme(
     display: flex;
     flex-direction: column;
 
-    & .fi-text-input_statusText {
+    & .fi-text-input_statusText_span {
       ${theme.typography.bodySemiBoldSmall}
     }
   }
@@ -31,7 +31,7 @@ export const baseStyles = withSuomifiTheme(
     & .fi-text-input_input {
       border-color: ${theme.colors.alertBase};
     }
-    & .fi-text-input_statusText {
+    & .fi-text-input_statusText_span {
       color: ${theme.colors.alertBase};
     }
   }

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -12,7 +12,7 @@ export const baseStyles = withSuomifiTheme(
     ${inputContainer({ theme })}
   }
 
-  & .fi-text-input_statusText {
+  & .fi-text-input_statusText_container {
     display: flex;
     flex-direction: column;
 

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -12,11 +12,11 @@ export const baseStyles = withSuomifiTheme(
     ${inputContainer({ theme })}
   }
 
-  & .fi-text-input_stateText {
+  & .fi-text-input_statusText {
     display: flex;
     flex-direction: column;
 
-    & .fi-text-input_stateText_label {
+    & .fi-text-input_statusText_label {
       ${theme.typography.bodySemiBoldSmall}
     }
   }
@@ -31,7 +31,7 @@ export const baseStyles = withSuomifiTheme(
     & .fi-text-input_input {
       border-color: ${theme.colors.alertBase};
     }
-    & .fi-text-input_stateText_label {
+    & .fi-text-input_statusText_label {
       color: ${theme.colors.alertBase};
     }
   }

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -29,3 +29,25 @@ import { TextInput } from 'suomifi-ui-components';
   />
 </>;
 ```
+
+```js
+import { TextInput } from 'suomifi-ui-components';
+
+const [errorState, setErrorState] = React.useState(false);
+const statusText = errorState
+  ? 'You entered invalid data'
+  : undefined;
+const variant = errorState ? 'error' : 'default';
+
+<>
+  <TextInput
+    labelText="Test TextInput"
+    statusText={statusText}
+    variant={variant}
+  />
+
+  <button onClick={() => setErrorState(!errorState)}>
+    Toggle error state
+  </button>
+</>;
+```

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -17,12 +17,14 @@ import { TextInput } from 'suomifi-ui-components';
     labelText="Test with hidden label"
     defaultValue="Test with hidden label"
   />
-  <TextInput.error
+  <TextInput
+    variant="error"
     labelMode="hidden"
     labelText="Error with hidden label"
     defaultValue="Error with hidden label"
   />
-  <TextInput.success
+  <TextInput
+    variant="success"
     labelMode="hidden"
     labelText="Success with hidden label"
     defaultValue="Success with hidden label"

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -18,13 +18,13 @@ import { TextInput } from 'suomifi-ui-components';
     defaultValue="Test with hidden label"
   />
   <TextInput
-    variant="error"
+    status="error"
     labelMode="hidden"
     labelText="Error with hidden label"
     defaultValue="Error with hidden label"
   />
   <TextInput
-    variant="success"
+    status="success"
     labelMode="hidden"
     labelText="Success with hidden label"
     defaultValue="Success with hidden label"
@@ -39,13 +39,13 @@ const [errorState, setErrorState] = React.useState(false);
 const statusText = errorState
   ? 'You entered invalid data'
   : undefined;
-const variant = errorState ? 'error' : 'default';
+const status = errorState ? 'error' : 'default';
 
 <>
   <TextInput
     labelText="Test TextInput"
     statusText={statusText}
-    variant={variant}
+    status={status}
   />
 
   <button onClick={() => setErrorState(!errorState)}>

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -5,7 +5,7 @@ import { axeTest } from '../../../utils/test/axe';
 import { TextInput } from './TextInput';
 
 const TestTextInput = (
-  <TextInput labelText="Test input" data-testid="textinput" />
+  <TextInput labelText="Test input" data-testid="textinput" id="test-id" />
 );
 
 test('calling render with the same component on the same container does not remount', () => {

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -70,14 +70,6 @@ const StyledTextInput = styled(
  * Use for user inputting text
  */
 export class TextInput extends Component<TextInputProps> {
-  static error = (props: TextInputProps) => (
-    <StyledTextInput {...withSuomifiDefaultProps(props)} variant="error" />
-  );
-
-  static success = (props: TextInputProps) => (
-    <StyledTextInput {...withSuomifiDefaultProps(props)} variant="success" />
-  );
-
   render() {
     const { ...passProps } = withSuomifiDefaultProps(this.props);
 

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -20,6 +20,10 @@ export const textInputClassNames = {
 type TextInputVariant = 'default' | 'error' | 'success';
 
 export interface TextInputProps extends CompTextInputProps, TokensProp {
+  /**
+   * 'default' | 'error' | 'success'
+   * @default default
+   */
   variant?: TextInputVariant;
 }
 
@@ -53,6 +57,7 @@ const StyledTextInput = styled(
           [textInputClassNames.error]: variant === 'error',
           [textInputClassNames.success]: variant === 'success',
         })}
+        aria-invalid={variant === 'error' ? 'true' : undefined}
       />
     );
   },

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -17,20 +17,20 @@ export const textInputClassNames = {
   error: `${baseClassName}--error`,
   success: `${baseClassName}--success`,
 };
-type TextInputVariant = 'default' | 'error' | 'success';
+type TextInputStatus = 'default' | 'error' | 'success';
 
 export interface TextInputProps extends CompTextInputProps, TokensProp {
   /**
    * 'default' | 'error' | 'success'
    * @default default
    */
-  variant?: TextInputVariant;
+  status?: TextInputStatus;
 }
 
 const StyledTextInput = styled(
   ({
     tokens,
-    variant,
+    status,
     className,
     labelTextProps = { className: undefined },
     inputContainerProps = { className: undefined },
@@ -54,10 +54,10 @@ const StyledTextInput = styled(
           ),
         }}
         className={classnames(className, {
-          [textInputClassNames.error]: variant === 'error',
-          [textInputClassNames.success]: variant === 'success',
+          [textInputClassNames.error]: status === 'error',
+          [textInputClassNames.success]: status === 'success',
         })}
-        aria-invalid={variant === 'error' ? 'true' : undefined}
+        aria-invalid={status === 'error' ? 'true' : undefined}
       />
     );
   },

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -57,7 +57,6 @@ const StyledTextInput = styled(
           [textInputClassNames.error]: status === 'error',
           [textInputClassNames.success]: status === 'success',
         })}
-        aria-invalid={status === 'error' ? 'true' : undefined}
       />
     );
   },

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`calling render with the same component on the same container does not r
   outline: none;
 }
 
-.c0 .fi-text-input_stateText {
+.c0 .fi-text-input_statusText {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -149,8 +149,7 @@ exports[`calling render with the same component on the same container does not r
   flex-direction: column;
 }
 
-.c0 .fi-text-input_stateText .fi-text-input_stateText_label {
-  height: 0em;
+.c0 .fi-text-input_statusText .fi-text-input_statusText_label {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -186,7 +185,7 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(3,59%,48%);
 }
 
-.c0.fi-text-input--error .fi-text-input_stateText_label {
+.c0.fi-text-input--error .fi-text-input_statusText_label {
   color: hsl(3,59%,48%);
 }
 
@@ -208,13 +207,13 @@ exports[`calling render with the same component on the same container does not r
     Test input
   </p>
   <div
-    class="fi-text-input_stateText c4"
+    class="fi-text-input_statusText c4"
   >
     <div
       class="fi-text-input_container c4"
     >
       <input
-        aria-describedby="test-id-stateText"
+        aria-describedby="test-id-statusText"
         class="fi-text-input_input c5"
         data-testid="textinput"
         id="test-id"
@@ -222,8 +221,8 @@ exports[`calling render with the same component on the same container does not r
       />
     </div>
     <label
-      class="fi-text-input_stateText_label c2"
-      id="test-id-stateText"
+      class="fi-text-input_statusText_label c2"
+      id="test-id-statusText"
     />
   </div>
 </label>

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`calling render with the same component on the same container does not r
   flex-direction: column;
 }
 
-.c0 .fi-text-input_statusText_container .fi-text-input_statusText {
+.c0 .fi-text-input_statusText_container .fi-text-input_statusText_span {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -209,7 +209,7 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(3,59%,48%);
 }
 
-.c0.fi-text-input--error .fi-text-input_statusText {
+.c0.fi-text-input--error .fi-text-input_statusText_span {
   color: hsl(3,59%,48%);
 }
 
@@ -245,7 +245,7 @@ exports[`calling render with the same component on the same container does not r
       />
     </div>
     <span
-      class="fi-text-input_statusText c6"
+      class="fi-text-input_statusText_span c6"
       id="test-id-statusText"
     />
   </div>

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`calling render with the same component on the same container does not r
   outline: none;
 }
 
-.c0 .fi-text-input_statusText {
+.c0 .fi-text-input_statusText_container {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -149,7 +149,7 @@ exports[`calling render with the same component on the same container does not r
   flex-direction: column;
 }
 
-.c0 .fi-text-input_statusText .fi-text-input_statusText_label {
+.c0 .fi-text-input_statusText_container .fi-text-input_statusText_label {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -207,7 +207,7 @@ exports[`calling render with the same component on the same container does not r
     Test input
   </p>
   <div
-    class="fi-text-input_statusText c4"
+    class="fi-text-input_statusText_container c4"
   >
     <div
       class="fi-text-input_container c4"

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -139,6 +139,24 @@ exports[`calling render with the same component on the same container does not r
   outline: none;
 }
 
+.c0 .fi-text-input_stateText {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 .fi-text-input_stateText .fi-text-input_stateText_label {
+  height: 0em;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
 .c0 .fi-text-input_input {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -165,12 +183,14 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c0.fi-text-input--error .fi-text-input_input {
-  color: hsl(3,59%,48%);
   border-color: hsl(3,59%,48%);
 }
 
+.c0.fi-text-input--error .fi-text-input_stateText_label {
+  color: hsl(3,59%,48%);
+}
+
 .c0.fi-text-input--success .fi-text-input_input {
-  color: hsl(166,90%,36%);
   border-color: hsl(166,90%,36%);
 }
 
@@ -183,12 +203,21 @@ exports[`calling render with the same component on the same container does not r
     Test input
   </p>
   <div
-    class="fi-text-input_container c4"
+    class="fi-text-input_stateText c4"
   >
-    <input
-      class="fi-text-input_input c5"
-      data-testid="textinput"
-      type="text"
+    <div
+      class="fi-text-input_container c4"
+    >
+      <input
+        aria-describedby="test-id"
+        class="fi-text-input_input c5"
+        data-testid="textinput"
+        type="text"
+      />
+    </div>
+    <label
+      class="fi-text-input_stateText_label c2"
+      id="test-id"
     />
   </div>
 </label>

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -214,15 +214,16 @@ exports[`calling render with the same component on the same container does not r
       class="fi-text-input_container c4"
     >
       <input
-        aria-describedby="test-id"
+        aria-describedby="test-id-stateText"
         class="fi-text-input_input c5"
         data-testid="textinput"
+        id="test-id"
         type="text"
       />
     </div>
     <label
       class="fi-text-input_stateText_label c2"
-      id="test-id"
+      id="test-id-stateText"
     />
   </div>
 </label>

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -194,6 +194,11 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(166,90%,36%);
 }
 
+.c0.fi-text-input--disabled .fi-text-input_input {
+  color: hsl(202,7%,67%);
+  background-color: hsl(202,7%,97%);
+}
+
 <label
   class="fi-text-input_label c0 c1 c2"
 >

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -73,6 +73,30 @@ exports[`calling render with the same component on the same container does not r
   max-width: 100%;
 }
 
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -149,7 +173,7 @@ exports[`calling render with the same component on the same container does not r
   flex-direction: column;
 }
 
-.c0 .fi-text-input_statusText_container .fi-text-input_statusText_label {
+.c0 .fi-text-input_statusText_container .fi-text-input_statusText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -185,7 +209,7 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(3,59%,48%);
 }
 
-.c0.fi-text-input--error .fi-text-input_statusText_label {
+.c0.fi-text-input--error .fi-text-input_statusText {
   color: hsl(3,59%,48%);
 }
 
@@ -220,8 +244,8 @@ exports[`calling render with the same component on the same container does not r
         type="text"
       />
     </div>
-    <label
-      class="fi-text-input_statusText_label c2"
+    <span
+      class="fi-text-input_statusText c6"
       id="test-id-statusText"
     />
   </div>


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
- Adds new prop `statusText` for the TextInput
  - it is shown under the text field
  - will not reserve space when the prop is given; space is taken only when the prop actually has some value ( !== undefined)
- TextInput text color won't anymore change based on variant as per design
- TextInput will now have the `status`-prop exposed publicly (previously `variant`)
  - status = 'default' | 'error' | 'success'
- Added example to styleguidist how to use new `statusText` in conjunction with `status` prop
- The possibility to use the static ones (TextInput.success / TextInput.error) were removed

## Motivation and Context

Changes made so that it will match the design and able to show the statusText for giving more context if needed.


## How Has This Been Tested?
- Locally on the browser
- `yarn validate`
