### PR TITLE
[Bugfix] Allow the input-field to take all width it can on the TextInput

### DIFF
--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -166,6 +166,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   line-height: 1;
   background-color: hsl(0,0%,100%);
+  width: 100%;
 }
 
 .c0.fi-text-input--error .fi-text-input_input {

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -15,6 +15,7 @@ export const baseStyles = withSuomifiTheme(
   & .fi-text-input_input {
     ${input({ theme })}
     background-color: ${theme.colors.whiteBase};
+    width: 100%;
   }
 
   &.fi-text-input--error {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -161,6 +161,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   line-height: 1;
   background-color: hsl(0,0%,100%);
+  width: 100%;
 }
 
 .c0.fi-text-input--error .fi-text-input_input {


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
- Allow the input-field to take all width it can on the `TextInput`
  - Fixes also the `SearchInput` as it uses `TextInput` under the hood
- Updated also the snapshots


## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- locally on the browser
- on CRA TS-project

## Screenshots
### Before fix
<img width="509" alt="TextInput_resize_bug_BEFORE_FIX" src="https://user-images.githubusercontent.com/53757053/76491259-f5e9b580-6435-11ea-9fd3-e0048931c9f8.png">

### After fix
<img width="513" alt="TextInput_resize_bug_AFTER_FIX" src="https://user-images.githubusercontent.com/53757053/76491256-f5e9b580-6435-11ea-93d3-c26c5636b4ba.png">