### PR TITLE
[Feature] Language menu improvements

### DIFF
--- a/src/components/LanguageMenu/LanguageMenu.tsx
+++ b/src/components/LanguageMenu/LanguageMenu.tsx
@@ -56,12 +56,12 @@ type OptionalLanguageMenuListProps = {
 export interface LanguageMenuProps {
   /** Name or content of menubutton */
   name: React.ReactNode | ((props: { isOpen: boolean }) => React.ReactNode);
-  /** onMenuOpen function callback for open / close event */
-  onMenuOpen?: (isOpen: boolean) => void;
   /** Custom classname to extend or customize */
   className?: string;
   /** Custom classname to extend or customize */
   languageMenuButtonClassName?: string;
+  /** Custom classname to apply when menu is open */
+  languageMenuOpenButtonClassName?: string;
   /** Properties given to LanguageMenu's List-component, className etc. */
   languageMenuListProps?: OptionalLanguageMenuListProps;
   languageMenuListComponent?: React.ComponentType<
@@ -72,24 +72,15 @@ export interface LanguageMenuProps {
 }
 
 export class LanguageMenu extends Component<LanguageMenuProps> {
-  handleMenuOpenEvent = (
-    isOpen: boolean,
-    onMenuOpen: ((isOpen: boolean) => void) | undefined,
-  ) => {
-    if (!!onMenuOpen) {
-      onMenuOpen(isOpen);
-    }
-  };
-
   render() {
     const {
       children,
       name,
       className,
       languageMenuButtonClassName: menuButtonClassName,
+      languageMenuOpenButtonClassName: menuButtonOpenClassName,
       languageMenuListProps: menuListProps = {},
       languageMenuListComponent: MenuListComponentReplace,
-      onMenuOpen,
       ...passProps
     } = this.props;
 
@@ -101,16 +92,14 @@ export class LanguageMenu extends Component<LanguageMenuProps> {
       <HtmlSpan className={classnames(className, baseClassName)}>
         <Menu>
           {({ isOpen }: { isOpen: boolean }) => {
-            console.log(isOpen);
             return (
               <Fragment>
                 <MenuButton
                   {...passProps}
-                  className={menuButtonClassName}
-                  onMouseDown={() =>
-                    this.handleMenuOpenEvent(isOpen, onMenuOpen)
-                  }
-                  onKeyDown={() => this.handleMenuOpenEvent(isOpen, onMenuOpen)}
+                  className={classnames(
+                    menuButtonClassName,
+                    isOpen ? menuButtonOpenClassName : '',
+                  )}
                 >
                   {name}
                 </MenuButton>

--- a/src/components/LanguageMenu/LanguageMenu.tsx
+++ b/src/components/LanguageMenu/LanguageMenu.tsx
@@ -98,7 +98,7 @@ export class LanguageMenu extends Component<LanguageMenuProps> {
                   {...passProps}
                   className={classnames(
                     menuButtonClassName,
-                    isOpen ? menuButtonOpenClassName : '',
+                    isOpen && menuButtonOpenClassName,
                   )}
                 >
                   {name}

--- a/src/components/LanguageMenu/LanguageMenu.tsx
+++ b/src/components/LanguageMenu/LanguageMenu.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, Fragment } from 'react';
 import classnames from 'classnames';
 import { HtmlSpan } from '../../reset/HtmlSpan/HtmlSpan';
 import {
@@ -55,7 +55,9 @@ type OptionalLanguageMenuListProps = {
 
 export interface LanguageMenuProps {
   /** Name or content of menubutton */
-  name: ReactNode;
+  name: React.ReactNode | ((props: { isOpen: boolean }) => React.ReactNode);
+  /** onMenuOpen function callback for open / close event */
+  onMenuOpen?: (isOpen: boolean) => void;
   /** Custom classname to extend or customize */
   className?: string;
   /** Custom classname to extend or customize */
@@ -70,6 +72,15 @@ export interface LanguageMenuProps {
 }
 
 export class LanguageMenu extends Component<LanguageMenuProps> {
+  handleMenuOpenEvent = (
+    isOpen: boolean,
+    onMenuOpen: ((isOpen: boolean) => void) | undefined,
+  ) => {
+    if (!!onMenuOpen) {
+      onMenuOpen(isOpen);
+    }
+  };
+
   render() {
     const {
       children,
@@ -78,6 +89,7 @@ export class LanguageMenu extends Component<LanguageMenuProps> {
       languageMenuButtonClassName: menuButtonClassName,
       languageMenuListProps: menuListProps = {},
       languageMenuListComponent: MenuListComponentReplace,
+      onMenuOpen,
       ...passProps
     } = this.props;
 
@@ -85,20 +97,33 @@ export class LanguageMenu extends Component<LanguageMenuProps> {
       logger.warn(`Menu '${name}' does not contain items`);
       return null;
     }
-
     return (
       <HtmlSpan className={classnames(className, baseClassName)}>
         <Menu>
-          <MenuButton {...passProps} className={menuButtonClassName}>
-            {name}
-          </MenuButton>
-          {!!MenuListComponentReplace ? (
-            <MenuListComponentReplace {...menuListProps}>
-              {children}
-            </MenuListComponentReplace>
-          ) : (
-            <MenuList {...menuListProps}>{children}</MenuList>
-          )}
+          {({ isOpen }: { isOpen: boolean }) => {
+            console.log(isOpen);
+            return (
+              <Fragment>
+                <MenuButton
+                  {...passProps}
+                  className={menuButtonClassName}
+                  onMouseDown={() =>
+                    this.handleMenuOpenEvent(isOpen, onMenuOpen)
+                  }
+                  onKeyDown={() => this.handleMenuOpenEvent(isOpen, onMenuOpen)}
+                >
+                  {name}
+                </MenuButton>
+                {!!MenuListComponentReplace ? (
+                  <MenuListComponentReplace {...menuListProps}>
+                    {children}
+                  </MenuListComponentReplace>
+                ) : (
+                  <MenuList {...menuListProps}>{children}</MenuList>
+                )}
+              </Fragment>
+            );
+          }}
         </Menu>
       </HtmlSpan>
     );

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -2,7 +2,6 @@ import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../theme';
 import { LanguageMenuProps } from './LanguageMenu';
 import { element, focus } from '../theme/reset';
-import { padding } from '../theme/utils';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme & Partial<LanguageMenuProps>) => css`
@@ -14,7 +13,8 @@ export const baseStyles = withSuomifiTheme(
     &.fi-language-menu-language_button {
       ${element({ theme })}
       ${theme.typography.actionElementInnerTextBold}
-      ${padding({ theme })('s', 'xs', 's', 's')}
+      padding: 5px ${theme.spacing.xs} 5px ${theme.spacing.s};
+      line-height: 28px;
       background-color: ${theme.colors.whiteBase};
       border: 1px solid ${theme.colors.depthBase};
       border-radius: ${theme.radius.basic};
@@ -24,6 +24,9 @@ export const baseStyles = withSuomifiTheme(
         width: 1.2em;
         transform: translateY(0.3em); 
         margin-left: ${theme.spacing.xs};
+      }
+      & > .fi-language-menu-language_open_icon {
+        transform: translateY(0.3em) rotate(180deg);
       }
     }
   }

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -25,10 +25,12 @@ export const baseStyles = withSuomifiTheme(
         transform: translateY(0.3em); 
         margin-left: ${theme.spacing.xs};
       }
-      & > .fi-language-menu-language_open_icon {
-        transform: translateY(0.3em) rotate(180deg);
-      }
     }
+    &.fi-language-menu-language_button_open {
+        & > .fi-language-menu-language_icon.fi-language-menu-language_icon {
+          transform: translateY(0.2em) rotate(180deg);
+        }
+      }
   }
 `,
 );

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -25,9 +25,11 @@ const itemClassName = 'fi-language-menu_item';
 const itemLangClassName = 'fi-language-menu-language_item';
 const buttonClassName = 'fi-language-menu_button';
 const buttonLangClassName = 'fi-language-menu-language_button';
+
 const listClassName = 'fi-language-menu_list';
 const listLangClassName = 'fi-language-menu-language_list';
 const iconLangClassName = 'fi-language-menu-language_icon';
+const iconLangOpenClassName = 'fi-language-menu-language_open_icon';
 
 export interface LanguageMenuProps extends CompLanguageMenuProps, TokensProp {}
 
@@ -57,10 +59,16 @@ const LanguageMenuListWithProps = (
     },
   );
 
-const languageName = (name: ReactNode) => (
+const languageName = (name: ReactNode, isMenuOpen: boolean) => (
   <Fragment>
     {name}
-    <Icon icon="chevronDown" className={iconLangClassName} />
+    <Icon
+      icon="chevronDown"
+      className={classnames(
+        iconLangClassName,
+        isMenuOpen ? iconLangOpenClassName : undefined,
+      )}
+    />
   </Fragment>
 );
 
@@ -74,7 +82,28 @@ const StyledMenuList = styled(
   ${props => languageMenuListStyles(props.theme)}
 `;
 
-class LanguageMenuVariation extends Component<LanguageMenuProps> {
+type LanguageMenuState = {
+  isMenuOpen: boolean;
+};
+
+class LanguageMenuVariation extends Component<
+  LanguageMenuProps,
+  LanguageMenuState
+> {
+  constructor(props: LanguageMenuProps) {
+    super(props);
+    this.state = {
+      isMenuOpen: false,
+    };
+  }
+
+  setIsMenuOpen = (isMenuOpen: boolean) => {
+    console.log(isMenuOpen, this.state.isMenuOpen);
+    if (isMenuOpen !== this.state.isMenuOpen) {
+      this.setState({ isMenuOpen });
+    }
+  };
+
   render() {
     const {
       children,
@@ -96,7 +125,8 @@ class LanguageMenuVariation extends Component<LanguageMenuProps> {
       <Fragment>
         <StyledLanguageMenu
           {...passProps}
-          name={languageName(name)}
+          onMenuOpen={this.setIsMenuOpen}
+          name={languageName(name, this.state.isMenuOpen)}
           languageMenuButtonClassName={languageMenuButtonClassName}
           languageMenuListProps={menuListProps}
           languageMenuListComponent={

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -24,12 +24,12 @@ import { Icon } from '../Icon/Icon';
 const itemClassName = 'fi-language-menu_item';
 const itemLangClassName = 'fi-language-menu-language_item';
 const buttonClassName = 'fi-language-menu_button';
+const buttonOpenClassName = 'fi-language-menu-language_button_open';
 const buttonLangClassName = 'fi-language-menu-language_button';
 
 const listClassName = 'fi-language-menu_list';
 const listLangClassName = 'fi-language-menu-language_list';
 const iconLangClassName = 'fi-language-menu-language_icon';
-const iconLangOpenClassName = 'fi-language-menu-language_open_icon';
 
 export interface LanguageMenuProps extends CompLanguageMenuProps, TokensProp {}
 
@@ -59,16 +59,10 @@ const LanguageMenuListWithProps = (
     },
   );
 
-const languageName = (name: ReactNode, isMenuOpen: boolean) => (
+const languageName = (name: ReactNode) => (
   <Fragment>
     {name}
-    <Icon
-      icon="chevronDown"
-      className={classnames(
-        iconLangClassName,
-        isMenuOpen ? iconLangOpenClassName : undefined,
-      )}
-    />
+    <Icon icon="chevronDown" className={iconLangClassName} />
   </Fragment>
 );
 
@@ -82,28 +76,7 @@ const StyledMenuList = styled(
   ${props => languageMenuListStyles(props.theme)}
 `;
 
-type LanguageMenuState = {
-  isMenuOpen: boolean;
-};
-
-class LanguageMenuVariation extends Component<
-  LanguageMenuProps,
-  LanguageMenuState
-> {
-  constructor(props: LanguageMenuProps) {
-    super(props);
-    this.state = {
-      isMenuOpen: false,
-    };
-  }
-
-  setIsMenuOpen = (isMenuOpen: boolean) => {
-    console.log(isMenuOpen, this.state.isMenuOpen);
-    if (isMenuOpen !== this.state.isMenuOpen) {
-      this.setState({ isMenuOpen });
-    }
-  };
-
+class LanguageMenuVariation extends Component<LanguageMenuProps> {
   render() {
     const {
       children,
@@ -125,9 +98,9 @@ class LanguageMenuVariation extends Component<
       <Fragment>
         <StyledLanguageMenu
           {...passProps}
-          onMenuOpen={this.setIsMenuOpen}
-          name={languageName(name, this.state.isMenuOpen)}
+          name={languageName(name)}
           languageMenuButtonClassName={languageMenuButtonClassName}
+          languageMenuOpenButtonClassName={buttonOpenClassName}
           languageMenuListProps={menuListProps}
           languageMenuListComponent={
             !!MenuListComponentProp ? MenuListComponentProp : StyledMenuList


### PR DESCRIPTION
## Description
Adjust language menu-button size to match designs (height 40px) and change menu icon rotation when menu is open.

## Motivation and Context

To allow menu to be used with buttons in designs where height is based on button defaults, the language menu height needed to be changed. Also, in order to better communicate the functionality of the menu button when the menu list is visible, the icon should be rotated 180 degrees from the original.

## How Has This Been Tested?
Tested using styleguidist, CRA typescript project and design system site using verdaccio.