### PR TITLE
[BugFix] Language menu positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "typescript": "3.3.1"
   },
   "dependencies": {
-    "@reach/menu-button": "0.8.5",
-    "@reach/popover": "0.8.5",
+    "@reach/menu-button": "0.9.0",
+    "@reach/popover": "0.9.0",
     "classnames": "2.2.6",
     "normalize.cssinjs": "1.1.0",
     "polished": "3.4.0",

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -6,6 +6,7 @@ import {
   MenuButton,
   MenuButtonProps,
   MenuPopoverProps,
+  MenuItems,
   MenuItem,
   MenuItemProps,
   MenuPopover,
@@ -17,7 +18,7 @@ export { MenuItem as DropdownItem };
 
 const baseClassName = 'fi-dropdown';
 const buttonClassName = `${baseClassName}_button`;
-const dropdownListClassName = `${baseClassName}_list`;
+const dropdownPopoverClassName = `${baseClassName}_popover`;
 const dropdownItemClassName = `${baseClassName}_item`;
 
 export interface DropdownItemProps {
@@ -27,7 +28,7 @@ export interface DropdownItemProps {
   children: ReactNode;
 }
 
-type DropdownListItems = DropdownItemProps;
+type DropdownPopoverItems = DropdownItemProps;
 
 interface DropdownState {
   selectedName: ReactNode;
@@ -36,7 +37,7 @@ interface DropdownState {
 type OptionalMenuButtonProps = {
   [K in keyof MenuButtonProps]?: MenuButtonProps[K];
 };
-type OptionalMenuListProps = {
+type OptionalMenuPopoverProps = {
   [K in keyof MenuPopoverProps]?: MenuPopoverProps[K];
 };
 type OptionalMenuItemProps = { [K in keyof MenuItemProps]?: MenuItemProps[K] };
@@ -52,15 +53,15 @@ export interface DropdownProps {
   className?: string;
   /** Properties given to dropdown's Button-component, className etc. */
   dropdownButtonProps?: OptionalMenuButtonProps;
-  /** Properties given to dropdown's list-component, className etc. */
-  dropdownListProps?: OptionalMenuListProps;
-  menuListComponent?: React.ComponentType<OptionalMenuListProps>;
+  /** Properties given to dropdown's popover-component, className etc. */
+  dropdownPopoverProps?: OptionalMenuPopoverProps;
+  menuPopoverComponent?: React.ComponentType<OptionalMenuPopoverProps>;
   /** Properties given to dropdown's item-component, className etc. */
   dropdownItemProps?: OptionalMenuItemProps;
   /** DropdownItems */
   children?:
-    | Array<ReactElement<DropdownListItems>>
-    | ReactElement<DropdownListItems>;
+    | Array<ReactElement<DropdownPopoverItems>>
+    | ReactElement<DropdownPopoverItems>;
 }
 
 export class Dropdown extends Component<DropdownProps> {
@@ -68,7 +69,7 @@ export class Dropdown extends Component<DropdownProps> {
 
   changeName = (name: ReactNode) => this.setState({ selectedName: name });
 
-  list = (
+  dropDownItems = (
     children: ReactNode,
     changeNameToSelection: boolean,
     dropdownItemProps?: OptionalMenuItemProps,
@@ -99,8 +100,8 @@ export class Dropdown extends Component<DropdownProps> {
       name,
       className,
       dropdownButtonProps = {},
-      dropdownListProps = {},
-      menuListComponent: MenuListComponentReplace,
+      dropdownPopoverProps = {},
+      menuPopoverComponent: MenuPopoverComponentReplace,
       dropdownItemProps = {},
       changeNameToSelection = true,
       ...passProps
@@ -116,9 +117,12 @@ export class Dropdown extends Component<DropdownProps> {
       ...dropdownButtonProps,
       className: classnames(buttonClassName, dropdownButtonProps.className),
     };
-    const passDropdownListProps = {
-      ...dropdownListProps,
-      className: classnames(dropdownListClassName, dropdownListProps.className),
+    const passDropdownPopoverProps = {
+      ...dropdownPopoverProps,
+      className: classnames(
+        dropdownPopoverClassName,
+        dropdownPopoverProps.className,
+      ),
     };
     const passDropdownItemProps = {
       ...dropdownItemProps,
@@ -131,24 +135,26 @@ export class Dropdown extends Component<DropdownProps> {
           <MenuButton {...passDropdownButtonProps}>
             {!!selectedName ? selectedName : name}
           </MenuButton>
-          {!!MenuListComponentReplace ? (
-            <MenuListComponentReplace {...passDropdownListProps}>
-              {this.list(
+          {!!MenuPopoverComponentReplace ? (
+            <MenuPopoverComponentReplace {...passDropdownPopoverProps}>
+              {this.dropDownItems(
                 children,
                 changeNameToSelection,
                 passDropdownItemProps,
               )}
-            </MenuListComponentReplace>
+            </MenuPopoverComponentReplace>
           ) : (
             <MenuPopover
               position={positionMatchWidth}
-              {...passDropdownListProps}
+              {...passDropdownPopoverProps}
             >
-              {this.list(
-                children,
-                changeNameToSelection,
-                passDropdownItemProps,
-              )}
+              <MenuItems>
+                {this.dropDownItems(
+                  children,
+                  changeNameToSelection,
+                  passDropdownItemProps,
+                )}
+              </MenuItems>
             </MenuPopover>
           )}
         </Menu>

--- a/src/components/LanguageMenu/LanguageMenu.tsx
+++ b/src/components/LanguageMenu/LanguageMenu.tsx
@@ -4,24 +4,18 @@ import { HtmlSpan } from '../../reset/HtmlSpan/HtmlSpan';
 import {
   Menu,
   MenuButton,
-  MenuList,
-  MenuListProps,
+  MenuItems,
   MenuItem,
   MenuLink,
   MenuPopover,
   MenuPopoverProps,
 } from '@reach/menu-button';
+import { positionDefault } from '@reach/popover';
+import { PRect } from '@reach/rect';
 import { logger } from '../../utils/logger';
 import { Omit } from '../../utils/typescript';
 
-export {
-  MenuList,
-  MenuListProps,
-  MenuItem,
-  MenuLink,
-  MenuPopover,
-  MenuPopoverProps,
-};
+export { MenuItems, MenuItem, MenuLink, MenuPopover, MenuPopoverProps, PRect };
 
 const baseClassName = 'fi-language-menu';
 export interface LanguageMenuItemProps {
@@ -46,11 +40,11 @@ interface LanguageMenuLinkPropsWithType {
 export interface LanguageMenuLinkProps
   extends Omit<LanguageMenuLinkPropsWithType, 'type'> {}
 
-export type LanguageMenuListItemsProps =
+export type LanguageMenuPopoverItemsProps =
   | LanguageMenuItemProps
   | LanguageMenuLinkPropsWithType;
-type OptionalLanguageMenuListProps = {
-  [K in keyof MenuListProps]?: MenuListProps[K];
+type OptionalLanguageMenuPopoverProps = {
+  [K in keyof MenuPopoverProps]?: MenuPopoverProps[K];
 };
 
 export interface LanguageMenuProps {
@@ -62,13 +56,13 @@ export interface LanguageMenuProps {
   languageMenuButtonClassName?: string;
   /** Custom classname to apply when menu is open */
   languageMenuOpenButtonClassName?: string;
-  /** Properties given to LanguageMenu's List-component, className etc. */
-  languageMenuListProps?: OptionalLanguageMenuListProps;
-  languageMenuListComponent?: React.ComponentType<
-    OptionalLanguageMenuListProps
+  /** Properties given to LanguageMenu's popover-component, className etc. */
+  languageMenuPopoverProps?: OptionalLanguageMenuPopoverProps;
+  languageMenuPopoverComponent?: React.ComponentType<
+    OptionalLanguageMenuPopoverProps
   >;
   /** Menu items: MenuItem or MenuLink */
-  children?: Array<React.ReactElement<LanguageMenuListItemsProps>>;
+  children?: Array<React.ReactElement<LanguageMenuPopoverItemsProps>>;
 }
 
 export class LanguageMenu extends Component<LanguageMenuProps> {
@@ -79,8 +73,8 @@ export class LanguageMenu extends Component<LanguageMenuProps> {
       className,
       languageMenuButtonClassName: menuButtonClassName,
       languageMenuOpenButtonClassName: menuButtonOpenClassName,
-      languageMenuListProps: menuListProps = {},
-      languageMenuListComponent: MenuListComponentReplace,
+      languageMenuPopoverProps: menuPopoverProps = {},
+      languageMenuPopoverComponent: MenuPopoverComponentReplace,
       ...passProps
     } = this.props;
 
@@ -103,12 +97,14 @@ export class LanguageMenu extends Component<LanguageMenuProps> {
                 >
                   {name}
                 </MenuButton>
-                {!!MenuListComponentReplace ? (
-                  <MenuListComponentReplace {...menuListProps}>
+                {!!MenuPopoverComponentReplace ? (
+                  <MenuPopoverComponentReplace {...menuPopoverProps}>
                     {children}
-                  </MenuListComponentReplace>
+                  </MenuPopoverComponentReplace>
                 ) : (
-                  <MenuList {...menuListProps}>{children}</MenuList>
+                  <MenuPopover position={positionDefault} {...menuPopoverProps}>
+                    <MenuItems>{children}</MenuItems>
+                  </MenuPopover>
                 )}
               </Fragment>
             );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,7 +20,7 @@ export { LinkExternal, LinkExternalProps } from './Link/LinkExternal';
 export {
   LanguageMenu,
   LanguageMenuProps,
-  LanguageMenuListItemsProps,
+  LanguageMenuPopoverItemsProps,
   LanguageMenuItemProps,
   LanguageMenuLinkProps as MenuLinkProps,
   MenuItem,

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -31,9 +31,9 @@ export const baseStyles = withSuomifiTheme(
   `,
 );
 
-export const menuListStyles = withSuomifiTheme(
+export const menuPopoverStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
-  &[data-reach-menu-popover].fi-dropdown_list {
+  &[data-reach-menu-popover].fi-dropdown_popover {
     ${element({ theme })}
     ${theme.typography.actionElementInnerText}
     margin-top: -1px;
@@ -47,6 +47,11 @@ export const menuListStyles = withSuomifiTheme(
     border-width: 0 1px 1px 1px;
     border-radius: 0px 0px ${theme.radius.basic} ${theme.radius.basic};
     overflow: hidden;
+  }
+  
+  & [data-reach-menu-items] {
+    border: 0;
+    padding: 0;
   }
 
   & [data-reach-menu-item].fi-dropdown_item {

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-// import { axe } from 'jest-axe';
-import { render, prettyDOM, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { Dropdown } from './Dropdown';
+import { baseStyles } from './Dropdown.baseStyles';
+import { cssFromBaseStyles } from '../utils';
+import { axeTest } from '../../utils/test/axe';
 
 const doNothing = () => ({});
 
@@ -13,22 +15,24 @@ const TestDropdown = (
   </Dropdown>
 );
 
-let html: string | boolean = false;
+test('calling render with the same component on the same container does not remount', () => {
+  const { container } = render(TestDropdown);
+  expect(container).toMatchSnapshot();
+});
 
-test('should not have basic accessibility issues', async () => {
-  act(() => {
-    const div = document.createElement('div');
-    document.body.appendChild(div);
-    const { container } = render(TestDropdown, {
-      container: div,
-    });
-    html = prettyDOM(container);
-  });
+// Don't validate aria-attributes since Portal is not rendered and there is no pair for aria-controls
+test(
+  'should not have basic accessibility issues',
+  axeTest(TestDropdown, {
+    rules: {
+      'aria-valid-attr-value': {
+        enabled: false,
+      },
+    },
+  }),
+);
 
-  if (typeof html === 'boolean') {
-    throw new Error('Dropdown did not render correctly');
-  } else {
-    // const results = await axe(html);
-    // expect(results).toHaveNoViolations();
-  }
+test('CSS export', () => {
+  const css = cssFromBaseStyles(baseStyles);
+  expect(css).toEqual(expect.stringContaining('color'));
 });

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { axeTest } from '../../utils/test/axe';
+// import { axe } from 'jest-axe';
+import { render, prettyDOM, act } from '@testing-library/react';
 
 import { Dropdown } from './Dropdown';
 
@@ -12,4 +13,22 @@ const TestDropdown = (
   </Dropdown>
 );
 
-test('should not have basic accessibility issues', axeTest(TestDropdown));
+let html: string | boolean = false;
+
+test('should not have basic accessibility issues', async () => {
+  act(() => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const { container } = render(TestDropdown, {
+      container: div,
+    });
+    html = prettyDOM(container);
+  });
+
+  if (typeof html === 'boolean') {
+    throw new Error('Dropdown did not render correctly');
+  } else {
+    // const results = await axe(html);
+    // expect(results).toHaveNoViolations();
+  }
+});

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -2,10 +2,11 @@ import React, { Component, Fragment } from 'react';
 import { default as styled } from 'styled-components';
 import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensProp, InternalTokensProp } from '../theme';
-import { baseStyles, menuListStyles } from './Dropdown.baseStyles';
+import { baseStyles, menuPopoverStyles } from './Dropdown.baseStyles';
 import {
   MenuPopover as CompMenuPopover,
-  MenuListProps as CompMenuListProps,
+  MenuPopoverProps as CompMenuPopoverProps,
+  MenuItems as CompMenuItems,
 } from '../../components/LanguageMenu/LanguageMenu';
 import {
   Dropdown as CompDropdown,
@@ -27,17 +28,21 @@ const StyledDropdown = styled(
   ${props => baseStyles(props)}
 `;
 
-interface MenuListProps extends CompMenuListProps, TokensProp {}
+interface MenuPopoverProps extends CompMenuPopoverProps, TokensProp {}
 
-const StyledMenuList = styled(({ tokens, ...passProps }: MenuListProps) => (
-  <CompMenuPopover position={positionMatchWidth} {...passProps} />
-))`
-  ${props => menuListStyles(props.theme)}
+const StyledMenuPopover = styled(
+  ({ tokens, children, ...passProps }: MenuPopoverProps) => (
+    <CompMenuPopover position={positionMatchWidth} {...passProps}>
+      <CompMenuItems>{children}</CompMenuItems>
+    </CompMenuPopover>
+  ),
+)`
+  ${props => menuPopoverStyles(props.theme)}
 `;
 
 /**
  * <i class="semantics" />
- * Use for selectable dropdown list.
+ * Use for selectable dropdown with items.
  */
 export class Dropdown extends Component<DropdownProps> {
   static item = (props: DropdownItemProps) => <DropdownItem {...props} />;
@@ -46,7 +51,7 @@ export class Dropdown extends Component<DropdownProps> {
     const props = withSuomifiDefaultProps(this.props);
     return (
       <Fragment>
-        <StyledDropdown {...props} menuListComponent={StyledMenuList} />
+        <StyledDropdown {...props} menuPopoverComponent={StyledMenuPopover} />
       </Fragment>
     );
   }

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calling render with the same component on the same container does not remount 1`] = `
+.c1 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0 > [data-reach-menu-button].fi-dropdown_button {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,67%);
+  border-radius: 2px;
+  line-height: 1;
+  position: relative;
+  padding-right: 30px;
+  text-align: left;
+  background-color: hsl(0,0%,100%);
+  cursor: pointer;
+}
+
+.c0 > [data-reach-menu-button].fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c0 > [data-reach-menu-button].fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c0 > [data-reach-menu-button].fi-dropdown_button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 > [data-reach-menu-button].fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(202,7%,40%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c0 > [data-reach-menu-button].fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(202,7%,40%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+<div>
+  <span
+    class="dropdown-test c0 fi-dropdown c1"
+  >
+    <button
+      aria-controls="menu--1"
+      aria-haspopup="true"
+      class="fi-dropdown_button"
+      data-reach-menu-button=""
+      id="menu-button--menu--1"
+      type="button"
+    >
+      Dropdown
+    </button>
+  </span>
+</div>
+`;

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -18,7 +18,6 @@ export const baseStyles = withSuomifiTheme(
       background-color: ${theme.colors.whiteBase};
       border: 1px solid ${theme.colors.depthBase};
       border-radius: ${theme.radius.basic};
-      text-transform: uppercase;
       & > .fi-language-menu-language_icon {
         height: 1.2em;
         width: 1.2em;

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -35,21 +35,19 @@ export const baseStyles = withSuomifiTheme(
 `,
 );
 
-export const languageMenuListStyles = withSuomifiTheme(
+export const languageMenuPopoverStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
-  &[data-reach-menu-list].fi-language-menu_list {
+  &[data-reach-menu-popover].fi-language-menu_popover {
     ${element({ theme })}
     ${theme.typography.bodyText}
     margin-top: -2px;
     background-color: ${theme.colors.whiteBase};
     border: none;
     box-shadow: ${theme.shadows.menuShadow};
-    &.fi-language-menu-language_list {
+    &.fi-language-menu-language_popover {
       ${theme.typography.actionElementInnerText}
       position: absolute;
       box-sizing: content-box;
-      right: -50px;
-      top: 0;
       margin-top: 12px;
       padding: 10px 0;
       border: 1px solid ${theme.colors.depthBase};
@@ -76,6 +74,11 @@ export const languageMenuListStyles = withSuomifiTheme(
         margin-right: -7px;
       }
     }
+  }
+
+  & [data-reach-menu-items] {
+    border: 0;
+    padding: 0;
   }
 
   & [data-reach-menu-item].fi-language-menu_item {

--- a/src/core/LanguageMenu/LanguageMenu.md
+++ b/src/core/LanguageMenu/LanguageMenu.md
@@ -19,7 +19,10 @@ import {
   LanguageMenuLink
 } from 'suomifi-ui-components';
 
-<LanguageMenu className="language-menu-language-test" name="FI">
+<LanguageMenu
+  className="language-menu-language-test"
+  name="Suomeksi (FI)"
+>
   <LanguageMenuItem onSelect={() => console.log('FI')} selected>
     Suomeksi (FI)
   </LanguageMenuItem>

--- a/src/core/LanguageMenu/LanguageMenu.md
+++ b/src/core/LanguageMenu/LanguageMenu.md
@@ -1,17 +1,3 @@
-<!-- ```js
-import { LanguageMenu, LanguageMenuItem, LanguageMenuLink } from 'suomifi-ui-components';
-
-<LanguageMenu className="language-menu-test" name="LanguageMenu">
-  <LanguageMenuItem onSelect={() => console.log('LanguageMenu test 1')}>
-    Item 1
-  </LanguageMenuItem>
-  <LanguageMenuItem onSelect={() => console.log('LanguageMenu test 2')}>
-    Item 2
-  </LanguageMenuItem>
-  <LanguageMenuLink href="http://www.suomi.fi/">Suomi.fi</LanguageMenuLink>
-</LanguageMenu>;
-``` -->
-
 ```js
 import {
   LanguageMenu,

--- a/src/core/LanguageMenu/LanguageMenu.test.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { axeTest } from '../../utils/test/axe';
+// import { axe } from 'jest-axe';
+import { render, prettyDOM, act } from '@testing-library/react';
 
 import { LanguageMenu } from './LanguageMenu';
 import { LanguageMenuItem, LanguageMenuLink } from './LanguageMenuItem';
@@ -15,4 +16,22 @@ const TestMenuLanguage = (
   </LanguageMenu>
 );
 
-test('should not have basic accessibility issues', axeTest(TestMenuLanguage));
+let html: string | boolean = false;
+
+test('should not have basic accessibility issues', async () => {
+  act(() => {
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const { container } = render(TestMenuLanguage, {
+      container: div,
+    });
+    html = prettyDOM(container);
+  });
+
+  if (typeof html === 'boolean') {
+    throw new Error('LanguageMenu did not render correctly');
+  } else {
+    // const results = await axe(html);
+    // expect(results).toHaveNoViolations();
+  }
+});

--- a/src/core/LanguageMenu/LanguageMenu.test.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-// import { axe } from 'jest-axe';
-import { render, prettyDOM, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { LanguageMenu } from './LanguageMenu';
 import { LanguageMenuItem, LanguageMenuLink } from './LanguageMenuItem';
+import { baseStyles } from './LanguageMenu.baseStyles';
+import { cssFromBaseStyles } from '../utils';
+import { axeTest } from '../../utils/test/axe';
 
 const doNothing = () => ({});
 
@@ -16,22 +18,24 @@ const TestMenuLanguage = (
   </LanguageMenu>
 );
 
-let html: string | boolean = false;
+test('calling render with the same component on the same container does not remount', () => {
+  const { container } = render(TestMenuLanguage);
+  expect(container).toMatchSnapshot();
+});
 
-test('should not have basic accessibility issues', async () => {
-  act(() => {
-    const div = document.createElement('div');
-    document.body.appendChild(div);
-    const { container } = render(TestMenuLanguage, {
-      container: div,
-    });
-    html = prettyDOM(container);
-  });
+// Don't validate aria-attributes since Portal is not rendered and there is no pair for aria-controls
+test(
+  'should not have basic accessibility issues',
+  axeTest(TestMenuLanguage, {
+    rules: {
+      'aria-valid-attr-value': {
+        enabled: false,
+      },
+    },
+  }),
+);
 
-  if (typeof html === 'boolean') {
-    throw new Error('LanguageMenu did not render correctly');
-  } else {
-    // const results = await axe(html);
-    // expect(results).toHaveNoViolations();
-  }
+test('CSS export', () => {
+  const css = cssFromBaseStyles(baseStyles);
+  expect(css).toEqual(expect.stringContaining('color'));
 });

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -82,6 +82,7 @@ const LanguageMenuPopoverPosition = (
   }
   return {
     left: `${targetRect.left - popoverRect.width + targetRect.width}px`,
+    // eslint-disable-next-line no-undef
     top: `${targetRect.top + targetRect.height + window.pageYOffset}px`,
   };
 };

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -4,13 +4,18 @@ import classnames from 'classnames';
 import { classnamesValue } from '../../utils/typescript';
 import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensProp, InternalTokensProp } from '../theme';
-import { baseStyles, languageMenuListStyles } from './LanguageMenu.baseStyles';
+import {
+  baseStyles,
+  languageMenuPopoverStyles,
+} from './LanguageMenu.baseStyles';
 import {
   LanguageMenu as CompLanguageMenu,
   LanguageMenuProps as CompLanguageMenuProps,
-  LanguageMenuListItemsProps,
-  MenuList as CompMenuList,
-  MenuListProps as CompMenuListProps,
+  LanguageMenuPopoverItemsProps,
+  MenuItems as CompMenuItems,
+  MenuPopover as CompMenuPopover,
+  MenuPopoverProps as CompMenuPopoverProps,
+  PRect,
 } from '../../components/LanguageMenu/LanguageMenu';
 import {
   LanguageMenuItemLanguage,
@@ -27,8 +32,8 @@ const buttonClassName = 'fi-language-menu_button';
 const buttonOpenClassName = 'fi-language-menu-language_button_open';
 const buttonLangClassName = 'fi-language-menu-language_button';
 
-const listClassName = 'fi-language-menu_list';
-const listLangClassName = 'fi-language-menu-language_list';
+const popoverClassName = 'fi-language-menu_popover';
+const popoverLangClassName = 'fi-language-menu-language_popover';
 const iconLangClassName = 'fi-language-menu-language_icon';
 
 export interface LanguageMenuProps extends CompLanguageMenuProps, TokensProp {}
@@ -41,13 +46,13 @@ const StyledLanguageMenu = styled(
   ${props => baseStyles(props)}
 `;
 
-const LanguageMenuListWithProps = (
+const LanguageMenuPopoverWithProps = (
   children: ReactNode,
   addClass?: classnamesValue,
 ) =>
   React.Children.map(
     children,
-    (child: React.ReactElement<LanguageMenuListItemsProps>) => {
+    (child: React.ReactElement<LanguageMenuPopoverItemsProps>) => {
       // Set defaul component-prop/type to be 'a' needed for links
       if (React.isValidElement(child)) {
         return React.cloneElement(child, {
@@ -66,14 +71,29 @@ const languageName = (name: ReactNode) => (
   </Fragment>
 );
 
-interface LanguageMenuListProps extends CompMenuListProps, TokensProp {}
+interface LanguageMenuPopoverProps extends CompMenuPopoverProps, TokensProp {}
 
-const StyledMenuList = styled(
-  ({ tokens, ...passProps }: LanguageMenuListProps) => (
-    <CompMenuList {...passProps} />
+const LanguageMenuPopoverPosition = (
+  targetRect: PRect | null,
+  popoverRect: PRect | null,
+): React.CSSProperties => {
+  if (!targetRect || !popoverRect) {
+    return {};
+  }
+  return {
+    left: `${targetRect.left - popoverRect.width + targetRect.width}px`,
+    top: `${targetRect.top + targetRect.height + window.pageYOffset}px`,
+  };
+};
+
+const StyledMenuPopover = styled(
+  ({ tokens, children, ...passProps }: LanguageMenuPopoverProps) => (
+    <CompMenuPopover {...passProps} position={LanguageMenuPopoverPosition}>
+      <CompMenuItems>{children}</CompMenuItems>
+    </CompMenuPopover>
   ),
 )`
-  ${props => languageMenuListStyles(props.theme)}
+  ${props => languageMenuPopoverStyles(props.theme)}
 `;
 
 class LanguageMenuVariation extends Component<LanguageMenuProps> {
@@ -82,7 +102,7 @@ class LanguageMenuVariation extends Component<LanguageMenuProps> {
       children,
       name,
       className,
-      languageMenuListComponent: MenuListComponentProp,
+      languageMenuPopoverComponent: MenuPopoverComponentProp,
       ...passProps
     } = withSuomifiDefaultProps(this.props);
     const languageMenuButtonClassName = classnames(
@@ -90,8 +110,8 @@ class LanguageMenuVariation extends Component<LanguageMenuProps> {
       buttonLangClassName,
       className,
     );
-    const menuListProps = {
-      className: classnames(listClassName, listLangClassName),
+    const menuPopoverProps = {
+      className: classnames(popoverClassName, popoverLangClassName),
     };
 
     return (
@@ -101,12 +121,14 @@ class LanguageMenuVariation extends Component<LanguageMenuProps> {
           name={languageName(name)}
           languageMenuButtonClassName={languageMenuButtonClassName}
           languageMenuOpenButtonClassName={buttonOpenClassName}
-          languageMenuListProps={menuListProps}
-          languageMenuListComponent={
-            !!MenuListComponentProp ? MenuListComponentProp : StyledMenuList
+          languageMenuPopoverProps={menuPopoverProps}
+          languageMenuPopoverComponent={
+            !!MenuPopoverComponentProp
+              ? MenuPopoverComponentProp
+              : StyledMenuPopover
           }
         >
-          {LanguageMenuListWithProps(children, itemLangClassName)}
+          {LanguageMenuPopoverWithProps(children, itemLangClassName)}
         </StyledLanguageMenu>
       </Fragment>
     );

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calling render with the same component on the same container does not remount 1`] = `
+.c1 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2 {
+  display: inline-block;
+  vertical-align: baseline;
+}
+
+.c0 > [data-reach-menu-button].fi-language-menu_button {
+  color: hsl(0,0%,16%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.c0 > [data-reach-menu-button].fi-language-menu_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c0 > [data-reach-menu-button].fi-language-menu_button:focus:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c0 > [data-reach-menu-button].fi-language-menu_button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c0 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button {
+  color: hsl(0,0%,16%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  padding: 5px 4px 5px 8px;
+  line-height: 28px;
+  background-color: hsl(0,0%,100%);
+  border: 1px solid hsl(202,7%,67%);
+  border-radius: 2px;
+  text-transform: uppercase;
+}
+
+.c0 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button > .fi-language-menu-language_icon {
+  height: 1.2em;
+  width: 1.2em;
+  -webkit-transform: translateY(0.3em);
+  -ms-transform: translateY(0.3em);
+  transform: translateY(0.3em);
+  margin-left: 4px;
+}
+
+.c0 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button_open > .fi-language-menu-language_icon.fi-language-menu-language_icon {
+  -webkit-transform: translateY(0.2em) rotate(180deg);
+  -ms-transform: translateY(0.2em) rotate(180deg);
+  transform: translateY(0.2em) rotate(180deg);
+}
+
+<div>
+  <span
+    class="c0 fi-language-menu c1"
+  >
+    <button
+      aria-controls="menu--1"
+      aria-haspopup="true"
+      class="fi-language-menu_button fi-language-menu-language_button menu-language-test"
+      data-reach-menu-button=""
+      id="menu-button--menu--1"
+      type="button"
+    >
+      FI
+      <svg
+        aria-hidden="true"
+        class="fi-language-menu-language_icon c2"
+        fill="hsl(202, 7%, 40%)"
+        focusable="false"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+      >
+        <path
+          d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+        />
+      </svg>
+    </button>
+  </span>
+</div>
+`;

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -74,7 +74,6 @@ exports[`calling render with the same component on the same container does not r
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(202,7%,67%);
   border-radius: 2px;
-  text-transform: uppercase;
 }
 
 .c0 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button > .fi-language-menu-language_icon {

--- a/src/utils/test/axe.ts
+++ b/src/utils/test/axe.ts
@@ -2,9 +2,11 @@ import { ReactElement } from 'react';
 import server from 'react-dom/server';
 import { axe } from 'jest-axe';
 
-export const axeTest = (element: ReactElement<any> | string) => async () => {
-  const html =
-    typeof element === 'string' ? element : server.renderToString(element);
-  const results = await axe(html);
+export const axeTest = (
+  element: ReactElement<any>,
+  options: any = {},
+) => async () => {
+  const html = server.renderToString(element);
+  const results = await axe(html, options);
   expect(results).toHaveNoViolations();
 };

--- a/src/utils/test/axe.ts
+++ b/src/utils/test/axe.ts
@@ -2,8 +2,9 @@ import { ReactElement } from 'react';
 import server from 'react-dom/server';
 import { axe } from 'jest-axe';
 
-export const axeTest = (element: ReactElement<any>) => async () => {
-  const html = server.renderToString(element);
+export const axeTest = (element: ReactElement<any> | string) => async () => {
+  const html =
+    typeof element === 'string' ? element : server.renderToString(element);
   const results = await axe(html);
   expect(results).toHaveNoViolations();
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -50,6 +50,15 @@ declare module '@reach/menu-button' {
 
   export const MenuPopover: React.SFC<MenuPopoverProps>;
 
+  export type MenuItemsProps = {
+    children: React.ReactNode;
+  } & React.HTMLAttributes<HTMLDivElement>;
+
+  export declare const MenuItems: React.ForwardRefExoticComponent<{
+    children: React.ReactNode;
+  } & React.HTMLAttributes<HTMLDivElement> &
+    React.RefAttributes<HTMLDivElement>>;
+
   type ResolvedMenuLinkProps<T> = T extends keyof JSX.IntrinsicElements
     ? JSX.IntrinsicElements[T]
     : T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,70 +1176,73 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@reach/auto-id@^0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.8.5.tgz#940500d4c93624852efa5ecbed29c5d7015eb6e9"
-  integrity sha512-FmyoQ5Mvw+WXLd3JOlDmHDQKqhTiZ+BwtEq9HW6pgzYMztq1wr5itv4lrSDqOYa/hJfNrkBC8iCtaIKcykuYnQ==
+"@reach/auto-id@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.9.0.tgz#73b5d34bcf432f3e73b235b9dcaa89ea05a0d4db"
+  integrity sha512-9/aXl+dT0pOenvpkB2kkmQnpMDlmSk8ZkBYmYFzFz3eA4PZFNuXcHVzQevFRhc0HVlskPjxwPNf92EkI9rdFOw==
   dependencies:
+    "@reach/utils" "^0.9.0"
     tslib "^1.10.0"
 
-"@reach/descendants@^0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.8.5.tgz#084b2410bd13be4a76ac663d5957a54325301df0"
-  integrity sha512-L1zGSeOtpK8m/SA/CyJsKBnk+z+kvraEJUq1u/apkw1n47j1Byu40nA7TwKvUxuZtEVaK1CdsGFRGeyHRfU/kg==
+"@reach/descendants@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.9.0.tgz#8cac90fcd5dad38098008b9aee6e88c8cd11269e"
+  integrity sha512-5xBAqre67nPMQ/Og/5PV3zRHfzXA3WMYkqAPDC7aMp35bT9sui7YqwVNeFIiOx3BMyhn8ee1+8OSPYVSdabJwA==
   dependencies:
-    "@reach/utils" "^0.8.5"
+    "@reach/utils" "^0.9.0"
     tslib "^1.10.0"
 
-"@reach/menu-button@0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.8.5.tgz#d37ea9f7a24fe1cb91daa57b6d036eeab25944e8"
-  integrity sha512-8fD4QOFiDORKhXzWWKGk6uDB1iojA7sgDmBwj21pS03crewmuzbAu/jJj31fbcRwm7xZjtm/UaGGjyaJOSJt/g==
+"@reach/menu-button@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.9.0.tgz#c79b5a2bd66c038c0f35ecd1d8feed73bb1d23b7"
+  integrity sha512-O82C4z8Ki8BTubIJNTtPlD578mIXP5tptqXT4u+1vS9QLKU6mIse03FWjLtbRiGAZSeukKKwIIc0N40OqUqgDQ==
   dependencies:
-    "@reach/auto-id" "^0.8.5"
-    "@reach/descendants" "^0.8.5"
-    "@reach/popover" "^0.8.5"
-    "@reach/utils" "^0.8.5"
+    "@reach/auto-id" "^0.9.0"
+    "@reach/descendants" "^0.9.0"
+    "@reach/popover" "^0.9.0"
+    "@reach/utils" "^0.9.0"
     prop-types "^15.7.2"
     tslib "^1.10.0"
     warning "^4.0.3"
 
-"@reach/observe-rect@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.0.5.tgz#28bf3c5c35da7fef72cd124af4ac32308d0c3f15"
-  integrity sha512-EQLHhquzwAh2TFtMJU0PXJRmhpOrAhzApgoI4Lwn72J7ygrMk3Ys3a3i8KDnV0TetbwAxn4XSHi4pE8sPWUYLg==
+"@reach/observe-rect@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.1.0.tgz#4e967a93852b6004c3895d9ed8d4e5b41895afde"
+  integrity sha512-kE+jvoj/OyJV24C03VvLt5zclb9ArJi04wWXMMFwQvdZjdHoBlN4g0ZQFjyy/ejPF1Z/dpUD5dhRdBiUmIGZTA==
 
-"@reach/popover@0.8.5", "@reach/popover@^0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@reach/popover/-/popover-0.8.5.tgz#0e64b89585655d5e4290fc5a41f8e62f5f617889"
-  integrity sha512-6s+DJGvuK9ZimQQP9/JFhWSdQAIafte7kwIPeNmQUQNf51RYHYRX30xyhAqcuuogXjEr+tRDWVOfEBXEmtt4RA==
+"@reach/popover@0.9.0", "@reach/popover@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@reach/popover/-/popover-0.9.0.tgz#5b96de41395d0806b2a153d139ecdf030ba2552c"
+  integrity sha512-HYr+gbBRcgOo3v6QoiTLx3cG+6ZWiXC0V/K0cV8kaCi5HpFiyHLNuyv/2/J63ZdJw2lE/JjSTKf0skQCKhnt2w==
   dependencies:
-    "@reach/portal" "^0.8.5"
-    "@reach/rect" "^0.8.2"
-    "@reach/utils" "^0.8.5"
+    "@reach/portal" "^0.9.0"
+    "@reach/rect" "^0.9.0"
+    "@reach/utils" "^0.9.0"
     tabbable "^4.0.0"
     tslib "^1.10.0"
 
-"@reach/portal@^0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.8.5.tgz#586e8686e9ba34368b1df3fc9a84c3ef923dd2d3"
-  integrity sha512-YRQgItjxw6DznndN4T3YS6Ikuq+FPZg8fekXeM1feuQSnMlAtEAyYVaMhpAKSD65+Yc9Zu0Utfxp5ji+wO+FLg==
+"@reach/portal@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.9.0.tgz#8346c4403aba071b36ff0bd5137b1363f70ade15"
+  integrity sha512-V3xmdKCWLyKwAdSvvF4EvO8wKPGInQsJXmCuo9c7RU5ZCDnErCQmiD/jqyD78UzGF0snXATiGHuQV0h/Ppjt0w==
   dependencies:
+    "@reach/utils" "^0.9.0"
     tslib "^1.10.0"
 
-"@reach/rect@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.8.2.tgz#4e51ef1b734f26a42c3cdfa8d812a11b8017d3ef"
-  integrity sha512-6vrGm/9Cjw5ygbzccJdmrERqLxmaR2dATzkOvmsnTuR54BH/UgUjUYMxy/pVCmHZacNMTZRqOJwAyJQBOdCD4w==
+"@reach/rect@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.9.0.tgz#395061af2d5e13166711716a80a0df39ce43abf4"
+  integrity sha512-ACUgv3lt6DOkgq5QmkfpTPJjVZoNULJ/u3cXg0UhaktzCxkUupIY2bue1X82MM3hf5wCfEdoZVnFi7k9KNJeAw==
   dependencies:
-    "@reach/observe-rect" "^1.0.5"
+    "@reach/observe-rect" "^1.1.0"
+    "@reach/utils" "^0.9.0"
     prop-types "^15.7.2"
     tslib "^1.10.0"
 
-"@reach/utils@^0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.8.5.tgz#6675d6f81054c8dce1b9d535280b0e3c5174fe7d"
-  integrity sha512-nc84exIqBa+EohJPBFjePQP88dBAP4l+tChxwWszzZ+R6tTtSgOg40WyQ5EjPYJFbltnbZIbASHefcEBrFxqng==
+"@reach/utils@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.9.0.tgz#ee47c25c79eb2f98e6c0e728a2672075cc9991d5"
+  integrity sha512-cmiykRaxuCysVTsSY3PgrLjySnEIt1PLiSYKh5rAH8nYyEmaOCtw0vaNItFAiqQIjfrxkixmcUE8dyD8kqVuJA==
   dependencies:
     tslib "^1.10.0"
     warning "^4.0.3"


### PR DESCRIPTION
## Description

This pull request introduces a fix for language menu positioning and enables variable menu name length. In addition, issues with keyboard navigation are now fixed for both, language menu and dropdown.

## Related Issue

Dropdown component keyboard navigation issues are fixed with this PR as well.

## Motivation and Context

The language menu component did not allow following designs and using longer language names in the button (e.g. Suomi (FI)). The underlying component was switched to lower level Reach-UI wrapper to allow using custom function for positioning. This revealed an issue with the list menu items used for dropdown as well. This issue was also fixed.

## How Has This Been Tested?
Test were updated to use snapshots. Aria attribute validity checks had to be disabled due to use of Portal with useLayoutEffect hook.

Manual testing was done using suomifi-design-system site, and empty create-react-app Typescript project with Verdaccio.
