### PR TITLE
[BreakingChange] Update to 5px based spacing and inset spacing.

### DIFF
--- a/.styleguidist/spacing.md
+++ b/.styleguidist/spacing.md
@@ -4,7 +4,6 @@ import { colors } from '../src/core/theme/colors';
 import { cssValueToString } from '../src/utils/css';
 import { element, fonts } from '../src/core/theme/reset';
 import { spacing } from '../src/core/theme/spacing';
-import { suomifiTheme } from '../src/core/theme';
 import { Text } from '../src/core/Text/Text';
 import clipboardCopy from 'clipboard-copy';
 

--- a/.styleguidist/spacing.md
+++ b/.styleguidist/spacing.md
@@ -4,6 +4,7 @@ import { colors } from '../src/core/theme/colors';
 import { cssValueToString } from '../src/utils/css';
 import { element, fonts } from '../src/core/theme/reset';
 import { spacing } from '../src/core/theme/spacing';
+import { suomifiTheme } from '../src/core/theme';
 import { Text } from '../src/core/Text/Text';
 import clipboardCopy from 'clipboard-copy';
 
@@ -42,7 +43,7 @@ const Square = styled(props => (
     flex: none;
     display: flex;
     align-items: flex-end;
-    width: 84px;
+    width: 100px;
 
     > .box {
       height: ${size};

--- a/.styleguidist/spacing.md
+++ b/.styleguidist/spacing.md
@@ -20,7 +20,7 @@ const Container = styled(({ size, name, ...passProps }) => (
   flex-direction: row;
   justify-content: space-between;
   align-items: flex-end;
-  margin-bottom: ${cssValueToString(spacing.l)};
+  margin-bottom: ${cssValueToString(spacing.xl)};
   cursor: pointer;
 
   * {
@@ -28,7 +28,7 @@ const Container = styled(({ size, name, ...passProps }) => (
   }
 
   > div:not(:first-of-type) {
-    margin-left: ${cssValueToString(spacing.m)};
+    margin-left: ${cssValueToString(spacing.s)};
   }
 `
 );
@@ -42,7 +42,7 @@ const Square = styled(props => (
     flex: none;
     display: flex;
     align-items: flex-end;
-    width: ${cssValueToString(spacing.xl)};
+    width: ${cssValueToString(spacing.xxxl)};
 
     > .box {
       height: ${size};

--- a/.styleguidist/spacing.md
+++ b/.styleguidist/spacing.md
@@ -42,7 +42,7 @@ const Square = styled(props => (
     flex: none;
     display: flex;
     align-items: flex-end;
-    width: ${cssValueToString(spacing.xxxl)};
+    width: 84px;
 
     > .box {
       height: ${size};

--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -47,7 +47,7 @@ module.exports = {
         },
         {
           name: 'Spacing',
-          content: './.styleguidist/spacing.insetXld',
+          content: './.styleguidist/spacing.insetXl',
         },
       ],
       sectionDepth: 1,

--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -47,7 +47,7 @@ module.exports = {
         },
         {
           name: 'Spacing',
-          content: './.styleguidist/spacing.insetXl',
+          content: './.styleguidist/spacing.md',
         },
       ],
       sectionDepth: 1,

--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -47,7 +47,7 @@ module.exports = {
         },
         {
           name: 'Spacing',
-          content: './.styleguidist/spacing.md',
+          content: './.styleguidist/spacing.insetXld',
         },
       ],
       sectionDepth: 1,

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "normalize.cssinjs": "1.1.0",
     "polished": "3.4.0",
     "react-svg": "7.2.2",
-    "suomifi-design-tokens": "0.7.1",
+    "suomifi-design-tokens": "0.8.0",
     "suomifi-icons": "0.1.0",
     "uuid": "3.3.2"
   },

--- a/src/core/Block/Block.md
+++ b/src/core/Block/Block.md
@@ -7,7 +7,7 @@ import { Block } from 'suomifi-ui-components';
 ```js
 import { Block } from 'suomifi-ui-components';
 
-<Block padding="xl">Block with xl-padding</Block>;
+<Block padding="xxxl">Block with xl-padding</Block>;
 ```
 
 ```js

--- a/src/core/Block/Block.test.tsx
+++ b/src/core/Block/Block.test.tsx
@@ -7,7 +7,7 @@ import { Block } from './Block';
 const TestBlock = (
   <div data-testid="test-block">
     <Block>Hey this is test</Block>
-    <Block padding="xl">Hey this is test lead</Block>
+    <Block padding="xxxl">Hey this is test lead</Block>
     <Block.section>Hey this is test bold</Block.section>
   </div>
 );

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -6,7 +6,7 @@ import {
   Block as CompBlock,
   BlockProps as CompBlockProps,
 } from '../../components/Block/Block';
-import { SpacingProp } from '../theme/spacing';
+import { SpacingWithoutInsetProp } from '../theme/spacing';
 import { baseStyles } from './Block.baseStyles';
 import classnames from 'classnames';
 
@@ -14,9 +14,9 @@ const baseClassName = 'fi-block';
 
 export interface BlockProps extends CompBlockProps, TokensProp {
   /** Padding from theme */
-  padding?: SpacingProp;
+  padding?: SpacingWithoutInsetProp;
   /** Margin from theme */
-  margin?: SpacingProp;
+  margin?: SpacingWithoutInsetProp;
 }
 
 const StyledBlock = styled(

--- a/src/core/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/core/Block/__snapshots__/Block.test.tsx.snap
@@ -43,51 +43,131 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c0.fi-block--margin-xxs {
-  margin: 2px;
+  margin: 5px;
 }
 
 .c0.fi-block--margin-xs {
-  margin: 4px;
+  margin: 10px;
 }
 
 .c0.fi-block--margin-s {
-  margin: 8px;
+  margin: 15px;
 }
 
 .c0.fi-block--margin-m {
-  margin: 16px;
+  margin: 20px;
 }
 
 .c0.fi-block--margin-l {
-  margin: 32px;
+  margin: 25px;
 }
 
 .c0.fi-block--margin-xl {
-  margin: 64px;
+  margin: 30px;
+}
+
+.c0.fi-block--margin-xxl {
+  margin: 40px;
+}
+
+.c0.fi-block--margin-xxxl {
+  margin: 60px;
+}
+
+.c0.fi-block--margin-xxxxl {
+  margin: 80px;
+}
+
+.c0.fi-block--margin-insetXss {
+  margin: 2px;
+}
+
+.c0.fi-block--margin-insetXs {
+  margin: 4px;
+}
+
+.c0.fi-block--margin-insetS {
+  margin: 6px;
+}
+
+.c0.fi-block--margin-insetM {
+  margin: 8px;
+}
+
+.c0.fi-block--margin-insetL {
+  margin: 10px;
+}
+
+.c0.fi-block--margin-insetXl {
+  margin: 16px;
+}
+
+.c0.fi-block--margin-insetXxl {
+  margin: 20px;
 }
 
 .c0.fi-block--padding-xxs {
-  padding: 2px;
+  padding: 5px;
 }
 
 .c0.fi-block--padding-xs {
-  padding: 4px;
+  padding: 10px;
 }
 
 .c0.fi-block--padding-s {
-  padding: 8px;
+  padding: 15px;
 }
 
 .c0.fi-block--padding-m {
-  padding: 16px;
+  padding: 20px;
 }
 
 .c0.fi-block--padding-l {
-  padding: 32px;
+  padding: 25px;
 }
 
 .c0.fi-block--padding-xl {
-  padding: 64px;
+  padding: 30px;
+}
+
+.c0.fi-block--padding-xxl {
+  padding: 40px;
+}
+
+.c0.fi-block--padding-xxxl {
+  padding: 60px;
+}
+
+.c0.fi-block--padding-xxxxl {
+  padding: 80px;
+}
+
+.c0.fi-block--padding-insetXss {
+  padding: 2px;
+}
+
+.c0.fi-block--padding-insetXs {
+  padding: 4px;
+}
+
+.c0.fi-block--padding-insetS {
+  padding: 6px;
+}
+
+.c0.fi-block--padding-insetM {
+  padding: 8px;
+}
+
+.c0.fi-block--padding-insetL {
+  padding: 10px;
+}
+
+.c0.fi-block--padding-insetXl {
+  padding: 16px;
+}
+
+.c0.fi-block--padding-insetXxl {
+  padding: 20px;
 }
 
 <div
@@ -99,7 +179,7 @@ exports[`calling render with the same component on the same container does not r
     Hey this is test
   </div>
   <div
-    class="fi-block c0 fi-block--padding-xl c1"
+    class="fi-block c0 fi-block--padding-xxxl c1"
   >
     Hey this is test lead
   </div>

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -87,7 +87,7 @@ const tertiaryStyles = ({ theme }: SuomifiThemeProp) => css`
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme & Partial<ButtonProps>) => css`
   ${button({ theme })}
-  padding: ${theme.spacing.s} ${theme.spacing.m};
+  padding: ${theme.spacing.insetM} ${theme.spacing.insetXl};
   min-height: 40px;
   color: ${theme.colors.whiteBase};
   background: ${theme.gradients.highlightBase};
@@ -130,12 +130,12 @@ export const baseStyles = withSuomifiTheme(
   & > .fi-button_icon {
     width: 16px;
     height: 16px;
-    margin-right: ${theme.spacing.s};
+    margin-right: ${theme.spacing.insetM};
     vertical-align: middle;
     transform: translateY(-0.1em);
     &.fi-button_icon--right {
       margin-right: 0;
-      margin-left: ${theme.spacing.s};
+      margin-left: ${theme.spacing.insetM};
     }
   }
 `,

--- a/src/core/Colors/Colors.baseStyles.tsx
+++ b/src/core/Colors/Colors.baseStyles.tsx
@@ -32,8 +32,8 @@ export const baseStyles = withSuomifiTheme(
         flex-direction: column;
         justify-content: flex-end;
         position: absolute;
-        left: ${theme.spacing.s};
-        bottom: ${theme.spacing.s};
+        left: ${theme.spacing.insetM};
+        bottom: ${theme.spacing.insetM};
       }
 
       svg {

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -57,7 +57,7 @@ export const menuPopoverStyles = withSuomifiTheme(
   & [data-reach-menu-item].fi-dropdown_item {
     ${element({ theme })}
     ${theme.typography.actionElementInnerText}
-    padding: ${theme.spacing.s} ${theme.spacing.m};
+    padding: ${theme.spacing.insetM} ${theme.spacing.insetXl};
     border: 0;
     &[data-selected] {
       ${theme.typography.actionElementInnerText}

--- a/src/core/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander.baseStyles.tsx
@@ -34,7 +34,7 @@ export const baseStyles = withSuomifiTheme(
     display: block;
     width: 100%;
     &--no-tag {
-      ${padding({ theme })('m', 'xl', 'm', 'm')}
+      ${padding({ theme })('insetXl', 'xxxl', 'insetXl', 'insetXl')}
       color: ${theme.colors.highlightBase};
     }
   }
@@ -42,7 +42,7 @@ export const baseStyles = withSuomifiTheme(
     position: absolute;
     top: 0;
     right: 0;
-    margin: ${theme.spacing.m};
+    margin: ${theme.spacing.insetXl};
   }
   & .fi-expander_title--open .fi-expander_title-icon,
   & .fi-expander_title-icon--open {
@@ -60,7 +60,7 @@ export const baseStyles = withSuomifiTheme(
       ${theme.transitions.basicTimingFunction}`};
     will-change: transition, height;
     &:not(.fi-expander_content--no-padding) {
-      padding: 0 ${theme.spacing.m};
+      padding: 0 ${theme.spacing.insetXl};
     }
     &.fi-expander_content--open {
       height: 10%;
@@ -69,7 +69,7 @@ export const baseStyles = withSuomifiTheme(
       animation: fi-expander_content-anim ${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction} 1 forwards;
       &:not(.fi-expander_content--no-padding) {
-        ${padding({ theme })('0', 'm', 'm', 'm')}
+        ${padding({ theme })('0', 'insetXl', 'insetXl', 'insetXl')}
       }
     }
     @keyframes fi-expander_content-anim {

--- a/src/core/Expander/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup.baseStyles.tsx
@@ -17,10 +17,10 @@ export const baseStyles = withSuomifiTheme(
         ${theme.transitions.basicTimingFunction}`};
       &.fi-expander--open {
         &:not(:first-of-type) {
-          margin-top: ${theme.spacing.m};
+          margin-top: ${theme.spacing.insetXl};
         }
         &:not(:last-of-type) {
-          margin-bottom: ${theme.spacing.m};
+          margin-bottom: ${theme.spacing.insetXl};
         }
       }
     }
@@ -33,8 +33,8 @@ export const baseStyles = withSuomifiTheme(
     flex: 1 1 auto;
     align-self: flex-end; 
     margin-left: auto;
-    margin-bottom: ${theme.spacing.s};
-    padding: ${theme.spacing.xs} 0;
+    margin-bottom: ${theme.spacing.insetM};
+    padding: ${theme.spacing.insetXs} 0;
     color: ${theme.colors.highlightBase};
     cursor: pointer;
   }

--- a/src/core/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/Expander.test.tsx.snap
@@ -196,7 +196,7 @@ exports[`calling render with the same component on the same container does not r
 
 .c0 .fi-expander_title--no-tag {
   padding-top: 16px;
-  padding-right: 64px;
+  padding-right: 60px;
   padding-bottom: 16px;
   padding-left: 16px;
   color: hsl(212,63%,45%);

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -9,12 +9,14 @@ export const baseStyles = withSuomifiTheme(
         position: relative;
       }
       &_input {
-        padding-right: ${math(`${theme.spacing.m} * 2 + ${theme.spacing.s}`)};
+        padding-right: ${math(
+          `${theme.spacing.insetXl} * 2 + ${theme.spacing.insetM}`,
+        )};
       }
       &_icon {
         position: absolute;
         top: 50%;
-        right: ${theme.spacing.m};
+        right: ${theme.spacing.insetXl};
         margin-top: -0.5em;
       }
     }

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -5,7 +5,7 @@ import { input, inputContainer } from '../../theme/reset';
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
   & .fi-text-input_label-p {
-    margin-bottom: ${theme.spacing.m};
+    margin-bottom: ${theme.spacing.insetXl};
   }
 
   & .fi-text-input_container {

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -50,7 +50,7 @@ export const baseStyles = withSuomifiTheme(
   & .fi-toggle_icon {
     width: ${iconWidth};
     height: ${iconHeight};
-    margin-right: ${theme.spacing.s};
+    margin-right: ${theme.spacing.insetM};
     vertical-align: bottom;
     overflow: visible;
     transform: translateY(-0.1em);

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -13,7 +13,7 @@ export const baseStyles = withSuomifiTheme(
     &.fi-language-menu-language_button {
       ${element({ theme })}
       ${theme.typography.actionElementInnerTextBold}
-      padding: 5px ${theme.spacing.xs} 5px ${theme.spacing.s};
+      padding: 5px ${theme.spacing.insetXs} 5px ${theme.spacing.insetM};
       line-height: 28px;
       background-color: ${theme.colors.whiteBase};
       border: 1px solid ${theme.colors.depthBase};
@@ -22,7 +22,7 @@ export const baseStyles = withSuomifiTheme(
         height: 1.2em;
         width: 1.2em;
         transform: translateY(0.3em); 
-        margin-left: ${theme.spacing.xs};
+        margin-left: ${theme.spacing.insetXs};
       }
     }
     &.fi-language-menu-language_button_open {

--- a/src/core/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link.baseStyles.ts
@@ -26,7 +26,7 @@ export const baseStyles = withSuomifiTheme(
 export const externalStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
     & .fi-link_icon {
-      padding-left: ${theme.spacing.xs};
+      padding-left: ${theme.spacing.insetXs};
       transform: translateY(0.1em);
     }
   `,

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -7,13 +7,13 @@ import {
   ParagraphProps as CompParagraphProps,
 } from '../../components/Paragraph/Paragraph';
 import { baseStyles } from './Paragraph.baseStyles';
-import { SpaceProp } from '../theme/utils/spacing';
+import { SpacingWithoutInsetProp } from '../theme/utils/spacing';
 
 export interface ParagraphProps extends CompParagraphProps, TokensProp {
   /** Change color */
   color?: ColorProp;
   /** Spacing token for bottom margin */
-  marginBottomSpacing?: SpaceProp;
+  marginBottomSpacing?: SpacingWithoutInsetProp;
 }
 
 const StyledParagraph = styled(

--- a/src/core/Text/Text.md
+++ b/src/core/Text/Text.md
@@ -3,7 +3,7 @@ import { Paragraph, Text } from 'suomifi-ui-components';
 
 <>
   <Paragraph>Paragraph text</Paragraph>
-  <Paragraph marginBottomSpacing="m">
+  <Paragraph marginBottomSpacing="insetXl">
     <Text.lead>Leading text</Text.lead>
   </Paragraph>
   <Paragraph>

--- a/src/core/Text/Text.test.tsx
+++ b/src/core/Text/Text.test.tsx
@@ -8,7 +8,7 @@ import { Text } from './Text';
 const TestTexts = (
   <div data-testid="test-text">
     <Paragraph>Paragraph text</Paragraph>
-    <Paragraph marginBottomSpacing="m">
+    <Paragraph marginBottomSpacing="insetXl">
       <Text.lead>Leading text</Text.lead>
     </Paragraph>
     <Paragraph>

--- a/src/core/Text/Text.test.tsx
+++ b/src/core/Text/Text.test.tsx
@@ -8,7 +8,7 @@ import { Text } from './Text';
 const TestTexts = (
   <div data-testid="test-text">
     <Paragraph>Paragraph text</Paragraph>
-    <Paragraph marginBottomSpacing="insetXl">
+    <Paragraph marginBottomSpacing="s">
       <Text.lead>Leading text</Text.lead>
     </Paragraph>
     <Paragraph>

--- a/src/core/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/core/Text/__snapshots__/Text.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
   margin-top: 0;
   margin-right: 0;
-  margin-bottom: 16px;
+  margin-bottom: 15px;
   margin-left: 0;
   color: hsl(0,0%,16%);
 }

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -310,7 +310,7 @@ exports[`snapshot testing 1`] = `
 
 .c6 .fi-expander_title--no-tag {
   padding-top: 16px;
-  padding-right: 64px;
+  padding-right: 60px;
   padding-bottom: 16px;
   padding-left: 16px;
   color: hsl(212,63%,45%);

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -33,7 +33,7 @@ export const input = (props: SuomifiThemeProp) => {
     ${font(props)('actionElementInnerText')}
     min-width: 245px;
     max-width: 100%;
-    padding: ${props.theme.spacing.s} ${props.theme.spacing.m};
+    padding: ${props.theme.spacing.insetM} ${props.theme.spacing.insetXl};
     border: 1px solid ${props.theme.colors.depthBase};
     border-radius: ${props.theme.radius.basic};
     line-height: 1;

--- a/src/core/theme/spacing.ts
+++ b/src/core/theme/spacing.ts
@@ -4,7 +4,9 @@ import {
 } from 'suomifi-design-tokens';
 export { SpacingDesignTokens };
 
-export type SpacingProp = keyof SpacingDesignTokens;
+export type SpacingProp = keyof SpacingDesignTokens | '0';
+
+export { SpacingWithoutInsetProp } from './utils/spacing';
 
 type SpacingDesignTokensKeys = keyof SpacingDesignTokens;
 

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -4,9 +4,19 @@ import { SpacingProp, spacingTokensKeys } from '../spacing';
 
 import { SuomifiThemeProp, SuomifiTheme } from '../';
 
-export type SpaceProp = SpacingProp | '0';
+export type SpacingWithoutInsetProp =
+  | 'xxs'
+  | 'xs'
+  | 's'
+  | 'm'
+  | 'l'
+  | 'xl'
+  | 'xxl'
+  | 'xxxl'
+  | 'xxxxl'
+  | '0';
 
-const spaceVal = (theme: SuomifiTheme) => (val?: SpaceProp) => {
+const spaceVal = (theme: SuomifiTheme) => (val?: SpacingProp) => {
   if (val === '0') return '0';
   return !!val ? theme.spacing[val] : '';
 };
@@ -30,10 +40,10 @@ const spaceVal = (theme: SuomifiTheme) => (val?: SpaceProp) => {
  * @return {(spacingType) => (spacingTokens) => String}
  */
 const space = (theme: SuomifiTheme) => (type: 'padding' | 'margin') => (
-  t?: SpaceProp,
-  r?: SpaceProp,
-  b?: SpaceProp,
-  l?: SpaceProp,
+  t?: SpacingProp,
+  r?: SpacingProp,
+  b?: SpacingProp,
+  l?: SpacingProp,
 ) =>
   !!t
     ? `${!!t ? `${type}-top: ${spaceVal(theme)(t)};` : ''}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12299,8 +12299,8 @@ sugarss@^2.0.0:
 
 suomifi-design-tokens@0.8.0:
   version "0.8.0"
-  resolved "http://localhost:4873/suomifi-design-tokens/-/suomifi-design-tokens-0.8.0.tgz#d3df12fd5682023ea42ef7de47ae1e414306d195"
-  integrity sha512-VCj4GoEuwzk7h1b1rjQ8jLtB4FN5DB4vOlkzJNYUj0wXsRBQbTjKj6/Phrtoeav4R4r/nzdcDGPIOQud7VPS7Q==
+  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.8.0.tgz#4667b3f69e94d18f03e718826f1e494bb3dbc4ab"
+  integrity sha512-aEj8o5oDR6XYo71qfduCV6Bvtir8VpqB+sTLCoOwuHXk4paKOuDy2DN8ygFsuW7CfUaUoxrWXhTpW5VCUVokBQ==
 
 suomifi-icons@0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12297,10 +12297,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-suomifi-design-tokens@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.7.1.tgz#faf606cfa69c3a7a32e8461939857663c4e333ed"
-  integrity sha512-0rsGyP+ed9d+H6O1n4A5W3e95/7tcxkKeCPnVZSiNesOsG7EYgJxxWI5+lEByvfyLYbpQoP+30oTgMYwDzAuug==
+suomifi-design-tokens@0.8.0:
+  version "0.8.0"
+  resolved "http://localhost:4873/suomifi-design-tokens/-/suomifi-design-tokens-0.8.0.tgz#d3df12fd5682023ea42ef7de47ae1e414306d195"
+  integrity sha512-VCj4GoEuwzk7h1b1rjQ8jLtB4FN5DB4vOlkzJNYUj0wXsRBQbTjKj6/Phrtoeav4R4r/nzdcDGPIOQud7VPS7Q==
 
 suomifi-icons@0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Description

This PR introduces new 5px based spacing tokens and inset spacing tokens and updates the components to use those internally.

The components remain mostly as-is. The exported theme will change and some existing exported spacing values will change.

## Motivation and Context

To match current designs, spacing system needed to be changed to be 5px based, but also support for smaller 2px based system for component internal spacing was needed.

## How Has This Been Tested?
Tested with suomifi-design-system and create-react-app using verdaccio.
