### PR TITLE
[Feature] Skip variant added for Link

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -67,7 +67,10 @@ module.exports = {
             },
             {
               name: 'Link',
-              components: getComponentWithVariants('Link')(['LinkExternal']),
+              components: getComponentWithVariants('Link')([
+                'LinkSkip',
+                'LinkExternal',
+              ]),
             },
             {
               name: 'Icons',

--- a/src/components/Link/LinkSkip.tsx
+++ b/src/components/Link/LinkSkip.tsx
@@ -1,0 +1,17 @@
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import { Link, LinkProps } from './Link';
+
+const skipClassName = 'fi-link--skip';
+
+export interface LinkSkipProps extends LinkProps {}
+
+export class LinkSkip extends Component<LinkSkipProps> {
+  render() {
+    const { className, ...passProps } = this.props;
+
+    return (
+      <Link {...passProps} className={classnames(className, skipClassName)} />
+    );
+  }
+}

--- a/src/core/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link.baseStyles.ts
@@ -31,3 +31,24 @@ export const externalStyles = withSuomifiTheme(
     }
   `,
 );
+
+export const skipStyles = withSuomifiTheme(
+  ({ theme }: TokensAndTheme) => css`
+    &.fi-link--skip {
+      position: absolute;
+      z-index: 10000;
+      left: -1000px;
+      margin: ${theme.spacing.insetXl};
+      padding: ${theme.spacing.insetM};
+      background: ${theme.colors.highlightLight3};
+      border: 1px solid ${theme.colors.depthLight1};
+      color: ${theme.colors.blackBase};
+      text-decoration: none;
+    }
+
+    &.fi-link--skip:focus {
+      position: absolute;
+      left: auto;
+    }
+  `,
+);

--- a/src/core/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link.baseStyles.ts
@@ -32,7 +32,7 @@ export const externalStyles = withSuomifiTheme(
   `,
 );
 
-export const skipStyles = withSuomifiTheme(
+export const skipLinkStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
     &.fi-link--skip {
       position: absolute;

--- a/src/core/Link/Link.md
+++ b/src/core/Link/Link.md
@@ -14,6 +14,16 @@ import { Link, Paragraph } from 'suomifi-ui-components';
 </Paragraph>;
 ```
 
+### Skip link
+
+Show link for keyboard navigation. Preview not working as intended, because it should be the first element on the page to gain focus on tab.
+
+```js
+import { Link } from 'suomifi-ui-components';
+
+<Link.skip>Skip to main content</Link.skip>;
+```
+
 ### External link
 
 ```js

--- a/src/core/Link/Link.md
+++ b/src/core/Link/Link.md
@@ -16,12 +16,28 @@ import { Link, Paragraph } from 'suomifi-ui-components';
 
 ### Skip link
 
-Show link for keyboard navigation. Preview not working as intended, because it should be the first element on the page to gain focus on tab.
+Show link for keyboard navigation.
+
+- Should be the first element that can gain focus on the page with the tab.
+- The target container should have `tabIndex={-1}` to handle better the functionality with screenreaders.
+- Because of the tabIndex you might want set the style of `outline=none` to the target container.
+- To see the component, click below on the dashed area and then press `Tab`.
 
 ```js
 import { Link } from 'suomifi-ui-components';
-
-<Link.skip>Skip to main content</Link.skip>;
+<div>
+  <div
+    style={{
+      height: '80px',
+      width: '210px',
+      borderStyle: 'dashed',
+      borderColor: '#000',
+      borderWidth: '1px'
+    }}
+  >
+    <Link.skip href="#">Skip to main content</Link.skip>
+  </div>
+</div>;
 ```
 
 ### External link

--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -8,9 +8,10 @@ import {
 } from '../../components/Link/Link';
 import { asPropType } from '../../utils/typescript';
 import { LinkExternal, LinkExternalProps } from './LinkExternal';
+import { LinkSkip, LinkSkipProps } from './LinkSkip';
 import { baseStyles } from './Link.baseStyles';
 
-type LinkVariant = 'default' | 'external';
+type LinkVariant = 'default' | 'external' | 'skip';
 export interface LinkProps extends CompLinkProps, TokensProp {
   variant?: LinkVariant;
   asProp?: asPropType;
@@ -31,11 +32,16 @@ const StyledLink = styled(
 export class Link extends Component<LinkProps | LinkExternalProps> {
   static external = (props: LinkExternalProps) => <LinkExternal {...props} />;
 
+  static skip = (props: LinkSkipProps) => <LinkSkip {...props} />;
+
   render() {
     const { variant, ...passProps } = withSuomifiDefaultProps(this.props);
 
     if (variant === 'external' && 'labelNewWindow' in passProps) {
       return <LinkExternal {...(passProps as LinkExternalProps)} />;
+    }
+    if (variant === 'skip') {
+      return <LinkSkip {...passProps} />;
     }
     return <StyledLink {...passProps} />;
   }

--- a/src/core/Link/LinkSkip.tsx
+++ b/src/core/Link/LinkSkip.tsx
@@ -8,7 +8,7 @@ import {
   LinkSkipProps as CompLinkSkipProps,
 } from '../../components/Link/LinkSkip';
 
-import { skipStyles } from './Link.baseStyles';
+import { skipLinkStyles } from './Link.baseStyles';
 
 export interface LinkSkipProps
   extends CompLinkSkipProps,
@@ -20,7 +20,7 @@ const StyledLinkSkip = styled(
     <Link {...passProps} asProp={CompLinkSkip} />
   ),
 )`
-  ${(props) => skipStyles(props)};
+  ${(props) => skipLinkStyles(props)};
 `;
 
 /**

--- a/src/core/Link/LinkSkip.tsx
+++ b/src/core/Link/LinkSkip.tsx
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import { default as styled } from 'styled-components';
+import { withSuomifiDefaultProps } from '../theme/utils';
+import { TokensProp, InternalTokensProp } from '../theme';
+import { Link, LinkProps } from './Link';
+import {
+  LinkSkip as CompLinkSkip,
+  LinkSkipProps as CompLinkSkipProps,
+} from '../../components/Link/LinkSkip';
+
+import { skipStyles } from './Link.baseStyles';
+
+export interface LinkSkipProps
+  extends CompLinkSkipProps,
+    LinkProps,
+    TokensProp {}
+
+const StyledLinkSkip = styled(
+  ({ tokens, ...passProps }: LinkSkipProps & InternalTokensProp) => (
+    <Link {...passProps} asProp={CompLinkSkip} />
+  ),
+)`
+  ${(props) => skipStyles(props)};
+`;
+
+/**
+ * <i class="semantics" />
+ * Used for adding skip link for keyboard and screenreader users
+ */
+export class LinkSkip extends Component<LinkSkipProps> {
+  render() {
+    const { children, ...passProps } = withSuomifiDefaultProps(this.props);
+    return <StyledLinkSkip {...passProps}>{children}</StyledLinkSkip>;
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ export {
 } from './core/StaticIcon/StaticIcon';
 export { Link, LinkProps } from './core/Link/Link';
 export { LinkExternal, LinkExternalProps } from './core/Link/LinkExternal';
+export { LinkSkip, LinkSkipProps } from './core/Link/LinkSkip';
 export {
   LanguageMenu,
   LanguageMenuProps,


### PR DESCRIPTION
## Description

Adds Skip-variant for Link-component

## Additional information

Currently the example for this is kind of component is hard to show. I added some context before the example. User of library can see how to use the component and put it to right context when using it.

## Related Issue

Closes #170 

## Motivation and Context

Able to provide skip link for users using keyboard navigation.

## Notes

Firefox by default is not behaving nicely with the links when trying to use tab

- https://support.mozilla.org/en-US/questions/846320
- https://stackoverflow.com/questions/11704828/how-to-allow-keyboard-focus-of-links-in-firefox/11713537#11713537


## How Has This Been Tested?
- Locally on DS-site to replace the **BypassLink.tsx**
- Locally on create-react-app skeleton