### PR TITLE
[Fix] Link's styleguidist page

### DIFF
--- a/src/core/Link/Link.tsx
+++ b/src/core/Link/Link.tsx
@@ -9,7 +9,6 @@ import {
 import { asPropType } from '../../utils/typescript';
 import { LinkExternal, LinkExternalProps } from './LinkExternal';
 import { baseStyles } from './Link.baseStyles';
-export { LinkExternal, LinkExternalProps };
 
 type LinkVariant = 'default' | 'external';
 export interface LinkProps extends CompLinkProps, TokensProp {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,12 +26,8 @@ export {
   IllustrativeIconKeys,
   DoctypeIconKeys,
 } from './core/StaticIcon/StaticIcon';
-export {
-  Link,
-  LinkProps,
-  LinkExternal,
-  LinkExternalProps,
-} from './core/Link/Link';
+export { Link, LinkProps } from './core/Link/Link';
+export { LinkExternal, LinkExternalProps } from './core/Link/LinkExternal';
 export {
   LanguageMenu,
   LanguageMenuProps,


### PR DESCRIPTION
## Description

Fixes the Link's styleguidist page where LinkExternal was too greed to present itself.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #137

## Motivation and Context

To prevent user from getting confused when reading Link-component's manual

## How Has This Been Tested?
Locally ran the styleguidist, `yarn start`

## Screenshots (if appropriate):

### Before
<img width="901" alt="link_before" src="https://user-images.githubusercontent.com/53757053/77914008-e7a4f180-729d-11ea-845f-49e0bfa246a0.png">

### After
<img width="901" alt="link-after" src="https://user-images.githubusercontent.com/53757053/77914013-ea074b80-729d-11ea-909d-d76ba6e27639.png">

