### PR TITLE
Replace UNSAFE_componentWillReceiveProps with getDerivedStateFromProps

### DIFF
--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -25,7 +25,7 @@ export interface ToggleInputProps {
 }
 
 export interface ToggleProps {
-  /** Controlled toggle-state - user actions use onClick to change  */
+  /** Controlled toggle-state - if provided, component will update only when this is explicitly changed */
   checked?: boolean;
   /** Default status of toggle when not using controlled 'checked' state
    * @default false

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -17,7 +17,7 @@ const StyledHtmlButton = styled(HtmlButton)`
 
 export class ToggleButton extends Component<ToggleProps> {
   state: ToggleState = {
-    toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
+    toggleState: !!this.props.checked || !!this.props.defaultChecked,
   };
 
   static getDerivedStateFromProps(

--- a/src/components/Form/ToggleButton.tsx
+++ b/src/components/Form/ToggleButton.tsx
@@ -20,12 +20,15 @@ export class ToggleButton extends Component<ToggleProps> {
     toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
   };
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: ToggleProps) {
+  static getDerivedStateFromProps(
+    nextProps: ToggleProps,
+    prevState: ToggleState,
+  ) {
     const { checked } = nextProps;
-    if (!!checked) {
-      this.setState({ toggleState: !!checked });
+    if (checked !== undefined && checked !== prevState.toggleState) {
+      return { toggleState: checked };
     }
+    return null;
   }
 
   handleClick = () => {

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -38,7 +38,7 @@ const StyledHtmlLabel = styled(HtmlLabel)`
 
 export class ToggleInput extends Component<ToggleProps> {
   state: ToggleState = {
-    toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
+    toggleState: !!this.props.checked || !!this.props.defaultChecked,
   };
 
   static getDerivedStateFromProps(

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -41,12 +41,15 @@ export class ToggleInput extends Component<ToggleProps> {
     toggleState: !!this.props.checked || !!this.props.defaultChecked || false,
   };
 
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps: ToggleProps) {
+  static getDerivedStateFromProps(
+    nextProps: ToggleProps,
+    prevState: ToggleState,
+  ) {
     const { checked } = nextProps;
-    if (!!checked) {
-      this.setState({ toggleState: !!checked });
+    if (checked !== undefined && checked !== prevState.toggleState) {
+      return { toggleState: checked };
     }
+    return null;
   }
 
   handleClick = () => {

--- a/src/core/Form/Toggle/Toggle.md
+++ b/src/core/Form/Toggle/Toggle.md
@@ -26,5 +26,12 @@ import { Toggle } from 'suomifi-ui-components';
   <Toggle onClick={({ toggleState }) => console.log(toggleState)}>
     Unchecked enabled using button
   </Toggle>
+
+  <Toggle
+    checked={false}
+    onClick={({ toggleState }) => console.log(toggleState)}
+  >
+    Controlled checked state.
+  </Toggle>
 </>;
 ```

--- a/src/core/Form/Toggle/Toggle.md
+++ b/src/core/Form/Toggle/Toggle.md
@@ -1,5 +1,10 @@
 ```js
+import { useState } from 'react';
+
 import { Toggle } from 'suomifi-ui-components';
+
+const [checked, setChecked] = useState(false);
+
 <>
   <Toggle
     defaultChecked
@@ -28,8 +33,12 @@ import { Toggle } from 'suomifi-ui-components';
   </Toggle>
 
   <Toggle
-    checked={false}
-    onClick={({ toggleState }) => console.log(toggleState)}
+    checked={checked}
+    onClick={({ toggleState }) => {
+      if (confirm('Change Toggle state?')) {
+        setChecked(toggleState);
+      }
+    }}
   >
     Controlled checked state.
   </Toggle>

--- a/src/core/Form/Toggle/Toggle.test.tsx
+++ b/src/core/Form/Toggle/Toggle.test.tsx
@@ -49,6 +49,10 @@ describe.each([['withInput'], ['default']])(
       const svgClassList = container.querySelector('svg')?.classList;
       expect(svgClassList).toContain('fi-toggle_icon');
       expect(svgClassList).toContain('fi-toggle_icon--checked');
+      if (variant === 'withInput') {
+        const inputElement = container.querySelector('input');
+        expect(inputElement).toBeChecked();
+      }
       fireEvent.click(toggle);
       expect(svgClassList).not.toContain('fi-toggle_icon--checked');
     });
@@ -72,6 +76,10 @@ describe.each([['withInput'], ['default']])(
       const svgClassList = container.querySelector('svg')?.classList;
       expect(svgClassList).toContain('fi-toggle_icon');
       expect(svgClassList).not.toContain('fi-toggle_icon--checked');
+      if (variant === 'withInput') {
+        const inputElement = container.querySelector('input');
+        expect(inputElement).not.toBeChecked();
+      }
     });
 
     test(

--- a/src/core/Form/Toggle/Toggle.test.tsx
+++ b/src/core/Form/Toggle/Toggle.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { axeTest } from '../../../utils/test/axe';
 
 import { Toggle } from './Toggle';
@@ -7,51 +7,76 @@ import { Toggle } from './Toggle';
 const doNothing = () => ({});
 
 const CreateTestToggle = (
-  withInput: boolean,
+  variant: 'withInput' | 'default',
   text: string,
   dataTestId: string,
+  onClick: () => {} = doNothing,
 ) => (
   <Toggle
-    onClick={doNothing}
+    onClick={onClick}
     data-testid={dataTestId}
     id="test-toggle"
-    variant={withInput ? 'withInput' : 'default'}
+    variant={variant}
   >
     {text}
   </Toggle>
 );
 
-const TestToggleWithInput = CreateTestToggle(true, 'Test', 'toggle');
-const TestToggleWithButton = CreateTestToggle(false, 'Test', 'toggle');
+describe.each([['withInput'], ['default']])(
+  'Toggle variant %s: ',
+  (variant: 'withInput' | 'default') => {
+    test('calling render with the same component on the same container does not remount', () => {
+      const toggleInputRendered = render(
+        CreateTestToggle(variant, 'Test', 'toggle'),
+      );
+      const { getByTestId, container, rerender } = toggleInputRendered;
+      expect(container.firstChild).toMatchSnapshot();
+      expect(getByTestId('toggle').textContent).toBe('Test');
 
-test('Input: calling render with the same component on the same container does not remount', () => {
-  const toggleInputRendered = render(TestToggleWithInput);
-  const { getByTestId, container, rerender } = toggleInputRendered;
-  expect(container.firstChild).toMatchSnapshot();
-  expect(getByTestId('toggle').textContent).toBe('Test');
+      // re-render the same component with different props
+      rerender(CreateTestToggle(variant, 'Test two', 'elggot'));
+      expect(getByTestId('elggot').textContent).toBe('Test two');
+    });
 
-  // re-render the same component with different props
-  rerender(CreateTestToggle(true, 'Test two', 'elggot'));
-  expect(getByTestId('elggot').textContent).toBe('Test two');
-});
+    test('onClick should activate toggle and deactivate when clicked again', async () => {
+      const mockClickHandler = jest.fn();
+      const { getByTestId, container } = render(
+        CreateTestToggle(variant, 'Test two', 'elggot', mockClickHandler),
+      );
+      const toggle = getByTestId('elggot');
+      fireEvent.click(toggle);
+      expect(mockClickHandler).toHaveBeenCalledTimes(1);
+      const svgClassList = container.querySelector('svg')?.classList;
+      expect(svgClassList).toContain('fi-toggle_icon');
+      expect(svgClassList).toContain('fi-toggle_icon--checked');
+      fireEvent.click(toggle);
+      expect(svgClassList).not.toContain('fi-toggle_icon--checked');
+    });
 
-test('Button: calling render with the same component on the same container does not remount', () => {
-  const toggleButtonRendered = render(TestToggleWithButton);
-  const { getByTestId, container, rerender } = toggleButtonRendered;
-  expect(container.firstChild).toMatchSnapshot();
-  expect(getByTestId('toggle').textContent).toBe('Test');
+    test('onClick should not change toggle state when checked is controlled', async () => {
+      const mockClickHandler = jest.fn();
+      const { getByTestId, container } = render(
+        <Toggle
+          variant={variant}
+          data-testid={'elggot'}
+          checked={false}
+          id="test-toggle"
+          onClick={mockClickHandler}
+        >
+          Controlled checked state
+        </Toggle>,
+      );
+      const toggle = getByTestId('elggot');
+      fireEvent.click(toggle);
+      expect(mockClickHandler).toHaveBeenCalledTimes(1);
+      const svgClassList = container.querySelector('svg')?.classList;
+      expect(svgClassList).toContain('fi-toggle_icon');
+      expect(svgClassList).not.toContain('fi-toggle_icon--checked');
+    });
 
-  // re-render the same component with different props
-  rerender(CreateTestToggle(false, 'Test two', 'elggot'));
-  expect(getByTestId('elggot').textContent).toBe('Test two');
-});
-
-test(
-  'Input: should not have basic accessibility issues',
-  axeTest(TestToggleWithInput),
-);
-
-test(
-  'Button: should not have basic accessibility issues',
-  axeTest(TestToggleWithButton),
+    test(
+      'should not have basic accessibility issues',
+      axeTest(CreateTestToggle(variant, 'Test', 'toggle')),
+    );
+  },
 );

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -50,7 +50,6 @@ class ToggleWithIcon extends Component<ToggleProps> {
     const {
       children,
       disabled = false,
-      checked: dissMissChecked,
       onClick,
       ...passProps
     } = withSuomifiDefaultProps(this.props);

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -35,6 +35,17 @@ const StyledToggle = styled(
 class ToggleWithIcon extends Component<ToggleProps> {
   state = { toggleStatus: !!this.props.checked || !!this.props.defaultChecked };
 
+  static getDerivedStateFromProps(
+    nextProps: ToggleProps,
+    prevState: { toggleStatus: boolean },
+  ) {
+    const { checked } = nextProps;
+    if (checked !== undefined && checked !== prevState.toggleStatus) {
+      return { toggleState: checked };
+    }
+    return null;
+  }
+
   handleToggle = () => {
     const { onClick, checked } = this.props;
     const { toggleStatus } = this.state;

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -41,7 +41,7 @@ class ToggleWithIcon extends Component<ToggleProps> {
   ) {
     const { checked } = nextProps;
     if (checked !== undefined && checked !== prevState.toggleStatus) {
-      return { toggleState: checked };
+      return { toggleStatus: checked };
     }
     return null;
   }

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -36,9 +36,11 @@ class ToggleWithIcon extends Component<ToggleProps> {
   state = { toggleStatus: !!this.props.checked || !!this.props.defaultChecked };
 
   handleToggle = () => {
-    const { onClick } = this.props;
+    const { onClick, checked } = this.props;
     const { toggleStatus } = this.state;
-    this.setState({ toggleStatus: !toggleStatus });
+    if (checked === undefined) {
+      this.setState({ toggleStatus: !toggleStatus });
+    }
     if (!!onClick) {
       onClick({ toggleState: !toggleStatus });
     }

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Button: calling render with the same component on the same container does not remount 1`] = `
+exports[`Toggle variant default:  calling render with the same component on the same container does not remount 1`] = `
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -513,7 +513,7 @@ exports[`Button: calling render with the same component on the same container do
 </button>
 `;
 
-exports[`Input: calling render with the same component on the same container does not remount 1`] = `
+exports[`Toggle variant withInput:  calling render with the same component on the same container does not remount 1`] = `
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;


### PR DESCRIPTION
## Description

This PR replaces UNSAFE_componentWillReceiveProps lifecycle methods with getDerivedStateFromProps for Toggle component. Functionality or API of the component does not change.

## Motivation and Context

UNSAFE_componentWillReceiveProps has been deprecated and should be replaced with other approaches. For Toggle component it should be relatively straight forward since rendering is always based on state. We are only interested on changes in checked prop when it is defined and differs from state (provided by parent component thus making the state controlled from outside). By using getDerivedStateFromProps we can achieve similar approach as was previously used with UNSAFE_componentWillReceiveProps.

## How Has This Been Tested?
Tested with Suomifi-design-system site, CRA TS project using controlled and uncontrolled approaches with checked.