### PR TITLE
[Feature] Add non-pseudo focus style

### DIFF
--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`calling render with the same component on the same container does not r
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`calling render with the same component on the same container does not r
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`calling render with the same component on the same container does not r
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/Expander.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`calling render with the same component on the same container does not r
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../theme';
 import { disabledCursor } from '../../../components/utils/css';
 import { element, font } from '../../theme/reset';
+import { focus } from '../../theme/utils/focus';
 
 /* stylelint-disable no-descending-specificity */
 const checkedStyles = ({ theme }: SuomifiThemeProp) => css`
@@ -126,12 +127,10 @@ export const baseStyles = withSuomifiTheme(
       top: 9px;
     }
 
-    /*TODO: use suomi.fi focus style */
     &:focus-within {
       & .fi-checkbox_label {
         &::before {
-          box-shadow: 0px 0px 3px 1px ${theme.colors.highlightBase};
-          outline: 3px solid transparent; /* For Windows high contrast mode. */
+          ${focus({ theme, noPseudo: true, variant: 'boxShadow' })}
         }
       }
     }

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -123,8 +123,13 @@ exports[`Calling render with the same component on the same container does not r
 }
 
 .c1:focus-within .fi-checkbox_label::before {
-  box-shadow: 0px 0px 3px 1px hsl(212,63%,45%);
-  outline: 3px solid transparent;
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
+}
+
+.c1:focus-within .fi-checkbox_label::before:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .c1 .fi-checkbox_input {

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -154,7 +154,7 @@ exports[`calling render with the same component on the same container does not r
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`calling render with the same component on the same container does not r
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;
@@ -246,7 +246,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;
@@ -727,7 +727,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;
@@ -760,7 +760,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`calling render with the same component on the same container does not r
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/__snapshots__/Link.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`calling render with the same component on the same container does not r
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`calling render with the same component on the same container does not r
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`snapshot testing 1`] = `
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;
@@ -208,7 +208,7 @@ exports[`snapshot testing 1`] = `
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;
@@ -298,7 +298,7 @@ exports[`snapshot testing 1`] = `
   left: -2px;
   border-radius: 2px;
   background-color: transparent;
-  border: 0px solid white;
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -118,9 +118,12 @@ export const gradients = {
 
 export const outlines = {
   afterPseudo: boxshadowOutline({
-    color: colors.accentSecondary,
     border: '0px',
     offset: '2px',
     zIndex: zindexes.focus,
+    afterPseudo: true,
+  }),
+  boxShadow: boxshadowOutline({
+    afterPseudo: false,
   }),
 };

--- a/src/core/theme/utils/focus.ts
+++ b/src/core/theme/utils/focus.ts
@@ -1,17 +1,24 @@
 import { css } from 'styled-components';
 import { themeOrTokens, TokensOrThemeProps } from '../utils';
 
+export interface FocusConfig {
+  variant?: 'outline' | 'afterPseudo' | 'boxShadow';
+  outline?: string;
+  noPseudo?: boolean;
+}
+
 export const focus = ({
   outline,
   noPseudo,
+  variant = 'afterPseudo',
   ...tokensOrTheme
-}: TokensOrThemeProps & {
-  outline?: string;
-  noPseudo?: boolean;
-}) => {
-  const style = !!outline
-    ? outline
-    : themeOrTokens(tokensOrTheme).outlines.afterPseudo;
+}: TokensOrThemeProps & FocusConfig) => {
+  const style =
+    variant === 'outline' && !!outline
+      ? outline
+      : variant === 'afterPseudo'
+      ? themeOrTokens(tokensOrTheme).outlines.afterPseudo
+      : themeOrTokens(tokensOrTheme).outlines.boxShadow;
   return !!noPseudo
     ? style
     : css`

--- a/src/core/theme/utils/outline.ts
+++ b/src/core/theme/utils/outline.ts
@@ -4,17 +4,13 @@ import { radius } from '../radius';
 
 const boxshadow = ({
   borderRadius,
-  border,
   color,
 }: {
   borderRadius: string;
-  border: string;
   color: string;
 }) => css`
   border-radius: ${borderRadius};
-  border: ${border} solid ${color};
-  box-sizing: border-box;
-  box-shadow: 0 0 10px 0 ${color};
+  box-shadow: 0 0 0 2px ${color};
 `;
 
 const afterBoxshadow = ({
@@ -50,7 +46,7 @@ const afterBoxshadow = ({
 
 // TODO Refactor, create interfaces (and extend with Partial<>), add JSDOC for functions
 export const boxshadowOutline = ({
-  color = colors.accentBase,
+  color = colors.accentSecondary,
   borderColor = 'white',
   offset = '0',
   border = '1px',
@@ -80,7 +76,7 @@ export const boxshadowOutline = ({
           borderColor,
           zIndex,
         })
-      : boxshadow({ borderRadius, border, color })}
+      : boxshadow({ borderRadius, color })}
     ${focusVisible}
   `;
 };

--- a/src/core/theme/utils/outline.ts
+++ b/src/core/theme/utils/outline.ts
@@ -47,7 +47,7 @@ const afterBoxshadow = ({
 // TODO Refactor, create interfaces (and extend with Partial<>), add JSDOC for functions
 export const boxshadowOutline = ({
   color = colors.accentSecondary,
-  borderColor = 'white',
+  borderColor = colors.whiteBase,
   offset = '0',
   border = '1px',
   borderRadius = radius.focus,


### PR DESCRIPTION
## Description

This PR implements a focus variant that only uses box shadow instead of a pseudo element. This can be used for inline elements to allow row wrapping focus styles as well as for pseudo elements such as the box in checkbox. This PR also implements the new focus style for checkbox.

## Motivation and Context

The previous focus styles didn't work correctly for inline elements and pseudo elements.

## How Has This Been Tested?

Tested by running locally and manually testing as well as with automated tests.
