### PR TITLE
[Bugfix] Align breadcrumb styles with styleguide

### DIFF
--- a/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -6,29 +6,34 @@ import { nav, list, listItem, font } from '../theme/reset';
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
   ${nav({ theme })}
-  ${font({ theme })('bodyText')}
+  ${font({ theme })('bodyTextSmall')}
   background-color: ${theme.colors.whiteBase};
   height: 1.5em;
 
   & .fi-breadcrumb {
     &_list {
       ${list({ theme })}
-      ${font({ theme })('bodyText')}
+      ${font({ theme })('bodyTextSmall')}
       margin: 0;
       padding: 0;
     }
     &_item {
       ${listItem({ theme })}
-      ${font({ theme })('bodyText')}
+      ${font({ theme })('bodyTextSmall')}
       float: left;
+      color: ${theme.colors.depthDark1};
     }
     &_item,
     &_link,
     &_icon {
-      font-size: ${cssValueToString(theme.values.typography.bodyText.fontSize)};
+      font-size: ${cssValueToString(
+        theme.values.typography.bodyTextSmall.fontSize,
+      )};
     }
     &_icon {
       transform: translateY(.2em);
+      margin: 0 ${theme.spacing.insetXs};
+      fill: ${theme.colors.depthDark1};
     }
   }
 `,

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`calling render with the same component on the same container does not r
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
   background-color: hsl(0,0%,100%);
@@ -226,7 +226,7 @@ exports[`calling render with the same component on the same container does not r
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
   margin: 0;
@@ -246,22 +246,25 @@ exports[`calling render with the same component on the same container does not r
   overflow-wrap: break-word;
   -webkit-font-smoothing: antialiased;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
   float: left;
+  color: hsl(202,7%,40%);
 }
 
 .c1 .fi-breadcrumb_item,
 .c1 .fi-breadcrumb_link,
 .c1 .fi-breadcrumb_icon {
-  font-size: 18px;
+  font-size: 16px;
 }
 
 .c1 .fi-breadcrumb_icon {
   -webkit-transform: translateY(.2em);
   -ms-transform: translateY(.2em);
   transform: translateY(.2em);
+  margin: 0 4px;
+  fill: hsl(202,7%,40%);
 }
 
 <nav


### PR DESCRIPTION
## Description
The breadcrumb implementation in the library didn't match the current design in the styleguide. This PR contains style changes that match the implementation with the design.

## Motivation and Context
To be a viable option for projects, the library needs to offer up-to-date components that match the styleguide.

## How Has This Been Tested?
Running locally and automated tests
## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/54316341/81648008-a3794500-9436-11ea-9aca-4a750caf2b2e.png)

After:
![image](https://user-images.githubusercontent.com/54316341/81647944-85abe000-9436-11ea-9ab5-15840711e5d3.png)
