### PR TITLE
[Bugfix] Align expander styles with the design

### DIFF
--- a/src/core/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander.baseStyles.tsx
@@ -34,7 +34,7 @@ export const baseStyles = withSuomifiTheme(
     display: block;
     width: 100%;
     font-size: ${theme.typography.bodySemiBold};
-    height: 60px;
+    min-height: 60px;
     &--no-tag {
       padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
       color: ${theme.colors.highlightBase};
@@ -58,6 +58,7 @@ export const baseStyles = withSuomifiTheme(
     display: block;
     height: 0;
     overflow: hidden;
+    word-break: break-word;
     transform: scaleY(0);
     transform-origin: top;
     transition: all ${`${theme.transitions.basicTime}

--- a/src/core/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander.baseStyles.tsx
@@ -33,16 +33,20 @@ export const baseStyles = withSuomifiTheme(
     position: relative;
     display: block;
     width: 100%;
+    font-size: ${theme.typography.bodySemiBold};
+    height: 60px;
     &--no-tag {
-      ${padding({ theme })('insetXl', 'xxxl', 'insetXl', 'insetXl')}
+      padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
       color: ${theme.colors.highlightBase};
     }
   }
   & .fi-expander_title-icon {
     position: absolute;
+    height: 20px;
+    width: 20px;
     top: 0;
     right: 0;
-    margin: ${theme.spacing.insetXl};
+    margin: ${theme.spacing.m};
   }
   & .fi-expander_title--open .fi-expander_title-icon,
   & .fi-expander_title-icon--open {
@@ -69,7 +73,7 @@ export const baseStyles = withSuomifiTheme(
       animation: fi-expander_content-anim ${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction} 1 forwards;
       &:not(.fi-expander_content--no-padding) {
-        ${padding({ theme })('0', 'insetXl', 'insetXl', 'insetXl')}
+        ${padding({ theme })('0', 'm', 'm', 'm')}
       }
     }
     @keyframes fi-expander_content-anim {

--- a/src/core/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/Expander.test.tsx.snap
@@ -168,6 +168,11 @@ exports[`calling render with the same component on the same container does not r
   position: relative;
   display: block;
   width: 100%;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  min-height: 60px;
 }
 
 .c2 .fi-expander_title:focus {
@@ -195,18 +200,17 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 .fi-expander_title--no-tag {
-  padding-top: 16px;
-  padding-right: 60px;
-  padding-bottom: 16px;
-  padding-left: 16px;
+  padding: 17px 60px 16px 20px;
   color: hsl(212,63%,45%);
 }
 
 .c2 .fi-expander_title-icon {
   position: absolute;
+  height: 20px;
+  width: 20px;
   top: 0;
   right: 0;
-  margin: 16px;
+  margin: 20px;
 }
 
 .c2 .fi-expander_title--open .fi-expander_title-icon,
@@ -221,6 +225,7 @@ exports[`calling render with the same component on the same container does not r
   display: block;
   height: 0;
   overflow: hidden;
+  word-break: break-word;
   -webkit-transform: scaleY(0);
   -ms-transform: scaleY(0);
   transform: scaleY(0);
@@ -245,9 +250,9 @@ exports[`calling render with the same component on the same container does not r
 
 .c2 > .fi-expander_content.fi-expander_content--open:not(.fi-expander_content--no-padding) {
   padding-top: 0;
-  padding-right: 16px;
-  padding-bottom: 16px;
-  padding-left: 16px;
+  padding-right: 20px;
+  padding-bottom: 20px;
+  padding-left: 20px;
 }
 
 <div

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -282,6 +282,11 @@ exports[`snapshot testing 1`] = `
   position: relative;
   display: block;
   width: 100%;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  min-height: 60px;
 }
 
 .c6 .fi-expander_title:focus {
@@ -309,18 +314,17 @@ exports[`snapshot testing 1`] = `
 }
 
 .c6 .fi-expander_title--no-tag {
-  padding-top: 16px;
-  padding-right: 60px;
-  padding-bottom: 16px;
-  padding-left: 16px;
+  padding: 17px 60px 16px 20px;
   color: hsl(212,63%,45%);
 }
 
 .c6 .fi-expander_title-icon {
   position: absolute;
+  height: 20px;
+  width: 20px;
   top: 0;
   right: 0;
-  margin: 16px;
+  margin: 20px;
 }
 
 .c6 .fi-expander_title--open .fi-expander_title-icon,
@@ -335,6 +339,7 @@ exports[`snapshot testing 1`] = `
   display: block;
   height: 0;
   overflow: hidden;
+  word-break: break-word;
   -webkit-transform: scaleY(0);
   -ms-transform: scaleY(0);
   transform: scaleY(0);
@@ -359,9 +364,9 @@ exports[`snapshot testing 1`] = `
 
 .c6 > .fi-expander_content.fi-expander_content--open:not(.fi-expander_content--no-padding) {
   padding-top: 0;
-  padding-right: 16px;
-  padding-bottom: 16px;
-  padding-left: 16px;
+  padding-right: 20px;
+  padding-bottom: 20px;
+  padding-left: 20px;
 }
 
 <div


### PR DESCRIPTION
## Description
This PR sets the expander component styles to match the latest design and adds a word break rule for the expander content to prevent it from stretching the component.

## Motivation and Context
Components need to be up-to-date with designs in order to be useful.

## How Has This Been Tested?
Tested manually in local environment
