### PR TITLE
[Fix] Expander's defaultOpen, open and onClick properties not working when inside ExpanderGroup

### DIFF
--- a/src/components/Expander/Expander.tsx
+++ b/src/components/Expander/Expander.tsx
@@ -157,12 +157,13 @@ class ExpanderItem extends Component<ExpanderProps> {
 
   handleClick = () => {
     const { open, onClick } = this.props;
-    const openState = !this.state.openState;
+    const { openState } = this.state;
     const controlled = open !== undefined;
+    const newOpenState = controlled ? !!open : !openState;
 
-    this.setState({ openState: controlled ? !!open : openState });
+    this.setState({ openState: newOpenState });
     if (!!onClick) {
-      onClick({ openState: controlled ? !!open : openState });
+      onClick({ openState: newOpenState });
     }
   };
 

--- a/src/components/Expander/Expander.tsx
+++ b/src/components/Expander/Expander.tsx
@@ -140,9 +140,12 @@ class ExpanderItem extends Component<ExpanderProps> {
       }
     }
 
+    const { open } = this.props;
+    const { openState } = this.state;
+    const controlled = open !== undefined;
     if (
-      prevState.openState !== this.state.openState ||
-      prevProps.open !== this.props.open
+      (prevState.openState !== openState && !controlled) ||
+      (prevProps.open !== open && controlled)
     ) {
       const {
         expanderGroup,
@@ -152,7 +155,8 @@ class ExpanderItem extends Component<ExpanderProps> {
         },
       } = this.props;
       if (!!expanderGroup && !!onExpanderOpenChange && index !== undefined) {
-        onExpanderOpenChange(index);
+        const currentState = controlled ? !!open : openState;
+        onExpanderOpenChange(index, currentState);
       }
     }
   }

--- a/src/components/Expander/Expander.tsx
+++ b/src/components/Expander/Expander.tsx
@@ -163,7 +163,9 @@ class ExpanderItem extends Component<ExpanderProps> {
     const controlled = open !== undefined;
     const newOpenState = controlled ? !!open : !openState;
 
-    this.setState({ openState: newOpenState });
+    if (!controlled) {
+      this.setState({ openState: newOpenState });
+    }
     if (!!onClick) {
       onClick({ openState: newOpenState });
     }

--- a/src/components/Expander/Expander.tsx
+++ b/src/components/Expander/Expander.tsx
@@ -147,10 +147,12 @@ class ExpanderItem extends Component<ExpanderProps> {
       const {
         expanderGroup,
         index,
-        consumer: { onClick: consumerOnClick } = { onClick: undefined },
+        consumer: { onExpanderOpenChange } = {
+          onExpanderOpenChange: undefined,
+        },
       } = this.props;
-      if (!!expanderGroup && !!consumerOnClick && index !== undefined) {
-        consumerOnClick(index);
+      if (!!expanderGroup && !!onExpanderOpenChange && index !== undefined) {
+        onExpanderOpenChange(index);
       }
     }
   }

--- a/src/components/Expander/ExpanderGroup.tsx
+++ b/src/components/Expander/ExpanderGroup.tsx
@@ -143,14 +143,14 @@ export class ExpanderGroup extends Component<ExpanderGroupProps> {
     });
   };
 
-  isEveryExpanderOpened = () => {
+  allExpandersOpen = () => {
     return this.props.children.length > this.state.openExpanders.length;
   };
 
   handleAllToggleClick = () => {
     this.setState({
       toggleAllExpanderState: {
-        toState: this.isEveryExpanderOpened(),
+        toState: this.allExpandersOpen(),
       },
     });
   };

--- a/src/components/Expander/ExpanderGroup.tsx
+++ b/src/components/Expander/ExpanderGroup.tsx
@@ -39,7 +39,7 @@ export interface ExpanderGroupProps extends OpenCloseAll {
 }
 
 export interface ExpanderProviderState {
-  onClick: (index: number) => void;
+  onExpanderOpenChange: (index: number) => void;
   toggleAllExpanderState: ToggleAllExpanderState;
 }
 
@@ -62,7 +62,7 @@ const ExpanderGroupItems = (
   );
 
 const defaultProviderValue: ExpanderProviderState = {
-  onClick: () => null,
+  onExpanderOpenChange: () => null,
   toggleAllExpanderState: {
     toState: false,
   },
@@ -130,7 +130,7 @@ export class ExpanderGroup extends Component<ExpanderGroupProps> {
     },
   };
 
-  handleClick = (index: number = 0) => {
+  handleExpanderOpenChange = (index: number = 0) => {
     this.setState((prevState: ExpanderGroupState) => {
       const { openExpanders: prevOpenExpanders } = prevState;
       const prevExpanderOpen = prevOpenExpanders.includes(index);
@@ -184,7 +184,7 @@ export class ExpanderGroup extends Component<ExpanderGroupProps> {
         <HtmlDiv className={expandersContainerClassName}>
           <Provider
             value={{
-              onClick: this.handleClick,
+              onExpanderOpenChange: this.handleExpanderOpenChange,
               toggleAllExpanderState,
             }}
           >

--- a/src/components/Expander/ExpanderGroup.tsx
+++ b/src/components/Expander/ExpanderGroup.tsx
@@ -130,7 +130,7 @@ export class ExpanderGroup extends Component<ExpanderGroupProps> {
     },
   };
 
-  handleExpanderOpenChange = (index: number = 0) => {
+  handleExpanderOpenChange = (index: number) => {
     this.setState((prevState: ExpanderGroupState) => {
       const { openExpanders: prevOpenExpanders } = prevState;
       const prevExpanderOpen = prevOpenExpanders.includes(index);

--- a/src/components/Expander/ExpanderGroup.tsx
+++ b/src/components/Expander/ExpanderGroup.tsx
@@ -143,14 +143,14 @@ export class ExpanderGroup extends Component<ExpanderGroupProps> {
     });
   };
 
-  isEvenOneExpanderClose = () => {
+  isEveryExpanderOpened = () => {
     return this.props.children.length > this.state.openExpanders.length;
   };
 
   handleAllToggleClick = () => {
     this.setState({
       toggleAllExpanderState: {
-        toState: this.isEvenOneExpanderClose(),
+        toState: this.isEveryExpanderOpened(),
       },
     });
   };

--- a/src/core/Expander/Expander.md
+++ b/src/core/Expander/Expander.md
@@ -24,7 +24,7 @@ import { Expander } from 'suomifi-ui-components';
 - `defaultOpen` prop will not work when Expander is in controlled state == `open` prop is given.
 
 ```jsx
-import { Expander } from 'suomifi-ui-components';
+import { Expander, Button } from 'suomifi-ui-components';
 
 const [expanderOneOpen, setExpanderOneOpen] = React.useState(false);
 const [expanderTwoOpen, setExpanderTwoOpen] = React.useState(false);
@@ -42,22 +42,23 @@ const [expanderThreeOpen, setExpanderThreeOpen] = React.useState(
   >
     <div
       style={{
+        width: 500,
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'space-between'
       }}
     >
-      <button onClick={() => setExpanderOneOpen(!expanderOneOpen)}>
+      <Button onClick={() => setExpanderOneOpen(!expanderOneOpen)}>
         Toggle Expander 1
-      </button>
-      <button onClick={() => setExpanderTwoOpen(!expanderTwoOpen)}>
+      </Button>
+      <Button onClick={() => setExpanderTwoOpen(!expanderTwoOpen)}>
         Toggle Expander 2
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={() => setExpanderThreeOpen(!expanderThreeOpen)}
       >
         Toggle Expander 3
-      </button>
+      </Button>
     </div>
   </div>
 

--- a/src/core/Expander/Expander.md
+++ b/src/core/Expander/Expander.md
@@ -26,34 +26,16 @@ import { Expander } from 'suomifi-ui-components';
 ```jsx
 import { Expander } from 'suomifi-ui-components';
 
-const [expanderOneOpen, setExpanderOneOpen] = React.useState(false);
-const [expanderTwoOpen, setExpanderTwoOpen] = React.useState(false);
 const [expanderThreeOpen, setExpanderThreeOpen] = React.useState(
   false
 );
 
 <>
   <Expander.group OpenAll="Open all" CloseAll="Close all">
-    <Expander
-      title="Test expander 1"
-      open={expanderOneOpen}
-      onClick={() => {
-        if (window.confirm('Toggle Expander 1')) {
-          setExpanderOneOpen(!expanderOneOpen);
-        }
-      }}
-    >
+    <Expander title="Test expander 1">
       Test expander content 1
     </Expander>
-    <Expander
-      title="Test expander 2"
-      open={expanderTwoOpen}
-      onClick={() => {
-        if (window.confirm('Toggle Expander 2')) {
-          setExpanderTwoOpen(!expanderTwoOpen);
-        }
-      }}
-    >
+    <Expander title="Test expander 2">
       Test expander content 2
     </Expander>
     <Expander

--- a/src/core/Expander/Expander.md
+++ b/src/core/Expander/Expander.md
@@ -15,3 +15,73 @@ import { Expander } from 'suomifi-ui-components';
   <Expander title="Test expander 3">Test expander content 3</Expander>
 </Expander.group>;
 ```
+
+## Controlled
+
+- State for the individual Expanders are stored outside of the component and user has full control.
+- Therefore when clicking the individual Expander they are not opened by default, user have to give the logic to change it.
+- It's user's responsibility to keep the state stored outside to be updated as Open/Close All is used.
+
+```jsx
+import { Expander } from 'suomifi-ui-components';
+
+const [expanderOneOpen, setExpanderOneOpen] = React.useState(false);
+const [expanderTwoOpen, setExpanderTwoOpen] = React.useState(false);
+const [expanderThreeOpen, setExpanderThreeOpen] = React.useState(
+  false
+);
+
+<>
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between'
+    }}
+  >
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between'
+      }}
+    >
+      <button onClick={() => setExpanderOneOpen(!expanderOneOpen)}>
+        Toggle Expander 1
+      </button>
+      <button onClick={() => setExpanderTwoOpen(!expanderTwoOpen)}>
+        Toggle Expander 2
+      </button>
+      <button
+        onClick={() => setExpanderThreeOpen(!expanderThreeOpen)}
+      >
+        Toggle Expander 3
+      </button>
+    </div>
+  </div>
+
+  <Expander.group OpenAll="Open all" CloseAll="Close all">
+    <Expander
+      title="Test expander 1"
+      open={expanderOneOpen}
+      onClick={() => setExpanderOneOpen(!expanderOneOpen)}
+    >
+      Test expander content 1
+    </Expander>
+    <Expander
+      title="Test expander 2"
+      open={expanderTwoOpen}
+      onClick={() => setExpanderTwoOpen(!expanderTwoOpen)}
+    >
+      Test expander content 2
+    </Expander>
+    <Expander
+      title="Test expander 3"
+      open={expanderThreeOpen}
+      onClick={() => setExpanderThreeOpen(!expanderThreeOpen)}
+    >
+      Test expander content 3
+    </Expander>
+  </Expander.group>
+</>;
+```

--- a/src/core/Expander/Expander.md
+++ b/src/core/Expander/Expander.md
@@ -21,6 +21,7 @@ import { Expander } from 'suomifi-ui-components';
 - State for the individual Expanders are stored outside of the component and user has full control.
 - Therefore when clicking the individual Expander they are not opened by default, user have to give the logic to change it.
 - It's user's responsibility to keep the state stored outside to be updated as Open/Close All is used.
+- `defaultOpen` prop will not work when Expander is in controlled state == `open` prop is given.
 
 ```jsx
 import { Expander } from 'suomifi-ui-components';

--- a/src/core/Expander/Expander.md
+++ b/src/core/Expander/Expander.md
@@ -41,9 +41,9 @@ const [expanderThreeOpen, setExpanderThreeOpen] = React.useState(
     <Expander
       title="Test expander 3"
       open={expanderThreeOpen}
-      onClick={() => {
+      onClick={({ openState }) => {
         if (window.confirm('Toggle Expander 3')) {
-          setExpanderThreeOpen(!expanderThreeOpen);
+          setExpanderThreeOpen(!openState);
         }
       }}
     >

--- a/src/core/Expander/Expander.md
+++ b/src/core/Expander/Expander.md
@@ -24,7 +24,7 @@ import { Expander } from 'suomifi-ui-components';
 - `defaultOpen` prop will not work when Expander is in controlled state == `open` prop is given.
 
 ```jsx
-import { Expander, Button } from 'suomifi-ui-components';
+import { Expander } from 'suomifi-ui-components';
 
 const [expanderOneOpen, setExpanderOneOpen] = React.useState(false);
 const [expanderTwoOpen, setExpanderTwoOpen] = React.useState(false);
@@ -33,54 +33,37 @@ const [expanderThreeOpen, setExpanderThreeOpen] = React.useState(
 );
 
 <>
-  <div
-    style={{
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'space-between'
-    }}
-  >
-    <div
-      style={{
-        width: 500,
-        display: 'flex',
-        flexDirection: 'row',
-        justifyContent: 'space-between'
-      }}
-    >
-      <Button onClick={() => setExpanderOneOpen(!expanderOneOpen)}>
-        Toggle Expander 1
-      </Button>
-      <Button onClick={() => setExpanderTwoOpen(!expanderTwoOpen)}>
-        Toggle Expander 2
-      </Button>
-      <Button
-        onClick={() => setExpanderThreeOpen(!expanderThreeOpen)}
-      >
-        Toggle Expander 3
-      </Button>
-    </div>
-  </div>
-
   <Expander.group OpenAll="Open all" CloseAll="Close all">
     <Expander
       title="Test expander 1"
       open={expanderOneOpen}
-      onClick={() => setExpanderOneOpen(!expanderOneOpen)}
+      onClick={() => {
+        if (window.confirm('Toggle Expander 1')) {
+          setExpanderOneOpen(!expanderOneOpen);
+        }
+      }}
     >
       Test expander content 1
     </Expander>
     <Expander
       title="Test expander 2"
       open={expanderTwoOpen}
-      onClick={() => setExpanderTwoOpen(!expanderTwoOpen)}
+      onClick={() => {
+        if (window.confirm('Toggle Expander 2')) {
+          setExpanderTwoOpen(!expanderTwoOpen);
+        }
+      }}
     >
       Test expander content 2
     </Expander>
     <Expander
       title="Test expander 3"
       open={expanderThreeOpen}
-      onClick={() => setExpanderThreeOpen(!expanderThreeOpen)}
+      onClick={() => {
+        if (window.confirm('Toggle Expander 3')) {
+          setExpanderThreeOpen(!expanderThreeOpen);
+        }
+      }}
     >
       Test expander content 3
     </Expander>

--- a/src/core/Expander/Expander.test.tsx
+++ b/src/core/Expander/Expander.test.tsx
@@ -1,19 +1,27 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { axeTest } from '../../utils/test/axe';
 
-import { Expander } from './Expander';
+import { Expander, ExpanderProps } from './Expander';
 import { cssFromBaseStyles } from '../utils';
 import { baseStyles } from './Expander.baseStyles';
 
-const TestExpander = (
-  <Expander
-    title="Test expander"
-    titleProps={{ 'data-testid': 'expander-title' }}
-    className="expander-test"
-  >
-    Test expander content
-  </Expander>
+const TestExpanderWithProps = (props: ExpanderProps, content: string) => {
+  const { title, ...passProps } = props;
+  return (
+    <Expander title={title} {...passProps}>
+      {content}
+    </Expander>
+  );
+};
+
+const TestExpander = TestExpanderWithProps(
+  {
+    title: 'Test expander',
+    titleProps: { 'data-testid': 'expander-title' },
+    className: 'expander-test',
+  },
+  'Test expander content',
 );
 
 test('calling render with the same component on the same container does not remount', () => {
@@ -24,14 +32,146 @@ test('calling render with the same component on the same container does not remo
 
   // re-render the same component with different props
   rerender(
-    <Expander
-      title="Test expander two"
-      titleProps={{ 'data-testid': 'expander-title-2' }}
-    >
-      Test expander content
-    </Expander>,
+    TestExpanderWithProps(
+      {
+        title: 'Test expander two',
+        titleProps: { 'data-testid': 'expander-title-2' },
+        className: 'expander-test',
+      },
+      'Test expander content',
+    ),
   );
   expect(getByTestId('expander-title-2').textContent).toBe('Test expander two');
+});
+
+describe('defaultOpen', () => {
+  it('gives the classname to expander title and icon', () => {
+    const { getByTestId } = render(
+      TestExpanderWithProps(
+        {
+          title: 'Test expander open by default',
+          titleProps: { 'data-testid': 'expander-open-by-default-title' },
+          className: 'expander-open-by-default-test',
+          defaultOpen: true,
+        },
+        'Test expander open by default content',
+      ),
+    );
+
+    const button = getByTestId('expander-open-by-default-title');
+    expect(button.classList.contains('fi-expander_title--open')).toBe(true);
+
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(true);
+  });
+
+  it('classnames will be removed when clicked', () => {
+    const mockClickHandler = jest.fn();
+    const { getByTestId } = render(
+      TestExpanderWithProps(
+        {
+          title: 'Test expander open by default',
+          titleProps: { 'data-testid': 'expander-open-by-default-title' },
+          className: 'expander-open-by-default-test',
+          defaultOpen: true,
+          onClick: mockClickHandler,
+        },
+        'Test expander open by default content',
+      ),
+    );
+
+    const buttonToClick = getByTestId('expander-open-by-default-title');
+    fireEvent.mouseDown(buttonToClick);
+
+    expect(buttonToClick.classList.contains('fi-expander_title--open')).toBe(
+      false,
+    );
+
+    expect(
+      buttonToClick
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(false);
+  });
+});
+
+describe('onClick', () => {
+  it('is called', async () => {
+    const mockClickHandler = jest.fn();
+    const { getByTestId } = render(
+      TestExpanderWithProps(
+        {
+          title: 'Test expander onClick testing',
+          titleProps: {
+            'data-testid': 'expander-onclick-testing-title',
+            onClick: mockClickHandler,
+          },
+          className: 'expander-onclick-test',
+        },
+        'Test expander click testing content',
+      ),
+    );
+    const button = getByTestId('expander-onclick-testing-title');
+    fireEvent.mouseDown(button);
+    expect(mockClickHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('open', () => {
+  it('open-classnames should be found ', async () => {
+    const { getByTestId } = render(
+      TestExpanderWithProps(
+        {
+          title: 'Test expander onClick testing',
+          titleProps: {
+            'data-testid': 'expander-onclick-testing-title',
+          },
+          className: 'expander-onclick-test',
+          open: true,
+        },
+        'Test expander click testing content',
+      ),
+    );
+    const button = getByTestId('expander-onclick-testing-title');
+    expect(button.classList.contains('fi-expander_title--open')).toBe(true);
+
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(true);
+  });
+
+  it('is clicked. Should not change as it is controlled outside', async () => {
+    const mockClickHandler = jest.fn();
+    const { getByTestId } = render(
+      TestExpanderWithProps(
+        {
+          title: 'Test expander onClick testing',
+          titleProps: {
+            'data-testid': 'expander-onclick-testing-title',
+            onClick: mockClickHandler,
+          },
+          className: 'expander-onclick-test',
+          open: true,
+        },
+        'Test expander click testing content',
+      ),
+    );
+    const button = getByTestId('expander-onclick-testing-title');
+    fireEvent.mouseDown(button);
+    expect(mockClickHandler).toHaveBeenCalledTimes(1);
+    expect(button.classList.contains('fi-expander_title--open')).toBe(true);
+
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(true);
+  });
 });
 
 test('CSS export', () => {

--- a/src/core/Expander/Expander.tsx
+++ b/src/core/Expander/Expander.tsx
@@ -91,9 +91,12 @@ class ExpanderItem extends Component<ExpanderProps> {
       }
     }
 
+    const { open } = this.props;
+    const { openState } = this.state;
+    const controlled = open !== undefined;
     if (
-      prevState.openState !== this.state.openState ||
-      prevProps.open !== this.props.open
+      (prevState.openState !== openState && !controlled) ||
+      (prevProps.open !== open && controlled)
     ) {
       const {
         expanderGroup,
@@ -103,7 +106,8 @@ class ExpanderItem extends Component<ExpanderProps> {
         },
       } = this.props;
       if (!!expanderGroup && !!onExpanderOpenChange && index !== undefined) {
-        onExpanderOpenChange(index);
+        const currentState = controlled ? !!open : openState;
+        onExpanderOpenChange(index, currentState);
       }
     }
   }

--- a/src/core/Expander/Expander.tsx
+++ b/src/core/Expander/Expander.tsx
@@ -108,12 +108,13 @@ class ExpanderItem extends Component<ExpanderProps> {
 
   handleClick = () => {
     const { open, onClick } = this.props;
-    const openState = !this.state.openState;
+    const { openState } = this.state;
     const controlled = open !== undefined;
+    const newOpenState = controlled ? !!open : !openState;
 
-    this.setState({ openState: controlled ? !!open : openState });
+    this.setState({ openState: newOpenState });
     if (!!onClick) {
-      onClick({ openState: controlled ? !!open : openState });
+      onClick({ openState: newOpenState });
     }
   };
 

--- a/src/core/Expander/Expander.tsx
+++ b/src/core/Expander/Expander.tsx
@@ -98,10 +98,12 @@ class ExpanderItem extends Component<ExpanderProps> {
       const {
         expanderGroup,
         index,
-        consumer: { onClick: consumerOnClick } = { onClick: undefined },
+        consumer: { onExpanderOpenChange } = {
+          onExpanderOpenChange: undefined,
+        },
       } = this.props;
-      if (!!expanderGroup && !!consumerOnClick && index !== undefined) {
-        consumerOnClick(index);
+      if (!!expanderGroup && !!onExpanderOpenChange && index !== undefined) {
+        onExpanderOpenChange(index);
       }
     }
   }

--- a/src/core/Expander/Expander.tsx
+++ b/src/core/Expander/Expander.tsx
@@ -112,9 +112,11 @@ class ExpanderItem extends Component<ExpanderProps> {
     const { open, onClick } = this.props;
     const { openState } = this.state;
     const controlled = open !== undefined;
-    const newOpenState = controlled ? !!open : !openState;
 
-    this.setState({ openState: newOpenState });
+    const newOpenState = controlled ? !!open : !openState;
+    if (!controlled) {
+      this.setState({ openState: newOpenState });
+    }
     if (!!onClick) {
       onClick({ openState: newOpenState });
     }

--- a/src/core/Expander/Expander.tsx
+++ b/src/core/Expander/Expander.tsx
@@ -9,7 +9,11 @@ import {
 } from '../../components/Expander/Expander';
 import { Icon } from '../Icon/Icon';
 import classnames from 'classnames';
-import { ExpanderGroupProps, ExpanderGroup } from './ExpanderGroup';
+import {
+  ExpanderGroupProps,
+  ExpanderGroup,
+  ExpanderGroupConsumer,
+} from './ExpanderGroup';
 
 const iconClassName = 'fi-expander_title-icon';
 const iconOpenClassName = `${iconClassName}--open`;
@@ -50,7 +54,7 @@ interface ExpanderState {
  * <i class="semantics" />
  * Used for openable expander
  */
-export class Expander extends Component<ExpanderProps> {
+class ExpanderItem extends Component<ExpanderProps> {
   static group = (props: ExpanderGroupProps) => {
     return <ExpanderGroup {...withSuomifiDefaultProps(props)} />;
   };
@@ -61,15 +65,55 @@ export class Expander extends Component<ExpanderProps> {
       this.props.defaultOpen !== undefined ? this.props.defaultOpen : false,
   };
 
+  componentDidUpdate(prevProps: ExpanderProps, prevState: ExpanderState) {
+    if (
+      !!this.props.consumer &&
+      !!prevProps.consumer &&
+      this.props.consumer.toggleAllExpanderState !==
+        prevProps.consumer.toggleAllExpanderState
+    ) {
+      const { openState } = this.state;
+      const {
+        expanderGroup,
+        index,
+        consumer: { toggleAllExpanderState },
+        open,
+      } = this.props;
+
+      if (
+        !!expanderGroup &&
+        index !== undefined &&
+        ((open === undefined &&
+          !!openState !== toggleAllExpanderState.toState) ||
+          (open !== undefined && !!open !== toggleAllExpanderState.toState))
+      ) {
+        this.handleClick();
+      }
+    }
+
+    if (
+      prevState.openState !== this.state.openState ||
+      prevProps.open !== this.props.open
+    ) {
+      const {
+        expanderGroup,
+        index,
+        consumer: { onClick: consumerOnClick } = { onClick: undefined },
+      } = this.props;
+      if (!!expanderGroup && !!consumerOnClick && index !== undefined) {
+        consumerOnClick(index);
+      }
+    }
+  }
+
   handleClick = () => {
     const { open, onClick } = this.props;
-    const { openState } = this.state;
-    const notControlled = open === undefined;
-    if (notControlled) {
-      this.setState({ openState: !openState });
-    }
+    const openState = !this.state.openState;
+    const controlled = open !== undefined;
+
+    this.setState({ openState: controlled ? !!open : openState });
     if (!!onClick) {
-      onClick({ openState: notControlled ? !openState : !!open });
+      onClick({ openState: controlled ? !!open : openState });
     }
   };
 
@@ -79,10 +123,11 @@ export class Expander extends Component<ExpanderProps> {
       open,
       title,
       titleTag,
+      index,
+      consumer,
       ...passProps
     } = withSuomifiDefaultProps(this.props);
-    const notControlled = open === undefined;
-    const openState = !notControlled ? open : this.state.openState;
+    const openState = open !== undefined ? !!open : this.state.openState;
 
     if (variant === 'expanderGroup' && 'openAll' in passProps) {
       return <ExpanderGroup {...(passProps as ExpanderGroupProps)} />;
@@ -91,6 +136,7 @@ export class Expander extends Component<ExpanderProps> {
     return (
       <StyledExpander
         {...passProps}
+        index={index}
         onClick={this.handleClick}
         open={open}
         titleTag={titleTag}
@@ -109,6 +155,22 @@ export class Expander extends Component<ExpanderProps> {
           </Fragment>
         }
       />
+    );
+  }
+}
+
+export class Expander extends Component<ExpanderProps> {
+  static group = (props: ExpanderGroupProps) => {
+    return <ExpanderGroup {...withSuomifiDefaultProps(props)} />;
+  };
+
+  render() {
+    return !!this.props.expanderGroup ? (
+      <ExpanderGroupConsumer>
+        {(consumer) => <ExpanderItem {...this.props} consumer={consumer} />}
+      </ExpanderGroupConsumer>
+    ) : (
+      <ExpanderItem {...this.props} />
     );
   }
 }

--- a/src/core/Expander/ExpanderGroup.test.tsx
+++ b/src/core/Expander/ExpanderGroup.test.tsx
@@ -1,0 +1,356 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { axeTest } from '../../utils/test/axe';
+
+import { Expander, ExpanderProps } from './Expander';
+
+const TestExpanderWithProps = (
+  props: ExpanderProps,
+  content: string,
+  key: number,
+) => {
+  const { title, ...passProps } = props;
+  return (
+    <Expander key={key} title={title} {...passProps}>
+      {content}
+    </Expander>
+  );
+};
+
+const TestExpanderGroup = (
+  expanderDatas: { expanderProps: ExpanderProps; content: string }[],
+) => (
+  <Expander.group OpenAll="Open all" CloseAll="Close all">
+    {expanderDatas.map((d, index) =>
+      TestExpanderWithProps(d.expanderProps, d.content, index),
+    )}
+  </Expander.group>
+);
+
+test('calling render with the same component on the same container does not remount', () => {
+  const { getByTestId, container, rerender } = render(
+    TestExpanderGroup([
+      {
+        expanderProps: {
+          title: 'First',
+          titleProps: { 'data-testid': 'expander-title-1' },
+        },
+        content: 'First content',
+      },
+      {
+        expanderProps: {
+          title: 'Second',
+          titleProps: { 'data-testid': 'expander-title-2' },
+        },
+        content: 'Second content',
+      },
+    ]),
+  );
+  expect(container.firstChild).toMatchSnapshot();
+  expect(getByTestId('expander-title-1').textContent).toBe('First');
+
+  rerender(
+    TestExpanderGroup([
+      {
+        expanderProps: {
+          title: 'First but not the best',
+          titleProps: { 'data-testid': 'expander-title-1-1' },
+        },
+        content: 'First but not the content',
+      },
+      {
+        expanderProps: {
+          title: 'Second',
+          titleProps: { 'data-testid': 'expander-title-2' },
+        },
+        content: 'Second content',
+      },
+    ]),
+  );
+  expect(getByTestId('expander-title-1-1').textContent).toBe(
+    'First but not the best',
+  );
+});
+
+describe('default behaviour', () => {
+  it('open/close all should open/close the Expanders', () => {
+    const { getByTestId, getByText } = render(
+      TestExpanderGroup([
+        {
+          expanderProps: {
+            title: 'First',
+            titleProps: { 'data-testid': 'expander-title-1' },
+          },
+          content: 'First content',
+        },
+        {
+          expanderProps: {
+            title: 'Second',
+            titleProps: { 'data-testid': 'expander-title-2' },
+          },
+          content: 'Second content',
+        },
+      ]),
+    );
+    const button = getByTestId('expander-title-2');
+    expect(button.classList.contains('fi-expander_title--open')).toBe(false);
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(false);
+    //
+    const allOpenButton = getByText('Open all');
+    fireEvent.click(allOpenButton);
+    expect(button.classList.contains('fi-expander_title--open')).toBe(true);
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(true);
+    //
+    const allCloseButton = getByText('Close all');
+    fireEvent.click(allCloseButton);
+    expect(button.classList.contains('fi-expander_title--open')).toBe(false);
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(false);
+  });
+});
+
+describe('defaultOpen', () => {
+  it('gives the classname to expander title and icon', () => {
+    const { getByTestId } = render(
+      TestExpanderGroup([
+        {
+          expanderProps: {
+            title: 'First',
+            titleProps: { 'data-testid': 'expander-title-1' },
+          },
+          content: 'First content',
+        },
+        {
+          expanderProps: {
+            title: 'Second',
+            titleProps: { 'data-testid': 'expander-title-2' },
+            defaultOpen: true,
+          },
+          content: 'Second content',
+        },
+      ]),
+    );
+    const button = getByTestId('expander-title-2');
+    expect(button.classList.contains('fi-expander_title--open')).toBe(true);
+
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(true);
+  });
+
+  it('classnames will be removed when clicked', () => {
+    const mockClickHandler = jest.fn();
+    const { getByTestId } = render(
+      TestExpanderGroup([
+        {
+          expanderProps: {
+            title: 'First',
+            titleProps: { 'data-testid': 'expander-title-1' },
+          },
+          content: 'First content',
+        },
+        {
+          expanderProps: {
+            title: 'Second',
+            titleProps: { 'data-testid': 'expander-title-2' },
+            defaultOpen: true,
+            onClick: mockClickHandler,
+          },
+          content: 'Second content',
+        },
+      ]),
+    );
+    const buttonToClick = getByTestId('expander-title-2');
+    fireEvent.mouseDown(buttonToClick);
+
+    expect(buttonToClick.classList.contains('fi-expander_title--open')).toBe(
+      false,
+    );
+
+    expect(
+      buttonToClick
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(false);
+  });
+});
+
+describe('onClick', () => {
+  it('is called', () => {
+    const mockClickHandler = jest.fn();
+    const { getByTestId } = render(
+      TestExpanderGroup([
+        {
+          expanderProps: {
+            title: 'First',
+            titleProps: { 'data-testid': 'expander-title-1' },
+          },
+          content: 'First content',
+        },
+        {
+          expanderProps: {
+            title: 'Second',
+            titleProps: { 'data-testid': 'expander-title-2' },
+            onClick: mockClickHandler,
+          },
+          content: 'Second content',
+        },
+      ]),
+    );
+    const button = getByTestId('expander-title-2');
+    fireEvent.mouseDown(button);
+    expect(mockClickHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('open', () => {
+  it('open-classnames should be found ', async () => {
+    const { getByTestId } = render(
+      TestExpanderGroup([
+        {
+          expanderProps: {
+            title: 'First',
+            titleProps: { 'data-testid': 'expander-title-1' },
+            open: true,
+          },
+          content: 'First content',
+        },
+        {
+          expanderProps: {
+            title: 'Second',
+            titleProps: { 'data-testid': 'expander-title-2' },
+            open: true,
+          },
+          content: 'Second content',
+        },
+      ]),
+    );
+    const button = getByTestId('expander-title-2');
+    expect(button.classList.contains('fi-expander_title--open')).toBe(true);
+
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(true);
+  });
+
+  it('is clicked. Should not change as it is controlled outside', async () => {
+    const mockClickHandler = jest.fn();
+    const { getByTestId } = render(
+      TestExpanderGroup([
+        {
+          expanderProps: {
+            title: 'First',
+            titleProps: { 'data-testid': 'expander-title-1' },
+            open: true,
+          },
+          content: 'First content',
+        },
+        {
+          expanderProps: {
+            title: 'Second',
+            titleProps: {
+              'data-testid': 'expander-title-2',
+              onClick: mockClickHandler,
+            },
+            open: true,
+          },
+          content: 'Second content',
+        },
+      ]),
+    );
+    const button = getByTestId('expander-title-2');
+    expect(button.classList.contains('fi-expander_title--open')).toBe(true);
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(true);
+
+    fireEvent.mouseDown(button);
+
+    expect(mockClickHandler).toHaveBeenCalledTimes(1);
+    expect(button.classList.contains('fi-expander_title--open')).toBe(true);
+
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(true);
+  });
+
+  it('open/close all clicked should not force the state to change.', () => {
+    const { getByTestId, getByText } = render(
+      TestExpanderGroup([
+        {
+          expanderProps: {
+            title: 'First',
+            titleProps: { 'data-testid': 'expander-title-1' },
+            open: false,
+          },
+          content: 'First content',
+        },
+        {
+          expanderProps: {
+            title: 'Second',
+            titleProps: { 'data-testid': 'expander-title-2' },
+            open: false,
+          },
+          content: 'Second content',
+        },
+      ]),
+    );
+    const button = getByTestId('expander-title-2');
+    expect(button.classList.contains('fi-expander_title--open')).toBe(false);
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(false);
+    //
+    const allOpenButton = getByText('Open all');
+    fireEvent.click(allOpenButton);
+    expect(button.classList.contains('fi-expander_title--open')).toBe(false);
+    expect(
+      button
+        .querySelector('svg')
+        ?.classList.contains('fi-expander_title-icon--open'),
+    ).toBe(false);
+  });
+});
+
+test(
+  'should not have basic accessibility issues',
+  axeTest(
+    TestExpanderGroup([
+      {
+        expanderProps: {
+          title: 'First',
+          titleProps: { 'data-testid': 'expander-title-1' },
+        },
+        content: 'First content',
+      },
+      {
+        expanderProps: {
+          title: 'Second',
+          titleProps: { 'data-testid': 'expander-title-2' },
+        },
+        content: 'Second content',
+      },
+    ]),
+  ),
+);

--- a/src/core/Expander/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup.tsx
@@ -73,7 +73,7 @@ const ExpanderGroupItems = (
   );
 
 const defaultProviderValue: CompExpanderProviderState = {
-  onClick: () => null,
+  onExpanderOpenChange: () => null,
   toggleAllExpanderState: {
     toState: false,
   },
@@ -110,7 +110,7 @@ export class ExpanderGroup extends React.Component<ExpanderGroupProps> {
     },
   };
 
-  handleClick = (index: number = 0) => {
+  handleExpanderOpenChange = (index: number = 0) => {
     this.setState((prevState: ExpanderGroupState) => {
       const { openExpanders: prevOpenExpanders } = prevState;
       const prevExpanderOpen = prevOpenExpanders.includes(index);
@@ -147,7 +147,7 @@ export class ExpanderGroup extends React.Component<ExpanderGroupProps> {
     return (
       <Provider
         value={{
-          onClick: this.handleClick,
+          onExpanderOpenChange: this.handleExpanderOpenChange,
           toggleAllExpanderState,
         }}
       >

--- a/src/core/Expander/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup.tsx
@@ -123,14 +123,14 @@ export class ExpanderGroup extends React.Component<ExpanderGroupProps> {
     });
   };
 
-  isEvenOneExpanderClose = () => {
+  isEveryExpanderOpened = () => {
     return this.props.children.length > this.state.openExpanders.length;
   };
 
   handleAllToggleClick = () => {
     this.setState({
       toggleAllExpanderState: {
-        toState: this.isEvenOneExpanderClose(),
+        toState: this.isEveryExpanderOpened(),
       },
     });
   };

--- a/src/core/Expander/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup.tsx
@@ -123,16 +123,14 @@ export class ExpanderGroup extends React.Component<ExpanderGroupProps> {
     });
   };
 
-  allExpandersOpen = () => {
-    return this.props.children.length > this.state.openExpanders.length;
-  };
-
   handleAllToggleClick = () => {
-    this.setState({
-      toggleAllExpanderState: {
-        toState: this.allExpandersOpen(),
+    this.setState(
+      (prevState: ExpanderGroupState, props: ExpanderGroupProps) => {
+        return {
+          toState: props.children.length > prevState.openExpanders.length,
+        };
       },
-    });
+    );
   };
 
   render() {

--- a/src/core/Expander/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup.tsx
@@ -123,14 +123,14 @@ export class ExpanderGroup extends React.Component<ExpanderGroupProps> {
     });
   };
 
-  isEveryExpanderOpened = () => {
+  allExpandersOpen = () => {
     return this.props.children.length > this.state.openExpanders.length;
   };
 
   handleAllToggleClick = () => {
     this.setState({
       toggleAllExpanderState: {
-        toState: this.isEveryExpanderOpened(),
+        toState: this.allExpandersOpen(),
       },
     });
   };

--- a/src/core/Expander/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup.tsx
@@ -6,13 +6,17 @@ import { TokensProp, InternalTokensProp } from '../theme';
 import {
   ExpanderGroup as CompExpanderGroup,
   ExpanderGroupProps as CompExpanderGroupProps,
+  ExpanderProviderState as CompExpanderProviderState,
+  ExpanderGroupState,
 } from '../../components/Expander/ExpanderGroup';
+import { ExpanderProps as CompExpanderProps } from '../../components/Expander/Expander';
 import { Button, ButtonProps } from '../Button/Button';
 import { baseStyles } from './ExpanderGroup.baseStyles';
 
 const openAllButtonClassName = 'fi-expander-group_all-button';
 
 type ButtonOrText = React.ReactElement<ButtonProps> | string;
+
 interface OpenCloseAll {
   /** 'Open all'-component (Button) */
   OpenAll: ButtonOrText;
@@ -50,25 +54,118 @@ const OpenAllButton = ({
   return children;
 };
 
+const ExpanderGroupItems = (
+  children: Array<React.ReactElement<CompExpanderProps>>,
+) =>
+  React.Children.map(
+    children,
+    (child: React.ReactElement<CompExpanderProps>, index) => {
+      if (React.isValidElement(child)) {
+        const isChildOpen = child.props.open;
+        return React.cloneElement(child, {
+          index,
+          expanderGroup: true,
+          open: isChildOpen,
+        });
+      }
+      return child;
+    },
+  );
+
+const defaultProviderValue: CompExpanderProviderState = {
+  onClick: () => null,
+  toggleAllExpanderState: {
+    toState: false,
+  },
+};
+const { Provider, Consumer: ExpanderGroupConsumer } = React.createContext(
+  defaultProviderValue,
+);
+
+const InitialStateOfExpanders = (
+  children: Array<React.ReactElement<CompExpanderProps>>,
+) => {
+  const openExpanders: number[] = [];
+  React.Children.forEach(children, (child, index) => {
+    if (React.isValidElement(child)) {
+      if (child.props.defaultOpen || child.props.open) {
+        openExpanders.push(index);
+      }
+    }
+  });
+  return openExpanders;
+};
+
 /**
  * <i class="semantics" />
  * Used for grouping expanders
  */
 export class ExpanderGroup extends React.Component<ExpanderGroupProps> {
+  state: ExpanderGroupState = {
+    openExpanders: InitialStateOfExpanders(this.props.children),
+    toggleAllExpanderState: {
+      toState:
+        InitialStateOfExpanders(this.props.children).length ===
+          this.props.children.length && this.props.children.length > 0,
+    },
+  };
+
+  handleClick = (index: number = 0) => {
+    this.setState((prevState: ExpanderGroupState) => {
+      const { openExpanders: prevOpenExpanders } = prevState;
+      const prevExpanderOpen = prevOpenExpanders.includes(index);
+      const openExpanders = prevExpanderOpen
+        ? prevOpenExpanders.filter((value) => value !== index)
+        : Array.from(new Set([...prevOpenExpanders, index]));
+      return {
+        openExpanders,
+      };
+    });
+  };
+
+  isEvenOneExpanderClose = () => {
+    return this.props.children.length > this.state.openExpanders.length;
+  };
+
+  handleAllToggleClick = () => {
+    this.setState({
+      toggleAllExpanderState: {
+        toState: this.isEvenOneExpanderClose(),
+      },
+    });
+  };
+
   render() {
-    const { OpenAll, CloseAll, ...passProps } = withSuomifiDefaultProps(
-      this.props,
-    );
+    const { toggleAllExpanderState } = this.state;
+    const {
+      OpenAll,
+      CloseAll,
+      children,
+      ...passProps
+    } = withSuomifiDefaultProps(this.props);
+
     return (
-      <StyledExpanderGroup
-        {...passProps}
-        OpenAll={
-          <OpenAllButton tokens={passProps.tokens}>{OpenAll}</OpenAllButton>
-        }
-        CloseAll={
-          <OpenAllButton tokens={passProps.tokens}>{CloseAll}</OpenAllButton>
-        }
-      />
+      <Provider
+        value={{
+          onClick: this.handleClick,
+          toggleAllExpanderState,
+        }}
+      >
+        <StyledExpanderGroup
+          {...passProps}
+          OpenAll={
+            <OpenAllButton tokens={passProps.tokens}>{OpenAll}</OpenAllButton>
+          }
+          CloseAll={
+            <OpenAllButton tokens={passProps.tokens}>{CloseAll}</OpenAllButton>
+          }
+          onClickAll={this.handleAllToggleClick}
+        >
+          {ExpanderGroupItems(children)}
+        </StyledExpanderGroup>
+      </Provider>
     );
   }
 }
+
+export { ExpanderGroupConsumer };

--- a/src/core/Expander/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup.tsx
@@ -110,7 +110,7 @@ export class ExpanderGroup extends React.Component<ExpanderGroupProps> {
     },
   };
 
-  handleExpanderOpenChange = (index: number = 0) => {
+  handleExpanderOpenChange = (index: number) => {
     this.setState((prevState: ExpanderGroupState) => {
       const { openExpanders: prevOpenExpanders } = prevState;
       const prevExpanderOpen = prevOpenExpanders.includes(index);

--- a/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`calling render with the same component on the same container does not r
 .c5:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;
@@ -202,6 +203,7 @@ exports[`calling render with the same component on the same container does not r
 .c2 > .fi-expander-group_all-button:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;
@@ -298,6 +300,7 @@ exports[`calling render with the same component on the same container does not r
 .c6 .fi-expander_title:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -278,10 +278,16 @@ exports[`calling render with the same component on the same container does not r
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  line-height: 1;
+  font-size: 14px;
+  line-height: 20px;
   position: relative;
   display: block;
   width: 100%;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  min-height: 60px;
 }
 
 .c6 .fi-expander_title:focus {
@@ -309,18 +315,17 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c6 .fi-expander_title--no-tag {
-  padding-top: 16px;
-  padding-right: 60px;
-  padding-bottom: 16px;
-  padding-left: 16px;
+  padding: 17px 60px 16px 20px;
   color: hsl(212,63%,45%);
 }
 
 .c6 .fi-expander_title-icon {
   position: absolute;
+  height: 20px;
+  width: 20px;
   top: 0;
   right: 0;
-  margin: 16px;
+  margin: 20px;
 }
 
 .c6 .fi-expander_title--open .fi-expander_title-icon,
@@ -335,6 +340,7 @@ exports[`calling render with the same component on the same container does not r
   display: block;
   height: 0;
   overflow: hidden;
+  word-break: break-word;
   -webkit-transform: scaleY(0);
   -ms-transform: scaleY(0);
   transform: scaleY(0);
@@ -359,9 +365,9 @@ exports[`calling render with the same component on the same container does not r
 
 .c6 > .fi-expander_content.fi-expander_content--open:not(.fi-expander_content--no-padding) {
   padding-top: 0;
-  padding-right: 16px;
-  padding-bottom: 16px;
-  padding-left: 16px;
+  padding-right: 20px;
+  padding-bottom: 20px;
+  padding-left: 20px;
 }
 
 <div

--- a/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -1,0 +1,452 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calling render with the same component on the same container does not remount 1`] = `
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+  cursor: pointer;
+}
+
+.c3:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c3::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c3::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c3::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c3::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4.fi-button--disabled {
+  cursor: not-allowed;
+}
+
+.c1 {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+}
+
+.c9 {
+  display: none;
+}
+
+.c7,
+.c7 * {
+  cursor: pointer;
+}
+
+.c7:hover,
+.c7:active,
+.c7:focus,
+.c7:focus-within {
+  cursor: pointer;
+}
+
+.c8 {
+  display: inline-block;
+  vertical-align: baseline;
+}
+
+.c5 {
+  color: hsl(0,0%,16%);
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.c5:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c5:focus:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c5:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c2 {
+  color: hsl(0,0%,16%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 > .fi-expander-group_expanders {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander {
+  margin-top: 0;
+  margin-bottom: 0;
+  -webkit-transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
+  transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:first-of-type) {
+  margin-top: 16px;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:last-of-type) {
+  margin-bottom: 16px;
+}
+
+.c2 > .fi-expander-group_all-button {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  margin-left: auto;
+  margin-bottom: 8px;
+  padding: 4px 0;
+  color: hsl(212,63%,45%);
+  cursor: pointer;
+}
+
+.c2 > .fi-expander-group_all-button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c2 > .fi-expander-group_all-button:focus:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c2 > .fi-expander-group_all-button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c6 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: hsl(0,0%,100%);
+  position: relative;
+  position: relative;
+  padding: 0;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px 0 rgba(41,41,41,0.14),0 1px 5px 0 rgba(41,41,41,0.12);
+}
+
+.c6:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.c6:before {
+  background-color: hsl(212,63%,98%);
+  opacity: 0;
+}
+
+.c6.fi-expander--open:before {
+  opacity: 1;
+  -webkit-transition: opacity 50ms cubic-bezier(0.28,0.84,0.42,1);
+  transition: opacity 50ms cubic-bezier(0.28,0.84,0.42,1);
+}
+
+.c6 .fi-expander_title {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  line-height: 1;
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+.c6 .fi-expander_title:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c6 .fi-expander_title:focus:after {
+  content: '';
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  bottom: -4px;
+  left: -4px;
+  border-radius: 4px;
+  background-color: transparent;
+  border: 1px solid hsl(23,82%,53%);
+  box-sizing: border-box;
+  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  z-index: 9999;
+}
+
+.c6 .fi-expander_title:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c6 .fi-expander_title--no-tag {
+  padding-top: 16px;
+  padding-right: 60px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  color: hsl(212,63%,45%);
+}
+
+.c6 .fi-expander_title-icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 16px;
+}
+
+.c6 .fi-expander_title--open .fi-expander_title-icon,
+.c6 .fi-expander_title-icon--open {
+  -webkit-transform: rotate(-180deg);
+  -ms-transform: rotate(-180deg);
+  transform: rotate(-180deg);
+}
+
+.c6 > .fi-expander_content {
+  position: relative;
+  display: block;
+  height: 0;
+  overflow: hidden;
+  -webkit-transform: scaleY(0);
+  -ms-transform: scaleY(0);
+  transform: scaleY(0);
+  -webkit-transform-origin: top;
+  -ms-transform-origin: top;
+  transform-origin: top;
+  -webkit-transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
+  transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
+  will-change: transition,height;
+}
+
+.c6 > .fi-expander_content:not(.fi-expander_content--no-padding) {
+  padding: 0 16px;
+}
+
+.c6 > .fi-expander_content.fi-expander_content--open {
+  height: 10%;
+  overflow: visible;
+  -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
+  animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
+}
+
+.c6 > .fi-expander_content.fi-expander_content--open:not(.fi-expander_content--no-padding) {
+  padding-top: 0;
+  padding-right: 16px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+}
+
+<div
+  class="c0 c1 c2 fi-expander-group"
+>
+  <button
+    aria-disabled="false"
+    class="c3 c4 fi-button c5 fi-expander-group_all-button fi-button"
+    tabindex="0"
+    tokens="[object Object]"
+    type="button"
+  >
+    Open all
+  </button>
+  <div
+    class="c0 fi-expander-group_expanders"
+  >
+    <div
+      class="c0 c1 c6 fi-expander"
+    >
+      <button
+        aria-disabled="false"
+        aria-expanded="false"
+        class="c3 c4 fi-button c7 fi-expander_title fi-expander_title--no-tag"
+        data-testid="expander-title-1"
+        tabindex="0"
+        type="button"
+      >
+        First
+        <svg
+          aria-hidden="true"
+          class="c8 fi-expander_title-icon"
+          fill="hsl(212, 63%, 45%)"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-hidden="true"
+        class="c0 c1 c9 fi-expander_content fi-expander"
+        hidden=""
+      >
+        First content
+      </div>
+    </div>
+    <div
+      class="c0 c1 c6 fi-expander"
+    >
+      <button
+        aria-disabled="false"
+        aria-expanded="false"
+        class="c3 c4 fi-button c7 fi-expander_title fi-expander_title--no-tag"
+        data-testid="expander-title-2"
+        tabindex="0"
+        type="button"
+      >
+        Second
+        <svg
+          aria-hidden="true"
+          class="c8 fi-expander_title-icon"
+          fill="hsl(212, 63%, 45%)"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-hidden="true"
+        class="c0 c1 c9 fi-expander_content fi-expander"
+        hidden=""
+      >
+        Second content
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -118,15 +118,15 @@ exports[`calling render with the same component on the same container does not r
 .c5:focus:after {
   content: '';
   position: absolute;
-  top: -4px;
-  right: -4px;
-  bottom: -4px;
-  left: -4px;
-  border-radius: 4px;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
   background-color: transparent;
-  border: 1px solid hsl(23,82%,53%);
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
-  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;
 }
 
@@ -202,15 +202,15 @@ exports[`calling render with the same component on the same container does not r
 .c2 > .fi-expander-group_all-button:focus:after {
   content: '';
   position: absolute;
-  top: -4px;
-  right: -4px;
-  bottom: -4px;
-  left: -4px;
-  border-radius: 4px;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
   background-color: transparent;
-  border: 1px solid hsl(23,82%,53%);
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
-  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;
 }
 
@@ -292,15 +292,15 @@ exports[`calling render with the same component on the same container does not r
 .c6 .fi-expander_title:focus:after {
   content: '';
   position: absolute;
-  top: -4px;
-  right: -4px;
-  bottom: -4px;
-  left: -4px;
-  border-radius: 4px;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
   background-color: transparent;
-  border: 1px solid hsl(23,82%,53%);
+  border: 0px solid hsl(0,0%,100%);
   box-sizing: border-box;
-  box-shadow: 0 0 10px 0 hsl(23,82%,53%);
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
   z-index: 9999;
 }
 


### PR DESCRIPTION


## Description

Expander components props `open`, `defaultOpen` and `onClick` was not working when Expander was inside ExpanderGroup.

When talking about **controlled** state it means that the Expander is given a `open` prop. User is then required to handle the open state of the Expander self.

- `open`, `defaultOpen` and `onClick` should now work as intended and documented.
- Added an example of the controlled state for the Expander. It can be seen on the Expander's styleguidist page.
- Opening state of the individual Expander is stored inside itself, not by parent.
  - Parent will keep own state to handle logic to show icon (*caret*) and text (*Open/Close all*)
- Added tests to verify the use of `open`, `defaultOpen` and `onClick`props when inside ExpanderGroup and when being just standalone Expander.

## Details

Some details about the props and what are they used for.

### open

`open` prop will tell that the component is in controlled state.

### defaultOpen

`defaultOpen` prop does not effect when in controlled state; user can change the state with the `open` prop if needed. Look the controlled example from the styleguidist.

### onClick

When in controlled state,  you can e.g use the Expander's `onClick` property to update the state of individual state of the Expander. Look the controlled example from the styleguidist.

## Motivation and Context

Will help to use the Expander and ExpanderGroup components as the props works as documented.

## How Has This Been Tested?

- Locally on the browser running the styleguidist
- Running tests and validation: `yarn validate`
