### PR TITLE
[Feature] Align dropdown styles with style guide

### DIFF
--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -55,6 +55,8 @@ export const menuPopoverStyles = withSuomifiTheme(
     border: 0;
     padding: 0;
     white-space: normal;
+    word-break: break-word;
+    overflow-wrap: break-word;
   }
 
   & [data-reach-menu-item].fi-dropdown_item {

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -54,6 +54,7 @@ export const menuPopoverStyles = withSuomifiTheme(
   & [data-reach-menu-items] {
     border: 0;
     padding: 0;
+    white-space: normal;
   }
 
   & [data-reach-menu-item].fi-dropdown_item {

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -7,15 +7,17 @@ export const baseStyles = withSuomifiTheme(
     & > [data-reach-menu-button].fi-dropdown_button {
       ${inputButton({ theme })}
       position: relative;
-      padding-right: 30px;
+      padding: 7px 38px 7px 7px;
       text-align: left;
+      line-height: 1.5;
       background-color: ${theme.colors.whiteBase};
+      box-shadow: ${theme.shadows.dropdownShadow};
       cursor: pointer;
       &:before {
         content: '';
         position: absolute;
         top: 50%;
-        right: 10px;
+        right: 16px;
         margin-top: -3px;
         border-style: solid;
         border-color: ${theme.colors.depthDark1} transparent transparent
@@ -42,7 +44,7 @@ export const menuPopoverStyles = withSuomifiTheme(
     font-size: 100%;
     border: 0;
     background-color: ${theme.colors.whiteBase};
-    border-color: ${theme.colors.depthBase};
+    border-color: ${theme.colors.depthLight1};
     border-style: solid;
     border-width: 0 1px 1px 1px;
     border-radius: 0px 0px ${theme.radius.basic} ${theme.radius.basic};
@@ -57,7 +59,8 @@ export const menuPopoverStyles = withSuomifiTheme(
   & [data-reach-menu-item].fi-dropdown_item {
     ${element({ theme })}
     ${theme.typography.actionElementInnerText}
-    padding: ${theme.spacing.insetM} ${theme.spacing.insetXl};
+    line-height: 1.5;
+    padding: ${theme.spacing.insetM};
     border: 0;
     &[data-selected] {
       ${theme.typography.actionElementInnerText}

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -43,13 +43,15 @@ exports[`calling render with the same component on the same container does not r
   min-width: 245px;
   max-width: 100%;
   padding: 8px 16px;
-  border: 1px solid hsl(202,7%,67%);
+  border: 1px solid hsl(202,7%,80%);
   border-radius: 2px;
   line-height: 1;
   position: relative;
-  padding-right: 30px;
+  padding: 7px 38px 7px 7px;
   text-align: left;
+  line-height: 1.5;
   background-color: hsl(0,0%,100%);
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
   cursor: pointer;
 }
 
@@ -81,7 +83,7 @@ exports[`calling render with the same component on the same container does not r
   content: '';
   position: absolute;
   top: 50%;
-  right: 10px;
+  right: 16px;
   margin-top: -3px;
   border-style: solid;
   border-color: hsl(202,7%,40%) transparent transparent transparent;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -203,7 +203,7 @@ exports[`calling render with the same component on the same container does not r
   min-width: 245px;
   max-width: 100%;
   padding: 8px 16px;
-  border: 1px solid hsl(202,7%,67%);
+  border: 1px solid hsl(202,7%,80%);
   border-radius: 2px;
   line-height: 1;
   background-color: hsl(0,0%,100%);

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`calling render with the same component on the same container does not r
   min-width: 245px;
   max-width: 100%;
   padding: 8px 16px;
-  border: 1px solid hsl(202,7%,67%);
+  border: 1px solid hsl(202,7%,80%);
   border-radius: 2px;
   line-height: 1;
   background-color: hsl(0,0%,100%);

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -88,6 +88,7 @@ export const shadows = {
   panelShadow: `0 1px 2px 0 ${alphaHex(0.14)(
     colors.blackBase,
   )}, 0 1px 5px 0 ${alphaHex(0.12)(colors.blackBase)}`,
+  dropdownShadow: `0 1px 2px 0 ${alphaHex(0.1)(colors.brandBase)} inset`,
 };
 
 export type IGradients = typeof gradients;

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -34,7 +34,7 @@ export const input = (props: SuomifiThemeProp) => {
     min-width: 245px;
     max-width: 100%;
     padding: ${props.theme.spacing.insetM} ${props.theme.spacing.insetXl};
-    border: 1px solid ${props.theme.colors.depthBase};
+    border: 1px solid ${props.theme.colors.depthLight1};
     border-radius: ${props.theme.radius.basic};
     line-height: 1;
   `;


### PR DESCRIPTION
## Description

Align dropdown component colors and spacing with style guide. Add missing shadow.

## Motivation and Context

Style guide has been updated without updating the ui-components implementation. Projects mostly follow the style guide, which prevents taking the library in use in the projects. This needs to be addressed by aligning the ui-components styles with the style guide.

## How Has This Been Tested?

Tested with styleguidist and create react app project using long texts for contents.
