### PR TITLE
[Bugfix] Align textinput and searchinput styles with design

### DIFF
--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -104,9 +104,11 @@ class BaseTextInput extends Component<TextInputProps> {
             />
             {children}
           </HtmlDiv>
-          <HtmlSpan className={statusTextSpanClassName} id={generatedId}>
-            {statusText}
-          </HtmlSpan>
+          {statusText && (
+            <HtmlSpan className={statusTextSpanClassName} id={generatedId}>
+              {statusText}
+            </HtmlSpan>
+          )}
         </HtmlDiv>
       </HtmlLabel>
     );

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -9,14 +9,17 @@ export const baseStyles = withSuomifiTheme(
         position: relative;
       }
       &_input {
+        min-height: 40px;
         padding-right: ${math(
           `${theme.spacing.insetXl} * 2 + ${theme.spacing.insetM}`,
         )};
       }
       &_icon {
         position: absolute;
+        width: 18px;
+        height: 18px;
         top: 50%;
-        right: ${theme.spacing.insetXl};
+        right: ${theme.spacing.insetL};
         margin-top: -0.5em;
       }
     }

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -169,8 +169,11 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
-  font-size: 14px;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
   font-weight: 600;
+  font-size: 14px;
   line-height: 20px;
 }
 

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -73,30 +73,6 @@ exports[`calling render with the same component on the same container does not r
   max-width: 100%;
 }
 
-.c7 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -131,7 +107,21 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 .fi-text-input_label-p {
-  margin-bottom: 16px;
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
 }
 
 .c2 .fi-text-input_container > input:focus {
@@ -179,9 +169,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
+  font-size: 14px;
   font-weight: 600;
 }
 
@@ -208,6 +196,24 @@ exports[`calling render with the same component on the same container does not r
   line-height: 1;
   background-color: hsl(0,0%,100%);
   width: 100%;
+  min-height: 40px;
+  padding-left: 10px;
+}
+
+.c2 .fi-text-input_input::-webkit-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::-moz-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:-ms-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::placeholder {
+  font-style: italic;
 }
 
 .c2.fi-text-input--error .fi-text-input_input {
@@ -215,6 +221,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2.fi-text-input--error .fi-text-input_statusText_span {
+  margin-top: 5px;
   color: hsl(3,59%,48%);
 }
 
@@ -232,13 +239,16 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 .fi-search-input_input {
+  min-height: 40px;
   padding-right: 40px;
 }
 
 .c2 .fi-search-input_icon {
   position: absolute;
+  width: 18px;
+  height: 18px;
   top: 50%;
-  right: 16px;
+  right: 10px;
   margin-top: -0.5em;
 }
 
@@ -277,10 +287,6 @@ exports[`calling render with the same component on the same container does not r
         />
       </svg>
     </div>
-    <span
-      class="c7 fi-text-input_statusText_span"
-      id="test-id-statusText"
-    />
   </div>
 </label>
 `;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -171,6 +171,7 @@ exports[`calling render with the same component on the same container does not r
 .c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
   font-size: 14px;
   font-weight: 600;
+  line-height: 20px;
 }
 
 .c2 .fi-text-input_input {

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -19,8 +19,8 @@ export const baseStyles = withSuomifiTheme(
     flex-direction: column;
 
     & .fi-text-input_statusText_span {
+      ${theme.typography.bodySemiBoldSmall}
       font-size: 14px;
-      font-weight: 600;
       line-height: 20px;
     }
   }

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -21,6 +21,7 @@ export const baseStyles = withSuomifiTheme(
     & .fi-text-input_statusText_span {
       font-size: 14px;
       font-weight: 600;
+      line-height: 20px;
     }
   }
 

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -1,11 +1,13 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../../theme';
-import { input, inputContainer } from '../../theme/reset';
+import { input, inputContainer, font } from '../../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
   & .fi-text-input_label-p {
-    margin-bottom: ${theme.spacing.insetXl};
+    margin-bottom: ${theme.spacing.insetL};
+    ${font({ theme })('actionElementInnerTextBold')};
+    color: ${theme.colors.blackBase};
   }
 
   & .fi-text-input_container {
@@ -17,7 +19,8 @@ export const baseStyles = withSuomifiTheme(
     flex-direction: column;
 
     & .fi-text-input_statusText_span {
-      ${theme.typography.bodySemiBoldSmall}
+      font-size: 14px;
+      font-weight: 600;
     }
   }
 
@@ -25,13 +28,19 @@ export const baseStyles = withSuomifiTheme(
     ${input({ theme })}
     background-color: ${theme.colors.whiteBase};
     width: 100%;
-  }
+    min-height:40px;
+    padding-left: ${theme.spacing.insetL};
+    ::placeholder{
+      font-style: italic;
+    }
+    }
 
   &.fi-text-input--error {
     & .fi-text-input_input {
       border-color: ${theme.colors.alertBase};
     }
     & .fi-text-input_statusText_span {
+      margin-top: ${theme.spacing.xxs};
       color: ${theme.colors.alertBase};
     }
   }

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -33,7 +33,7 @@ import { TextInput } from 'suomifi-ui-components';
 ```
 
 ```js
-import { TextInput } from 'suomifi-ui-components';
+import { TextInput, Button } from 'suomifi-ui-components';
 
 const [errorState, setErrorState] = React.useState(false);
 const statusText = errorState
@@ -48,8 +48,8 @@ const status = errorState ? 'error' : 'default';
     status={status}
   />
 
-  <button onClick={() => setErrorState(!errorState)}>
+  <Button onClick={() => setErrorState(!errorState)}>
     Toggle error state
-  </button>
+  </Button>
 </>;
 ```

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -164,8 +164,11 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
-  font-size: 14px;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
   font-weight: 600;
+  font-size: 14px;
   line-height: 20px;
 }
 

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -166,6 +166,7 @@ exports[`calling render with the same component on the same container does not r
 .c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
   font-size: 14px;
   font-weight: 600;
+  line-height: 20px;
 }
 
 .c2 .fi-text-input_input {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -73,30 +73,6 @@ exports[`calling render with the same component on the same container does not r
   max-width: 100%;
 }
 
-.c6 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -126,7 +102,21 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 .fi-text-input_label-p {
-  margin-bottom: 16px;
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
 }
 
 .c2 .fi-text-input_container > input:focus {
@@ -174,9 +164,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
+  font-size: 14px;
   font-weight: 600;
 }
 
@@ -203,6 +191,24 @@ exports[`calling render with the same component on the same container does not r
   line-height: 1;
   background-color: hsl(0,0%,100%);
   width: 100%;
+  min-height: 40px;
+  padding-left: 10px;
+}
+
+.c2 .fi-text-input_input::-webkit-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::-moz-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:-ms-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::placeholder {
+  font-style: italic;
 }
 
 .c2.fi-text-input--error .fi-text-input_input {
@@ -210,6 +216,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2.fi-text-input--error .fi-text-input_statusText_span {
+  margin-top: 5px;
   color: hsl(3,59%,48%);
 }
 
@@ -244,10 +251,6 @@ exports[`calling render with the same component on the same container does not r
         type="text"
       />
     </div>
-    <span
-      class="c6 fi-text-input_statusText_span"
-      id="test-id-statusText"
-    />
   </div>
 </label>
 `;


### PR DESCRIPTION
## Description
This PR aligns the TextInput and SearchInput styles to the design. Some larger rebuilding still remains in the searchinput, but that's outside of the scope of this PR.

While adjusting styles, a couple of related matters got sorted. The statustext element is now conditionally rendered depending on if it has content or not. Also, the button in the styleguidist example was changed to suomifi button.

## Motivation and Context
Textinput and searchinput had styles that differed from the latest designs. 

## How Has This Been Tested?
Running locally and manually testing.
