### PR TITLE
[Feature] Update textinput styles to include inner shadow

### DIFF
--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -11,7 +11,7 @@ export const baseStyles = withSuomifiTheme(
       text-align: left;
       line-height: 1.5;
       background-color: ${theme.colors.whiteBase};
-      box-shadow: ${theme.shadows.dropdownShadow};
+      box-shadow: ${theme.shadows.inputBoxShadow};
       cursor: pointer;
       &:before {
         content: '';

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -11,7 +11,7 @@ export const baseStyles = withSuomifiTheme(
       text-align: left;
       line-height: 1.5;
       background-color: ${theme.colors.whiteBase};
-      box-shadow: ${theme.shadows.inputBoxShadow};
+      box-shadow: ${theme.shadows.actionElementBoxShadow};
       cursor: pointer;
       &:before {
         content: '';

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -18,9 +18,8 @@ export const baseStyles = withSuomifiTheme(
         position: absolute;
         width: 18px;
         height: 18px;
-        top: 50%;
+        top: ${theme.spacing.insetL};
         right: ${theme.spacing.insetL};
-        margin-top: -0.5em;
       }
     }
   `,

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -220,6 +220,10 @@ exports[`calling render with the same component on the same container does not r
   font-style: italic;
 }
 
+.c2 .fi-text-input_input:focus {
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+}
+
 .c2.fi-text-input--error .fi-text-input_input {
   border-color: hsl(3,59%,48%);
 }
@@ -251,9 +255,8 @@ exports[`calling render with the same component on the same container does not r
   position: absolute;
   width: 18px;
   height: 18px;
-  top: 50%;
+  top: 10px;
   right: 10px;
-  margin-top: -0.5em;
 }
 
 <label

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -35,7 +35,7 @@ export const baseStyles = withSuomifiTheme(
       font-style: italic;
     }
     :focus {
-      box-shadow: ${theme.shadows.inputBoxShadow};
+      box-shadow: ${theme.shadows.actionElementBoxShadow};
     }
     }
 

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -34,6 +34,9 @@ export const baseStyles = withSuomifiTheme(
     ::placeholder{
       font-style: italic;
     }
+    :focus {
+      box-shadow: ${theme.shadows.inputBoxShadow};
+    }
     }
 
   &.fi-text-input--error {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -215,6 +215,10 @@ exports[`calling render with the same component on the same container does not r
   font-style: italic;
 }
 
+.c2 .fi-text-input_input:focus {
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+}
+
 .c2.fi-text-input--error .fi-text-input_input {
   border-color: hsl(3,59%,48%);
 }

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -88,7 +88,9 @@ export const shadows = {
   panelShadow: `0 1px 2px 0 ${alphaHex(0.14)(
     colors.blackBase,
   )}, 0 1px 5px 0 ${alphaHex(0.12)(colors.blackBase)}`,
-  inputBoxShadow: `0 1px 2px 0 ${alphaHex(0.1)(colors.brandBase)} inset`,
+  actionElementBoxShadow: `0 1px 2px 0 ${alphaHex(0.1)(
+    colors.brandBase,
+  )} inset`,
 };
 
 export type IGradients = typeof gradients;

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -88,7 +88,7 @@ export const shadows = {
   panelShadow: `0 1px 2px 0 ${alphaHex(0.14)(
     colors.blackBase,
   )}, 0 1px 5px 0 ${alphaHex(0.12)(colors.blackBase)}`,
-  dropdownShadow: `0 1px 2px 0 ${alphaHex(0.1)(colors.brandBase)} inset`,
+  inputBoxShadow: `0 1px 2px 0 ${alphaHex(0.1)(colors.brandBase)} inset`,
 };
 
 export type IGradients = typeof gradients;


### PR DESCRIPTION
## Description
This PR adds inset box shadows to textinput and searchinput as well as fixes an issue with the placement of the searchinput icon.

Since the shadow being used in dropdown is exactly the same, it was renamed to inputBoxShadow and implemented in the textinput and searchinput as well as in dropdown.

## Motivation and Context
Implementations need to match styleguide in order to be usable in projects.

## How Has This Been Tested?
Manual testing plus automated tests.
