### PR TITLE
[Feature] Align toggle styles with style guide

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "polished": "3.5.1",
     "react-svg": "11.0.16",
     "suomifi-design-tokens": "0.8.0",
-    "suomifi-icons": "0.1.1",
+    "suomifi-icons": "0.1.2",
     "uuid": "7.0.3"
   },
   "peerDependencies": {

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -50,7 +50,7 @@ export const baseStyles = withSuomifiTheme(
   & .fi-toggle_icon {
     width: ${iconWidth};
     height: ${iconHeight};
-    margin-right: ${theme.spacing.insetM};
+    margin-right: ${theme.spacing.insetL};
     vertical-align: bottom;
     overflow: visible;
     transform: translateY(-0.1em);

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -8,6 +8,15 @@ const svgPrefix = 'icon-toggle_svg__';
 const iconWidth = '40px';
 const iconHeight = '24px';
 
+const focusOverrides = css`
+  position: absolute;
+  &:after {
+    border-radius: 14px;
+    right: -4px;
+    left: -4px;
+  }
+`;
+
 /* stylelint-disable no-descending-specificity */
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
@@ -30,12 +39,7 @@ export const baseStyles = withSuomifiTheme(
         outline: 0;
         & .fi-toggle_icon-container {
           ${focus({ theme, noPseudo: true })}
-          position: absolute;
-          &:after {
-            border-radius: 14px;
-            right: -4px;
-            left: -4px;
-          }
+          ${focusOverrides}
         }
       }
       &:focus:not(:focus-visible) {
@@ -53,12 +57,7 @@ export const baseStyles = withSuomifiTheme(
         outline: 0;
         & .fi-toggle_icon-container {
           ${focus({ theme, noPseudo: true })}
-          position: absolute;
-          &:after {
-            border-radius: 14px;
-            right: -4px;
-            left: -4px;
-          }
+          ${focusOverrides}
         }
       }
       &:focus-within:not(:focus-visible) {
@@ -87,10 +86,12 @@ export const baseStyles = withSuomifiTheme(
       height: ${iconHeight};
       vertical-align: bottom;
       overflow: visible;
-    
       .${svgPrefix}fi-toggle-icon-circle {
-          fill: ${theme.colors.whiteBase};
-        }
+        fill: ${theme.colors.whiteBase};
+      }
+      .${svgPrefix}fi-toggle-icon-knob {
+        transform: translateX(0%);
+      }
       &.fi-toggle_icon--disabled {
         .${svgPrefix}fi-toggle-icon-circle {
           fill: ${theme.colors.depthLight3};

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -8,86 +8,118 @@ const svgPrefix = 'icon-toggle_svg__';
 const iconWidth = '40px';
 const iconHeight = '24px';
 
+/* stylelint-disable no-descending-specificity */
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
-  ${element({ theme })}
-  ${font({ theme })('bodyText')}
-  background-color: ${theme.colors.whiteBase};
+    ${element({ theme })}
+    ${font({ theme })('bodyText')}
+    background-color: ${theme.colors.whiteBase};
+    padding-left: 50px;
+    position: relative;
+    display: inline-block;
+
+    & .fi-toggle_icon-container {
+      position: absolute;
+      margin-right: ${theme.spacing.insetL};
+      left: 0;
+      top: 2px;
+      padding-right: 2px;
+      padding-left: 2px;
+    }
+
     & + .fi-toggle--with-button {
       &:focus {
         outline: 0;
-        ${focus({ theme, noPseudo: true })}
+        & .fi-toggle_icon-container {
+          ${focus({ theme, noPseudo: true })}
+          position: absolute;
+          &:after {
+            border-radius: 14px;
+          }
+        }
       }
       &:focus:not(:focus-visible) {
         outline: 0;
-        &:after {
-          content: none;
+        & .fi-toggle_icon-container {
+          &:after {
+            content: none;
+          }
         }
       }
     }
+
     & + .fi-toggle--with-input {
       &:focus-within {
         outline: 0;
-        ${focus({ theme, noPseudo: true })}
+        & .fi-toggle_icon-container {
+          ${focus({ theme, noPseudo: true })}
+          position: absolute;
+          &:after {
+            border-radius: 14px;
+          }
+        }
       }
       &:focus-within:not(:focus-visible) {
         outline: 0;
-        &:after {
-          content: none;
+        & .fi-toggle_icon-container {
+          &:after {
+            content: none;
+          }
         }
       }
     }
-  & > .fi-toggle_input {
-    ${element({ theme })}
-    ${font({ theme })('bodyText')}
-    position: absolute;
-    width: ${iconWidth};
-    height: ${iconHeight};
-    opacity: 0;
-    z-index: -9999;
-    background-color: ${theme.colors.whiteBase};
-  }
-  & .fi-toggle_icon {
-    width: ${iconWidth};
-    height: ${iconHeight};
-    margin-right: ${theme.spacing.insetL};
-    vertical-align: bottom;
-    overflow: visible;
-    transform: translateY(-0.1em);
-  
-    & .${svgPrefix}fi-toggle-icon-knob {
-      transform: translateX(0%);
+
+    & > .fi-toggle_input {
+      ${element({ theme })}
+      ${font({ theme })('bodyText')}
+      position: absolute;
+      width: ${iconWidth};
+      height: ${iconHeight};
+      opacity: 0;
+      z-index: -9999;
+      background-color: ${theme.colors.whiteBase};
     }
-    .${svgPrefix}fi-toggle-icon-circle {
-        fill: ${theme.colors.whiteBase};
+
+    & .fi-toggle_icon {
+      width: ${iconWidth};
+      height: ${iconHeight};
+      vertical-align: bottom;
+      overflow: visible;
+      transform: translateY(-0.05em);
+    
+      & .${svgPrefix}fi-toggle-icon-knob {
+        transform: translateX(0%);
       }
-    & .${svgPrefix}fi-toggle-icon-slide {
-      transform: translateY(1px);
-    }
-    &.fi-toggle_icon--disabled {
       .${svgPrefix}fi-toggle-icon-circle {
-        fill: ${theme.colors.depthLight3};
-      }
+          fill: ${theme.colors.whiteBase};
+        }
       & .${svgPrefix}fi-toggle-icon-slide {
-        fill: ${theme.colors.depthLight2};
-    }
-    }
-    &.fi-toggle_icon--checked {
-      .${svgPrefix}fi-toggle-icon-knob {
-        transform: translateX(50%);
-      }
-      .${svgPrefix}fi-toggle-icon-slide {
-        fill: ${theme.colors.successSecondary};
-      }
-      .${svgPrefix}fi-toggle-icon-circle {
-        fill: ${theme.colors.successBase};
+        transform: translateY(1px);
       }
       &.fi-toggle_icon--disabled {
-      .${svgPrefix}fi-toggle-icon-circle {
-        fill: ${theme.colors.successSecondary};
+        .${svgPrefix}fi-toggle-icon-circle {
+          fill: ${theme.colors.depthLight3};
+        }
+        & .${svgPrefix}fi-toggle-icon-slide {
+          fill: ${theme.colors.depthLight2};
+        }
+      }
+      &.fi-toggle_icon--checked {
+        .${svgPrefix}fi-toggle-icon-knob {
+          transform: translateX(55%);
+        }
+        .${svgPrefix}fi-toggle-icon-slide {
+          fill: ${theme.colors.successSecondary};
+        }
+        .${svgPrefix}fi-toggle-icon-circle {
+          fill: ${theme.colors.successBase};
+        }
+        &.fi-toggle_icon--disabled {
+        .${svgPrefix}fi-toggle-icon-circle {
+          fill: ${theme.colors.successSecondary};
+          }
+        }
       }
     }
-  }
-  }
 `,
 );

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -106,7 +106,7 @@ export const baseStyles = withSuomifiTheme(
       }
       &.fi-toggle_icon--checked {
         .${svgPrefix}fi-toggle-icon-knob {
-          transform: translateX(55%);
+          transform: translateX(50%);
         }
         .${svgPrefix}fi-toggle-icon-slide {
           fill: ${theme.colors.successSecondary};

--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -22,9 +22,7 @@ export const baseStyles = withSuomifiTheme(
       position: absolute;
       margin-right: ${theme.spacing.insetL};
       left: 0;
-      top: 2px;
-      padding-right: 2px;
-      padding-left: 2px;
+      top: 0.1em;
     }
 
     & + .fi-toggle--with-button {
@@ -35,6 +33,8 @@ export const baseStyles = withSuomifiTheme(
           position: absolute;
           &:after {
             border-radius: 14px;
+            right: -4px;
+            left: -4px;
           }
         }
       }
@@ -56,6 +56,8 @@ export const baseStyles = withSuomifiTheme(
           position: absolute;
           &:after {
             border-radius: 14px;
+            right: -4px;
+            left: -4px;
           }
         }
       }
@@ -85,17 +87,10 @@ export const baseStyles = withSuomifiTheme(
       height: ${iconHeight};
       vertical-align: bottom;
       overflow: visible;
-      transform: translateY(-0.05em);
     
-      & .${svgPrefix}fi-toggle-icon-knob {
-        transform: translateX(0%);
-      }
       .${svgPrefix}fi-toggle-icon-circle {
           fill: ${theme.colors.whiteBase};
         }
-      & .${svgPrefix}fi-toggle-icon-slide {
-        transform: translateY(1px);
-      }
       &.fi-toggle_icon--disabled {
         .${svgPrefix}fi-toggle-icon-circle {
           fill: ${theme.colors.depthLight3};
@@ -106,7 +101,7 @@ export const baseStyles = withSuomifiTheme(
       }
       &.fi-toggle_icon--checked {
         .${svgPrefix}fi-toggle-icon-knob {
-          transform: translateX(50%);
+          transform: translateX(47%);
         }
         .${svgPrefix}fi-toggle-icon-slide {
           fill: ${theme.colors.successSecondary};

--- a/src/core/Form/Toggle/Toggle.md
+++ b/src/core/Form/Toggle/Toggle.md
@@ -40,7 +40,7 @@ const [checked, setChecked] = useState(false);
       }
     }}
   >
-    Controlled checked state.
+    Controlled checked state
   </Toggle>
 </>;
 ```

--- a/src/core/Form/Toggle/Toggle.tsx
+++ b/src/core/Form/Toggle/Toggle.tsx
@@ -12,11 +12,13 @@ import {
 } from '../../../components/Form/Toggle';
 import { ComponentIcon } from '../../StaticIcon/StaticIcon';
 import { Text } from '../../Text/Text';
+import { HtmlSpan } from '../../../reset';
 
 export interface ToggleProps extends CompToggleProps, TokensProp {}
 export interface ToggleInputProps extends CompToggleInputProps, TokensProp {}
 
 const iconBaseClassName = 'fi-toggle_icon';
+const iconContainerClassName = 'fi-toggle_icon-container';
 const iconDisabledClassName = `${iconBaseClassName}--disabled`;
 const iconCheckedClassName = `${iconBaseClassName}--checked`;
 
@@ -72,13 +74,15 @@ class ToggleWithIcon extends Component<ToggleProps> {
         {...passProps}
         onClick={this.handleToggle}
       >
-        <ComponentIcon
-          icon="toggle"
-          className={classnames(iconBaseClassName, {
-            [iconDisabledClassName]: !!disabled,
-            [iconCheckedClassName]: !!toggleStatus,
-          })}
-        />
+        <HtmlSpan className={iconContainerClassName}>
+          <ComponentIcon
+            icon="toggle"
+            className={classnames(iconBaseClassName, {
+              [iconDisabledClassName]: !!disabled,
+              [iconCheckedClassName]: !!toggleStatus,
+            })}
+          />
+        </HtmlSpan>
         <Text color={!!disabled ? 'depthBase' : 'blackBase'}>{children}</Text>
       </StyledToggle>
     );

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -328,6 +328,12 @@ exports[`Toggle variant default:  calling render with the same component on the 
   fill: hsl(0,0%,100%);
 }
 
+.c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-knob {
+  -webkit-transform: translateX(0%);
+  -ms-transform: translateX(0%);
+  transform: translateX(0%);
+}
+
 .c1 .fi-toggle_icon.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-circle {
   fill: hsl(202,7%,97%);
 }
@@ -860,6 +866,12 @@ exports[`Toggle variant withInput:  calling render with the same component on th
 
 .c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-circle {
   fill: hsl(0,0%,100%);
+}
+
+.c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-knob {
+  -webkit-transform: translateX(0%);
+  -ms-transform: translateX(0%);
+  transform: translateX(0%);
 }
 
 .c1 .fi-toggle_icon.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-circle {

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -205,9 +205,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
   position: absolute;
   margin-right: 10px;
   left: 0;
-  top: 2px;
-  padding-right: 2px;
-  padding-left: 2px;
+  top: 0.1em;
 }
 
 .c1 + .fi-toggle--with-button:focus {
@@ -241,6 +239,8 @@ exports[`Toggle variant default:  calling render with the same component on the 
 
 .c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   border-radius: 14px;
+  right: -4px;
+  left: -4px;
 }
 
 .c1 + .fi-toggle--with-button:focus:not(:focus-visible) {
@@ -282,6 +282,8 @@ exports[`Toggle variant default:  calling render with the same component on the 
 
 .c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   border-radius: 14px;
+  right: -4px;
+  left: -4px;
 }
 
 .c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) {
@@ -320,25 +322,10 @@ exports[`Toggle variant default:  calling render with the same component on the 
   height: 24px;
   vertical-align: bottom;
   overflow: visible;
-  -webkit-transform: translateY(-0.05em);
-  -ms-transform: translateY(-0.05em);
-  transform: translateY(-0.05em);
-}
-
-.c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-knob {
-  -webkit-transform: translateX(0%);
-  -ms-transform: translateX(0%);
-  transform: translateX(0%);
 }
 
 .c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-circle {
   fill: hsl(0,0%,100%);
-}
-
-.c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-slide {
-  -webkit-transform: translateY(1px);
-  -ms-transform: translateY(1px);
-  transform: translateY(1px);
 }
 
 .c1 .fi-toggle_icon.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-circle {
@@ -350,9 +337,9 @@ exports[`Toggle variant default:  calling render with the same component on the 
 }
 
 .c1 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-knob {
-  -webkit-transform: translateX(50%);
-  -ms-transform: translateX(50%);
-  transform: translateX(50%);
+  -webkit-transform: translateX(47%);
+  -ms-transform: translateX(47%);
+  transform: translateX(47%);
 }
 
 .c1 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-slide {
@@ -384,7 +371,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
       class="c3 fi-toggle_icon"
       focusable="false"
       height="1em"
-      viewBox="0 0 38 23"
+      viewBox="0 0 37 20"
       width="1em"
     >
       <defs>
@@ -397,14 +384,17 @@ exports[`Toggle variant default:  calling render with the same component on the 
         >
           <stop
             offset="0%"
+            stop-color="#292929"
             stop-opacity="0"
           />
           <stop
             offset="80%"
+            stop-color="#292929"
             stop-opacity="0.02"
           />
           <stop
             offset="100%"
+            stop-color="#292929"
             stop-opacity="0.04"
           />
         </lineargradient>
@@ -458,7 +448,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
           <fecolormatrix
             in="shadowBlurOuter1"
             result="shadowMatrixOuter1"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"
+            values="0 0 0 0 0.160784314 0 0 0 0 0.160784314 0 0 0 0 0.160784314 0 0 0 0.2 0"
           />
           <feoffset
             in="SourceAlpha"
@@ -478,7 +468,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
           <fecolormatrix
             in="shadowBlurOuter2"
             result="shadowMatrixOuter2"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+            values="0 0 0 0 0.160784314 0 0 0 0 0.160784314 0 0 0 0 0.160784314 0 0 0 0.2 0"
           />
           <femerge>
             <femergenode
@@ -491,7 +481,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
         </filter>
         <circle
           cx="10"
-          cy="12"
+          cy="10"
           id="icon-toggle_svg__b"
           r="10"
         />
@@ -502,12 +492,11 @@ exports[`Toggle variant default:  calling render with the same component on the 
       >
         <path
           class="icon-toggle_svg__fi-toggle-icon-slide"
-          d="M38 11c0 3.9-3.1 7-7 7H11c-3.9 0-7-3.1-7-7s3.1-7 7-7h20c3.9 0 7 3.1 7 7z"
-          fill="#C9CDCF"
+          d="M36.5 10c0 3.9-3.282 7-7.412 7H7.912C3.782 17 .5 13.9.5 10s3.282-7 7.412-7h21.176c4.13 0 7.412 3.1 7.412 7z"
+          fill="#A5ADB1"
         />
         <g
           class="icon-toggle_svg__fi-toggle-icon-knob"
-          transform="translate(1 -1)"
         >
           <use
             fill="#000"
@@ -517,8 +506,8 @@ exports[`Toggle variant default:  calling render with the same component on the 
           <circle
             class="icon-toggle_svg__fi-toggle-icon-circle"
             cx="10"
-            cy="12"
-            fill="#F6F6F7"
+            cy="10"
+            fill="#FFF"
             r="9.75"
             stroke="url(#icon-toggle_svg__c)"
             stroke-linejoin="square"
@@ -526,7 +515,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
           />
           <circle
             cx="10"
-            cy="12"
+            cy="10"
             r="9.75"
             stroke="url(#icon-toggle_svg__d)"
             stroke-linejoin="square"
@@ -750,9 +739,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   position: absolute;
   margin-right: 10px;
   left: 0;
-  top: 2px;
-  padding-right: 2px;
-  padding-left: 2px;
+  top: 0.1em;
 }
 
 .c1 + .fi-toggle--with-button:focus {
@@ -786,6 +773,8 @@ exports[`Toggle variant withInput:  calling render with the same component on th
 
 .c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   border-radius: 14px;
+  right: -4px;
+  left: -4px;
 }
 
 .c1 + .fi-toggle--with-button:focus:not(:focus-visible) {
@@ -827,6 +816,8 @@ exports[`Toggle variant withInput:  calling render with the same component on th
 
 .c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   border-radius: 14px;
+  right: -4px;
+  left: -4px;
 }
 
 .c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) {
@@ -865,25 +856,10 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   height: 24px;
   vertical-align: bottom;
   overflow: visible;
-  -webkit-transform: translateY(-0.05em);
-  -ms-transform: translateY(-0.05em);
-  transform: translateY(-0.05em);
-}
-
-.c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-knob {
-  -webkit-transform: translateX(0%);
-  -ms-transform: translateX(0%);
-  transform: translateX(0%);
 }
 
 .c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-circle {
   fill: hsl(0,0%,100%);
-}
-
-.c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-slide {
-  -webkit-transform: translateY(1px);
-  -ms-transform: translateY(1px);
-  transform: translateY(1px);
 }
 
 .c1 .fi-toggle_icon.fi-toggle_icon--disabled .icon-toggle_svg__fi-toggle-icon-circle {
@@ -895,9 +871,9 @@ exports[`Toggle variant withInput:  calling render with the same component on th
 }
 
 .c1 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-knob {
-  -webkit-transform: translateX(50%);
-  -ms-transform: translateX(50%);
-  transform: translateX(50%);
+  -webkit-transform: translateX(47%);
+  -ms-transform: translateX(47%);
+  transform: translateX(47%);
 }
 
 .c1 .fi-toggle_icon.fi-toggle_icon--checked .icon-toggle_svg__fi-toggle-icon-slide {
@@ -930,7 +906,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
       class="c4 fi-toggle_icon"
       focusable="false"
       height="1em"
-      viewBox="0 0 38 23"
+      viewBox="0 0 37 20"
       width="1em"
     >
       <defs>
@@ -943,14 +919,17 @@ exports[`Toggle variant withInput:  calling render with the same component on th
         >
           <stop
             offset="0%"
+            stop-color="#292929"
             stop-opacity="0"
           />
           <stop
             offset="80%"
+            stop-color="#292929"
             stop-opacity="0.02"
           />
           <stop
             offset="100%"
+            stop-color="#292929"
             stop-opacity="0.04"
           />
         </lineargradient>
@@ -1004,7 +983,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
           <fecolormatrix
             in="shadowBlurOuter1"
             result="shadowMatrixOuter1"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"
+            values="0 0 0 0 0.160784314 0 0 0 0 0.160784314 0 0 0 0 0.160784314 0 0 0 0.2 0"
           />
           <feoffset
             in="SourceAlpha"
@@ -1024,7 +1003,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
           <fecolormatrix
             in="shadowBlurOuter2"
             result="shadowMatrixOuter2"
-            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+            values="0 0 0 0 0.160784314 0 0 0 0 0.160784314 0 0 0 0 0.160784314 0 0 0 0.2 0"
           />
           <femerge>
             <femergenode
@@ -1037,7 +1016,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
         </filter>
         <circle
           cx="10"
-          cy="12"
+          cy="10"
           id="icon-toggle_svg__b"
           r="10"
         />
@@ -1048,12 +1027,11 @@ exports[`Toggle variant withInput:  calling render with the same component on th
       >
         <path
           class="icon-toggle_svg__fi-toggle-icon-slide"
-          d="M38 11c0 3.9-3.1 7-7 7H11c-3.9 0-7-3.1-7-7s3.1-7 7-7h20c3.9 0 7 3.1 7 7z"
-          fill="#C9CDCF"
+          d="M36.5 10c0 3.9-3.282 7-7.412 7H7.912C3.782 17 .5 13.9.5 10s3.282-7 7.412-7h21.176c4.13 0 7.412 3.1 7.412 7z"
+          fill="#A5ADB1"
         />
         <g
           class="icon-toggle_svg__fi-toggle-icon-knob"
-          transform="translate(1 -1)"
         >
           <use
             fill="#000"
@@ -1063,8 +1041,8 @@ exports[`Toggle variant withInput:  calling render with the same component on th
           <circle
             class="icon-toggle_svg__fi-toggle-icon-circle"
             cx="10"
-            cy="12"
-            fill="#F6F6F7"
+            cy="10"
+            fill="#FFF"
             r="9.75"
             stroke="url(#icon-toggle_svg__c)"
             stroke-linejoin="square"
@@ -1072,7 +1050,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
           />
           <circle
             cx="10"
-            cy="12"
+            cy="10"
             r="9.75"
             stroke="url(#icon-toggle_svg__d)"
             stroke-linejoin="square"

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toggle variant default:  calling render with the same component on the same container does not remount 1`] = `
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -77,7 +77,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
   cursor: not-allowed;
 }
 
-.c2 {
+.c3 {
   display: inline-block;
   vertical-align: baseline;
 }
@@ -196,15 +196,31 @@ exports[`Toggle variant default:  calling render with the same component on the 
   line-height: 1.5;
   font-weight: 400;
   background-color: hsl(0,0%,100%);
+  padding-left: 50px;
+  position: relative;
+  display: inline-block;
+}
+
+.c1 .fi-toggle_icon-container {
+  position: absolute;
+  margin-right: 10px;
+  left: 0;
+  top: 2px;
+  padding-right: 2px;
+  padding-left: 2px;
 }
 
 .c1 + .fi-toggle--with-button:focus {
   outline: 0;
-  outline: 0;
-  position: relative;
 }
 
-.c1 + .fi-toggle--with-button:focus:after {
+.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container {
+  outline: 0;
+  position: relative;
+  position: absolute;
+}
+
+.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
   top: -2px;
@@ -219,25 +235,33 @@ exports[`Toggle variant default:  calling render with the same component on the 
   z-index: 9999;
 }
 
-.c1 + .fi-toggle--with-button:focus:not(:focus-visible):after {
+.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:not(:focus-visible):after {
   content: none;
+}
+
+.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
+  border-radius: 14px;
 }
 
 .c1 + .fi-toggle--with-button:focus:not(:focus-visible) {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-button:focus:not(:focus-visible):after {
+.c1 + .fi-toggle--with-button:focus:not(:focus-visible) .fi-toggle_icon-container:after {
   content: none;
 }
 
 .c1 + .fi-toggle--with-input:focus-within {
   outline: 0;
-  outline: 0;
-  position: relative;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:after {
+.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container {
+  outline: 0;
+  position: relative;
+  position: absolute;
+}
+
+.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
   top: -2px;
@@ -252,15 +276,19 @@ exports[`Toggle variant default:  calling render with the same component on the 
   z-index: 9999;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible):after {
+.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:not(:focus-visible):after {
   content: none;
+}
+
+.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
+  border-radius: 14px;
 }
 
 .c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible):after {
+.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) .fi-toggle_icon-container:after {
   content: none;
 }
 
@@ -290,12 +318,11 @@ exports[`Toggle variant default:  calling render with the same component on the 
 .c1 .fi-toggle_icon {
   width: 40px;
   height: 24px;
-  margin-right: 10px;
   vertical-align: bottom;
   overflow: visible;
-  -webkit-transform: translateY(-0.1em);
-  -ms-transform: translateY(-0.1em);
-  transform: translateY(-0.1em);
+  -webkit-transform: translateY(-0.05em);
+  -ms-transform: translateY(-0.05em);
+  transform: translateY(-0.05em);
 }
 
 .c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-knob {
@@ -349,164 +376,168 @@ exports[`Toggle variant default:  calling render with the same component on the 
   tabindex="0"
   type="button"
 >
-  <svg
-    aria-hidden="true"
-    class="c2 fi-toggle_icon"
-    focusable="false"
-    height="1em"
-    viewBox="0 0 38 23"
-    width="1em"
-  >
-    <defs>
-      <lineargradient
-        id="icon-toggle_svg__c"
-        x1="50%"
-        x2="50%"
-        y1="0%"
-        y2="99.021%"
-      >
-        <stop
-          offset="0%"
-          stop-opacity="0"
-        />
-        <stop
-          offset="80%"
-          stop-opacity="0.02"
-        />
-        <stop
-          offset="100%"
-          stop-opacity="0.04"
-        />
-      </lineargradient>
-      <lineargradient
-        id="icon-toggle_svg__d"
-        x1="50%"
-        x2="50%"
-        y1="0%"
-        y2="100%"
-      >
-        <stop
-          offset="0%"
-          stop-color="#FFF"
-          stop-opacity="0.12"
-        />
-        <stop
-          offset="20%"
-          stop-color="#FFF"
-          stop-opacity="0.06"
-        />
-        <stop
-          offset="100%"
-          stop-color="#FFF"
-          stop-opacity="0"
-        />
-      </lineargradient>
-      <filter
-        filterUnits="objectBoundingBox"
-        height="120%"
-        id="icon-toggle_svg__a"
-        width="117.5%"
-        x="-8.8%"
-        y="-8.8%"
-      >
-        <feoffset
-          dy="1"
-          in="SourceAlpha"
-          result="shadowOffsetOuter1"
-        />
-        <fegaussianblur
-          in="shadowOffsetOuter1"
-          result="shadowBlurOuter1"
-          stdDeviation="0.25"
-        />
-        <fecomposite
-          in="shadowBlurOuter1"
-          in2="SourceAlpha"
-          operator="out"
-          result="shadowBlurOuter1"
-        />
-        <fecolormatrix
-          in="shadowBlurOuter1"
-          result="shadowMatrixOuter1"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"
-        />
-        <feoffset
-          in="SourceAlpha"
-          result="shadowOffsetOuter2"
-        />
-        <fegaussianblur
-          in="shadowOffsetOuter2"
-          result="shadowBlurOuter2"
-          stdDeviation="0.5"
-        />
-        <fecomposite
-          in="shadowBlurOuter2"
-          in2="SourceAlpha"
-          operator="out"
-          result="shadowBlurOuter2"
-        />
-        <fecolormatrix
-          in="shadowBlurOuter2"
-          result="shadowMatrixOuter2"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
-        />
-        <femerge>
-          <femergenode
-            in="shadowMatrixOuter1"
-          />
-          <femergenode
-            in="shadowMatrixOuter2"
-          />
-        </femerge>
-      </filter>
-      <circle
-        cx="10"
-        cy="12"
-        id="icon-toggle_svg__b"
-        r="10"
-      />
-    </defs>
-    <g
-      fill="none"
-      fill-rule="evenodd"
-    >
-      <path
-        class="icon-toggle_svg__fi-toggle-icon-slide"
-        d="M38 11c0 3.9-3.1 7-7 7H11c-3.9 0-7-3.1-7-7s3.1-7 7-7h20c3.9 0 7 3.1 7 7z"
-        fill="#C9CDCF"
-      />
-      <g
-        class="icon-toggle_svg__fi-toggle-icon-knob"
-        transform="translate(1 -1)"
-      >
-        <use
-          fill="#000"
-          filter="url(#icon-toggle_svg__a)"
-          xlink:href="#icon-toggle_svg__b"
-        />
-        <circle
-          class="icon-toggle_svg__fi-toggle-icon-circle"
-          cx="10"
-          cy="12"
-          fill="#F6F6F7"
-          r="9.75"
-          stroke="url(#icon-toggle_svg__c)"
-          stroke-linejoin="square"
-          stroke-width="0.5"
-        />
-        <circle
-          cx="10"
-          cy="12"
-          r="9.75"
-          stroke="url(#icon-toggle_svg__d)"
-          stroke-linejoin="square"
-          stroke-width="0.5"
-        />
-      </g>
-    </g>
-  </svg>
   <span
-    class="c3 fi-text c4 fi-text--body"
+    class="c2 fi-toggle_icon-container"
+  >
+    <svg
+      aria-hidden="true"
+      class="c3 fi-toggle_icon"
+      focusable="false"
+      height="1em"
+      viewBox="0 0 38 23"
+      width="1em"
+    >
+      <defs>
+        <lineargradient
+          id="icon-toggle_svg__c"
+          x1="50%"
+          x2="50%"
+          y1="0%"
+          y2="99.021%"
+        >
+          <stop
+            offset="0%"
+            stop-opacity="0"
+          />
+          <stop
+            offset="80%"
+            stop-opacity="0.02"
+          />
+          <stop
+            offset="100%"
+            stop-opacity="0.04"
+          />
+        </lineargradient>
+        <lineargradient
+          id="icon-toggle_svg__d"
+          x1="50%"
+          x2="50%"
+          y1="0%"
+          y2="100%"
+        >
+          <stop
+            offset="0%"
+            stop-color="#FFF"
+            stop-opacity="0.12"
+          />
+          <stop
+            offset="20%"
+            stop-color="#FFF"
+            stop-opacity="0.06"
+          />
+          <stop
+            offset="100%"
+            stop-color="#FFF"
+            stop-opacity="0"
+          />
+        </lineargradient>
+        <filter
+          filterUnits="objectBoundingBox"
+          height="120%"
+          id="icon-toggle_svg__a"
+          width="117.5%"
+          x="-8.8%"
+          y="-8.8%"
+        >
+          <feoffset
+            dy="1"
+            in="SourceAlpha"
+            result="shadowOffsetOuter1"
+          />
+          <fegaussianblur
+            in="shadowOffsetOuter1"
+            result="shadowBlurOuter1"
+            stdDeviation="0.25"
+          />
+          <fecomposite
+            in="shadowBlurOuter1"
+            in2="SourceAlpha"
+            operator="out"
+            result="shadowBlurOuter1"
+          />
+          <fecolormatrix
+            in="shadowBlurOuter1"
+            result="shadowMatrixOuter1"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"
+          />
+          <feoffset
+            in="SourceAlpha"
+            result="shadowOffsetOuter2"
+          />
+          <fegaussianblur
+            in="shadowOffsetOuter2"
+            result="shadowBlurOuter2"
+            stdDeviation="0.5"
+          />
+          <fecomposite
+            in="shadowBlurOuter2"
+            in2="SourceAlpha"
+            operator="out"
+            result="shadowBlurOuter2"
+          />
+          <fecolormatrix
+            in="shadowBlurOuter2"
+            result="shadowMatrixOuter2"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+          />
+          <femerge>
+            <femergenode
+              in="shadowMatrixOuter1"
+            />
+            <femergenode
+              in="shadowMatrixOuter2"
+            />
+          </femerge>
+        </filter>
+        <circle
+          cx="10"
+          cy="12"
+          id="icon-toggle_svg__b"
+          r="10"
+        />
+      </defs>
+      <g
+        fill="none"
+        fill-rule="evenodd"
+      >
+        <path
+          class="icon-toggle_svg__fi-toggle-icon-slide"
+          d="M38 11c0 3.9-3.1 7-7 7H11c-3.9 0-7-3.1-7-7s3.1-7 7-7h20c3.9 0 7 3.1 7 7z"
+          fill="#C9CDCF"
+        />
+        <g
+          class="icon-toggle_svg__fi-toggle-icon-knob"
+          transform="translate(1 -1)"
+        >
+          <use
+            fill="#000"
+            filter="url(#icon-toggle_svg__a)"
+            xlink:href="#icon-toggle_svg__b"
+          />
+          <circle
+            class="icon-toggle_svg__fi-toggle-icon-circle"
+            cx="10"
+            cy="12"
+            fill="#F6F6F7"
+            r="9.75"
+            stroke="url(#icon-toggle_svg__c)"
+            stroke-linejoin="square"
+            stroke-width="0.5"
+          />
+          <circle
+            cx="10"
+            cy="12"
+            r="9.75"
+            stroke="url(#icon-toggle_svg__d)"
+            stroke-linejoin="square"
+            stroke-width="0.5"
+          />
+        </g>
+      </g>
+    </svg>
+  </span>
+  <span
+    class="c2 fi-text c4 fi-text--body"
   >
     Test
   </span>
@@ -542,7 +573,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   opacity: 0.54;
 }
 
-.c4 {
+.c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -591,7 +622,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   cursor: not-allowed;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   vertical-align: baseline;
 }
@@ -710,15 +741,31 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   line-height: 1.5;
   font-weight: 400;
   background-color: hsl(0,0%,100%);
+  padding-left: 50px;
+  position: relative;
+  display: inline-block;
+}
+
+.c1 .fi-toggle_icon-container {
+  position: absolute;
+  margin-right: 10px;
+  left: 0;
+  top: 2px;
+  padding-right: 2px;
+  padding-left: 2px;
 }
 
 .c1 + .fi-toggle--with-button:focus {
   outline: 0;
-  outline: 0;
-  position: relative;
 }
 
-.c1 + .fi-toggle--with-button:focus:after {
+.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container {
+  outline: 0;
+  position: relative;
+  position: absolute;
+}
+
+.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
   top: -2px;
@@ -733,25 +780,33 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   z-index: 9999;
 }
 
-.c1 + .fi-toggle--with-button:focus:not(:focus-visible):after {
+.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:not(:focus-visible):after {
   content: none;
+}
+
+.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
+  border-radius: 14px;
 }
 
 .c1 + .fi-toggle--with-button:focus:not(:focus-visible) {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-button:focus:not(:focus-visible):after {
+.c1 + .fi-toggle--with-button:focus:not(:focus-visible) .fi-toggle_icon-container:after {
   content: none;
 }
 
 .c1 + .fi-toggle--with-input:focus-within {
   outline: 0;
-  outline: 0;
-  position: relative;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:after {
+.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container {
+  outline: 0;
+  position: relative;
+  position: absolute;
+}
+
+.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
   top: -2px;
@@ -766,15 +821,19 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   z-index: 9999;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible):after {
+.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:not(:focus-visible):after {
   content: none;
+}
+
+.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
+  border-radius: 14px;
 }
 
 .c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible):after {
+.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) .fi-toggle_icon-container:after {
   content: none;
 }
 
@@ -804,12 +863,11 @@ exports[`Toggle variant withInput:  calling render with the same component on th
 .c1 .fi-toggle_icon {
   width: 40px;
   height: 24px;
-  margin-right: 10px;
   vertical-align: bottom;
   overflow: visible;
-  -webkit-transform: translateY(-0.1em);
-  -ms-transform: translateY(-0.1em);
-  transform: translateY(-0.1em);
+  -webkit-transform: translateY(-0.05em);
+  -ms-transform: translateY(-0.05em);
+  transform: translateY(-0.05em);
 }
 
 .c1 .fi-toggle_icon .icon-toggle_svg__fi-toggle-icon-knob {
@@ -864,164 +922,168 @@ exports[`Toggle variant withInput:  calling render with the same component on th
     id="test-toggle"
     type="checkbox"
   />
-  <svg
-    aria-hidden="true"
-    class="c3 fi-toggle_icon"
-    focusable="false"
-    height="1em"
-    viewBox="0 0 38 23"
-    width="1em"
-  >
-    <defs>
-      <lineargradient
-        id="icon-toggle_svg__c"
-        x1="50%"
-        x2="50%"
-        y1="0%"
-        y2="99.021%"
-      >
-        <stop
-          offset="0%"
-          stop-opacity="0"
-        />
-        <stop
-          offset="80%"
-          stop-opacity="0.02"
-        />
-        <stop
-          offset="100%"
-          stop-opacity="0.04"
-        />
-      </lineargradient>
-      <lineargradient
-        id="icon-toggle_svg__d"
-        x1="50%"
-        x2="50%"
-        y1="0%"
-        y2="100%"
-      >
-        <stop
-          offset="0%"
-          stop-color="#FFF"
-          stop-opacity="0.12"
-        />
-        <stop
-          offset="20%"
-          stop-color="#FFF"
-          stop-opacity="0.06"
-        />
-        <stop
-          offset="100%"
-          stop-color="#FFF"
-          stop-opacity="0"
-        />
-      </lineargradient>
-      <filter
-        filterUnits="objectBoundingBox"
-        height="120%"
-        id="icon-toggle_svg__a"
-        width="117.5%"
-        x="-8.8%"
-        y="-8.8%"
-      >
-        <feoffset
-          dy="1"
-          in="SourceAlpha"
-          result="shadowOffsetOuter1"
-        />
-        <fegaussianblur
-          in="shadowOffsetOuter1"
-          result="shadowBlurOuter1"
-          stdDeviation="0.25"
-        />
-        <fecomposite
-          in="shadowBlurOuter1"
-          in2="SourceAlpha"
-          operator="out"
-          result="shadowBlurOuter1"
-        />
-        <fecolormatrix
-          in="shadowBlurOuter1"
-          result="shadowMatrixOuter1"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"
-        />
-        <feoffset
-          in="SourceAlpha"
-          result="shadowOffsetOuter2"
-        />
-        <fegaussianblur
-          in="shadowOffsetOuter2"
-          result="shadowBlurOuter2"
-          stdDeviation="0.5"
-        />
-        <fecomposite
-          in="shadowBlurOuter2"
-          in2="SourceAlpha"
-          operator="out"
-          result="shadowBlurOuter2"
-        />
-        <fecolormatrix
-          in="shadowBlurOuter2"
-          result="shadowMatrixOuter2"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
-        />
-        <femerge>
-          <femergenode
-            in="shadowMatrixOuter1"
-          />
-          <femergenode
-            in="shadowMatrixOuter2"
-          />
-        </femerge>
-      </filter>
-      <circle
-        cx="10"
-        cy="12"
-        id="icon-toggle_svg__b"
-        r="10"
-      />
-    </defs>
-    <g
-      fill="none"
-      fill-rule="evenodd"
-    >
-      <path
-        class="icon-toggle_svg__fi-toggle-icon-slide"
-        d="M38 11c0 3.9-3.1 7-7 7H11c-3.9 0-7-3.1-7-7s3.1-7 7-7h20c3.9 0 7 3.1 7 7z"
-        fill="#C9CDCF"
-      />
-      <g
-        class="icon-toggle_svg__fi-toggle-icon-knob"
-        transform="translate(1 -1)"
-      >
-        <use
-          fill="#000"
-          filter="url(#icon-toggle_svg__a)"
-          xlink:href="#icon-toggle_svg__b"
-        />
-        <circle
-          class="icon-toggle_svg__fi-toggle-icon-circle"
-          cx="10"
-          cy="12"
-          fill="#F6F6F7"
-          r="9.75"
-          stroke="url(#icon-toggle_svg__c)"
-          stroke-linejoin="square"
-          stroke-width="0.5"
-        />
-        <circle
-          cx="10"
-          cy="12"
-          r="9.75"
-          stroke="url(#icon-toggle_svg__d)"
-          stroke-linejoin="square"
-          stroke-width="0.5"
-        />
-      </g>
-    </g>
-  </svg>
   <span
-    class="c4 fi-text c5 fi-text--body"
+    class="c3 fi-toggle_icon-container"
+  >
+    <svg
+      aria-hidden="true"
+      class="c4 fi-toggle_icon"
+      focusable="false"
+      height="1em"
+      viewBox="0 0 38 23"
+      width="1em"
+    >
+      <defs>
+        <lineargradient
+          id="icon-toggle_svg__c"
+          x1="50%"
+          x2="50%"
+          y1="0%"
+          y2="99.021%"
+        >
+          <stop
+            offset="0%"
+            stop-opacity="0"
+          />
+          <stop
+            offset="80%"
+            stop-opacity="0.02"
+          />
+          <stop
+            offset="100%"
+            stop-opacity="0.04"
+          />
+        </lineargradient>
+        <lineargradient
+          id="icon-toggle_svg__d"
+          x1="50%"
+          x2="50%"
+          y1="0%"
+          y2="100%"
+        >
+          <stop
+            offset="0%"
+            stop-color="#FFF"
+            stop-opacity="0.12"
+          />
+          <stop
+            offset="20%"
+            stop-color="#FFF"
+            stop-opacity="0.06"
+          />
+          <stop
+            offset="100%"
+            stop-color="#FFF"
+            stop-opacity="0"
+          />
+        </lineargradient>
+        <filter
+          filterUnits="objectBoundingBox"
+          height="120%"
+          id="icon-toggle_svg__a"
+          width="117.5%"
+          x="-8.8%"
+          y="-8.8%"
+        >
+          <feoffset
+            dy="1"
+            in="SourceAlpha"
+            result="shadowOffsetOuter1"
+          />
+          <fegaussianblur
+            in="shadowOffsetOuter1"
+            result="shadowBlurOuter1"
+            stdDeviation="0.25"
+          />
+          <fecomposite
+            in="shadowBlurOuter1"
+            in2="SourceAlpha"
+            operator="out"
+            result="shadowBlurOuter1"
+          />
+          <fecolormatrix
+            in="shadowBlurOuter1"
+            result="shadowMatrixOuter1"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"
+          />
+          <feoffset
+            in="SourceAlpha"
+            result="shadowOffsetOuter2"
+          />
+          <fegaussianblur
+            in="shadowOffsetOuter2"
+            result="shadowBlurOuter2"
+            stdDeviation="0.5"
+          />
+          <fecomposite
+            in="shadowBlurOuter2"
+            in2="SourceAlpha"
+            operator="out"
+            result="shadowBlurOuter2"
+          />
+          <fecolormatrix
+            in="shadowBlurOuter2"
+            result="shadowMatrixOuter2"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"
+          />
+          <femerge>
+            <femergenode
+              in="shadowMatrixOuter1"
+            />
+            <femergenode
+              in="shadowMatrixOuter2"
+            />
+          </femerge>
+        </filter>
+        <circle
+          cx="10"
+          cy="12"
+          id="icon-toggle_svg__b"
+          r="10"
+        />
+      </defs>
+      <g
+        fill="none"
+        fill-rule="evenodd"
+      >
+        <path
+          class="icon-toggle_svg__fi-toggle-icon-slide"
+          d="M38 11c0 3.9-3.1 7-7 7H11c-3.9 0-7-3.1-7-7s3.1-7 7-7h20c3.9 0 7 3.1 7 7z"
+          fill="#C9CDCF"
+        />
+        <g
+          class="icon-toggle_svg__fi-toggle-icon-knob"
+          transform="translate(1 -1)"
+        >
+          <use
+            fill="#000"
+            filter="url(#icon-toggle_svg__a)"
+            xlink:href="#icon-toggle_svg__b"
+          />
+          <circle
+            class="icon-toggle_svg__fi-toggle-icon-circle"
+            cx="10"
+            cy="12"
+            fill="#F6F6F7"
+            r="9.75"
+            stroke="url(#icon-toggle_svg__c)"
+            stroke-linejoin="square"
+            stroke-width="0.5"
+          />
+          <circle
+            cx="10"
+            cy="12"
+            r="9.75"
+            stroke="url(#icon-toggle_svg__d)"
+            stroke-linejoin="square"
+            stroke-width="0.5"
+          />
+        </g>
+      </g>
+    </svg>
+  </span>
+  <span
+    class="c3 fi-text c5 fi-text--body"
   >
     Test
   </span>

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -290,7 +290,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
 .c1 .fi-toggle_icon {
   width: 40px;
   height: 24px;
-  margin-right: 8px;
+  margin-right: 10px;
   vertical-align: bottom;
   overflow: visible;
   -webkit-transform: translateY(-0.1em);
@@ -804,7 +804,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
 .c1 .fi-toggle_icon {
   width: 40px;
   height: 24px;
-  margin-right: 8px;
+  margin-right: 10px;
   vertical-align: bottom;
   overflow: visible;
   -webkit-transform: translateY(-0.1em);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12429,10 +12429,10 @@ suomifi-design-tokens@0.8.0:
   resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-0.8.0.tgz#4667b3f69e94d18f03e718826f1e494bb3dbc4ab"
   integrity sha512-aEj8o5oDR6XYo71qfduCV6Bvtir8VpqB+sTLCoOwuHXk4paKOuDy2DN8ygFsuW7CfUaUoxrWXhTpW5VCUVokBQ==
 
-suomifi-icons@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.1.1.tgz#b5cfa13e5f88b740d65613a478fb982e6106ea29"
-  integrity sha512-IB9cM3x3GLq5TKh6xPs8t3MF2JN3FOJZdwF0n7CFYu4kRy2CnqQrpferUGE/blCdmYHWFqBIIyeLSLKm5adIKA==
+suomifi-icons@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-0.1.2.tgz#fe138013547b9b379b030b1c06f39a23b6277437"
+  integrity sha512-BNIaSlcpxqFt7+XmrF/LO1n/TXtDXWbVPbjkSgAxGJqP256DW70Y78N8hXi05eNhtDsXOyUT6Q33ctEWDDBfCA==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
This PR aligns Toggle component styles with style guide. Focus styles have now rounded corners and only focus on toggle button / input instead of label also. Positioning of the toggle knob has been slightly adjusted. A stronger shadow is also present.

Due to the changes, the component width changes slightly.

## How Has This Been Tested?
Tested with Create react app Typescript project and styleguidist build.