### PR TITLE
[Fix] Grouped expanders corners rounded and separator between

### DIFF
--- a/src/components/Expander/Expander.tsx
+++ b/src/components/Expander/Expander.tsx
@@ -39,10 +39,7 @@ interface StyledExpanderContentProps extends SharedExpanderProps {
 
 export const StyledExpanderContent = styled(
   ({ openState, className, ...passProps }: StyledExpanderContentProps) => (
-    <StyledDiv
-      {...passProps}
-      className={classnames(className, baseClassName)}
-    />
+    <StyledDiv {...passProps} className={classnames(className)} />
   ),
 )`
   display: ${({ openState }) => (!!openState ? 'block' : 'none')};

--- a/src/core/Expander/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup.baseStyles.tsx
@@ -13,6 +13,7 @@ export const baseStyles = withSuomifiTheme(
     & .fi-expander {
       margin-top: 0;
       margin-bottom: 0;
+      border-radius: 0;
       transition: margin ${`${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction}`};
       &.fi-expander--open {
@@ -22,6 +23,18 @@ export const baseStyles = withSuomifiTheme(
         &:not(:last-of-type) {
           margin-bottom: ${theme.spacing.insetXl};
         }
+        &:first-child, &:first-child:before {
+          border-radius: ${theme.radius.basic} ${theme.radius.basic} 0 0;
+        }
+        &:last-child, &:last-child:before {
+          border-radius: 0 0 ${theme.radius.basic} ${theme.radius.basic};
+        }
+      }
+      &:first-child {
+        border-radius: ${theme.radius.basic} ${theme.radius.basic} 0 0;
+      }
+      &:last-child {
+        border-radius: 0 0 ${theme.radius.basic} ${theme.radius.basic};
       }
     }
   }

--- a/src/core/Expander/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup.baseStyles.tsx
@@ -14,9 +14,20 @@ export const baseStyles = withSuomifiTheme(
       margin-top: 0;
       margin-bottom: 0;
       border-radius: 0;
+      border-top: 1px solid ${theme.colors.depthLight1};
       transition: margin ${`${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction}`};
+
+      &:first-child {
+        border-radius: ${theme.radius.basic} ${theme.radius.basic} 0 0;
+        border-top: none;
+      }
+      &:last-child {
+        border-radius: 0 0 ${theme.radius.basic} ${theme.radius.basic};
+      }
+
       &.fi-expander--open {
+        border-top: none;
         &:not(:first-of-type) {
           margin-top: ${theme.spacing.insetXl};
         }
@@ -29,12 +40,9 @@ export const baseStyles = withSuomifiTheme(
         &:last-child, &:last-child:before {
           border-radius: 0 0 ${theme.radius.basic} ${theme.radius.basic};
         }
-      }
-      &:first-child {
-        border-radius: ${theme.radius.basic} ${theme.radius.basic} 0 0;
-      }
-      &:last-child {
-        border-radius: 0 0 ${theme.radius.basic} ${theme.radius.basic};
+        & + .fi-expander {
+          border-top: none;
+        }
       }
     }
   }

--- a/src/core/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/Expander.test.tsx.snap
@@ -285,7 +285,7 @@ exports[`calling render with the same component on the same container does not r
   </button>
   <div
     aria-hidden="true"
-    class="c0 c1 c7 fi-expander_content fi-expander"
+    class="c0 c1 c7 fi-expander_content"
     hidden=""
   >
     Test expander content

--- a/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -155,8 +155,23 @@ exports[`calling render with the same component on the same container does not r
 .c2 > .fi-expander-group_expanders .fi-expander {
   margin-top: 0;
   margin-bottom: 0;
+  border-radius: 0;
+  border-top: 1px solid hsl(202,7%,80%);
   -webkit-transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
   transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander:first-child {
+  border-radius: 2px 2px 0 0;
+  border-top: none;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander:last-child {
+  border-radius: 0 0 2px 2px;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open {
+  border-top: none;
 }
 
 .c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:first-of-type) {
@@ -165,6 +180,20 @@ exports[`calling render with the same component on the same container does not r
 
 .c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:last-of-type) {
   margin-bottom: 16px;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:first-child,
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:first-child:before {
+  border-radius: 2px 2px 0 0;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:last-child,
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:last-child:before {
+  border-radius: 0 0 2px 2px;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open + .fi-expander {
+  border-top: none;
 }
 
 .c2 > .fi-expander-group_all-button {
@@ -416,7 +445,7 @@ exports[`calling render with the same component on the same container does not r
       </button>
       <div
         aria-hidden="true"
-        class="c0 c1 c9 fi-expander_content fi-expander"
+        class="c0 c1 c9 fi-expander_content"
         hidden=""
       >
         First content
@@ -450,7 +479,7 @@ exports[`calling render with the same component on the same container does not r
       </button>
       <div
         aria-hidden="true"
-        class="c0 c1 c9 fi-expander_content fi-expander"
+        class="c0 c1 c9 fi-expander_content"
         hidden=""
       >
         Second content

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -155,6 +155,7 @@ exports[`snapshot testing 1`] = `
 .c2 > .fi-expander-group_expanders .fi-expander {
   margin-top: 0;
   margin-bottom: 0;
+  border-radius: 0;
   -webkit-transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
   transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
 }
@@ -165,6 +166,24 @@ exports[`snapshot testing 1`] = `
 
 .c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:last-of-type) {
   margin-bottom: 16px;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:first-child,
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:first-child:before {
+  border-radius: 2px 2px 0 0;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:last-child,
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:last-child:before {
+  border-radius: 0 0 2px 2px;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander:first-child {
+  border-radius: 2px 2px 0 0;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander:last-child {
+  border-radius: 0 0 2px 2px;
 }
 
 .c2 > .fi-expander-group_all-button {

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -156,8 +156,22 @@ exports[`snapshot testing 1`] = `
   margin-top: 0;
   margin-bottom: 0;
   border-radius: 0;
+  border-top: 1px solid hsl(202,7%,80%);
   -webkit-transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
   transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander:first-child {
+  border-radius: 2px 2px 0 0;
+  border-top: none;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander:last-child {
+  border-radius: 0 0 2px 2px;
+}
+
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open {
+  border-top: none;
 }
 
 .c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:first-of-type) {
@@ -178,12 +192,8 @@ exports[`snapshot testing 1`] = `
   border-radius: 0 0 2px 2px;
 }
 
-.c2 > .fi-expander-group_expanders .fi-expander:first-child {
-  border-radius: 2px 2px 0 0;
-}
-
-.c2 > .fi-expander-group_expanders .fi-expander:last-child {
-  border-radius: 0 0 2px 2px;
+.c2 > .fi-expander-group_expanders .fi-expander.fi-expander--open + .fi-expander {
+  border-top: none;
 }
 
 .c2 > .fi-expander-group_all-button {

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -434,7 +434,7 @@ exports[`snapshot testing 1`] = `
       </button>
       <div
         aria-hidden="true"
-        class="c0 c1 c9 fi-expander_content fi-expander"
+        class="c0 c1 c9 fi-expander_content"
         hidden=""
       >
         Test expander content 1
@@ -467,7 +467,7 @@ exports[`snapshot testing 1`] = `
       </button>
       <div
         aria-hidden="true"
-        class="c0 c1 c9 fi-expander_content fi-expander"
+        class="c0 c1 c9 fi-expander_content"
         hidden=""
       >
         Test expander content 2
@@ -500,7 +500,7 @@ exports[`snapshot testing 1`] = `
       </button>
       <div
         aria-hidden="true"
-        class="c0 c1 c9 fi-expander_content fi-expander"
+        class="c0 c1 c9 fi-expander_content"
         hidden=""
       >
         Test expander content 3


### PR DESCRIPTION
## Description

- Fixed the Expander's corner rounding when inside ExpanderGroup
- Added separator between Expanders when inside ExpanderGroup

## Details

Showing the rounded corners only on top and bottom like in the [Material-UI](https://material-ui.com/components/expansion-panels/)

- This is not currently yet in the designs but was discussed for this change to be good to go
- Previously the rounding in the designs were all over the place and it was not possible to do it with just the CSS. It would have required also code changes to get it to match the design 100% and not really worth the effort as Material-UI way is simplistic and good looking.

## Motivation and Context

To better match with the design and component to look good.

## How Has This Been Tested?

- Locally in the Chrome

## Screenshots 

Explanation to the screenshot (with the changes of this PR)
- Rounded corners surrounded by circles
- Corners without rounding marked by rectangles 

<img width="800" alt="expandergroup_kulmat" src="https://user-images.githubusercontent.com/53757053/82900169-ca6e6580-9f64-11ea-8c12-02aacc5fb8c6.png">


## Release notes for this PR
- Rounded top and bottom corners for Expander groups and separator between as detailed in the design. (#338)