### PR TITLE
[Feature] Adjust link focus styles

### DIFF
--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -152,27 +152,12 @@ exports[`calling render with the same component on the same container does not r
 
 .c5:focus {
   outline: 0;
-  position: relative;
-}
-
-.c5:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
   border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
-  z-index: 9999;
 }
 
-.c5:focus:not(:focus-visible):after {
-  content: none;
+.c5:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .c5:hover,
@@ -182,10 +167,14 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(212,63%,45%);
 }
 
-.c5:hover,
-.c5:active,
 .c5:focus,
 .c5:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5:hover,
+.c5:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }

--- a/src/core/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link.baseStyles.ts
@@ -1,20 +1,22 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../theme';
-import { element, font, focus } from '../theme/reset';
+import { element, font } from '../theme/reset';
+import { focus } from '../theme/utils';
 import { allStates } from '../../utils/css';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
   ${element({ theme })}
   ${font({ theme })('bodyText')}
-  ${focus({ theme })}
+  ${focus({ theme, variant: 'boxShadow' })}
   ${allStates(`color: ${theme.colors.highlightBase};`)};
   color: ${theme.colors.highlightBase};
   text-decoration: none;
+  &:focus, &:focus-within {
+    text-decoration: none;
+  }
   &:hover,
-  &:active,
-  &:focus,
-  &:focus-within {
+  &:active {
     text-decoration: underline;
   }
   &:visited {

--- a/src/core/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/__snapshots__/Link.test.tsx.snap
@@ -56,27 +56,12 @@ exports[`calling render with the same component on the same container does not r
 
 .c1:focus {
   outline: 0;
-  position: relative;
-}
-
-.c1:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
   border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
-  z-index: 9999;
 }
 
-.c1:focus:not(:focus-visible):after {
-  content: none;
+.c1:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .c1:hover,
@@ -86,10 +71,14 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(212,63%,45%);
 }
 
-.c1:hover,
-.c1:active,
 .c1:focus,
 .c1:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1:hover,
+.c1:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -104,27 +104,12 @@ exports[`calling render with the same component on the same container does not r
 
 .c1:focus {
   outline: 0;
-  position: relative;
-}
-
-.c1:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
   border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,55%);
-  z-index: 9999;
 }
 
-.c1:focus:not(:focus-visible):after {
-  content: none;
+.c1:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .c1:hover,
@@ -134,10 +119,14 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(212,63%,45%);
 }
 
-.c1:hover,
-.c1:active,
 .c1:focus,
 .c1:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1:hover,
+.c1:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }


### PR DESCRIPTION
## Description

Adjust Link component focus styles to use box shadow to allow multiline links and not show underline while focused. Update related snapshots.

Affects all Link variants including skip link. Also snapshot for Language Menu was updated, but none of the changed styles have an actual effect on the visible styles.

## Motivation and Context

Change was needed to support links that have line breaks in between or don't fit into one line. Using box shadow instead of after pseudo based focus style allows inline elements to span across multiple lines without breaking the focus style. Style was also adjusted to not show underline when navigating with keyboard.

## How Has This Been Tested?

Tested using Styleguidist build and Create React App TypeScript project. Tested with Brave, Chrome, Firefox and Safari browsers.
## Screenshots (if appropriate):
<img width="1256" alt="chrome-link-focus" src="https://user-images.githubusercontent.com/53744258/83256762-b2445380-a1bb-11ea-9800-87c80884124c.png">

## Release notes
Add support for multiline link focus style by using box shadow. Remove link underline while focused.