### PR TITLE
Remove mouse-events from focus pseudo element

### DIFF
--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -158,6 +158,7 @@ exports[`calling render with the same component on the same container does not r
 .c5:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`calling render with the same component on the same container does not r
 .c2:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -63,6 +63,7 @@ exports[`calling render with the same component on the same container does not r
 .c1 > [data-reach-menu-button].fi-dropdown_button:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/Expander.test.tsx.snap
@@ -184,6 +184,7 @@ exports[`calling render with the same component on the same container does not r
 .c2 .fi-expander_title:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -138,6 +138,7 @@ exports[`calling render with the same component on the same container does not r
 .c2 .fi-text-input_container:focus-within:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`calling render with the same component on the same container does not r
 .c2 .fi-text-input_container:focus-within:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -221,6 +221,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
 .c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;
@@ -264,6 +265,7 @@ exports[`Toggle variant default:  calling render with the same component on the 
 .c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;
@@ -761,6 +763,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
 .c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;
@@ -804,6 +807,7 @@ exports[`Toggle variant withInput:  calling render with the same component on th
 .c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`calling render with the same component on the same container does not r
 .c1 > [data-reach-menu-button].fi-language-menu_button:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/__snapshots__/Link.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`calling render with the same component on the same container does not r
 .c1:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -110,6 +110,7 @@ exports[`calling render with the same component on the same container does not r
 .c1:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`snapshot testing 1`] = `
 .c5:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;
@@ -202,6 +203,7 @@ exports[`snapshot testing 1`] = `
 .c2 > .fi-expander-group_all-button:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;
@@ -298,6 +300,7 @@ exports[`snapshot testing 1`] = `
 .c6 .fi-expander_title:focus:after {
   content: '';
   position: absolute;
+  pointer-events: none;
   top: -2px;
   right: -2px;
   bottom: -2px;

--- a/src/core/theme/utils/outline.ts
+++ b/src/core/theme/utils/outline.ts
@@ -32,6 +32,7 @@ const afterBoxshadow = ({
   &:after {
     content: '';
     position: absolute;
+    pointer-events: none;
     top: -${offset};
     right: -${offset};
     bottom: -${offset};


### PR DESCRIPTION
## Description

Fix after-pseudo based focus styles to ignore all pointer events. A recent update to chrome causes input elements with this style to crash the page with "Aw, Snap!" message.

## Motivation and Context

Apparently there is a new feature or a bug in the latest chrome / chromium browser which causes the browser to crash the page when encountering bad focus styles.

## How Has This Been Tested?

Tested with deploy preview styleguidist build.

## Screenshots (if appropriate):

## Release notes

Remove pointer events from after pseudo focus style element to fix browser crash.