### PR TITLE
[Bugfix] Fix incorrect internal state handling in checkbox

### DIFF
--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -82,7 +82,7 @@ export class Checkbox extends Component<CheckboxProps> {
   ) {
     const { checked } = nextProps;
     if (checked !== undefined && checked !== prevState.checkedState) {
-      return { checkboxState: checked };
+      return { checkedState: checked };
     }
     return null;
   }


### PR DESCRIPTION
## Description
Checkbox controlled checked status wasn't working correctly, which resulted in conflicted internal state as well as screen readers announcing wrong states. This PR fixes the problem.

## Motivation and Context
Components need to work reliably and be accessible. Checkbox was neither without the fix.

## How Has This Been Tested?
Running locally and testing changing the state with different methods both in controlled and regular mode.

## Release notes
Fixed a bug in checkbox internal state handling.
