### PR TITLE
[Bugfix] Set checkbox and toggle input variant to use event data for state change

### DIFF
--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -87,14 +87,13 @@ export class Checkbox extends Component<CheckboxProps> {
     return null;
   }
 
-  handleClick = () => {
+  handleClick = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, onClick } = this.props;
-    const { checkedState } = this.state;
     if (checked === undefined) {
-      this.setState({ checkedState: !checkedState });
+      this.setState({ checkedState: event.target.checked });
     }
     if (!!onClick) {
-      onClick({ checkboxState: !checkedState });
+      onClick({ checkboxState: event.target.checked });
     }
   };
 

--- a/src/components/Form/ToggleInput.tsx
+++ b/src/components/Form/ToggleInput.tsx
@@ -52,14 +52,13 @@ export class ToggleInput extends Component<ToggleProps> {
     return null;
   }
 
-  handleClick = () => {
+  handleClick = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, onClick } = this.props;
-    const { toggleState } = this.state;
     if (checked === undefined) {
-      this.setState({ toggleState: !toggleState });
+      this.setState({ toggleState: event.target.checked });
     }
     if (!!onClick) {
-      onClick({ toggleState: !toggleState });
+      onClick({ toggleState: event.target.checked });
     }
   };
 


### PR DESCRIPTION
## Description
In cases where a confirm dialog or similar prompt interrupts the state change of checkbox and toggle input, instead of announcing the state change, screenreaders might read the wrong (previous) state upon focus returning to the input element.

This is a matter of how fast the changed state takes effect and might not occur on all machines and screenreaders. The solution in this PR is to use the event data of the onChange event instead of the old state to set the new state. This seems to be fast enough for the change to take effect before the focus returns to the input element.

## Motivation and Context
Components need to be accessible in all cases. Having wrong states announced in input elements is not tolerable.

## How Has This Been Tested?
Tested by running locally and using components with NVDA and android with TalkBack on.

## Release notes
Fixed an accessibility bug regarding checkbox and toggle switch in controlled state
