### PR TITLE
[Fix] Remove mentions of bare accessible components as it is not possible

### DIFF
--- a/.styleguidist/modules.md
+++ b/.styleguidist/modules.md
@@ -1,3 +1,1 @@
 Collection of suomi.fi styleguide specific components with accessibility and suomi.fi-styles.
-
-You can import bare accessible components versions with `'suomifi-ui-components/components'`.

--- a/.styleguidist/primitive.md
+++ b/.styleguidist/primitive.md
@@ -1,3 +1,1 @@
 Collection of primitive components to give the basic of accessibility and suomi.fi-styles.
-
-You can import bare accessible components versions with `'suomifi-ui-components/components'`.

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,3 +1,1 @@
 # <img src="https://avatars0.githubusercontent.com/u/11345641?s=88&v=4" alt="VRK" width="18"/> suomifi-ui-components
-
-This directory contains bare accessible components used in this library. You can import them with `'suomifi-ui-components/components'`.


### PR DESCRIPTION
## Description

Remove mentions of bare accessible components as it is not possible.

## Related Issue
Related #303 where the cleanup was previously done but these were left behind.

## Motivation and Context
To keep documentation updated


## Release notes
Removed mentions of bare accessible components as it is not possible to use library that way.
