### PR TITLE
[Feature] Align languagemenu styles with design

### DIFF
--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -13,16 +13,17 @@ export const baseStyles = withSuomifiTheme(
     &.fi-language-menu-language_button {
       ${element({ theme })}
       ${theme.typography.actionElementInnerTextBold}
-      padding: 5px ${theme.spacing.insetXs} 5px ${theme.spacing.insetM};
-      line-height: 28px;
+      padding: ${theme.spacing.xs};
+      line-height: 24px;
       background-color: ${theme.colors.whiteBase};
       border: 1px solid ${theme.colors.depthBase};
       border-radius: ${theme.radius.basic};
       & > .fi-language-menu-language_icon {
-        height: 1.2em;
-        width: 1.2em;
-        transform: translateY(0.3em); 
-        margin-left: ${theme.spacing.insetXs};
+        height: 1em;
+        width: 1em;
+        transform: translateY(0.2em); 
+        margin-left: 10px;
+        fill: ${theme.colors.highlightBase};
       }
     }
     &.fi-language-menu-language_button_open {

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -73,8 +73,8 @@ export const languageMenuPopoverStyles = withSuomifiTheme(
       }
       &:after {
         border-bottom-color: ${theme.colors.whiteBase};
-        border-width: 7px;
-        margin-right: -7px;
+        border-width: 6.5px;
+        margin-right: -6.5px;
       }
     }
   }

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -16,7 +16,7 @@ export const baseStyles = withSuomifiTheme(
       padding: ${theme.spacing.xs};
       line-height: 24px;
       background-color: ${theme.colors.whiteBase};
-      border: 1px solid ${theme.colors.depthBase};
+      border: 1px solid ${theme.colors.depthLight1};
       border-radius: ${theme.radius.basic};
       & > .fi-language-menu-language_icon {
         height: 1em;
@@ -49,8 +49,7 @@ export const languageMenuPopoverStyles = withSuomifiTheme(
       position: absolute;
       box-sizing: content-box;
       margin-top: 12px;
-      padding: 10px 0;
-      border: 1px solid ${theme.colors.depthBase};
+      border: 1px solid ${theme.colors.depthLight1};
       border-radius: ${theme.radius.basic};
       &:before,
       &:after {
@@ -64,7 +63,7 @@ export const languageMenuPopoverStyles = withSuomifiTheme(
         pointer-events: none;
       }
       &:before {
-        border-bottom-color: ${theme.colors.depthBase};
+        border-bottom-color: ${theme.colors.depthLight1};
         border-width: 8px;
         margin-right: -8px;
       }
@@ -92,11 +91,13 @@ export const languageMenuPopoverStyles = withSuomifiTheme(
     &.fi-language-menu-language_item,
     &[data-selected].fi-language-menu-language_item {
       ${theme.typography.actionElementInnerText}
-      padding: 6px 20px 6px 14px;
-      border-left: 6px solid transparent;
+      margin: 10px 0;
+      padding: 0px 20px 0px 5px;
+      border-left: 4px solid transparent;
       background-color: transparent;
       &.fi-language-menu-lang-item-selected {
         ${theme.typography.actionElementInnerTextBold};
+        border-left-color: ${theme.colors.highlightBase};
       }
     }
     &[data-selected].fi-language-menu-language_item {

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -96,7 +96,7 @@ export const languageMenuPopoverStyles = withSuomifiTheme(
     &[data-selected].fi-language-menu-language_item {
       ${theme.typography.actionElementInnerText}
       margin: ${theme.spacing.m} 0;
-      padding: 0px ${theme.spacing.m} 0px ${theme.spacing.xxs};
+      padding: 0 ${theme.spacing.m} 0 ${theme.spacing.xxs};
       border-left: 4px solid transparent;
       background-color: transparent;
       &.fi-language-menu-lang-item-selected {

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -16,7 +16,7 @@ export const baseStyles = withSuomifiTheme(
       padding: ${theme.spacing.xs};
       line-height: 24px;
       background-color: ${theme.colors.whiteBase};
-      border: 1px solid ${theme.colors.depthLight1};
+      border: 1px solid transparent;
       border-radius: ${theme.radius.basic};
       & > .fi-language-menu-language_icon {
         height: 1em;
@@ -25,8 +25,12 @@ export const baseStyles = withSuomifiTheme(
         margin-left: 10px;
         fill: ${theme.colors.highlightBase};
       }
+      &:hover{
+        border-color: ${theme.colors.depthLight1};
+      }
     }
     &.fi-language-menu-language_button_open {
+      border-color: ${theme.colors.depthLight1};
         & > .fi-language-menu-language_icon.fi-language-menu-language_icon {
           transform: translateY(0.2em) rotate(180deg);
         }

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -13,7 +13,7 @@ export const baseStyles = withSuomifiTheme(
     &.fi-language-menu-language_button {
       ${element({ theme })}
       ${theme.typography.actionElementInnerTextBold}
-      padding: ${theme.spacing.xs};
+      padding: 9px ${theme.spacing.xs};
       line-height: 24px;
       background-color: ${theme.colors.whiteBase};
       border: 1px solid transparent;
@@ -22,7 +22,7 @@ export const baseStyles = withSuomifiTheme(
         height: 1em;
         width: 1em;
         transform: translateY(0.2em); 
-        margin-left: 10px;
+        margin-left: ${theme.spacing.xs};
         fill: ${theme.colors.highlightBase};
       }
       &:hover{
@@ -62,7 +62,7 @@ export const languageMenuPopoverStyles = withSuomifiTheme(
         height: 0;
         width: 0;
         bottom: 100%;
-        right: 20px;
+        right: ${theme.spacing.l};
         border: solid transparent;
         pointer-events: none;
       }
@@ -95,8 +95,8 @@ export const languageMenuPopoverStyles = withSuomifiTheme(
     &.fi-language-menu-language_item,
     &[data-selected].fi-language-menu-language_item {
       ${theme.typography.actionElementInnerText}
-      margin: 10px 0;
-      padding: 0px 20px 0px 5px;
+      margin: ${theme.spacing.m} 0;
+      padding: 0px ${theme.spacing.m} 0px ${theme.spacing.xxs};
       border-left: 4px solid transparent;
       background-color: transparent;
       &.fi-language-menu-lang-item-selected {

--- a/src/core/LanguageMenu/LanguageMenu.md
+++ b/src/core/LanguageMenu/LanguageMenu.md
@@ -13,5 +13,6 @@ import {
     Suomeksi (FI)
   </LanguageMenuItem>
   <LanguageMenuLink href="/sv">På svenska (SV)</LanguageMenuLink>
+  <LanguageMenuLink href="/en">In English (EN)</LanguageMenuLink>
 </LanguageMenu>;
 ```

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`calling render with the same component on the same container does not r
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  padding: 10px;
+  padding: 9px 10px;
   line-height: 24px;
   background-color: hsl(0,0%,100%);
   border: 1px solid transparent;

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -70,20 +70,29 @@ exports[`calling render with the same component on the same container does not r
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  padding: 5px 4px 5px 8px;
-  line-height: 28px;
+  padding: 10px;
+  line-height: 24px;
   background-color: hsl(0,0%,100%);
-  border: 1px solid hsl(202,7%,67%);
+  border: 1px solid transparent;
   border-radius: 2px;
 }
 
 .c1 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button > .fi-language-menu-language_icon {
-  height: 1.2em;
-  width: 1.2em;
-  -webkit-transform: translateY(0.3em);
-  -ms-transform: translateY(0.3em);
-  transform: translateY(0.3em);
-  margin-left: 4px;
+  height: 1em;
+  width: 1em;
+  -webkit-transform: translateY(0.2em);
+  -ms-transform: translateY(0.2em);
+  transform: translateY(0.2em);
+  margin-left: 10px;
+  fill: hsl(212,63%,45%);
+}
+
+.c1 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button:hover {
+  border-color: hsl(202,7%,80%);
+}
+
+.c1 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button_open {
+  border-color: hsl(202,7%,80%);
 }
 
 .c1 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button_open > .fi-language-menu-language_icon.fi-language-menu-language_icon {


### PR DESCRIPTION
## Description
The designs for the language menu were updated lately, and the component needs to be aligned with the new designs to be usable.

This PR contains changes to align the implementation with the latest designs. Changes in short:
- Size and spacing of the menu button changed
- Borders for menu button only visible on hover and when menu is open
- Popover spacing changed
- Popover border 'notch' now uses sub-pixel values to make it look better
- Popover selected and hover styles changed to show the left side marker both for the selected option and when hovering on an option.

## Motivation and Context
Implementation needs to match the design to be usable in projects.

## How Has This Been Tested?
Running locally and testing with multiple browsers as well as on mobile (android with chrome).

## Screenshots (if appropriate):
![languagemenu](https://user-images.githubusercontent.com/54316341/84025972-22f62780-a995-11ea-8576-936503bffb15.gif)

## Release notes
- Language menu styles adjusted to match latest designs
