### PR TITLE
[Fix] CheckBox hintText to use different color token

### DIFF
--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -145,7 +145,7 @@ export const baseStyles = withSuomifiTheme(
       display: block;
       padding-left: ${theme.spacing.l};
       font-size: ${theme.typography.bodyTextSmall};
-      color: ${theme.colors.depthBase};
+      color: ${theme.colors.depthDark1};
     }
 
     & .fi-checkbox_status {

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`Calling render with the same component on the same container does not r
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-  color: hsl(202,7%,67%);
+  color: hsl(202,7%,40%);
 }
 
 .c1 .fi-checkbox_status {


### PR DESCRIPTION
## Description

Changed the CheckBox hintText to use different color token: `depthBase` --> `depthDark1`

## Motivation and Context

Using the color that was in the design. The wrong color was noticed as it was not accessible, because of it's low contrast.

## How Has This Been Tested?
Ran in local styleguidist.

## Release notes

**Fix**
- Checkbox `hintText` color changed