### PR TITLE
[Bugfix] Replace wrong token in languagemenu styles

### DIFF
--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -95,7 +95,7 @@ export const languageMenuPopoverStyles = withSuomifiTheme(
     &.fi-language-menu-language_item,
     &[data-selected].fi-language-menu-language_item {
       ${theme.typography.actionElementInnerText}
-      margin: ${theme.spacing.m} 0;
+      margin: ${theme.spacing.xs} 0;
       padding: 0 ${theme.spacing.m} 0 ${theme.spacing.xxs};
       border-left: 4px solid transparent;
       background-color: transparent;


### PR DESCRIPTION
## Description
Fixed a bug where language menu menuitem had wrong margin.

Tested by running locally.

## Release notes
- Fix spacing of language menu items
