### PR TITLE
[Fix] Button style fixes

### DIFF
--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -2,6 +2,7 @@ import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme, SuomifiThemeProp } from '../theme';
 import { ButtonProps } from './Button';
 import { element, focus, button } from '../theme/reset';
+import { alphaHex } from '../../utils/css';
 
 const invertedStyles = ({ theme }: SuomifiThemeProp) => css`
   &.fi-button--inverted {
@@ -108,7 +109,7 @@ export const baseStyles = withSuomifiTheme(
   &.fi-button--disabled,
   &[disabled],
   &:disabled {
-    text-shadow: 0 1px 1px ${theme.colors.blackBase};
+    text-shadow: 0 1px 1px ${alphaHex(0.5)(theme.colors.blackBase)};
     background: ${theme.gradients.depthLight1ToDepthBase};
     user-select: none;
   }

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -140,6 +140,9 @@ export const baseStyles = withSuomifiTheme(
       margin-left: ${theme.spacing.insetM};
     }
   }
+  &.fi-button--disabled > .fi-button_icon {
+    cursor: not-allowed;
+  }
 `,
 );
 

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -23,7 +23,7 @@ const invertedStyles = ({ theme }: SuomifiThemeProp) => css`
     &.fi-button--disabled,
     &[disabled],
     &:disabled {
-      opacity: 0.5;
+      opacity: 0.41;
       background: none;
       background-color: none;
     }

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -68,23 +68,6 @@ const StyledButton = styled(
   ${(props) => baseStyles(props)}
 `;
 
-const iconColor = ({
-  tokens,
-  invert,
-  disabled,
-}: {
-  invert?: boolean;
-  disabled?: boolean;
-} & InternalTokensProp) => {
-  const defaultColor = !!disabled
-    ? tokens.colors.depthBase
-    : tokens.colors.whiteBase;
-  const secondaryColor = !!disabled
-    ? tokens.colors.depthBase
-    : tokens.colors.highlightBase;
-  return !!invert ? secondaryColor : defaultColor;
-};
-
 class ButtonWithIcon extends Component<ButtonProps & InternalTokensProp> {
   render() {
     const {
@@ -93,29 +76,20 @@ class ButtonWithIcon extends Component<ButtonProps & InternalTokensProp> {
       iconProps = { className: undefined },
       ...passProps
     } = this.props;
-    const { tokens, disabled, variant } = passProps;
+    const { variant } = passProps;
     const { className: iconPropsClassName, ...passIconProps } = iconProps;
 
     if (variant === 'unstyled') {
       return <UnstyledButton {...passProps} />;
     }
 
-    const secondaryOrTertiary =
-      !!variant &&
-      (variant === 'secondary' ||
-        variant === 'secondary-noborder' ||
-        variant === 'tertiary');
     return (
       <StyledButton {...passProps}>
         {!!icon && (
           <Icon
             mousePointer={true}
             icon={icon}
-            color={iconColor({
-              tokens,
-              disabled,
-              invert: secondaryOrTertiary,
-            })}
+            color="currentColor"
             className={classnames(iconClassName, iconPropsClassName)}
             {...passIconProps}
           />
@@ -125,11 +99,7 @@ class ButtonWithIcon extends Component<ButtonProps & InternalTokensProp> {
           <Icon
             mousePointer={true}
             icon={iconRight}
-            color={iconColor({
-              tokens,
-              disabled,
-              invert: secondaryOrTertiary,
-            })}
+            color="currentColor"
             className={classnames(
               iconClassName,
               iconRightClassName,

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`calling render with the same component on the same container does not r
   background: linear-gradient(0deg,hsl(212,63%,37%) 0%,hsl(212,63%,45%) 100%);
   border-radius: 2px;
   text-align: center;
-  text-shadow: 0 1px 1px hsl(214,100%,24%);
+  text-shadow: 0 1px 1px rgba(0,53,122,0.5);
   cursor: pointer;
 }
 
@@ -116,7 +116,7 @@ exports[`calling render with the same component on the same container does not r
 .c2.fi-button--disabled,
 .c2[disabled],
 .c2:disabled {
-  text-shadow: 0 1px 1px hsl(0,0%,16%);
+  text-shadow: 0 1px 1px rgba(41,41,41,0.5);
   background: linear-gradient(0deg,hsl(202,7%,67%) 0%,hsl(202,7%,80%) 100%);
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -153,7 +153,7 @@ exports[`calling render with the same component on the same container does not r
 .c2.fi-button--inverted.fi-button--disabled,
 .c2.fi-button--inverted[disabled],
 .c2.fi-button--inverted:disabled {
-  opacity: 0.5;
+  opacity: 0.41;
   background: none;
   background-color: none;
 }
@@ -263,6 +263,10 @@ exports[`calling render with the same component on the same container does not r
 .c2 > .fi-button_icon.fi-button_icon--right {
   margin-right: 0;
   margin-left: 8px;
+}
+
+.c2.fi-button--disabled > .fi-button_icon {
+  cursor: not-allowed;
 }
 
 <button

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -83,7 +83,7 @@ export const colorTokens = {
 export type IShadows = typeof shadows;
 
 export const shadows = {
-  invertTextShadow: `0 1px 1px ${colors.brandBase}`,
+  invertTextShadow: `0 1px 1px ${alphaHex(0.5)(colors.brandBase)}`,
   menuShadow: `0 2px 3px 0 ${alphaHex(0.2)(colors.blackBase)}`,
   panelShadow: `0 1px 2px 0 ${alphaHex(0.14)(
     colors.blackBase,


### PR DESCRIPTION
## Description

- Fixes the invert text shadow to have opacity of 50%
- Disabled Button text-shadow to have opacity of 50%
- Disabled Button icon is now showing correct cursor, `not-allowed`
- Disabled inverted button opacity changed from 50% to 41% to match with the design
- Button icon color is now using the `currentColor` so that it will use same color as the text

## Motivation and Context

Wanted to match the Button styles with the design.

## How Has This Been Tested?

Locally ran in Styleguidist on Brave.

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
**Fix**
- Button text-shadow and icon color changes.