### PR TITLE
[Feature] Add visual placeholder for TextInput

### DIFF
--- a/src/components/Form/SearchInput.tsx
+++ b/src/components/Form/SearchInput.tsx
@@ -1,21 +1,8 @@
 import React, { Component } from 'react';
 import { StyledBaseTextInput, TextInputProps } from './TextInput';
-import { logger } from '../../utils/logger';
 
 export class SearchInput extends Component<TextInputProps> {
   render() {
-    const { placeholder, ...passProps } = this.props;
-
-    if (!!placeholder) {
-      logger.warn(
-        'Manually set placeholder attribute is not supported, use labelText instead',
-      );
-    }
-    const labelAsPlaceholder = this.props.labelMode === 'hidden';
-    const props = {
-      placeholder: labelAsPlaceholder ? this.props.labelText : undefined,
-    };
-
-    return <StyledBaseTextInput {...passProps} {...props} />;
+    return <StyledBaseTextInput {...this.props} />;
   }
 }

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../reset';
 import { VisuallyHidden } from '../Visually-hidden/Visually-hidden';
 import { Paragraph, ParagraphProps } from '../Paragraph/Paragraph';
-import { logger } from '../../utils/logger';
 import classnames from 'classnames';
 import styled from 'styled-components';
 import { disabledCursor } from '../utils/css';
@@ -48,13 +47,12 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
   /** Label */
   labelText: string;
-  /** Label displaymode -
-   * visible: show above, hidden: show as placeholder
+  /** Hide or show label. Label element is always present, but can be visually hidden.
    * @default visible
    */
   labelMode?: Label;
-
-  placeholder?: string;
+  /** Placeholder text for input. Use only as visual aid, not for instructions. */
+  visualPlaceholder?: string;
   /** Input container div to define custom styling */
   inputContainerProps?: HtmlDivProps;
   children?: ReactNode;
@@ -74,6 +72,7 @@ class BaseTextInput extends Component<TextInputProps> {
       inputContainerProps,
       children,
       statusText,
+      visualPlaceholder,
       id: propId,
       ...passProps
     } = this.props;
@@ -101,6 +100,7 @@ class BaseTextInput extends Component<TextInputProps> {
               className={classnames(inputBaseClassName, inputClassName)}
               type="text"
               aria-describedby={generatedId}
+              placeholder={visualPlaceholder}
             />
             {children}
           </HtmlDiv>
@@ -125,19 +125,6 @@ export const StyledBaseTextInput = styled((props: TextInputProps) => (
 
 export class TextInput extends Component<TextInputProps> {
   render() {
-    const { placeholder, ...passProps } = this.props;
-
-    if (!!placeholder) {
-      logger.error(
-        'Using placeholder in text inputs is not accessible and it is ignored. Use labelText instead',
-      );
-    }
-
-    const showPlaceholder = this.props.labelMode === 'hidden';
-    const props = {
-      placeholder: showPlaceholder ? this.props.labelText : undefined,
-    };
-
-    return <StyledBaseTextInput {...passProps} {...props} />;
+    return <StyledBaseTextInput {...this.props} />;
   }
 }

--- a/src/core/Form/SearchInput/SearchInput.md
+++ b/src/core/Form/SearchInput/SearchInput.md
@@ -5,13 +5,14 @@ import { SearchInput } from 'suomifi-ui-components';
     onBlur={(event) => console.log(event.target.value)}
     labelText="Search..."
     labelMode="hidden"
+    visualPlaceholder="Search..."
   />
 
   <SearchInput
     onBlur={(event) => console.log(event.target.value)}
-    labelText="Search..."
+    labelText="Search the site"
     labelMode="visible"
-    placeholder="Any value (see console)"
+    visualPlaceholder="Search..."
   />
 </>;
 ```

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -1,10 +1,17 @@
 ```js
 import { TextInput } from 'suomifi-ui-components';
-
-<TextInput
-  onBlur={(event) => console.log(event.target.value)}
-  labelText="Test TextInput"
-/>;
+<>
+  <TextInput
+    onBlur={(event) => console.log(event.target.value)}
+    labelText="TextInput with visible label"
+  />
+  <TextInput
+    onBlur={(event) => console.log(event.target.value)}
+    labelText="Test TextInput with hidden label and a visual placeholder"
+    labelMode="hidden"
+    visualPlaceholder="This input has a hidden label"
+  />
+</>;
 ```
 
 ```js

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -29,22 +29,22 @@ const TestTextInput3 = (
   />
 );
 
-test('calling render with the same component on the same container does not remount - minimal implementation', () => {
-  const buttonRendered = render(TestTextInput);
-  const { container } = buttonRendered;
-  expect(container.firstChild).toMatchSnapshot();
-});
-
-test('calling render with the same component on the same container does not remount - hidden label with placeholder', () => {
-  const buttonRendered = render(TestTextInput2);
-  const { container } = buttonRendered;
-  expect(container.firstChild).toMatchSnapshot();
-});
-
-test('calling render with the same component on the same container does not remount - error status with statustext', () => {
-  const buttonRendered = render(TestTextInput3);
-  const { container } = buttonRendered;
-  expect(container.firstChild).toMatchSnapshot();
+describe('snapshots match', () => {
+  test('minimal implementation', () => {
+    const buttonRendered = render(TestTextInput);
+    const { container } = buttonRendered;
+    expect(container.firstChild).toMatchSnapshot();
+  });
+  test('hidden label with placeholder', () => {
+    const buttonRendered = render(TestTextInput2);
+    const { container } = buttonRendered;
+    expect(container.firstChild).toMatchSnapshot();
+  });
+  test('error status with statustext', () => {
+    const buttonRendered = render(TestTextInput3);
+    const { container } = buttonRendered;
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });
 
 test('should not have basic accessibility issues', axeTest(TestTextInput));

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -29,19 +29,19 @@ const TestTextInput3 = (
   />
 );
 
-test('calling render with the same component on the same container does not remount', () => {
+test('calling render with the same component on the same container does not remount - minimal implementation', () => {
   const buttonRendered = render(TestTextInput);
   const { container } = buttonRendered;
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('calling render with the same component on the same container does not remount', () => {
+test('calling render with the same component on the same container does not remount - hidden label with placeholder', () => {
   const buttonRendered = render(TestTextInput2);
   const { container } = buttonRendered;
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('calling render with the same component on the same container does not remount', () => {
+test('calling render with the same component on the same container does not remount - error status with statustext', () => {
   const buttonRendered = render(TestTextInput3);
   const { container } = buttonRendered;
   expect(container.firstChild).toMatchSnapshot();

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -8,8 +8,41 @@ const TestTextInput = (
   <TextInput labelText="Test input" data-testid="textinput" id="test-id" />
 );
 
+const TestTextInput2 = (
+  <TextInput
+    labelText="Test input"
+    data-testid="textinput1"
+    id="test-id1"
+    labelMode="hidden"
+    visualPlaceholder="Test TextInput"
+  />
+);
+
+const TestTextInput3 = (
+  <TextInput
+    labelText="Test input"
+    data-testid="textinput2"
+    id="test-id2"
+    visualPlaceholder="Test TextInput"
+    statusText="This is a status text"
+    status="error"
+  />
+);
+
 test('calling render with the same component on the same container does not remount', () => {
   const buttonRendered = render(TestTextInput);
+  const { container } = buttonRendered;
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('calling render with the same component on the same container does not remount', () => {
+  const buttonRendered = render(TestTextInput2);
+  const { container } = buttonRendered;
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('calling render with the same component on the same container does not remount', () => {
+  const buttonRendered = render(TestTextInput3);
   const { container } = buttonRendered;
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -1,547 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calling render with the same component on the same container does not remount 1`] = `
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c5 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  overflow: visible;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline-block;
-  max-width: 100%;
-}
-
-.c5::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
-.c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c1.fi-text-input--disabled {
-  cursor: not-allowed;
-}
-
-.c2 .fi-text-input_label-p {
-  margin-bottom: 10px;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(0,0%,16%);
-}
-
-.c2 .fi-text-input_container > input:focus {
-  outline-color: hsl(23,82%,53%);
-  outline-width: 4px;
-  outline-offset: 2px;
-}
-
-.c2 .fi-text-input_container:focus-within {
-  outline: 0;
-  position: relative;
-}
-
-.c2 .fi-text-input_container:focus-within:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,55%);
-  z-index: 9999;
-}
-
-.c2 .fi-text-input_container:focus-within:not(:focus-visible):after {
-  content: none;
-}
-
-.c2 .fi-text-input_container:focus-within > input:focus {
-  outline: none;
-}
-
-.c2 .fi-text-input_statusText_container {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c2 .fi-text-input_input {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  min-width: 245px;
-  max-width: 100%;
-  padding: 8px 16px;
-  border: 1px solid hsl(202,7%,80%);
-  border-radius: 2px;
-  line-height: 1;
-  background-color: hsl(0,0%,100%);
-  width: 100%;
-  min-height: 40px;
-  padding-left: 10px;
-}
-
-.c2 .fi-text-input_input::-webkit-input-placeholder {
-  font-style: italic;
-}
-
-.c2 .fi-text-input_input::-moz-placeholder {
-  font-style: italic;
-}
-
-.c2 .fi-text-input_input:-ms-input-placeholder {
-  font-style: italic;
-}
-
-.c2 .fi-text-input_input::placeholder {
-  font-style: italic;
-}
-
-.c2 .fi-text-input_input:focus {
-  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
-}
-
-.c2.fi-text-input--error .fi-text-input_input {
-  border-color: hsl(3,59%,48%);
-}
-
-.c2.fi-text-input--error .fi-text-input_statusText_span {
-  margin-top: 5px;
-  color: hsl(3,59%,48%);
-}
-
-.c2.fi-text-input--success .fi-text-input_input {
-  border-color: hsl(166,90%,36%);
-}
-
-.c2.fi-text-input--disabled .fi-text-input_input {
-  color: hsl(202,7%,67%);
-  background-color: hsl(202,7%,97%);
-}
-
-<label
-  class="c0 fi-text-input_label c1 c2"
->
-  <p
-    class="c3 fi-paragraph fi-text-input_label-p"
-  >
-    Test input
-  </p>
-  <div
-    class="c4 fi-text-input_statusText_container"
-  >
-    <div
-      class="c4 fi-text-input_container"
-    >
-      <input
-        aria-describedby="test-id-statusText"
-        class="c5 fi-text-input_input"
-        data-testid="textinput"
-        id="test-id"
-        type="text"
-      />
-    </div>
-  </div>
-</label>
-`;
-
-exports[`calling render with the same component on the same container does not remount 2`] = `
-.c5 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c6 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  overflow: visible;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline-block;
-  max-width: 100%;
-}
-
-.c6::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
-.c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-}
-
-.c1.fi-text-input--disabled {
-  cursor: not-allowed;
-}
-
-.c2 .fi-text-input_label-p {
-  margin-bottom: 10px;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(0,0%,16%);
-}
-
-.c2 .fi-text-input_container > input:focus {
-  outline-color: hsl(23,82%,53%);
-  outline-width: 4px;
-  outline-offset: 2px;
-}
-
-.c2 .fi-text-input_container:focus-within {
-  outline: 0;
-  position: relative;
-}
-
-.c2 .fi-text-input_container:focus-within:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,55%);
-  z-index: 9999;
-}
-
-.c2 .fi-text-input_container:focus-within:not(:focus-visible):after {
-  content: none;
-}
-
-.c2 .fi-text-input_container:focus-within > input:focus {
-  outline: none;
-}
-
-.c2 .fi-text-input_statusText_container {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c2 .fi-text-input_input {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  min-width: 245px;
-  max-width: 100%;
-  padding: 8px 16px;
-  border: 1px solid hsl(202,7%,80%);
-  border-radius: 2px;
-  line-height: 1;
-  background-color: hsl(0,0%,100%);
-  width: 100%;
-  min-height: 40px;
-  padding-left: 10px;
-}
-
-.c2 .fi-text-input_input::-webkit-input-placeholder {
-  font-style: italic;
-}
-
-.c2 .fi-text-input_input::-moz-placeholder {
-  font-style: italic;
-}
-
-.c2 .fi-text-input_input:-ms-input-placeholder {
-  font-style: italic;
-}
-
-.c2 .fi-text-input_input::placeholder {
-  font-style: italic;
-}
-
-.c2 .fi-text-input_input:focus {
-  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
-}
-
-.c2.fi-text-input--error .fi-text-input_input {
-  border-color: hsl(3,59%,48%);
-}
-
-.c2.fi-text-input--error .fi-text-input_statusText_span {
-  margin-top: 5px;
-  color: hsl(3,59%,48%);
-}
-
-.c2.fi-text-input--success .fi-text-input_input {
-  border-color: hsl(166,90%,36%);
-}
-
-.c2.fi-text-input--disabled .fi-text-input_input {
-  color: hsl(202,7%,67%);
-  background-color: hsl(202,7%,97%);
-}
-
-<label
-  class="c0 fi-text-input_label c1 c2"
->
-  <span
-    class="c3 c4 fi-visually-hidden"
-  >
-    Test input
-  </span>
-  <div
-    class="c5 fi-text-input_statusText_container"
-  >
-    <div
-      class="c5 fi-text-input_container"
-    >
-      <input
-        aria-describedby="test-id1-statusText"
-        class="c6 fi-text-input_input"
-        data-testid="textinput1"
-        id="test-id1"
-        placeholder="Test TextInput"
-        type="text"
-      />
-    </div>
-  </div>
-</label>
-`;
-
-exports[`calling render with the same component on the same container does not remount 3`] = `
+exports[`calling render with the same component on the same container does not remount - error status with statustext 1`] = `
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -832,6 +291,547 @@ exports[`calling render with the same component on the same container does not r
     >
       This is a status text
     </span>
+  </div>
+</label>
+`;
+
+exports[`calling render with the same component on the same container does not remount - hidden label with placeholder 1`] = `
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c6::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c1.fi-text-input--disabled {
+  cursor: not-allowed;
+}
+
+.c2 .fi-text-input_label-p {
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+}
+
+.c2 .fi-text-input_container > input:focus {
+  outline-color: hsl(23,82%,53%);
+  outline-width: 4px;
+  outline-offset: 2px;
+}
+
+.c2 .fi-text-input_container:focus-within {
+  outline: 0;
+  position: relative;
+}
+
+.c2 .fi-text-input_container:focus-within:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
+  z-index: 9999;
+}
+
+.c2 .fi-text-input_container:focus-within:not(:focus-visible):after {
+  content: none;
+}
+
+.c2 .fi-text-input_container:focus-within > input:focus {
+  outline: none;
+}
+
+.c2 .fi-text-input_statusText_container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c2 .fi-text-input_input {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  background-color: hsl(0,0%,100%);
+  width: 100%;
+  min-height: 40px;
+  padding-left: 10px;
+}
+
+.c2 .fi-text-input_input::-webkit-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::-moz-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:-ms-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:focus {
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+}
+
+.c2.fi-text-input--error .fi-text-input_input {
+  border-color: hsl(3,59%,48%);
+}
+
+.c2.fi-text-input--error .fi-text-input_statusText_span {
+  margin-top: 5px;
+  color: hsl(3,59%,48%);
+}
+
+.c2.fi-text-input--success .fi-text-input_input {
+  border-color: hsl(166,90%,36%);
+}
+
+.c2.fi-text-input--disabled .fi-text-input_input {
+  color: hsl(202,7%,67%);
+  background-color: hsl(202,7%,97%);
+}
+
+<label
+  class="c0 fi-text-input_label c1 c2"
+>
+  <span
+    class="c3 c4 fi-visually-hidden"
+  >
+    Test input
+  </span>
+  <div
+    class="c5 fi-text-input_statusText_container"
+  >
+    <div
+      class="c5 fi-text-input_container"
+    >
+      <input
+        aria-describedby="test-id1-statusText"
+        class="c6 fi-text-input_input"
+        data-testid="textinput1"
+        id="test-id1"
+        placeholder="Test TextInput"
+        type="text"
+      />
+    </div>
+  </div>
+</label>
+`;
+
+exports[`calling render with the same component on the same container does not remount - minimal implementation 1`] = `
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c5::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c1.fi-text-input--disabled {
+  cursor: not-allowed;
+}
+
+.c2 .fi-text-input_label-p {
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+}
+
+.c2 .fi-text-input_container > input:focus {
+  outline-color: hsl(23,82%,53%);
+  outline-width: 4px;
+  outline-offset: 2px;
+}
+
+.c2 .fi-text-input_container:focus-within {
+  outline: 0;
+  position: relative;
+}
+
+.c2 .fi-text-input_container:focus-within:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
+  z-index: 9999;
+}
+
+.c2 .fi-text-input_container:focus-within:not(:focus-visible):after {
+  content: none;
+}
+
+.c2 .fi-text-input_container:focus-within > input:focus {
+  outline: none;
+}
+
+.c2 .fi-text-input_statusText_container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c2 .fi-text-input_input {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  background-color: hsl(0,0%,100%);
+  width: 100%;
+  min-height: 40px;
+  padding-left: 10px;
+}
+
+.c2 .fi-text-input_input::-webkit-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::-moz-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:-ms-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:focus {
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+}
+
+.c2.fi-text-input--error .fi-text-input_input {
+  border-color: hsl(3,59%,48%);
+}
+
+.c2.fi-text-input--error .fi-text-input_statusText_span {
+  margin-top: 5px;
+  color: hsl(3,59%,48%);
+}
+
+.c2.fi-text-input--success .fi-text-input_input {
+  border-color: hsl(166,90%,36%);
+}
+
+.c2.fi-text-input--disabled .fi-text-input_input {
+  color: hsl(202,7%,67%);
+  background-color: hsl(202,7%,97%);
+}
+
+<label
+  class="c0 fi-text-input_label c1 c2"
+>
+  <p
+    class="c3 fi-paragraph fi-text-input_label-p"
+  >
+    Test input
+  </p>
+  <div
+    class="c4 fi-text-input_statusText_container"
+  >
+    <div
+      class="c4 fi-text-input_container"
+    >
+      <input
+        aria-describedby="test-id-statusText"
+        class="c5 fi-text-input_input"
+        data-testid="textinput"
+        id="test-id"
+        type="text"
+      />
+    </div>
   </div>
 </label>
 `;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calling render with the same component on the same container does not remount - error status with statustext 1`] = `
+exports[`snapshots match error status with statustext 1`] = `
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -295,7 +295,7 @@ exports[`calling render with the same component on the same container does not r
 </label>
 `;
 
-exports[`calling render with the same component on the same container does not remount - hidden label with placeholder 1`] = `
+exports[`snapshots match hidden label with placeholder 1`] = `
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -572,7 +572,7 @@ exports[`calling render with the same component on the same container does not r
 </label>
 `;
 
-exports[`calling render with the same component on the same container does not remount - minimal implementation 1`] = `
+exports[`snapshots match minimal implementation 1`] = `
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -263,3 +263,575 @@ exports[`calling render with the same component on the same container does not r
   </div>
 </label>
 `;
+
+exports[`calling render with the same component on the same container does not remount 2`] = `
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c6::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c1.fi-text-input--disabled {
+  cursor: not-allowed;
+}
+
+.c2 .fi-text-input_label-p {
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+}
+
+.c2 .fi-text-input_container > input:focus {
+  outline-color: hsl(23,82%,53%);
+  outline-width: 4px;
+  outline-offset: 2px;
+}
+
+.c2 .fi-text-input_container:focus-within {
+  outline: 0;
+  position: relative;
+}
+
+.c2 .fi-text-input_container:focus-within:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
+  z-index: 9999;
+}
+
+.c2 .fi-text-input_container:focus-within:not(:focus-visible):after {
+  content: none;
+}
+
+.c2 .fi-text-input_container:focus-within > input:focus {
+  outline: none;
+}
+
+.c2 .fi-text-input_statusText_container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c2 .fi-text-input_input {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  background-color: hsl(0,0%,100%);
+  width: 100%;
+  min-height: 40px;
+  padding-left: 10px;
+}
+
+.c2 .fi-text-input_input::-webkit-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::-moz-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:-ms-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:focus {
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+}
+
+.c2.fi-text-input--error .fi-text-input_input {
+  border-color: hsl(3,59%,48%);
+}
+
+.c2.fi-text-input--error .fi-text-input_statusText_span {
+  margin-top: 5px;
+  color: hsl(3,59%,48%);
+}
+
+.c2.fi-text-input--success .fi-text-input_input {
+  border-color: hsl(166,90%,36%);
+}
+
+.c2.fi-text-input--disabled .fi-text-input_input {
+  color: hsl(202,7%,67%);
+  background-color: hsl(202,7%,97%);
+}
+
+<label
+  class="c0 fi-text-input_label c1 c2"
+>
+  <span
+    class="c3 c4 fi-visually-hidden"
+  >
+    Test input
+  </span>
+  <div
+    class="c5 fi-text-input_statusText_container"
+  >
+    <div
+      class="c5 fi-text-input_container"
+    >
+      <input
+        aria-describedby="test-id1-statusText"
+        class="c6 fi-text-input_input"
+        data-testid="textinput1"
+        id="test-id1"
+        placeholder="Test TextInput"
+        type="text"
+      />
+    </div>
+  </div>
+</label>
+`;
+
+exports[`calling render with the same component on the same container does not remount 3`] = `
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c5::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c1.fi-text-input--disabled {
+  cursor: not-allowed;
+}
+
+.c2 .fi-text-input_label-p {
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+}
+
+.c2 .fi-text-input_container > input:focus {
+  outline-color: hsl(23,82%,53%);
+  outline-width: 4px;
+  outline-offset: 2px;
+}
+
+.c2 .fi-text-input_container:focus-within {
+  outline: 0;
+  position: relative;
+}
+
+.c2 .fi-text-input_container:focus-within:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
+  z-index: 9999;
+}
+
+.c2 .fi-text-input_container:focus-within:not(:focus-visible):after {
+  content: none;
+}
+
+.c2 .fi-text-input_container:focus-within > input:focus {
+  outline: none;
+}
+
+.c2 .fi-text-input_statusText_container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c2 .fi-text-input_input {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  background-color: hsl(0,0%,100%);
+  width: 100%;
+  min-height: 40px;
+  padding-left: 10px;
+}
+
+.c2 .fi-text-input_input::-webkit-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::-moz-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:-ms-input-placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input::placeholder {
+  font-style: italic;
+}
+
+.c2 .fi-text-input_input:focus {
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+}
+
+.c2.fi-text-input--error .fi-text-input_input {
+  border-color: hsl(3,59%,48%);
+}
+
+.c2.fi-text-input--error .fi-text-input_statusText_span {
+  margin-top: 5px;
+  color: hsl(3,59%,48%);
+}
+
+.c2.fi-text-input--success .fi-text-input_input {
+  border-color: hsl(166,90%,36%);
+}
+
+.c2.fi-text-input--disabled .fi-text-input_input {
+  color: hsl(202,7%,67%);
+  background-color: hsl(202,7%,97%);
+}
+
+<label
+  class="c0 fi-text-input_label c1 c2 fi-text-input--error"
+>
+  <p
+    class="c3 fi-paragraph fi-text-input_label-p"
+  >
+    Test input
+  </p>
+  <div
+    class="c4 fi-text-input_statusText_container"
+  >
+    <div
+      class="c4 fi-text-input_container"
+    >
+      <input
+        aria-describedby="test-id2-statusText"
+        class="c5 fi-text-input_input"
+        data-testid="textinput2"
+        id="test-id2"
+        placeholder="Test TextInput"
+        type="text"
+      />
+    </div>
+    <span
+      class="c6 fi-text-input_statusText_span"
+      id="test-id2-statusText"
+    >
+      This is a status text
+    </span>
+  </div>
+</label>
+`;


### PR DESCRIPTION
## Description
TextInput had a somewhat strange placeholder logic since inaccessible use of placeholders wanted to be kept to the minimum. This PR introduces a visualPlaceholder prop that gets passed to the component as placeholder.

These changes also slightly affected SearchInput, so the necessary changes were made to accommodate the changes.

The examples were also adjusted to show the new prop and logic.

## Related Issue
https://github.com/vrk-kpa/suomifi-ui-components/issues/259

Closes #259

## Motivation and Context
Placeholders are in use in many of the designs for Suomi.fi. To aid the implementation of the ui-components, a concession was made to implement it. However, the API description should guide the developers to the right track in terms of placeholders.

## How Has This Been Tested?
Yarn test and running locally

## Release notes
Implemented placeholder text for TextInput