### PR TITLE
[Fix] Icons to use currentColor

### DIFF
--- a/src/core/Breadcrumb/BreadcrumbLink.tsx
+++ b/src/core/Breadcrumb/BreadcrumbLink.tsx
@@ -44,11 +44,7 @@ export const BreadcrumbLink = ({
       >
         {children}
       </Link>
-      <Icon
-        icon="linkBreadcrumb"
-        className={iconClassName}
-        color={passProps.tokens.colors.blackBase}
-      />
+      <Icon icon="linkBreadcrumb" className={iconClassName} />
     </Fragment>
   );
 };

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -276,8 +276,8 @@ exports[`calling render with the same component on the same container does not r
       </a>
       <svg
         aria-hidden="true"
-        class="c6 fi-breadcrumb_icon"
-        fill="hsl(0, 0%, 16%)"
+        class="fi-icon c6 fi-breadcrumb_icon"
+        fill="currentColor"
         focusable="false"
         height="1em"
         viewBox="0 0 24 24"
@@ -299,8 +299,8 @@ exports[`calling render with the same component on the same container does not r
       </a>
       <svg
         aria-hidden="true"
-        class="c6 fi-breadcrumb_icon"
-        fill="hsl(0, 0%, 16%)"
+        class="fi-icon c6 fi-breadcrumb_icon"
+        fill="currentColor"
         focusable="false"
         height="1em"
         viewBox="0 0 24 24"

--- a/src/core/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/Expander.test.tsx.snap
@@ -271,7 +271,7 @@ exports[`calling render with the same component on the same container does not r
     Test expander
     <svg
       aria-hidden="true"
-      class="c6 fi-expander_title-icon"
+      class="fi-icon c6 fi-expander_title-icon"
       fill="hsl(212, 63%, 45%)"
       focusable="false"
       height="1em"

--- a/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -431,7 +431,7 @@ exports[`calling render with the same component on the same container does not r
         First
         <svg
           aria-hidden="true"
-          class="c8 fi-expander_title-icon"
+          class="fi-icon c8 fi-expander_title-icon"
           fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"
@@ -465,7 +465,7 @@ exports[`calling render with the same component on the same container does not r
         Second
         <svg
           aria-hidden="true"
-          class="c8 fi-expander_title-icon"
+          class="fi-icon c8 fi-expander_title-icon"
           fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -20,6 +20,7 @@ export const baseStyles = withSuomifiTheme(
         height: 18px;
         top: ${theme.spacing.insetL};
         right: ${theme.spacing.insetL};
+        fill: ${theme.colors.depthDark1};
       }
     }
   `,

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -258,6 +258,7 @@ exports[`calling render with the same component on the same container does not r
   height: 18px;
   top: 10px;
   right: 10px;
+  fill: hsl(202,7%,40%);
 }
 
 <label
@@ -283,8 +284,8 @@ exports[`calling render with the same component on the same container does not r
       />
       <svg
         aria-hidden="true"
-        class="c6 fi-search-input_icon"
-        fill="hsl(202, 7%, 40%)"
+        class="fi-icon c6 fi-search-input_icon"
+        fill="currentColor"
         focusable="false"
         height="1em"
         viewBox="0 0 24 24"

--- a/src/core/Icon/Icon.md
+++ b/src/core/Icon/Icon.md
@@ -1,11 +1,22 @@
+- Uses currentColor by default if `fill` prop is not given.
+
 ```jsx
 import { Icon } from 'suomifi-ui-components';
 
-<Icon
-  icon="login"
-  ariaLabel="Login here"
-  className="my-icon--test"
-/>;
+<>
+  <Icon
+    icon="login"
+    ariaLabel="Login here"
+    className="my-icon--test"
+  />
+  <div style={{ color: 'orange' }}>
+    <Icon
+      icon="login"
+      ariaLabel="Login here"
+      className="my-icon--test"
+    />
+  </div>
+</>;
 ```
 
 ### Icon with no label
@@ -21,11 +32,13 @@ import { Icon } from 'suomifi-ui-components';
 import { default as styled } from 'styled-components';
 import { baseIcons } from 'suomifi-icons';
 import clipboardCopy from 'clipboard-copy';
+import { suomifiDesignTokens } from 'suomifi-design-tokens';
 
 const StyledIcon = styled((props) => <Icon {...props} />)({
   height: '50px',
   width: 'auto',
-  margin: '8px'
+  margin: '8px',
+  fill: `${suomifiDesignTokens.colors.depthDark1}`
 });
 
 <div>

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -65,7 +65,7 @@ export class Icon extends Component<IconProps> {
     );
     const { className, ariaLabel } = this.props;
 
-    const iconColor = color !== undefined ? color : tokens.colors.depthDark1;
+    const iconColor = color !== undefined ? color : 'currentColor';
 
     if (icon !== undefined) {
       return <StyledSuomifiIcon {...passProps} icon={icon} color={iconColor} />;

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
+import classnames from 'classnames';
 import { iconBaseStyles } from './Icon.baseStyles';
 import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensProp } from '../theme';
@@ -10,6 +11,8 @@ import {
 import { SuomifiIcon, SuomifiIconInterface } from 'suomifi-icons';
 import { logger } from '../../utils/logger';
 export { BaseIconKeys } from 'suomifi-icons';
+
+const baseClassName = 'fi-icon';
 
 export interface IconBaseProps extends TokensProp {
   /** Aria-label for SVG, undefined hides SVG from screen reader
@@ -42,9 +45,10 @@ export const iconLogger = (
  * Apply Suomifi styles to Icon
  */
 const StyledSuomifiIcon = styled(
-  ({ ariaLabel, mousePointer, ...passProps }: IconProps) => {
+  ({ ariaLabel, mousePointer, className, ...passProps }: IconProps) => {
     return (
       <SuomifiIcon
+        className={classnames(baseClassName, className)}
         {...passProps}
         {...ariaLabelOrHidden(ariaLabel)}
         {...ariaFocusableNoLabel(ariaLabel)}

--- a/src/core/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/core/Icon/__snapshots__/Icon.test.tsx.snap
@@ -9,9 +9,9 @@ exports[`calling render with the same component on the same container does not r
 <div>
   <svg
     aria-label="Test label"
-    class="c0 my-icon--test"
+    class="fi-icon c0 my-icon--test"
     data-testid="icon"
-    fill="hsl(202, 7%, 40%)"
+    fill="currentColor"
     height="1em"
     role="img"
     viewBox="0 0 24 24"
@@ -23,8 +23,8 @@ exports[`calling render with the same component on the same container does not r
   </svg>
   <svg
     aria-hidden="true"
-    class="c0"
-    fill="hsl(202, 7%, 40%)"
+    class="fi-icon c0"
+    fill="currentColor"
     focusable="false"
     height="1em"
     viewBox="0 0 24 24"

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -116,8 +116,8 @@ exports[`calling render with the same component on the same container does not r
       FI
       <svg
         aria-hidden="true"
-        class="c2 fi-language-menu-language_icon"
-        fill="hsl(202, 7%, 40%)"
+        class="fi-icon c2 fi-language-menu-language_icon"
+        fill="currentColor"
         focusable="false"
         height="1em"
         viewBox="0 0 24 24"

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`calling render with the same component on the same container does not r
   </span>
   <svg
     aria-hidden="true"
-    class="c5 fi-link_icon"
+    class="fi-icon c5 fi-link_icon"
     fill="currentColor"
     focusable="false"
     height="1em"

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -430,7 +430,7 @@ exports[`snapshot testing 1`] = `
         Test expander 1
         <svg
           aria-hidden="true"
-          class="c8 fi-expander_title-icon"
+          class="fi-icon c8 fi-expander_title-icon"
           fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"
@@ -463,7 +463,7 @@ exports[`snapshot testing 1`] = `
         Test expander 2
         <svg
           aria-hidden="true"
-          class="c8 fi-expander_title-icon"
+          class="fi-icon c8 fi-expander_title-icon"
           fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"
@@ -496,7 +496,7 @@ exports[`snapshot testing 1`] = `
         Test expander 3
         <svg
           aria-hidden="true"
-          class="c8 fi-expander_title-icon"
+          class="fi-icon c8 fi-expander_title-icon"
           fill="hsl(212, 63%, 45%)"
           focusable="false"
           height="1em"


### PR DESCRIPTION

## Description

**Changes**
- Icon is now using `currentColor` by default
- BreadCrumbLink was tellin wrong and unnecessary color token on the code side as it was overrided by the css
- SearchInput has now fill color set explicitly as it no longer can use the default color
- Added example how `currentColor` affects the icon
- Icon now have baseClassName: `fi-icon`
- Snapshots updated


## Related Issue
Related issue is no longer totally valid with the colors mentioned there.

Closes #229 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Icon usage is easier to have same color as the text without the need of complex logic to handle all different cases.
It is now possible to use the `fi-icon` also to override the colouring if needed.

## How Has This Been Tested?
- Locally with the styleguidist
- Locally with CRA JS-project

## Release notes

🚨**Breaking change**
- Icon is now using `currentColor` by default