### PR TITLE
[Feature] Dropdown label and placeholder

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 import React, { Component, ReactNode, ReactElement } from 'react';
 import classnames from 'classnames';
-import { HtmlLabel, HtmlLabelProps } from '../../reset';
+import { HtmlLabel, HtmlLabelProps, HtmlSpan } from '../../reset';
 import { Paragraph, ParagraphProps } from '../Paragraph/Paragraph';
 import {
   Menu,
@@ -14,7 +14,7 @@ import {
 } from '@reach/menu-button';
 import { positionMatchWidth } from '@reach/popover';
 import { logger } from '../../utils/logger';
-
+import { idGenerator } from '../../utils/uuid';
 export { MenuItem as DropdownItem };
 
 const baseClassName = 'fi-dropdown';
@@ -23,7 +23,7 @@ export const dropdownClassNames = {
   baseClassName,
   label: `${baseClassName}_label`,
   button: `${baseClassName}_button`,
-  popover: `${baseClassName}}_popover`,
+  popover: `${baseClassName}_popover`,
   item: `${baseClassName}_item`,
 };
 
@@ -51,6 +51,8 @@ type OptionalMenuPopoverProps = {
 type OptionalMenuItemProps = { [K in keyof MenuItemProps]?: MenuItemProps[K] };
 
 export interface DropdownProps {
+  /** id */
+  id?: string;
   /** Label */
   labelText: string;
   /** Pass custom props to label container */
@@ -110,6 +112,7 @@ export class Dropdown extends Component<DropdownProps> {
 
   render() {
     const {
+      id: propId,
       children,
       labelProps,
       labelText,
@@ -128,6 +131,8 @@ export class Dropdown extends Component<DropdownProps> {
       logger.warn(`Dropdown '${name}' does not contain items`);
       return null;
     }
+
+    const id = idGenerator(propId);
 
     const { selectedName } = this.state;
     const passDropdownButtonProps = {
@@ -153,16 +158,15 @@ export class Dropdown extends Component<DropdownProps> {
     };
 
     return (
-      <HtmlLabel
-        {...labelProps}
-        className={classnames(
-          dropdownClassNames.label,
-          className,
-          baseClassName,
-        )}
-      >
-        <Paragraph {...labelTextProps}>{labelText}</Paragraph>
-        <Menu {...passProps}>
+      <HtmlSpan className={classnames(className, baseClassName)}>
+        <HtmlLabel
+          htmlFor={id}
+          {...labelProps}
+          className={dropdownClassNames.label}
+        >
+          <Paragraph {...labelTextProps}>{labelText}</Paragraph>
+        </HtmlLabel>
+        <Menu {...passProps} id={id}>
           <MenuButton {...passDropdownButtonProps}>
             {!!selectedName ? selectedName : name}
           </MenuButton>
@@ -189,7 +193,7 @@ export class Dropdown extends Component<DropdownProps> {
             </MenuPopover>
           )}
         </Menu>
-      </HtmlLabel>
+      </HtmlSpan>
     );
   }
 }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -141,7 +141,6 @@ export class Dropdown extends Component<DropdownProps> {
       changeVisualPlaceholderToSelection: changeNameToSelection = true,
       ...passProps
     } = this.props;
-
     if (React.Children.count(children) < 1) {
       logger.warn(`Dropdown '${name}' does not contain items`);
       return null;
@@ -149,10 +148,14 @@ export class Dropdown extends Component<DropdownProps> {
 
     const id = idGenerator(propId);
     const labelId = `${id}-label`;
+    const buttonId = !!dropdownButtonProps.id
+      ? dropdownButtonProps.id
+      : `${id}_button`;
 
     const { selectedName } = this.state;
     const passDropdownButtonProps = {
       ...dropdownButtonProps,
+      id: buttonId,
       className: classnames(
         dropdownClassNames.button,
         dropdownButtonProps.className,
@@ -161,6 +164,7 @@ export class Dropdown extends Component<DropdownProps> {
         !!ariaLabelledBy ? `${ariaLabelledBy} ` : ''
       }${labelId}`,
     };
+
     const passDropdownPopoverProps = {
       ...dropdownPopoverProps,
       className: classnames(

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -59,12 +59,12 @@ export interface DropdownProps {
   labelProps?: DropdownLabelProps;
   /** Pass custom props to Label text element */
   labelTextProps?: ParagraphProps;
-  /** Name to show for the dropdown */
-  name: ReactNode;
-  /** Change name by selection
+  /** visual hint to show if nothing is selected */
+  visualPlaceholder?: ReactNode;
+  /** Change visualPlaceholder by selection
    * @default true
    */
-  changeNameToSelection?: boolean;
+  changeVisualPlaceholderToSelection?: boolean;
   /** Custom classname to extend or customize */
   className?: string;
   /** Properties given to dropdown's Button-component, className etc. */
@@ -117,13 +117,13 @@ export class Dropdown extends Component<DropdownProps> {
       labelProps,
       labelText,
       labelTextProps,
-      name,
+      visualPlaceholder: name,
       className,
       dropdownButtonProps = {},
       dropdownPopoverProps = {},
       menuPopoverComponent: MenuPopoverComponentReplace,
       dropdownItemProps = {},
-      changeNameToSelection = true,
+      changeVisualPlaceholderToSelection: changeNameToSelection = true,
       ...passProps
     } = this.props;
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -147,7 +147,7 @@ export class Dropdown extends Component<DropdownProps> {
         dropdownClassNames.button,
         dropdownButtonProps.className,
       ),
-      'aria-labelledby': `${ariaLabelledBy} ${id}`,
+      'aria-labelledby': `${!!ariaLabelledBy ? `${ariaLabelledBy} ` : ''}${id}`,
     };
     const passDropdownPopoverProps = {
       ...dropdownPopoverProps,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -54,9 +54,13 @@ type OptionalMenuItemProps = { [K in keyof MenuItemProps]?: MenuItemProps[K] };
 type DropdownLabel = 'hidden' | 'top';
 
 export interface DropdownProps {
-  /** id */
+  /**
+   * Unique id
+   * If no id is specified, one will be generated using uuid
+   * @default uuidV4
+   */
   id?: string;
-  /** Label */
+  /** Label for the Dropdown component. */
   labelText: string;
   /** Custom props for label container */
   labelProps?: DropdownLabelProps;
@@ -64,7 +68,7 @@ export interface DropdownProps {
   labelTextProps?: ParagraphProps;
   /** Label displaymode -
    * top: show above, hidden: use only for screenreader
-   * @default visible
+   * @default top
    */
   labelMode?: DropdownLabel;
   /**
@@ -72,7 +76,7 @@ export interface DropdownProps {
    * Used in addition to labelText for screen readers.
    */
   'aria-labelledby'?: string;
-  /** visual hint to show if nothing is selected */
+  /** Visual hint to show if nothing is selected */
   visualPlaceholder?: ReactNode;
   /** Change visualPlaceholder by selection
    * @default true
@@ -148,11 +152,14 @@ export class Dropdown extends Component<DropdownProps> {
 
     const id = idGenerator(propId);
     const labelId = `${id}-label`;
+    const ariaLabelledByIds = `${
+      !!ariaLabelledBy ? `${ariaLabelledBy} ` : ''
+    }${labelId}`;
     const buttonId = !!dropdownButtonProps.id
       ? dropdownButtonProps.id
       : `${id}_button`;
-
     const { selectedName } = this.state;
+
     const passDropdownButtonProps = {
       ...dropdownButtonProps,
       id: buttonId,
@@ -160,9 +167,7 @@ export class Dropdown extends Component<DropdownProps> {
         dropdownClassNames.button,
         dropdownButtonProps.className,
       ),
-      'aria-labelledby': `${
-        !!ariaLabelledBy ? `${ariaLabelledBy} ` : ''
-      }${labelId}`,
+      'aria-labelledby': ariaLabelledByIds,
     };
 
     const passDropdownPopoverProps = {
@@ -172,6 +177,7 @@ export class Dropdown extends Component<DropdownProps> {
         dropdownPopoverProps.className,
       ),
     };
+
     const passDropdownItemProps = {
       ...dropdownItemProps,
       className: classnames(

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -21,7 +21,7 @@ const baseClassName = 'fi-dropdown';
 
 export const dropdownClassNames = {
   baseClassName,
-  label: `${baseClassName}_label-p`,
+  label: `${baseClassName}_label`,
   button: `${baseClassName}_button`,
   popover: `${baseClassName}}_popover`,
   item: `${baseClassName}_item`,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ReactNode, ReactElement } from 'react';
 import classnames from 'classnames';
-import { HtmlSpan } from '../../reset/HtmlSpan/HtmlSpan';
+import { HtmlLabel, HtmlLabelProps } from '../../reset';
+import { Paragraph, ParagraphProps } from '../Paragraph/Paragraph';
 import {
   Menu,
   MenuButton,
@@ -17,9 +18,16 @@ import { logger } from '../../utils/logger';
 export { MenuItem as DropdownItem };
 
 const baseClassName = 'fi-dropdown';
-const buttonClassName = `${baseClassName}_button`;
-const dropdownPopoverClassName = `${baseClassName}_popover`;
-const dropdownItemClassName = `${baseClassName}_item`;
+
+export const dropdownClassNames = {
+  baseClassName,
+  label: `${baseClassName}_label-p`,
+  button: `${baseClassName}_button`,
+  popover: `${baseClassName}}_popover`,
+  item: `${baseClassName}_item`,
+};
+
+export interface DropdownLabelProps extends HtmlLabelProps {}
 
 export interface DropdownItemProps {
   /** Operation to run on select */
@@ -43,6 +51,12 @@ type OptionalMenuPopoverProps = {
 type OptionalMenuItemProps = { [K in keyof MenuItemProps]?: MenuItemProps[K] };
 
 export interface DropdownProps {
+  /** Label */
+  labelText: string;
+  /** Pass custom props to label container */
+  labelProps?: DropdownLabelProps;
+  /** Pass custom props to Label text element */
+  labelTextProps?: ParagraphProps;
   /** Name to show for the dropdown */
   name: ReactNode;
   /** Change name by selection
@@ -97,6 +111,9 @@ export class Dropdown extends Component<DropdownProps> {
   render() {
     const {
       children,
+      labelProps,
+      labelText,
+      labelTextProps,
       name,
       className,
       dropdownButtonProps = {},
@@ -115,22 +132,36 @@ export class Dropdown extends Component<DropdownProps> {
     const { selectedName } = this.state;
     const passDropdownButtonProps = {
       ...dropdownButtonProps,
-      className: classnames(buttonClassName, dropdownButtonProps.className),
+      className: classnames(
+        dropdownClassNames.button,
+        dropdownButtonProps.className,
+      ),
     };
     const passDropdownPopoverProps = {
       ...dropdownPopoverProps,
       className: classnames(
-        dropdownPopoverClassName,
+        dropdownClassNames.popover,
         dropdownPopoverProps.className,
       ),
     };
     const passDropdownItemProps = {
       ...dropdownItemProps,
-      className: classnames(dropdownItemClassName, dropdownItemProps.className),
+      className: classnames(
+        dropdownClassNames.item,
+        dropdownItemProps.className,
+      ),
     };
 
     return (
-      <HtmlSpan className={classnames(className, baseClassName)}>
+      <HtmlLabel
+        {...labelProps}
+        className={classnames(
+          dropdownClassNames.label,
+          className,
+          baseClassName,
+        )}
+      >
+        <Paragraph {...labelTextProps}>{labelText}</Paragraph>
         <Menu {...passProps}>
           <MenuButton {...passDropdownButtonProps}>
             {!!selectedName ? selectedName : name}
@@ -158,7 +189,7 @@ export class Dropdown extends Component<DropdownProps> {
             </MenuPopover>
           )}
         </Menu>
-      </HtmlSpan>
+      </HtmlLabel>
     );
   }
 }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -55,10 +55,15 @@ export interface DropdownProps {
   id?: string;
   /** Label */
   labelText: string;
-  /** Pass custom props to label container */
+  /** Custom props for label container */
   labelProps?: DropdownLabelProps;
-  /** Pass custom props to Label text element */
+  /** Custom props for Label text element */
   labelTextProps?: ParagraphProps;
+  /**
+   * Additional label id. E.g. form group label.
+   * Used in addition to labelText for screen readers.
+   */
+  'aria-labelledby'?: string;
   /** visual hint to show if nothing is selected */
   visualPlaceholder?: ReactNode;
   /** Change visualPlaceholder by selection
@@ -117,6 +122,7 @@ export class Dropdown extends Component<DropdownProps> {
       labelProps,
       labelText,
       labelTextProps,
+      'aria-labelledby': ariaLabelledBy,
       visualPlaceholder: name,
       className,
       dropdownButtonProps = {},
@@ -141,6 +147,7 @@ export class Dropdown extends Component<DropdownProps> {
         dropdownClassNames.button,
         dropdownButtonProps.className,
       ),
+      'aria-labelledby': `${ariaLabelledBy} ${id}`,
     };
     const passDropdownPopoverProps = {
       ...dropdownPopoverProps,
@@ -159,14 +166,10 @@ export class Dropdown extends Component<DropdownProps> {
 
     return (
       <HtmlSpan className={classnames(className, baseClassName)}>
-        <HtmlLabel
-          htmlFor={id}
-          {...labelProps}
-          className={dropdownClassNames.label}
-        >
+        <HtmlLabel id={id} {...labelProps} className={dropdownClassNames.label}>
           <Paragraph {...labelTextProps}>{labelText}</Paragraph>
         </HtmlLabel>
-        <Menu {...passProps} id={id}>
+        <Menu {...passProps}>
           <MenuButton {...passDropdownButtonProps}>
             {!!selectedName ? selectedName : name}
           </MenuButton>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -13,6 +13,7 @@ import {
   MenuPopover,
 } from '@reach/menu-button';
 import { positionMatchWidth } from '@reach/popover';
+import { VisuallyHidden } from '../Visually-hidden/Visually-hidden';
 import { logger } from '../../utils/logger';
 import { idGenerator } from '../../utils/uuid';
 export { MenuItem as DropdownItem };
@@ -50,6 +51,8 @@ type OptionalMenuPopoverProps = {
 };
 type OptionalMenuItemProps = { [K in keyof MenuItemProps]?: MenuItemProps[K] };
 
+type DropdownLabel = 'hidden' | 'top';
+
 export interface DropdownProps {
   /** id */
   id?: string;
@@ -59,6 +62,11 @@ export interface DropdownProps {
   labelProps?: DropdownLabelProps;
   /** Custom props for Label text element */
   labelTextProps?: ParagraphProps;
+  /** Label displaymode -
+   * top: show above, hidden: use only for screenreader
+   * @default visible
+   */
+  labelMode?: DropdownLabel;
   /**
    * Additional label id. E.g. form group label.
    * Used in addition to labelText for screen readers.
@@ -122,6 +130,7 @@ export class Dropdown extends Component<DropdownProps> {
       labelProps,
       labelText,
       labelTextProps,
+      labelMode = 'top',
       'aria-labelledby': ariaLabelledBy,
       visualPlaceholder: name,
       className,
@@ -139,6 +148,7 @@ export class Dropdown extends Component<DropdownProps> {
     }
 
     const id = idGenerator(propId);
+    const labelId = `${id}-label`;
 
     const { selectedName } = this.state;
     const passDropdownButtonProps = {
@@ -147,7 +157,9 @@ export class Dropdown extends Component<DropdownProps> {
         dropdownClassNames.button,
         dropdownButtonProps.className,
       ),
-      'aria-labelledby': `${!!ariaLabelledBy ? `${ariaLabelledBy} ` : ''}${id}`,
+      'aria-labelledby': `${
+        !!ariaLabelledBy ? `${ariaLabelledBy} ` : ''
+      }${labelId}`,
     };
     const passDropdownPopoverProps = {
       ...dropdownPopoverProps,
@@ -165,11 +177,23 @@ export class Dropdown extends Component<DropdownProps> {
     };
 
     return (
-      <HtmlSpan className={classnames(className, baseClassName)}>
-        <HtmlLabel id={id} {...labelProps} className={dropdownClassNames.label}>
-          <Paragraph {...labelTextProps}>{labelText}</Paragraph>
+      <HtmlSpan
+        className={classnames(className, baseClassName)}
+        id={id}
+        {...passProps}
+      >
+        <HtmlLabel
+          id={labelId}
+          {...labelProps}
+          className={dropdownClassNames.label}
+        >
+          {labelMode === 'hidden' ? (
+            <VisuallyHidden>{labelText}</VisuallyHidden>
+          ) : (
+            <Paragraph {...labelTextProps}>{labelText}</Paragraph>
+          )}
         </HtmlLabel>
-        <Menu {...passProps}>
+        <Menu>
           <MenuButton {...passDropdownButtonProps}>
             {!!selectedName ? selectedName : name}
           </MenuButton>

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -1,9 +1,15 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../theme';
-import { element, inputButton } from '../theme/reset';
+import { element, inputButton, font } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
+    & .fi-dropdown_label-p {
+      margin-bottom: ${theme.spacing.insetL};
+      ${font({ theme })('actionElementInnerTextBold')};
+      color: ${theme.colors.blackBase};
+    }
+
     & > [data-reach-menu-button].fi-dropdown_button {
       ${inputButton({ theme })}
       position: relative;

--- a/src/core/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown.md
@@ -1,4 +1,34 @@
 ```js
+import { Dropdown } from 'suomifi-ui-components';
+
+<Dropdown visualPlaceholder="Dropdown" labelText="Dropdown label">
+  <Dropdown.item onSelect={() => console.log('dropdown item 1')}>
+    Dropdown Item 1
+  </Dropdown.item>
+  <Dropdown.item onSelect={() => console.log('dropdown item 2')}>
+    Dropdown Item 2
+  </Dropdown.item>
+</Dropdown>;
+```
+
+```js
+import { Dropdown } from 'suomifi-ui-components';
+
+<Dropdown
+  visualPlaceholder="Dropdown with visually hidden label"
+  labelText="Dropdown label"
+  labelMode="hidden"
+>
+  <Dropdown.item onSelect={() => console.log('dropdown item 1')}>
+    Dropdown Item 1
+  </Dropdown.item>
+  <Dropdown.item onSelect={() => console.log('dropdown item 2')}>
+    Dropdown Item 2
+  </Dropdown.item>
+</Dropdown>;
+```
+
+```js
 import { Dropdown, Block } from 'suomifi-ui-components';
 
 const dropdownProps = {
@@ -12,16 +42,16 @@ const dropdownProps = {
   <Block padding="xs">
     <Dropdown
       visualPlaceholder="Dropdown 1"
-      labelText="Dropdown test 1"
+      labelText="Dropdown 1 label"
       {...dropdownProps}
     >
       <Dropdown.item
-        onSelect={() => console.log('dropdown 1 test 1')}
+        onSelect={() => console.log('dropdown 1 item 1')}
       >
         Dropdown 1 Item 1
       </Dropdown.item>
       <Dropdown.item
-        onSelect={() => console.log('dropdown 1 test 2')}
+        onSelect={() => console.log('dropdown 1 item 2')}
       >
         Dropdown 1 Item 2
       </Dropdown.item>
@@ -30,16 +60,16 @@ const dropdownProps = {
   <Block padding="xs">
     <Dropdown
       visualPlaceholder="Dropdown 2"
-      labelText="Dropdown test 2"
+      labelText="Dropdown 2 label"
       {...dropdownProps}
     >
       <Dropdown.item
-        onSelect={() => console.log('dropdown 2 test 2')}
+        onSelect={() => console.log('dropdown 2 item 2')}
       >
         Dropdown 2 Item 1
       </Dropdown.item>
       <Dropdown.item
-        onSelect={() => console.log('dropdown 2 test 2')}
+        onSelect={() => console.log('dropdown 2 item 2')}
       >
         Dropdown 2 Item 2
       </Dropdown.item>

--- a/src/core/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown.md
@@ -16,14 +16,14 @@ const dropdownProps = {
       {...dropdownProps}
     >
       <Dropdown.item
-        onSelect={() => console.log('dropdown test 1 1')}
+        onSelect={() => console.log('dropdown 1 test 1')}
       >
-        Item 1
+        Dropdown 1 Item 1
       </Dropdown.item>
       <Dropdown.item
-        onSelect={() => console.log('dropdown test 1 2')}
+        onSelect={() => console.log('dropdown 1 test 2')}
       >
-        Item 2
+        Dropdown 1 Item 2
       </Dropdown.item>
     </Dropdown>
   </Block>
@@ -34,14 +34,14 @@ const dropdownProps = {
       {...dropdownProps}
     >
       <Dropdown.item
-        onSelect={() => console.log('dropdown test 2 1')}
+        onSelect={() => console.log('dropdown 2 test 2')}
       >
-        Item 1
+        Dropdown 2 Item 1
       </Dropdown.item>
       <Dropdown.item
-        onSelect={() => console.log('dropdown test 2 2')}
+        onSelect={() => console.log('dropdown 2 test 2')}
       >
-        Item 2
+        Dropdown 2 Item 2
       </Dropdown.item>
     </Dropdown>
   </Block>

--- a/src/core/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown.md
@@ -1,16 +1,49 @@
 ```js
-import { Dropdown } from 'suomifi-ui-components';
+import { Dropdown, Block } from 'suomifi-ui-components';
 
-<Dropdown
-  className="dropdown-test"
-  name="Dropdown"
-  labelText="Dropdown test"
->
-  <Dropdown.item onSelect={() => console.log('dropdown test 1')}>
-    Item 1
-  </Dropdown.item>
-  <Dropdown.item onSelect={() => console.log('dropdown test 2')}>
-    Item 2
-  </Dropdown.item>
-</Dropdown>;
+const dropdownProps = {
+  'aria-labelledby': 'dropdown-group'
+};
+
+<div>
+  <label id="dropdown-group">
+    <p>Dropdown group</p>
+  </label>
+  <Block padding="xs">
+    <Dropdown
+      visualPlaceholder="Dropdown 1"
+      labelText="Dropdown test 1"
+      {...dropdownProps}
+    >
+      <Dropdown.item
+        onSelect={() => console.log('dropdown test 1 1')}
+      >
+        Item 1
+      </Dropdown.item>
+      <Dropdown.item
+        onSelect={() => console.log('dropdown test 1 2')}
+      >
+        Item 2
+      </Dropdown.item>
+    </Dropdown>
+  </Block>
+  <Block padding="xs">
+    <Dropdown
+      visualPlaceholder="Dropdown 2"
+      labelText="Dropdown test 2"
+      {...dropdownProps}
+    >
+      <Dropdown.item
+        onSelect={() => console.log('dropdown test 2 1')}
+      >
+        Item 1
+      </Dropdown.item>
+      <Dropdown.item
+        onSelect={() => console.log('dropdown test 2 2')}
+      >
+        Item 2
+      </Dropdown.item>
+    </Dropdown>
+  </Block>
+</div>;
 ```

--- a/src/core/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown.md
@@ -1,7 +1,11 @@
 ```js
 import { Dropdown } from 'suomifi-ui-components';
 
-<Dropdown className="dropdown-test" name="Dropdown">
+<Dropdown
+  className="dropdown-test"
+  name="Dropdown"
+  labelText="Dropdown test"
+>
   <Dropdown.item onSelect={() => console.log('dropdown test 1')}>
     Item 1
   </Dropdown.item>

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -1,34 +1,90 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
-import { Dropdown } from './Dropdown';
+import { Dropdown, DropdownProps } from './Dropdown';
 import { baseStyles } from './Dropdown.baseStyles';
 import { cssFromBaseStyles } from '../utils';
 import { axeTest } from '../../utils/test/axe';
 
 const doNothing = () => ({});
 
-const TestDropdown = (
-  <Dropdown
-    labelText="Dropdown test"
-    className="dropdown-test"
-    visualPlaceholder="Dropdown"
-    id="test-id"
-  >
+const dropdownProps = {
+  labelText: 'Dropdown test',
+  className: 'dropdown-test',
+  visualPlaceholder: 'Dropdown',
+  id: 'test-id',
+};
+
+const TestDropdown = (props: DropdownProps, testId?: string) => (
+  <Dropdown {...props} data-testid={!!testId ? testId : ''}>
     <Dropdown.item onSelect={doNothing}>Item 1</Dropdown.item>
     <Dropdown.item onSelect={doNothing}>Item 2</Dropdown.item>
   </Dropdown>
 );
 
-test('calling render with the same component on the same container does not remount', () => {
-  const { container } = render(TestDropdown);
-  expect(container).toMatchSnapshot();
+describe('Basic dropdown', () => {
+  const BasicDropdown = TestDropdown(dropdownProps, 'dropdown-test-id');
+  const { container } = render(BasicDropdown);
+
+  test('should match snapshot', () => {
+    expect(container).toMatchSnapshot();
+  });
+
+  const dropdowns = screen.getAllByTestId('dropdown-test-id');
+
+  test('should have provided ids', () => {
+    dropdowns.forEach((dropdown) => {
+      expect(dropdown).toHaveAttribute('id', 'test-id');
+      const labels = dropdown.getElementsByTagName('label');
+      expect(labels[0]).toHaveAttribute('id', 'test-id-label');
+    });
+  });
+
+  test('should have visual placeholder', () => {
+    dropdowns.forEach((dropdown) => {
+      const buttons = dropdown.getElementsByTagName('button');
+      expect(buttons[0]).toHaveTextContent('Dropdown');
+    });
+  });
+
+  test('should open menu when clicked', () => {
+    expect(container).toBeTruthy();
+  });
+});
+
+describe('Dropdown with hidden label', () => {
+  const hiddenProps: DropdownProps = {
+    labelMode: 'hidden',
+    ...dropdownProps,
+  };
+  const DropdownWithHiddenLabel = TestDropdown(hiddenProps);
+  const { container } = render(DropdownWithHiddenLabel);
+
+  test('should have visually hidden label', () => {
+    // have hidden label
+    // have placeholder
+    expect(container).toMatchSnapshot();
+  });
+});
+
+describe('additional label', () => {
+  const additionalLabelProps: DropdownProps = {
+    'aria-labelledby': 'test-label-id',
+    ...dropdownProps,
+  };
+  const TestDropdownWithExtraLabel = TestDropdown(additionalLabelProps);
+  const { container } = render(TestDropdownWithExtraLabel);
+
+  test('using aria-labelledby prop should attach provided label-id', () => {
+    // have both, internal and provided label-id in aria-labelledby
+    expect(container).toMatchSnapshot();
+  });
 });
 
 // Don't validate aria-attributes since Portal is not rendered and there is no pair for aria-controls
 test(
   'should not have basic accessibility issues',
-  axeTest(TestDropdown, {
+  axeTest(TestDropdown(dropdownProps), {
     rules: {
       'aria-valid-attr-value': {
         enabled: false,

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -9,7 +9,12 @@ import { axeTest } from '../../utils/test/axe';
 const doNothing = () => ({});
 
 const TestDropdown = (
-  <Dropdown labelText="Dropdown test" className="dropdown-test" name="Dropdown">
+  <Dropdown
+    labelText="Dropdown test"
+    className="dropdown-test"
+    name="Dropdown"
+    id="test-id"
+  >
     <Dropdown.item onSelect={doNothing}>Item 1</Dropdown.item>
     <Dropdown.item onSelect={doNothing}>Item 2</Dropdown.item>
   </Dropdown>

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -26,26 +26,33 @@ describe('Basic dropdown', () => {
   const BasicDropdown = TestDropdown(dropdownProps, 'dropdown-test-id');
 
   it('should have provided ids', () => {
-    const { getAllByTestId } = render(BasicDropdown);
-    const dropdowns = getAllByTestId('dropdown-test-id');
-    dropdowns.forEach((dropdown) => {
-      expect(dropdown).toHaveAttribute('id', 'test-id');
-      const labels = dropdown.getElementsByTagName('label');
-      expect(labels[0]).toHaveAttribute('id', 'test-id-label');
+    let dropdown: any;
+    let label: any;
+    act(() => {
+      const { getAllByTestId } = render(BasicDropdown);
+      dropdown = getAllByTestId('dropdown-test-id')[0];
+      label = dropdown.getElementsByTagName('label')[0];
     });
+    expect(dropdown).toHaveAttribute('id', 'test-id');
+    expect(label).toHaveAttribute('id', 'test-id-label');
   });
 
   it('should have visual placeholder', () => {
-    const { getAllByTestId } = render(BasicDropdown);
-    const dropdowns = getAllByTestId('dropdown-test-id');
-    dropdowns.forEach((dropdown) => {
-      const buttons = dropdown.getElementsByTagName('button');
-      expect(buttons[0]).toHaveTextContent('Dropdown');
+    let button: any;
+    act(() => {
+      const { getAllByTestId } = render(BasicDropdown);
+      const dropdown = getAllByTestId('dropdown-test-id')[0];
+      button = dropdown.getElementsByTagName('button')[0];
     });
+    expect(button).toHaveTextContent('Dropdown');
   });
 
   it('should match snapshot', () => {
-    const { container } = render(BasicDropdown);
+    let container: any;
+    act(() => {
+      const { container: cont } = render(BasicDropdown);
+      container = cont;
+    });
     expect(container).toMatchSnapshot();
   });
 });
@@ -70,7 +77,11 @@ describe('Dropdown with hidden label', () => {
   });
 
   it('should match snapshot', () => {
-    const { container } = render(DropdownWithHiddenLabel);
+    let container: any;
+    act(() => {
+      const { container: cont } = render(DropdownWithHiddenLabel);
+      container = cont;
+    });
     expect(container).toMatchSnapshot();
   });
 });
@@ -94,7 +105,11 @@ describe('Dropdown with additional aria-label', () => {
   });
 
   it('should match snapshot', () => {
-    const { container } = render(DropdownWithExtraLabel);
+    let container: any;
+    act(() => {
+      const { container: cont } = render(DropdownWithExtraLabel);
+      container = cont;
+    });
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -93,7 +93,7 @@ describe('Dropdown with additional aria-label', () => {
   };
   const DropdownWithExtraLabel = TestDropdown(additionalLabelProps);
 
-  it('should have aria-labelledby composed from labe-id and provided aria-labelledby prop', () => {
+  it('should have aria-labelledby composed from label-id and provided aria-labelledby prop', () => {
     let button: any;
     act(() => {
       const { getAllByRole } = render(DropdownWithExtraLabel);

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 
 import { Dropdown, DropdownProps } from './Dropdown';
 import { baseStyles } from './Dropdown.baseStyles';
@@ -24,15 +24,10 @@ const TestDropdown = (props: DropdownProps, testId?: string) => (
 
 describe('Basic dropdown', () => {
   const BasicDropdown = TestDropdown(dropdownProps, 'dropdown-test-id');
-  const { container } = render(BasicDropdown);
 
-  test('should match snapshot', () => {
-    expect(container).toMatchSnapshot();
-  });
-
-  const dropdowns = screen.getAllByTestId('dropdown-test-id');
-
-  test('should have provided ids', () => {
+  it('should have provided ids', () => {
+    const { getAllByTestId } = render(BasicDropdown);
+    const dropdowns = getAllByTestId('dropdown-test-id');
     dropdowns.forEach((dropdown) => {
       expect(dropdown).toHaveAttribute('id', 'test-id');
       const labels = dropdown.getElementsByTagName('label');
@@ -40,58 +35,83 @@ describe('Basic dropdown', () => {
     });
   });
 
-  test('should have visual placeholder', () => {
+  it('should have visual placeholder', () => {
+    const { getAllByTestId } = render(BasicDropdown);
+    const dropdowns = getAllByTestId('dropdown-test-id');
     dropdowns.forEach((dropdown) => {
       const buttons = dropdown.getElementsByTagName('button');
       expect(buttons[0]).toHaveTextContent('Dropdown');
     });
   });
 
-  test('should open menu when clicked', () => {
-    expect(container).toBeTruthy();
+  it('should match snapshot', () => {
+    const { container } = render(BasicDropdown);
+    expect(container).toMatchSnapshot();
   });
 });
 
 describe('Dropdown with hidden label', () => {
   const hiddenProps: DropdownProps = {
+    ...dropdownProps,
     labelMode: 'hidden',
-    ...dropdownProps,
   };
-  const DropdownWithHiddenLabel = TestDropdown(hiddenProps);
-  const { container } = render(DropdownWithHiddenLabel);
+  const DropdownWithHiddenLabel = TestDropdown(
+    hiddenProps,
+    'dropdown-hidden-label-test-id',
+  );
 
-  test('should have visually hidden label', () => {
-    // have hidden label
-    // have placeholder
+  it('should have hidden label', () => {
+    let label: any;
+    act(() => {
+      const { getAllByText } = render(DropdownWithHiddenLabel);
+      label = getAllByText('Dropdown test')[0];
+    });
+    expect(label).toHaveClass('fi-visually-hidden');
+  });
+
+  it('should match snapshot', () => {
+    const { container } = render(DropdownWithHiddenLabel);
     expect(container).toMatchSnapshot();
   });
 });
 
-describe('additional label', () => {
+describe('Dropdown with additional aria-label', () => {
   const additionalLabelProps: DropdownProps = {
-    'aria-labelledby': 'test-label-id',
     ...dropdownProps,
+    'aria-labelledby': 'additional-label-id',
   };
-  const TestDropdownWithExtraLabel = TestDropdown(additionalLabelProps);
-  const { container } = render(TestDropdownWithExtraLabel);
+  const DropdownWithExtraLabel = TestDropdown(additionalLabelProps);
 
-  test('using aria-labelledby prop should attach provided label-id', () => {
-    // have both, internal and provided label-id in aria-labelledby
+  it('should have aria-labelledby composed from labe-id and provided aria-labelledby prop', () => {
+    let button: any;
+    act(() => {
+      const { getAllByRole } = render(DropdownWithExtraLabel);
+      button = getAllByRole('button')[0];
+    });
+    expect(button.getAttribute('aria-labelledby')).toBe(
+      'additional-label-id test-id-label',
+    );
+  });
+
+  it('should match snapshot', () => {
+    const { container } = render(DropdownWithExtraLabel);
     expect(container).toMatchSnapshot();
   });
 });
 
-// Don't validate aria-attributes since Portal is not rendered and there is no pair for aria-controls
-test(
-  'should not have basic accessibility issues',
-  axeTest(TestDropdown(dropdownProps), {
-    rules: {
-      'aria-valid-attr-value': {
-        enabled: false,
+describe('Dropdown', () => {
+  // Don't validate aria-attributes since Portal is not rendered and there is no pair for aria-controls
+  it(
+    'should not have basic accessibility issues',
+    axeTest(TestDropdown(dropdownProps), {
+      rules: {
+        'aria-valid-attr-value': {
+          enabled: false,
+        },
       },
-    },
-  }),
-);
+    }),
+  );
+});
 
 test('CSS export', () => {
   const css = cssFromBaseStyles(baseStyles);

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -9,7 +9,7 @@ import { axeTest } from '../../utils/test/axe';
 const doNothing = () => ({});
 
 const TestDropdown = (
-  <Dropdown className="dropdown-test" name="Dropdown">
+  <Dropdown labelText="Dropdown test" className="dropdown-test" name="Dropdown">
     <Dropdown.item onSelect={doNothing}>Item 1</Dropdown.item>
     <Dropdown.item onSelect={doNothing}>Item 2</Dropdown.item>
   </Dropdown>

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -12,7 +12,7 @@ const TestDropdown = (
   <Dropdown
     labelText="Dropdown test"
     className="dropdown-test"
-    name="Dropdown"
+    visualPlaceholder="Dropdown"
     id="test-id"
   >
     <Dropdown.item onSelect={doNothing}>Item 1</Dropdown.item>

--- a/src/core/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { default as styled } from 'styled-components';
+import classnames from 'classnames';
 import { withSuomifiDefaultProps } from '../theme/utils';
 import { TokensProp, InternalTokensProp } from '../theme';
 import { baseStyles, menuPopoverStyles } from './Dropdown.baseStyles';
@@ -15,12 +16,30 @@ import {
 import { DropdownItem, DropdownItemProps } from './DropdownItem';
 import { positionMatchWidth } from '@reach/popover';
 
+const baseClassName = 'fi-dropdown';
+
+export const textInputClassNames = {
+  baseClassName,
+  labelParagraph: `${baseClassName}_label-p`,
+};
+
 export interface DropdownProps extends CompDropdownProps, TokensProp {}
 
 const StyledDropdown = styled(
-  ({ tokens, ...passProps }: DropdownProps & InternalTokensProp) => (
+  ({
+    tokens,
+    labelTextProps = { className: undefined },
+    ...passProps
+  }: DropdownProps & InternalTokensProp) => (
     <CompDropdown
       {...passProps}
+      labelTextProps={{
+        ...labelTextProps,
+        className: classnames(
+          labelTextProps.className,
+          textInputClassNames.labelParagraph,
+        ),
+      }}
       dropdownItemProps={{ className: 'fi-dropdown_item' }}
     />
   ),

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,29 +1,186 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Basic dropdown should match snapshot 1`] = `
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c1 .fi-dropdown_label-p {
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  position: relative;
+  padding: 7px 38px 7px 7px;
+  text-align: left;
+  line-height: 1.5;
+  background-color: hsl(0,0%,100%);
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+  cursor: pointer;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
+  z-index: 9999;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(202,7%,40%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(202,7%,40%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
 <div>
   <span
-    class="sc-AxjAm iLdZYh sc-fzplWN caKHsX dropdown-test fi-dropdown"
+    class="c0 c1 dropdown-test fi-dropdown"
     data-testid="dropdown-test-id"
     id="test-id"
   >
     <label
-      class="sc-AxheI bkuqrK fi-dropdown_label"
+      class="c2 fi-dropdown_label"
       id="test-id-label"
     >
       <p
-        class="sc-fzoLsD fGoDSi fi-paragraph fi-dropdown_label-p"
+        class="c3 fi-paragraph fi-dropdown_label-p"
       >
         Dropdown test
       </p>
     </label>
     <button
-      aria-controls="menu--1"
+      aria-controls="menu--7"
       aria-haspopup="true"
       aria-labelledby="test-id-label"
       class="fi-dropdown_button"
       data-reach-menu-button=""
-      id="menu-button--menu--1"
+      id="test-id_button"
       type="button"
     >
       Dropdown
@@ -32,6 +189,368 @@ exports[`Basic dropdown should match snapshot 1`] = `
 </div>
 `;
 
-exports[`Dropdown with hidden label should have visually hidden label 1`] = `<div />`;
+exports[`Dropdown with additional aria-label should match snapshot 1`] = `
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
 
-exports[`additional label using aria-labelledby prop should attach provided label-id 1`] = `<div />`;
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c1 .fi-dropdown_label-p {
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  position: relative;
+  padding: 7px 38px 7px 7px;
+  text-align: left;
+  line-height: 1.5;
+  background-color: hsl(0,0%,100%);
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+  cursor: pointer;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
+  z-index: 9999;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(202,7%,40%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(202,7%,40%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+<div>
+  <span
+    class="c0 c1 dropdown-test fi-dropdown"
+    data-testid=""
+    id="test-id"
+  >
+    <label
+      class="c2 fi-dropdown_label"
+      id="test-id-label"
+    >
+      <p
+        class="c3 fi-paragraph fi-dropdown_label-p"
+      >
+        Dropdown test
+      </p>
+    </label>
+    <button
+      aria-controls="menu--19"
+      aria-haspopup="true"
+      aria-labelledby="additional-label-id test-id-label"
+      class="fi-dropdown_button"
+      data-reach-menu-button=""
+      id="test-id_button"
+      type="button"
+    >
+      Dropdown
+    </button>
+  </span>
+</div>
+`;
+
+exports[`Dropdown with hidden label should match snapshot 1`] = `
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c1 .fi-dropdown_label-p {
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  position: relative;
+  padding: 7px 38px 7px 7px;
+  text-align: left;
+  line-height: 1.5;
+  background-color: hsl(0,0%,100%);
+  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+  cursor: pointer;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,55%);
+  z-index: 9999;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:focus:not(:focus-visible):after {
+  content: none;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(202,7%,40%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1 > [data-reach-menu-button].fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(202,7%,40%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+<div>
+  <span
+    class="c0 c1 dropdown-test fi-dropdown"
+    data-testid="dropdown-hidden-label-test-id"
+    id="test-id"
+  >
+    <label
+      class="c2 fi-dropdown_label"
+      id="test-id-label"
+    >
+      <span
+        class="c0 c3 fi-visually-hidden"
+      >
+        Dropdown test
+      </span>
+    </label>
+    <button
+      aria-controls="menu--13"
+      aria-haspopup="true"
+      aria-labelledby="test-id-label"
+      class="fi-dropdown_button"
+      data-reach-menu-button=""
+      id="test-id_button"
+      type="button"
+    >
+      Dropdown
+    </button>
+  </span>
+</div>
+`;

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -18,10 +18,34 @@ exports[`calling render with the same component on the same container does not r
   color: inherit;
   background: none;
   cursor: inherit;
+  display: inline;
   max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
 }
 
 .c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -135,24 +159,29 @@ exports[`calling render with the same component on the same container does not r
 }
 
 <div>
-  <label
-    class="c0 fi-dropdown_label c1 dropdown-test fi-dropdown"
+  <span
+    class="c0 c1 dropdown-test fi-dropdown"
   >
-    <p
-      class="c2 fi-paragraph fi-dropdown_label-p"
+    <label
+      class="c2 fi-dropdown_label"
+      for="test-id"
     >
-      Dropdown test
-    </p>
+      <p
+        class="c3 fi-paragraph fi-dropdown_label-p"
+      >
+        Dropdown test
+      </p>
+    </label>
     <button
-      aria-controls="menu--1"
+      aria-controls="test-id"
       aria-haspopup="true"
       class="fi-dropdown_button"
       data-reach-menu-button=""
-      id="menu-button--menu--1"
+      id="menu-button--test-id"
       type="button"
     >
       Dropdown
     </button>
-  </label>
+  </span>
 </div>
 `;

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,173 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calling render with the same component on the same container does not remount 1`] = `
-.c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c1 .fi-dropdown_label-p {
-  margin-bottom: 10px;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(0,0%,16%);
-}
-
-.c1 > [data-reach-menu-button].fi-dropdown_button {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  min-width: 245px;
-  max-width: 100%;
-  padding: 8px 16px;
-  border: 1px solid hsl(202,7%,80%);
-  border-radius: 2px;
-  line-height: 1;
-  position: relative;
-  padding: 7px 38px 7px 7px;
-  text-align: left;
-  line-height: 1.5;
-  background-color: hsl(0,0%,100%);
-  box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
-  cursor: pointer;
-}
-
-.c1 > [data-reach-menu-button].fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1 > [data-reach-menu-button].fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,55%);
-  z-index: 9999;
-}
-
-.c1 > [data-reach-menu-button].fi-dropdown_button:focus:not(:focus-visible):after {
-  content: none;
-}
-
-.c1 > [data-reach-menu-button].fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(202,7%,40%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c1 > [data-reach-menu-button].fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(202,7%,40%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
+exports[`Basic dropdown should match snapshot 1`] = `
 <div>
   <span
-    class="c0 c1 dropdown-test fi-dropdown"
+    class="sc-AxjAm iLdZYh sc-fzplWN caKHsX dropdown-test fi-dropdown"
+    data-testid="dropdown-test-id"
+    id="test-id"
   >
     <label
-      class="c2 fi-dropdown_label"
-      id="test-id"
+      class="sc-AxheI bkuqrK fi-dropdown_label"
+      id="test-id-label"
     >
       <p
-        class="c3 fi-paragraph fi-dropdown_label-p"
+        class="sc-fzoLsD fGoDSi fi-paragraph fi-dropdown_label-p"
       >
         Dropdown test
       </p>
@@ -175,7 +20,7 @@ exports[`calling render with the same component on the same container does not r
     <button
       aria-controls="menu--1"
       aria-haspopup="true"
-      aria-labelledby="test-id"
+      aria-labelledby="test-id-label"
       class="fi-dropdown_button"
       data-reach-menu-button=""
       id="menu-button--menu--1"
@@ -186,3 +31,7 @@ exports[`calling render with the same component on the same container does not r
   </span>
 </div>
 `;
+
+exports[`Dropdown with hidden label should have visually hidden label 1`] = `<div />`;
+
+exports[`additional label using aria-labelledby prop should attach provided label-id 1`] = `<div />`;

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`calling render with the same component on the same container does not r
   >
     <label
       class="c2 fi-dropdown_label"
-      for="test-id"
+      id="test-id"
     >
       <p
         class="c3 fi-paragraph fi-dropdown_label-p"
@@ -173,11 +173,12 @@ exports[`calling render with the same component on the same container does not r
       </p>
     </label>
     <button
-      aria-controls="test-id"
+      aria-controls="menu--1"
       aria-haspopup="true"
+      aria-labelledby="test-id"
       class="fi-dropdown_button"
       data-reach-menu-button=""
-      id="menu-button--test-id"
+      id="menu-button--menu--1"
       type="button"
     >
       Dropdown

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -18,11 +18,49 @@ exports[`calling render with the same component on the same container does not r
   color: inherit;
   background: none;
   cursor: inherit;
-  display: inline;
+  max-width: 100%;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
   max-width: 100%;
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c1 .fi-dropdown_label-p {
+  margin-bottom: 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
 }
 
 .c1 > [data-reach-menu-button].fi-dropdown_button {
@@ -97,9 +135,14 @@ exports[`calling render with the same component on the same container does not r
 }
 
 <div>
-  <span
-    class="c0 c1 dropdown-test fi-dropdown"
+  <label
+    class="c0 fi-dropdown_label c1 dropdown-test fi-dropdown"
   >
+    <p
+      class="c2 fi-paragraph fi-dropdown_label-p"
+    >
+      Dropdown test
+    </p>
     <button
       aria-controls="menu--1"
       aria-haspopup="true"
@@ -110,6 +153,6 @@ exports[`calling render with the same component on the same container does not r
     >
       Dropdown
     </button>
-  </span>
+  </label>
 </div>
 `;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,6 +20,7 @@ declare module '@reach/menu-button' {
   }
 
   export interface IMenuProps {
+    id?: string;
     children: React.ReactNode;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,7 +20,6 @@ declare module '@reach/menu-button' {
   }
 
   export interface IMenuProps {
-    id?: string;
     children: React.ReactNode;
   }
 
@@ -30,6 +29,7 @@ declare module '@reach/menu-button' {
     onClick?: (e: React.MouseEvent<HTMLElement>) => void;
     onKeyDown?: (e: React.KeyboardEvent<HTMLElement>) => void;
     children: React.ReactNode;
+    'aria-labelledby'?: string;
   };
 
   export const MenuButton: React.SFC<MenuButtonProps>;


### PR DESCRIPTION
## Description

This PR adds mandatory label and related options for dropdown. In addition, name prop is renamed to visiblePlaceholder and is now ignored by screen readers.

## Motivation and Context

The dropdown component was not accessible due to lack of label. Label is now added as mandatory prop. Label can be hidden, when it's only available for screen readers. When label is hidden, a visualPlaceholder or other means should be used to communicate the purpose of the dropdown for non screen reader users.

Name prop is now renamed as visualPlaceholder which is intended to be shown as additional visual hint when there is no selection for the dropdown.

## How Has This Been Tested?

Tested with Create React App TS project and Styleguidist using both mouse and keyboard navigation and VoiceOver for macOS. Tested using all supported browsers on Mac. Still needs testing with Win10 latest Edge and NVDA.

## Release notes
- Name prop is now called visual placeholder and is ignored by screen readers. Label has been added as mandatory prop.