### PR TITLE
[Bugfix] Checkbox statustext margins

### DIFF
--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -57,7 +57,6 @@ const errorStyles = ({ theme }: SuomifiThemeProp) => css`
     }
     & .fi-checkbox_status {
       color: ${theme.colors.alertBase};
-      margin-top: ${theme.spacing.xxs};
     }
   }
 `;
@@ -150,6 +149,7 @@ export const baseStyles = withSuomifiTheme(
 
     & .fi-checkbox_status {
       display: block;
+      margin-top: ${theme.spacing.xxs};
       color: ${theme.colors.blackBase};
       font-size: 14px;
       line-height: 18px;

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -70,8 +70,8 @@ const DisabledTestCheckbox = createTestCheckbox(
 );
 
 test('Calling render with the same component on the same container does not remount', () => {
-  const toggleInputRendered = render(RegularTestCheckbox);
-  const { getByTestId, container, rerender } = toggleInputRendered;
+  const checkboxRendered = render(RegularTestCheckbox);
+  const { getByTestId, container, rerender } = checkboxRendered;
   expect(container.firstChild).toMatchSnapshot();
   expect(getByTestId('regular_id').textContent).toBe('Regular');
 

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`Calling render with the same component on the same container does not r
 
 .c1 .fi-checkbox_status {
   display: block;
+  margin-top: 5px;
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 18px;
@@ -203,7 +204,6 @@ exports[`Calling render with the same component on the same container does not r
 
 .c1.fi-checkbox--error .fi-checkbox_status {
   color: hsl(3,59%,48%);
-  margin-top: 5px;
 }
 
 .c1.fi-checkbox--disabled .fi-checkbox_label {


### PR DESCRIPTION
## Description
Checkbox status text element styles were off. The top margin was applied only with the error status. It now applies to the statustext element regardless of the actual status.

Also found a naming error in the tests while doing this and fixed it since it was a minor thing and didn't affect anything else. 

## Motivation and Context
We want the library to be as bug-free as possible. 

## How Has This Been Tested?
Running locally and automated tests.

## Release notes
Fixed a bug in checkbox status text spacing
