### PR TITLE
[Bugfix] Toggle focus styles not applied to first instance

### DIFF
--- a/src/core/Form/Toggle/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/Toggle.baseStyles.tsx
@@ -34,7 +34,7 @@ export const baseStyles = withSuomifiTheme(
       top: 0.1em;
     }
 
-    & + .fi-toggle--with-button {
+    &.fi-toggle--with-button {
       &:focus {
         outline: 0;
         & .fi-toggle_icon-container {
@@ -52,7 +52,7 @@ export const baseStyles = withSuomifiTheme(
       }
     }
 
-    & + .fi-toggle--with-input {
+    &.fi-toggle--with-input {
       &:focus-within {
         outline: 0;
         & .fi-toggle_icon-container {

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -208,17 +208,17 @@ exports[`Toggle variant default:  calling render with the same component on the 
   top: 0.1em;
 }
 
-.c1 + .fi-toggle--with-button:focus {
+.c1.fi-toggle--with-button:focus {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container {
+.c1.fi-toggle--with-button:focus .fi-toggle_icon-container {
   outline: 0;
   position: relative;
   position: absolute;
 }
 
-.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -234,35 +234,35 @@ exports[`Toggle variant default:  calling render with the same component on the 
   z-index: 9999;
 }
 
-.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:not(:focus-visible):after {
+.c1.fi-toggle--with-button:focus .fi-toggle_icon-container:not(:focus-visible):after {
   content: none;
 }
 
-.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   border-radius: 14px;
   right: -4px;
   left: -4px;
 }
 
-.c1 + .fi-toggle--with-button:focus:not(:focus-visible) {
+.c1.fi-toggle--with-button:focus:not(:focus-visible) {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-button:focus:not(:focus-visible) .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-button:focus:not(:focus-visible) .fi-toggle_icon-container:after {
   content: none;
 }
 
-.c1 + .fi-toggle--with-input:focus-within {
+.c1.fi-toggle--with-input:focus-within {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container {
+.c1.fi-toggle--with-input:focus-within .fi-toggle_icon-container {
   outline: 0;
   position: relative;
   position: absolute;
 }
 
-.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -278,21 +278,21 @@ exports[`Toggle variant default:  calling render with the same component on the 
   z-index: 9999;
 }
 
-.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:not(:focus-visible):after {
+.c1.fi-toggle--with-input:focus-within .fi-toggle_icon-container:not(:focus-visible):after {
   content: none;
 }
 
-.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   border-radius: 14px;
   right: -4px;
   left: -4px;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) {
+.c1.fi-toggle--with-input:focus-within:not(:focus-visible) {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-input:focus-within:not(:focus-visible) .fi-toggle_icon-container:after {
   content: none;
 }
 
@@ -750,17 +750,17 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   top: 0.1em;
 }
 
-.c1 + .fi-toggle--with-button:focus {
+.c1.fi-toggle--with-button:focus {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container {
+.c1.fi-toggle--with-button:focus .fi-toggle_icon-container {
   outline: 0;
   position: relative;
   position: absolute;
 }
 
-.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -776,35 +776,35 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   z-index: 9999;
 }
 
-.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:not(:focus-visible):after {
+.c1.fi-toggle--with-button:focus .fi-toggle_icon-container:not(:focus-visible):after {
   content: none;
 }
 
-.c1 + .fi-toggle--with-button:focus .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-button:focus .fi-toggle_icon-container:after {
   border-radius: 14px;
   right: -4px;
   left: -4px;
 }
 
-.c1 + .fi-toggle--with-button:focus:not(:focus-visible) {
+.c1.fi-toggle--with-button:focus:not(:focus-visible) {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-button:focus:not(:focus-visible) .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-button:focus:not(:focus-visible) .fi-toggle_icon-container:after {
   content: none;
 }
 
-.c1 + .fi-toggle--with-input:focus-within {
+.c1.fi-toggle--with-input:focus-within {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container {
+.c1.fi-toggle--with-input:focus-within .fi-toggle_icon-container {
   outline: 0;
   position: relative;
   position: absolute;
 }
 
-.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -820,21 +820,21 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   z-index: 9999;
 }
 
-.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:not(:focus-visible):after {
+.c1.fi-toggle--with-input:focus-within .fi-toggle_icon-container:not(:focus-visible):after {
   content: none;
 }
 
-.c1 + .fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-input:focus-within .fi-toggle_icon-container:after {
   border-radius: 14px;
   right: -4px;
   left: -4px;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) {
+.c1.fi-toggle--with-input:focus-within:not(:focus-visible) {
   outline: 0;
 }
 
-.c1 + .fi-toggle--with-input:focus-within:not(:focus-visible) .fi-toggle_icon-container:after {
+.c1.fi-toggle--with-input:focus-within:not(:focus-visible) .fi-toggle_icon-container:after {
   content: none;
 }
 


### PR DESCRIPTION
## Description
Toggle had a bug where the first instance of Toggle following some other element had incorrect focus styles. This was due to an erroneous CSS selector, which this PR fixes.

## Motivation and Context
Component default styles need to be uniform and correct in all situations.

## How Has This Been Tested?
Running locally (only styleguidist).

## Release notes
Fixed a bug in Toggle focus style logic
