### PR TITLE
[Feature] Locking Reach UI versions with resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "deploy-dev": "gh-pages -d styleguide -e dev -m \"[skip ci] Updates\""
   },
   "devDependencies": {
-    "@reach/rect": "0.10.3",
+    "@reach/rect": "0.10.4",
     "@testing-library/jest-dom": "5.3.0",
     "@testing-library/react": "10.0.2",
     "@types/classnames": "2.2.10",
@@ -114,8 +114,8 @@
     "webpack": "4.42.1"
   },
   "dependencies": {
-    "@reach/menu-button": "0.10.3",
-    "@reach/popover": "0.10.3",
+    "@reach/menu-button": "0.10.4",
+    "@reach/popover": "0.10.4",
     "classnames": "2.2.6",
     "normalize.cssinjs": "1.1.1",
     "polished": "3.5.1",
@@ -123,15 +123,6 @@
     "suomifi-design-tokens": "0.9.0",
     "suomifi-icons": "0.1.2",
     "uuid": "7.0.3"
-  },
-  "resolutions": {
-    "@reach/utils": "0.10.3",
-    "@reach/auto-id": "0.10.3",
-    "@reach/descendants": "0.10.3",
-    "@reach/popover": "0.10.3",
-    "@reach/observe-rect": "1.1.0",
-    "@reach/portal": "0.10.3",
-    "@reach/rect": "0.10.3"
   },
   "peerDependencies": {
     "@types/styled-components": "4.1.8",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,15 @@
     "suomifi-icons": "0.1.2",
     "uuid": "7.0.3"
   },
+  "resolutions": {
+    "@reach/utils": "0.10.3",
+    "@reach/auto-id": "0.10.3",
+    "@reach/descendants": "0.10.3",
+    "@reach/popover": "0.10.3",
+    "@reach/observe-rect": "1.1.0",
+    "@reach/portal": "0.10.3",
+    "@reach/rect": "0.10.3"
+  },
   "peerDependencies": {
     "@types/styled-components": "4.1.8",
     "@types/warning": ">=3.0.0",

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -175,7 +175,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
       </p>
     </label>
     <button
-      aria-controls="menu--7"
+      aria-controls="menu--11"
       aria-haspopup="true"
       aria-labelledby="test-id-label"
       class="fi-dropdown_button"
@@ -364,7 +364,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
       </p>
     </label>
     <button
-      aria-controls="menu--19"
+      aria-controls="menu--31"
       aria-haspopup="true"
       aria-labelledby="additional-label-id test-id-label"
       class="fi-dropdown_button"
@@ -541,7 +541,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
       </span>
     </label>
     <button
-      aria-controls="menu--13"
+      aria-controls="menu--21"
       aria-haspopup="true"
       aria-labelledby="test-id-label"
       class="fi-dropdown_button"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,75 +1204,75 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@reach/auto-id@0.10.3", "@reach/auto-id@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.10.3.tgz#d2b6fe3ccb81b0fb44dc8bd3aca567c94ac11f5e"
-  integrity sha512-LK3qIsurXnga+gUbjl6t6msrZ+F3aZMY+k2go5Xcns9b85bNRyF/LwlUtcGSqmhgqbVYvMcnLeEdSQLZRxCGnQ==
+"@reach/auto-id@0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.10.4.tgz#ba9c0c96c3fd037f2d3c70e9e2e6a784a83abfab"
+  integrity sha512-hJIjqOBIYdIdrjefWYfuBAntrUSP2sRp5jj3rJNSXW/Txhv6NUhfk5z5Xwsi6HST9rBS15btM8YaQBvJYicZsQ==
   dependencies:
-    "@reach/utils" "^0.10.3"
-    tslib "^1.11.2"
+    "@reach/utils" "0.10.4"
+    tslib "^2.0.0"
 
-"@reach/descendants@0.10.3", "@reach/descendants@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.10.3.tgz#c2cbd14c172cb82189bf6f290b09577193926a1a"
-  integrity sha512-1uwe2w49xSMF0ei1KedydB30sEWfyksk5axI3nEanwUDO7Sd1kCyt2GHZHoP2ESr6VQx2a9ETzMw8gKHsoy79g==
+"@reach/descendants@0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.10.4.tgz#1f5248ed50b2f25429af008ee553bc2f6cf94fa6"
+  integrity sha512-Oc0fiT2AKUZJs92qqqh6xcBA9lJkjvGtldm+Zh12K4elPoz7OVBCWFSzvKZM1WrCJGhmfczEiuYTnuB4TchBog==
   dependencies:
-    "@reach/utils" "^0.10.3"
-    tslib "^1.11.2"
+    "@reach/utils" "0.10.4"
+    tslib "^2.0.0"
 
-"@reach/menu-button@0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.10.3.tgz#6e72cd122e16f28c4b15a140f329be256adc72c8"
-  integrity sha512-50C5nl7JJG9YcKqngmwTLVft+ZF2MMieto1GSCC7qEU8ykUNz0p69Ipup+Eqjk7KRHpSIYPlYIfAOS75dDuiZQ==
+"@reach/menu-button@0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@reach/menu-button/-/menu-button-0.10.4.tgz#b707c8e99da4f52488ca4dea628c772e39f8f75e"
+  integrity sha512-Yi/awRXgcbspg8K3trjQabvXcQRSpslGWCa1Xpq1MAwDfPNrYA8WXtOZdM4YYOpZMTABUvyqXXVhIf4jyfD9Lg==
   dependencies:
-    "@reach/auto-id" "^0.10.3"
-    "@reach/descendants" "^0.10.3"
-    "@reach/popover" "^0.10.3"
-    "@reach/utils" "^0.10.3"
+    "@reach/auto-id" "0.10.4"
+    "@reach/descendants" "0.10.4"
+    "@reach/popover" "0.10.4"
+    "@reach/utils" "0.10.4"
     prop-types "^15.7.2"
-    tslib "^1.11.2"
+    tslib "^2.0.0"
 
-"@reach/observe-rect@1.1.0", "@reach/observe-rect@^1.1.0":
+"@reach/observe-rect@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.1.0.tgz#4e967a93852b6004c3895d9ed8d4e5b41895afde"
   integrity sha512-kE+jvoj/OyJV24C03VvLt5zclb9ArJi04wWXMMFwQvdZjdHoBlN4g0ZQFjyy/ejPF1Z/dpUD5dhRdBiUmIGZTA==
 
-"@reach/popover@0.10.3", "@reach/popover@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@reach/popover/-/popover-0.10.3.tgz#82e29b91748869923756a165758a29c8269b93e3"
-  integrity sha512-41iNfdjd9/5HtYuhezTc9z9WGkloYFVB8wBmPX3QOTuBP4qYd0La5sXClrfyiVqPn/uj1gGzehrZKuh8oSkorw==
+"@reach/popover@0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@reach/popover/-/popover-0.10.4.tgz#3171594446dd096ed5d3e4d9b0612b8280e8f447"
+  integrity sha512-TCfjPzFX8rJONaXqcYIhdwIoGZBxOMTDfZ9YeENqQ6Fad29SWzPIiWCCcEoJkohejp6Y4y0D9Oi0j6E7j/a7YQ==
   dependencies:
-    "@reach/portal" "^0.10.3"
-    "@reach/rect" "^0.10.3"
-    "@reach/utils" "^0.10.3"
+    "@reach/portal" "0.10.4"
+    "@reach/rect" "0.10.4"
+    "@reach/utils" "0.10.4"
     tabbable "^4.0.0"
-    tslib "^1.11.2"
+    tslib "^2.0.0"
 
-"@reach/portal@0.10.3", "@reach/portal@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.10.3.tgz#2eb408cc246d3eabbbf3b47ca4dc9c381cdb1d88"
-  integrity sha512-t8c+jtDxMLSPRGg93sQd2s6dDNilh5/qdrwmx88ki7l9h8oIXqMxPP3kSkOqZ9cbVR0b2A68PfMhCDOwMGvkoQ==
+"@reach/portal@0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.10.4.tgz#388b16c1285bf4ad357285dfcbb02b73bf6efe39"
+  integrity sha512-7qkG+l6yvFlafbKW36lG5PzJnRJHEj/KZa9DyNNibojmWd6Z1wUzy34LsMldlvY7v2OMl35SR0iLooiyrtQIww==
   dependencies:
-    "@reach/utils" "^0.10.3"
-    tslib "^1.11.2"
+    "@reach/utils" "0.10.4"
+    tslib "^2.0.0"
 
-"@reach/rect@0.10.3", "@reach/rect@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.10.3.tgz#b4fd7c730d27eaf5fdf04c9a65227cc805787803"
-  integrity sha512-OmnGfG+MdumviJXK5oPcrw2Nd4EgMPKLMCs03GrbkmZJwtXIQJNhQrVg60PQT6HKAKI0+0LobHKxHFT+7Ri7kw==
+"@reach/rect@0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@reach/rect/-/rect-0.10.4.tgz#b3b6bca77c58af9a5a47434111cdeff673819241"
+  integrity sha512-h3nRvOD+poiSQ7xQSucggj/c4g3LLLzn+jAfMvxjcTl72IjCFrULEboWeIVTMMOiyb34rIw0LZVR78FleqCdNg==
   dependencies:
-    "@reach/observe-rect" "^1.1.0"
-    "@reach/utils" "^0.10.3"
+    "@reach/observe-rect" "1.1.0"
+    "@reach/utils" "0.10.4"
     prop-types "^15.7.2"
-    tslib "^1.11.2"
+    tslib "^2.0.0"
 
-"@reach/utils@0.10.3", "@reach/utils@^0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.10.3.tgz#e30f9b172d131161953df7dd01553c57ca4e78f8"
-  integrity sha512-LoIZSfVAJMA+DnzAMCMfc/wAM39iKT8BQQ9gI1FODpxd8nPFP4cKisMuRXImh2/iVtG2Z6NzzCNgceJSrywqFQ==
+"@reach/utils@0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.10.4.tgz#164ea50910db2d1015505a10fac6a48e7b3c54e7"
+  integrity sha512-eQ7T/5yPE5VMThBOst+7bDQvsa+4z8IH+CMBnT06jUithLCed70pxS0YJVV/4rqV7/PmYwUgSrQOKQLmW6CMcg==
   dependencies:
     "@types/warning" "^3.0.0"
-    tslib "^1.11.2"
+    tslib "^2.0.0"
     warning "^4.0.3"
 
 "@rollup/plugin-commonjs@^11.0.0":
@@ -12950,10 +12950,10 @@ tslib@1.11.1, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^1.11.2:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
-  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
 tsutils@^3.17.1:
   version "3.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,7 +1204,7 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@reach/auto-id@^0.10.3":
+"@reach/auto-id@0.10.3", "@reach/auto-id@^0.10.3":
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.10.3.tgz#d2b6fe3ccb81b0fb44dc8bd3aca567c94ac11f5e"
   integrity sha512-LK3qIsurXnga+gUbjl6t6msrZ+F3aZMY+k2go5Xcns9b85bNRyF/LwlUtcGSqmhgqbVYvMcnLeEdSQLZRxCGnQ==
@@ -1212,7 +1212,7 @@
     "@reach/utils" "^0.10.3"
     tslib "^1.11.2"
 
-"@reach/descendants@^0.10.3":
+"@reach/descendants@0.10.3", "@reach/descendants@^0.10.3":
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/@reach/descendants/-/descendants-0.10.3.tgz#c2cbd14c172cb82189bf6f290b09577193926a1a"
   integrity sha512-1uwe2w49xSMF0ei1KedydB30sEWfyksk5axI3nEanwUDO7Sd1kCyt2GHZHoP2ESr6VQx2a9ETzMw8gKHsoy79g==
@@ -1232,7 +1232,7 @@
     prop-types "^15.7.2"
     tslib "^1.11.2"
 
-"@reach/observe-rect@^1.1.0":
+"@reach/observe-rect@1.1.0", "@reach/observe-rect@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.1.0.tgz#4e967a93852b6004c3895d9ed8d4e5b41895afde"
   integrity sha512-kE+jvoj/OyJV24C03VvLt5zclb9ArJi04wWXMMFwQvdZjdHoBlN4g0ZQFjyy/ejPF1Z/dpUD5dhRdBiUmIGZTA==
@@ -1248,7 +1248,7 @@
     tabbable "^4.0.0"
     tslib "^1.11.2"
 
-"@reach/portal@^0.10.3":
+"@reach/portal@0.10.3", "@reach/portal@^0.10.3":
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.10.3.tgz#2eb408cc246d3eabbbf3b47ca4dc9c381cdb1d88"
   integrity sha512-t8c+jtDxMLSPRGg93sQd2s6dDNilh5/qdrwmx88ki7l9h8oIXqMxPP3kSkOqZ9cbVR0b2A68PfMhCDOwMGvkoQ==
@@ -1266,7 +1266,7 @@
     prop-types "^15.7.2"
     tslib "^1.11.2"
 
-"@reach/utils@^0.10.3":
+"@reach/utils@0.10.3", "@reach/utils@^0.10.3":
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.10.3.tgz#e30f9b172d131161953df7dd01553c57ca4e78f8"
   integrity sha512-LoIZSfVAJMA+DnzAMCMfc/wAM39iKT8BQQ9gI1FODpxd8nPFP4cKisMuRXImh2/iVtG2Z6NzzCNgceJSrywqFQ==


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

Locking the Reach UI versions with resolutions added to `package.json`.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Want to prevent breaking changes from the Reach UI as they are not currently using semantic versioning in their packages outside or inside.

## How Has This Been Tested?
Tested locally and could not reproduce the problem (The error can be see when using e.g 0.10.0 version).

## Release notes

**Fixes**
- Reach UI versions locked with **resolutions** in `package.json`

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
