### PR TITLE
[Fix] Disable generated button with disabled-attribute

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -138,6 +138,7 @@ export class Button extends Component<ButtonProps> {
           {...onClickProps}
           aria-disabled={disabled}
           tabIndex={0}
+          disabled={!!disabled}
           className={classnames(baseClassName, className, {
             [disabledClassName]: !!disabled,
           })}

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -19,6 +19,23 @@ test('calling render with the same component on the same container does not remo
   expect(getByTestId('nottub').textContent).toBe('Test two');
 });
 
+test('disabled button is disabled', () => {
+  const button = render(
+    <Button data-testid="button" disabled={true}>
+      Test
+    </Button>,
+  );
+  const { getByTestId, rerender } = button;
+  expect(getByTestId('button')).toBeDisabled();
+
+  rerender(
+    <Button data-testid="button" disabled={false}>
+      Test
+    </Button>,
+  );
+  expect(getByTestId('button')).toBeEnabled();
+});
+
 test('should not have basic accessibility issues', axeTest(TestButton));
 
 test('CSS export', () => {


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Disable generated button -element properly, if instantiating Button with disabled={true}.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Current implementation doesn't actually disable button, it only makes the button look like disabled.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
