### PR TITLE
[Feature] name and value props for Checkbox

### DIFF
--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -65,6 +65,7 @@ export interface CheckboxProps {
    * @default uuidV4
    */
   id?: string;
+  name?: string;
 }
 
 export interface CheckboxState {
@@ -111,6 +112,7 @@ export class Checkbox extends Component<CheckboxProps> {
       hintText,
       status,
       statusText,
+      name,
       ...passProps
     } = this.props;
     const { checkedState } = this.state;
@@ -146,6 +148,7 @@ export class Checkbox extends Component<CheckboxProps> {
           {...newCheckboxInputProps}
           type="checkbox"
           aria-describedby={infoElementIds}
+          name={name}
         />
         <HtmlLabel
           htmlFor={id}

--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -141,7 +141,7 @@ export class Checkbox extends Component<CheckboxProps> {
       className: checkboxBaseClassNames.input,
       onChange: this.handleClick,
       name,
-      value,
+      ...(value ? { value } : {}),
     };
 
     return (

--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -65,7 +65,9 @@ export interface CheckboxProps {
    * @default uuidV4
    */
   id?: string;
+  /** Name */
   name?: string;
+  /** Value */
   value?: string;
 }
 

--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -66,6 +66,7 @@ export interface CheckboxProps {
    */
   id?: string;
   name?: string;
+  value?: string;
 }
 
 export interface CheckboxState {
@@ -113,6 +114,7 @@ export class Checkbox extends Component<CheckboxProps> {
       status,
       statusText,
       name,
+      value,
       ...passProps
     } = this.props;
     const { checkedState } = this.state;
@@ -138,6 +140,8 @@ export class Checkbox extends Component<CheckboxProps> {
       checked: !!checkedState,
       className: checkboxBaseClassNames.input,
       onChange: this.handleClick,
+      name,
+      value,
     };
 
     return (
@@ -148,7 +152,6 @@ export class Checkbox extends Component<CheckboxProps> {
           {...newCheckboxInputProps}
           type="checkbox"
           aria-describedby={infoElementIds}
-          name={name}
         />
         <HtmlLabel
           htmlFor={id}

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -1,72 +1,43 @@
 import React from 'react';
 import { axeTest } from '../../../utils/test/axe';
 import { render } from '@testing-library/react';
-import { Checkbox } from './Checkbox';
+import { Checkbox, CheckboxProps } from './Checkbox';
 
-const createTestCheckbox = (
-  large: boolean,
-  error: boolean,
-  defaultChecked: boolean,
-  labelText: string,
-  hint?: string,
-  statusText?: string,
-  dataTestId?: string,
-  disabled?: boolean,
-) => (
-  <Checkbox
-    variant={large ? 'large' : 'small'}
-    defaultChecked={defaultChecked}
-    status={error ? 'error' : 'default'}
-    hintText={hint}
-    statusText={statusText}
-    data-testid={dataTestId}
-    id="test"
-    disabled={disabled}
+const BaseCheckbox = (props: CheckboxProps) => {
+  const { id, children, ...passProps } = props;
+  return (
+    <Checkbox id="test" {...passProps}>
+      {children}
+    </Checkbox>
+  );
+};
+
+const RegularTestCheckbox = (
+  <BaseCheckbox data-testid="regular_id">Regular</BaseCheckbox>
+);
+
+const LargeTestCheckboxWithHintText = (
+  <BaseCheckbox data-testid="large_id" variant="large" hintText="Take a hint">
+    Large
+  </BaseCheckbox>
+);
+
+const CheckedLargeTestCheckboxWithError = (
+  <BaseCheckbox
+    data-testid="largeError_id"
+    variant="large"
+    statusText="EROR EROR"
+    defaultChecked
+    status="error"
   >
-    {labelText}
-  </Checkbox>
+    Large Checked with error
+  </BaseCheckbox>
 );
 
-const RegularTestCheckbox = createTestCheckbox(
-  false,
-  false,
-  false,
-  'Regular',
-  undefined,
-  undefined,
-  'regular_id',
-  false,
-);
-const LargeTestCheckbox = createTestCheckbox(
-  true,
-  false,
-  false,
-  'Large',
-  'Take a hint',
-  undefined,
-  'large_id',
-  false,
-);
-const CheckedLargeTestCheckboxWithError = createTestCheckbox(
-  true,
-  true,
-  true,
-  'Large Checked with error',
-  undefined,
-  'EROR EROR',
-  'largeError_id',
-  false,
-);
-
-const DisabledTestCheckbox = createTestCheckbox(
-  false,
-  false,
-  false,
-  'Regular',
-  undefined,
-  undefined,
-  'regular_id',
-  true,
+const DisabledTestCheckbox = (
+  <BaseCheckbox data-testid="reguarlDisabled_id" disabled>
+    Regular disabled
+  </BaseCheckbox>
 );
 
 test('Calling render with the same component on the same container does not remount', () => {
@@ -77,15 +48,9 @@ test('Calling render with the same component on the same container does not remo
 
   // re-render the same component with different props
   rerender(
-    createTestCheckbox(
-      false,
-      false,
-      false,
-      'Regular changed',
-      undefined,
-      undefined,
-      'regular_id_changed',
-    ),
+    <BaseCheckbox data-testid="regular_id_changed">
+      Regular changed
+    </BaseCheckbox>,
   );
   expect(getByTestId('regular_id_changed').textContent).toBe('Regular changed');
 });
@@ -97,7 +62,7 @@ test(
 
 test(
   'Input should not have basic accessibility issues',
-  axeTest(LargeTestCheckbox),
+  axeTest(LargeTestCheckboxWithHintText),
 );
 
 test(

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -55,25 +55,27 @@ test('Calling render with the same component on the same container does not remo
   expect(getByTestId('regular_id_changed').textContent).toBe('Regular changed');
 });
 
-test(
-  'Input should not have basic accessibility issues',
-  axeTest(RegularTestCheckbox),
-);
+describe('accessibility', () => {
+  test(
+    'RegularTestCheckbox should not have basic accessibility issues',
+    axeTest(RegularTestCheckbox),
+  );
 
-test(
-  'Input should not have basic accessibility issues',
-  axeTest(LargeTestCheckboxWithHintText),
-);
+  test(
+    'LargeTestCheckboxWithHintText should not have basic accessibility issues',
+    axeTest(LargeTestCheckboxWithHintText),
+  );
 
-test(
-  'Input should not have basic accessibility issues',
-  axeTest(CheckedLargeTestCheckboxWithError),
-);
+  test(
+    'CheckedLargeTestCheckboxWithError should not have basic accessibility issues',
+    axeTest(CheckedLargeTestCheckboxWithError),
+  );
 
-test(
-  'Input should not have basic accessibility issues',
-  axeTest(DisabledTestCheckbox),
-);
+  test(
+    'DisabledTestCheckbox should not have basic accessibility issues',
+    axeTest(DisabledTestCheckbox),
+  );
+});
 
 describe('props', () => {
   describe('name', () => {

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -72,6 +72,12 @@ describe('props', () => {
   });
 
   describe('value', () => {
+    it('do not have value attribute if prop is not given', () => {
+      const { getByRole } = render(<BaseCheckbox />);
+      const input = getByRole('checkbox');
+      expect(input).not.toHaveAttribute('value');
+    });
+
     it('has the given value prop on start and after prop change', () => {
       const { getByRole, rerender } = render(
         <BaseCheckbox value="test-value-1" />,

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -7,7 +7,7 @@ const BaseCheckbox = (props: CheckboxProps) => {
   const { id, children, ...passProps } = props;
   return (
     <Checkbox id="test" {...passProps}>
-      {children}
+      {children || 'Default label'}
     </Checkbox>
   );
 };
@@ -74,3 +74,13 @@ test(
   'Input should not have basic accessibility issues',
   axeTest(DisabledTestCheckbox),
 );
+
+describe('props', () => {
+  describe('name', () => {
+    it('name', () => {
+      const { getByRole } = render(<BaseCheckbox name="magical" />);
+      const input = getByRole('checkbox');
+      expect(input).toHaveAttribute('name', 'magical');
+    });
+  });
+});

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -37,21 +37,6 @@ const DisabledTestCheckbox = (
   <BaseCheckbox disabled>Regular disabled</BaseCheckbox>
 );
 
-test('Calling render with the same component on the same container does not remount', () => {
-  const checkboxRendered = render(RegularTestCheckbox);
-  const { getByTestId, container, rerender } = checkboxRendered;
-  expect(container.firstChild).toMatchSnapshot();
-  expect(getByTestId('regular_id').textContent).toBe('Regular');
-
-  // re-render the same component with different props
-  rerender(
-    <BaseCheckbox data-testid="regular_id_changed">
-      Regular changed
-    </BaseCheckbox>,
-  );
-  expect(getByTestId('regular_id_changed').textContent).toBe('Regular changed');
-});
-
 describe('accessibility', () => {
   test(
     'RegularTestCheckbox should not have basic accessibility issues',
@@ -76,10 +61,34 @@ describe('accessibility', () => {
 
 describe('props', () => {
   describe('name', () => {
-    it('name', () => {
-      const { getByRole } = render(<BaseCheckbox name="magical" />);
+    it('has the given name prop on start and after prop change', () => {
+      const { getByRole, rerender } = render(<BaseCheckbox name="magical" />);
       const input = getByRole('checkbox');
       expect(input).toHaveAttribute('name', 'magical');
+
+      rerender(<BaseCheckbox name="unicorn" />);
+      expect(input).toHaveAttribute('name', 'unicorn');
+    });
+  });
+
+  describe('children', () => {
+    it('has the given children and it changes on prop change', () => {
+      const { getByTestId, rerender } = render(RegularTestCheckbox);
+      expect(getByTestId('regular_id').textContent).toBe('Regular');
+
+      rerender(
+        <BaseCheckbox data-testid="regular_id_changed">
+          Regular changed
+        </BaseCheckbox>,
+      );
+      expect(getByTestId('regular_id_changed').textContent).toBe(
+        'Regular changed',
+      );
+    });
+
+    it('has matching snapshot', () => {
+      const { container } = render(RegularTestCheckbox);
+      expect(container.firstChild).toMatchSnapshot();
     });
   });
 });

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -71,6 +71,19 @@ describe('props', () => {
     });
   });
 
+  describe('value', () => {
+    it('has the given value prop on start and after prop change', () => {
+      const { getByRole, rerender } = render(
+        <BaseCheckbox value="test-value-1" />,
+      );
+      const input = getByRole('checkbox');
+      expect(input).toHaveAttribute('value', 'test-value-1');
+
+      rerender(<BaseCheckbox value="test-value-2" />);
+      expect(input).toHaveAttribute('value', 'test-value-2');
+    });
+  });
+
   describe('children', () => {
     it('has the given children and it changes on prop change', () => {
       const { getByTestId, rerender } = render(RegularTestCheckbox);

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -17,14 +17,13 @@ const RegularTestCheckbox = (
 );
 
 const LargeTestCheckboxWithHintText = (
-  <BaseCheckbox data-testid="large_id" variant="large" hintText="Take a hint">
+  <BaseCheckbox variant="large" hintText="Take a hint">
     Large
   </BaseCheckbox>
 );
 
 const CheckedLargeTestCheckboxWithError = (
   <BaseCheckbox
-    data-testid="largeError_id"
     variant="large"
     statusText="EROR EROR"
     defaultChecked
@@ -35,9 +34,7 @@ const CheckedLargeTestCheckboxWithError = (
 );
 
 const DisabledTestCheckbox = (
-  <BaseCheckbox data-testid="reguarlDisabled_id" disabled>
-    Regular disabled
-  </BaseCheckbox>
+  <BaseCheckbox disabled>Regular disabled</BaseCheckbox>
 );
 
 test('Calling render with the same component on the same container does not remount', () => {

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -233,6 +233,7 @@ exports[`props children has matching snapshot 1`] = `
     class="c2 fi-checkbox_input"
     id="test"
     type="checkbox"
+    value=""
   />
   <label
     class="c3 fi-checkbox_label"

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -233,7 +233,6 @@ exports[`props children has matching snapshot 1`] = `
     class="c2 fi-checkbox_input"
     id="test"
     type="checkbox"
-    value=""
   />
   <label
     class="c3 fi-checkbox_label"

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Calling render with the same component on the same container does not remount 1`] = `
+exports[`props children has matching snapshot 1`] = `
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
- Adds `name` and `value` props for Checkbox.
  - Checkbox is now usable when using in form.
- Small refactoring to tests.
- More tests added.


## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Checkbox was not working correctly when used in forms as the value and name was not available for form.

## How Has This Been Tested?
- Locally run on CRA-TS project
- Locally run on CRA-JS project with form

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

Feature
- Adds `name` and `value` props for Checkbox.