### PR TITLE
[Feature] TextInput improvements

### DIFF
--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -29,6 +29,8 @@ export interface TextInputLabelProps extends HtmlLabelProps {}
 
 type Label = 'hidden' | 'visible';
 
+type InputType = 'text' | 'email' | 'number' | 'password' | 'tel' | 'url';
+
 export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   /** Custom classname for the input to extend or customize */
   className?: string;
@@ -61,6 +63,10 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   hintText?: string;
   /** Status text to be shown below the component and hint text. Use e.g. for validation error */
   statusText?: string;
+  /** 'text' | 'email' | 'number' | 'password' | 'tel' | 'url'
+   * @default text
+   */
+  type?: InputType;
 }
 
 class BaseTextInput extends Component<TextInputProps> {
@@ -78,6 +84,7 @@ class BaseTextInput extends Component<TextInputProps> {
       hintText,
       visualPlaceholder,
       id: propId,
+      type = 'text',
       ...passProps
     } = this.props;
 
@@ -111,7 +118,7 @@ class BaseTextInput extends Component<TextInputProps> {
               id={propId}
               {...passProps}
               className={classnames(inputBaseClassName, inputClassName)}
-              type="text"
+              type={type}
               aria-describedby={[
                 generatedStatusTextId,
                 generatedHintTextId,

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -23,6 +23,7 @@ const inputBaseClassName = `${baseClassName}_input`;
 const statusTextClassName = `${baseClassName}_statusText`;
 const statusTextContainerClassName = `${statusTextClassName}_container`;
 const statusTextSpanClassName = `${baseClassName}_statusText_span`;
+const hintTextSpanClassName = `${baseClassName}_hintText_p`;
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
 
@@ -56,7 +57,9 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   /** Input container div to define custom styling */
   inputContainerProps?: HtmlDivProps;
   children?: ReactNode;
-  /** Showing the status text; like validation error beneath the component */
+  /** Hint text to be shown below the component */
+  hintText?: string;
+  /** Status text to be shown below the component and hint text. Use e.g. for validation error */
   statusText?: string;
 }
 
@@ -72,6 +75,7 @@ class BaseTextInput extends Component<TextInputProps> {
       inputContainerProps,
       children,
       statusText,
+      hintText,
       visualPlaceholder,
       id: propId,
       ...passProps
@@ -91,6 +95,11 @@ class BaseTextInput extends Component<TextInputProps> {
           <VisuallyHidden>{labelText}</VisuallyHidden>
         ) : (
           <Paragraph {...labelTextProps}>{labelText}</Paragraph>
+        )}
+        {hintText && (
+          <Paragraph className={hintTextSpanClassName} id={generatedId}>
+            {hintText}
+          </Paragraph>
         )}
         <HtmlDiv className={statusTextContainerClassName}>
           <HtmlDiv {...inputContainerProps}>

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -82,7 +82,8 @@ class BaseTextInput extends Component<TextInputProps> {
     } = this.props;
 
     const hideLabel = labelMode === 'hidden';
-    const generatedId = `${idGenerator(propId)}-statusText`;
+    const generatedStatusTextId = `${idGenerator(propId)}-statusText`;
+    const generatedHintTextId = `${idGenerator(propId)}-hintText`;
 
     return (
       <HtmlLabel
@@ -97,7 +98,7 @@ class BaseTextInput extends Component<TextInputProps> {
           <Paragraph {...labelTextProps}>{labelText}</Paragraph>
         )}
         {hintText && (
-          <Paragraph className={hintTextSpanClassName} id={generatedId}>
+          <Paragraph className={hintTextSpanClassName} id={generatedHintTextId}>
             {hintText}
           </Paragraph>
         )}
@@ -108,13 +109,19 @@ class BaseTextInput extends Component<TextInputProps> {
               {...passProps}
               className={classnames(inputBaseClassName, inputClassName)}
               type="text"
-              aria-describedby={generatedId}
+              aria-describedby={[
+                generatedStatusTextId,
+                generatedHintTextId,
+              ].join(' ')}
               placeholder={visualPlaceholder}
             />
             {children}
           </HtmlDiv>
           {statusText && (
-            <HtmlSpan className={statusTextSpanClassName} id={generatedId}>
+            <HtmlSpan
+              className={statusTextSpanClassName}
+              id={generatedStatusTextId}
+            >
               {statusText}
             </HtmlSpan>
           )}

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -22,7 +22,6 @@ const labelBaseClassName = `${baseClassName}_label`;
 const inputBaseClassName = `${baseClassName}_input`;
 const statusTextClassName = `${baseClassName}_statusText`;
 const statusTextContainerClassName = `${statusTextClassName}_container`;
-const statusTextSpanClassName = `${baseClassName}_statusText_span`;
 const hintTextClassName = `${baseClassName}_hintText`;
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
@@ -126,7 +125,7 @@ class BaseTextInput extends Component<TextInputProps> {
           </HtmlDiv>
           {statusText && (
             <HtmlSpan
-              className={statusTextSpanClassName}
+              className={statusTextClassName}
               id={generatedStatusTextId}
             >
               {statusText}

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -23,7 +23,7 @@ const inputBaseClassName = `${baseClassName}_input`;
 const statusTextClassName = `${baseClassName}_statusText`;
 const statusTextContainerClassName = `${statusTextClassName}_container`;
 const statusTextSpanClassName = `${baseClassName}_statusText_span`;
-const hintTextSpanClassName = `${baseClassName}_hintText_p`;
+const hintTextParagraphClassName = `${baseClassName}_hintText_p`;
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
 
@@ -98,7 +98,10 @@ class BaseTextInput extends Component<TextInputProps> {
           <Paragraph {...labelTextProps}>{labelText}</Paragraph>
         )}
         {hintText && (
-          <Paragraph className={hintTextSpanClassName} id={generatedHintTextId}>
+          <Paragraph
+            className={hintTextParagraphClassName}
+            id={generatedHintTextId}
+          >
             {hintText}
           </Paragraph>
         )}

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -91,10 +91,17 @@ class BaseTextInput extends Component<TextInputProps> {
     const generatedStatusTextId = `${idGenerator(propId)}-statusText`;
     const generatedHintTextId = `${idGenerator(propId)}-hintText`;
 
-    const describedBy = [
-      ...(statusText ? [generatedStatusTextId] : []),
-      ...(hintText ? [generatedHintTextId] : []),
-    ].join(' ');
+    const getDescribedBy = () => {
+      if (statusText || hintText) {
+        return {
+          'aria-describedby': [
+            ...(statusText ? [generatedStatusTextId] : []),
+            ...(hintText ? [generatedHintTextId] : []),
+          ].join(' '),
+        };
+      }
+      return;
+    };
 
     return (
       <HtmlLabel
@@ -120,7 +127,7 @@ class BaseTextInput extends Component<TextInputProps> {
               {...passProps}
               className={classnames(inputBaseClassName, inputClassName)}
               type={type}
-              aria-describedby={describedBy}
+              {...getDescribedBy()}
               placeholder={visualPlaceholder}
             />
             {children}

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -100,7 +100,7 @@ class BaseTextInput extends Component<TextInputProps> {
           ].join(' '),
         };
       }
-      return;
+      return {};
     };
 
     return (

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -91,6 +91,11 @@ class BaseTextInput extends Component<TextInputProps> {
     const generatedStatusTextId = `${idGenerator(propId)}-statusText`;
     const generatedHintTextId = `${idGenerator(propId)}-hintText`;
 
+    const describedBy = [
+      ...(statusText ? [generatedStatusTextId] : []),
+      ...(hintText ? [generatedHintTextId] : []),
+    ].join(' ');
+
     return (
       <HtmlLabel
         {...labelProps}
@@ -115,10 +120,7 @@ class BaseTextInput extends Component<TextInputProps> {
               {...passProps}
               className={classnames(inputBaseClassName, inputClassName)}
               type={type}
-              aria-describedby={[
-                generatedStatusTextId,
-                generatedHintTextId,
-              ].join(' ')}
+              aria-describedby={describedBy}
               placeholder={visualPlaceholder}
             />
             {children}

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -23,7 +23,7 @@ const inputBaseClassName = `${baseClassName}_input`;
 const statusTextClassName = `${baseClassName}_statusText`;
 const statusTextContainerClassName = `${statusTextClassName}_container`;
 const statusTextSpanClassName = `${baseClassName}_statusText_span`;
-const hintTextParagraphClassName = `${baseClassName}_hintText_p`;
+const hintTextClassName = `${baseClassName}_hintText`;
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
 
@@ -105,10 +105,7 @@ class BaseTextInput extends Component<TextInputProps> {
           <Paragraph {...labelTextProps}>{labelText}</Paragraph>
         )}
         {hintText && (
-          <Paragraph
-            className={hintTextParagraphClassName}
-            id={generatedHintTextId}
-          >
+          <Paragraph className={hintTextClassName} id={generatedHintTextId}>
             {hintText}
           </Paragraph>
         )}

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`calling render with the same component on the same container does not r
       class="c4 fi-search-input_input-container fi-text-input_container"
     >
       <input
-        aria-describedby="test-id-statusText test-id-hintText"
+        aria-describedby=""
         class="c5 fi-text-input_input fi-search-input_input"
         data-testid="textinput"
         id="test-id"

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -182,7 +182,16 @@ exports[`calling render with the same component on the same container does not r
   display: block;
   color: hsl(0,0%,16%);
   margin-bottom: 10px;
-  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -286,7 +295,7 @@ exports[`calling render with the same component on the same container does not r
       class="c4 fi-search-input_input-container fi-text-input_container"
     >
       <input
-        aria-describedby="test-id-statusText"
+        aria-describedby="test-id-statusText test-id-hintText"
         class="c5 fi-text-input_input fi-search-input_input"
         data-testid="textinput"
         id="test-id"

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`calling render with the same component on the same container does not r
   flex-direction: column;
 }
 
-.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
+.c2 .fi-text-input_statusText_container .fi-text-input_statusText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -178,7 +178,7 @@ exports[`calling render with the same component on the same container does not r
   line-height: 20px;
 }
 
-.c2 .fi-text-input_hintText_p {
+.c2 .fi-text-input_hintText {
   display: block;
   color: hsl(0,0%,16%);
   margin-bottom: 10px;
@@ -248,7 +248,7 @@ exports[`calling render with the same component on the same container does not r
   border-color: hsl(3,59%,48%);
 }
 
-.c2.fi-text-input--error .fi-text-input_statusText_span {
+.c2.fi-text-input--error .fi-text-input_statusText {
   margin-top: 5px;
   color: hsl(3,59%,48%);
 }

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -180,6 +180,7 @@ exports[`calling render with the same component on the same container does not r
 
 .c2 .fi-text-input_hintText_p {
   display: block;
+  color: hsl(0,0%,16%);
   margin-bottom: 10px;
   font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -178,6 +178,15 @@ exports[`calling render with the same component on the same container does not r
   line-height: 20px;
 }
 
+.c2 .fi-text-input_hintText_p {
+  display: block;
+  margin-bottom: 10px;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .c2 .fi-text-input_input {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -295,7 +295,6 @@ exports[`calling render with the same component on the same container does not r
       class="c4 fi-search-input_input-container fi-text-input_container"
     >
       <input
-        aria-describedby=""
         class="c5 fi-text-input_input fi-search-input_input"
         data-testid="textinput"
         id="test-id"

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -28,7 +28,7 @@ export const baseStyles = withSuomifiTheme(
       display: block;
       color: ${theme.colors.blackBase};
       margin-bottom: ${theme.spacing.xs};
-      font-size: ${theme.typography.bodyTextSmall};
+      ${font({ theme })('bodyTextSmall')};
     }
 
   & .fi-text-input_input {

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -18,13 +18,13 @@ export const baseStyles = withSuomifiTheme(
     display: flex;
     flex-direction: column;
 
-    & .fi-text-input_statusText_span {
+    & .fi-text-input_statusText {
       ${theme.typography.bodySemiBoldSmall}
       font-size: 14px;
       line-height: 20px;
     }
   }
-  & .fi-text-input_hintText_p {
+  & .fi-text-input_hintText {
       display: block;
       color: ${theme.colors.blackBase};
       margin-bottom: ${theme.spacing.xs};
@@ -49,7 +49,7 @@ export const baseStyles = withSuomifiTheme(
     & .fi-text-input_input {
       border-color: ${theme.colors.alertBase};
     }
-    & .fi-text-input_statusText_span {
+    & .fi-text-input_statusText {
       margin-top: ${theme.spacing.xxs};
       color: ${theme.colors.alertBase};
     }

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -5,7 +5,7 @@ import { input, inputContainer, font } from '../../theme/reset';
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
   & .fi-text-input_label-p {
-    margin-bottom: ${theme.spacing.insetL};
+    margin-bottom: ${theme.spacing.xs};
     ${font({ theme })('actionElementInnerTextBold')};
     color: ${theme.colors.blackBase};
   }
@@ -24,6 +24,11 @@ export const baseStyles = withSuomifiTheme(
       line-height: 20px;
     }
   }
+  & .fi-text-input_hintText_p {
+      display: block;
+      margin-bottom: ${theme.spacing.xs};
+      font-size: ${theme.typography.bodyTextSmall};
+    }
 
   & .fi-text-input_input {
     ${input({ theme })}

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -26,6 +26,7 @@ export const baseStyles = withSuomifiTheme(
   }
   & .fi-text-input_hintText_p {
       display: block;
+      color: ${theme.colors.blackBase};
       margin-bottom: ${theme.spacing.xs};
       font-size: ${theme.typography.bodyTextSmall};
     }

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -65,3 +65,20 @@ const status = errorState ? 'error' : 'default';
   </Button>
 </>;
 ```
+
+```js
+import { TextInput } from 'suomifi-ui-components';
+
+<>
+  <TextInput
+    labelText="TextInput with numbers"
+    type="number"
+    value={123}
+  />
+  <TextInput
+    labelText="TextInput with password"
+    type="password"
+    value="password"
+  />
+</>;
+```

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -73,12 +73,12 @@ import { TextInput } from 'suomifi-ui-components';
   <TextInput
     labelText="TextInput with numbers"
     type="number"
-    value={123}
+    defaultValue={123}
   />
   <TextInput
     labelText="TextInput with password"
     type="password"
-    value="password"
+    defaultValue="password"
   />
 </>;
 ```

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -11,6 +11,11 @@ import { TextInput } from 'suomifi-ui-components';
     labelMode="hidden"
     visualPlaceholder="This input has a hidden label"
   />
+  <TextInput
+    onBlur={(event) => console.log(event.target.value)}
+    labelText="TextInput with hint text"
+    hintText="An example hint text"
+  />
 </>;
 ```
 

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -48,3 +48,24 @@ describe('snapshots match', () => {
 });
 
 test('should not have basic accessibility issues', axeTest(TestTextInput));
+
+describe('props', () => {
+  describe('className', () => {
+    it('has the given custom className', () => {
+      const { container } = render(
+        <TextInput labelText="Test input" className="custom-style" />,
+      );
+      expect(container.firstChild).toHaveClass('custom-style');
+    });
+  });
+
+  describe('hintText', () => {
+    it('has the hint text element', () => {
+      const { getByText } = render(
+        <TextInput labelText="Test input" hintText="Example hint text" />,
+      );
+      const hintText = getByText('Example hint text');
+      expect(hintText).toHaveClass('fi-text-input_hintText');
+    });
+  });
+});

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { axeTest } from '../../../utils/test/axe';
 
 import { TextInput } from './TextInput';
@@ -66,6 +66,99 @@ describe('props', () => {
       );
       const hintText = getByText('Example hint text');
       expect(hintText).toHaveClass('fi-text-input_hintText');
+    });
+  });
+
+  describe('type', () => {
+    describe('text (default)', () => {
+      const textInput = (
+        <TextInput
+          labelText="Test input"
+          type="text"
+          data-testid="text-input"
+        />
+      );
+      const { getByTestId } = render(textInput);
+      const textfield = getByTestId('text-input') as HTMLInputElement;
+
+      it('shows the inputted text', () => {
+        fireEvent.change(textfield, { target: { value: 'abc 123' } });
+        expect(textfield.value).toBe('abc 123');
+      });
+    });
+
+    describe('number', () => {
+      const textInput = (
+        <TextInput
+          labelText="Test input"
+          type="number"
+          data-testid="number-input"
+        />
+      );
+      const { getByTestId } = render(textInput);
+      const numberfield = getByTestId('number-input') as HTMLInputElement;
+
+      it('shows the inputted numbers', () => {
+        fireEvent.change(numberfield, { target: { value: '123' } });
+        expect(numberfield.value).toBe('123');
+      });
+
+      it('does not allow text', () => {
+        fireEvent.change(numberfield, { target: { value: 'abc' } });
+        expect(numberfield.value).toBe('');
+        fireEvent.change(numberfield, { target: { value: 'abc 123' } });
+        expect(numberfield.value).toBe('');
+      });
+    });
+  });
+
+  describe('disabled', () => {
+    it('has disabled attribute and classname', () => {
+      const { container, getByTestId } = render(
+        <TextInput labelText="Test input" data-testid="input" disabled />,
+      );
+      expect(container.firstChild).toHaveClass('fi-text-input--disabled');
+
+      const inputField = getByTestId('input') as HTMLInputElement;
+      expect(inputField).toHaveAttribute('disabled');
+    });
+  });
+
+  describe('labelText', () => {
+    it('should be found ', () => {
+      const { getByText } = render(<TextInput labelText="Test input" />);
+      const label = getByText('Test input');
+      expect(label).toHaveClass('fi-text-input_label-p');
+    });
+  });
+
+  describe('labelMode', () => {
+    it('should be visible by default', () => {
+      const { getByText } = render(<TextInput labelText="Test input" />);
+      const label = getByText('Test input');
+      expect(label).toHaveClass('fi-text-input_label-p');
+    });
+
+    it('should be hidden', () => {
+      const { getByText } = render(
+        <TextInput labelText="Test input" labelMode="hidden" />,
+      );
+      const label = getByText('Test input');
+      expect(label).toHaveClass('fi-visually-hidden');
+    });
+  });
+
+  describe('visualPlaceholder', () => {
+    it('should have the given text', () => {
+      const { getByTestId } = render(
+        <TextInput
+          labelText="Test input"
+          data-testid="input"
+          visualPlaceholder="Enter text here"
+        />,
+      );
+      const inputField = getByTestId('input') as HTMLInputElement;
+      expect(inputField).toHaveAttribute('placeholder', 'Enter text here');
     });
   });
 });

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -53,7 +53,7 @@ const StyledTextInput = styled(
             textInputClassNames.inputContainer,
           ),
         }}
-        className={classnames(className, {
+        className={classnames(baseClassName, className, {
           [textInputClassNames.error]: status === 'error',
           [textInputClassNames.success]: status === 'success',
         })}

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -199,6 +199,7 @@ exports[`snapshots match error status with statustext 1`] = `
 
 .c2 .fi-text-input_hintText_p {
   display: block;
+  color: hsl(0,0%,16%);
   margin-bottom: 10px;
   font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -491,6 +492,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 
 .c2 .fi-text-input_hintText_p {
   display: block;
+  color: hsl(0,0%,16%);
   margin-bottom: 10px;
   font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -765,6 +767,7 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c2 .fi-text-input_hintText_p {
   display: block;
+  color: hsl(0,0%,16%);
   margin-bottom: 10px;
   font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -296,7 +296,7 @@ exports[`snapshots match error status with statustext 1`] = `
       class="c4 fi-text-input_container"
     >
       <input
-        aria-describedby="test-id2-statusText test-id2-hintText"
+        aria-describedby="test-id2-statusText"
         class="c5 fi-text-input_input"
         data-testid="textinput2"
         id="test-id2"
@@ -598,7 +598,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
       class="c5 fi-text-input_container"
     >
       <input
-        aria-describedby="test-id1-statusText test-id1-hintText"
+        aria-describedby=""
         class="c6 fi-text-input_input"
         data-testid="textinput1"
         id="test-id1"
@@ -882,7 +882,7 @@ exports[`snapshots match minimal implementation 1`] = `
       class="c4 fi-text-input_container"
     >
       <input
-        aria-describedby="test-id-statusText test-id-hintText"
+        aria-describedby=""
         class="c5 fi-text-input_input"
         data-testid="textinput"
         id="test-id"

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -201,7 +201,16 @@ exports[`snapshots match error status with statustext 1`] = `
   display: block;
   color: hsl(0,0%,16%);
   margin-bottom: 10px;
-  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -287,7 +296,7 @@ exports[`snapshots match error status with statustext 1`] = `
       class="c4 fi-text-input_container"
     >
       <input
-        aria-describedby="test-id2-statusText"
+        aria-describedby="test-id2-statusText test-id2-hintText"
         class="c5 fi-text-input_input"
         data-testid="textinput2"
         id="test-id2"
@@ -494,7 +503,16 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   display: block;
   color: hsl(0,0%,16%);
   margin-bottom: 10px;
-  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -580,7 +598,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
       class="c5 fi-text-input_container"
     >
       <input
-        aria-describedby="test-id1-statusText"
+        aria-describedby="test-id1-statusText test-id1-hintText"
         class="c6 fi-text-input_input"
         data-testid="textinput1"
         id="test-id1"
@@ -769,7 +787,16 @@ exports[`snapshots match minimal implementation 1`] = `
   display: block;
   color: hsl(0,0%,16%);
   margin-bottom: 10px;
-  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
@@ -855,7 +882,7 @@ exports[`snapshots match minimal implementation 1`] = `
       class="c4 fi-text-input_container"
     >
       <input
-        aria-describedby="test-id-statusText"
+        aria-describedby="test-id-statusText test-id-hintText"
         class="c5 fi-text-input_input"
         data-testid="textinput"
         id="test-id"

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -197,6 +197,15 @@ exports[`snapshots match error status with statustext 1`] = `
   line-height: 20px;
 }
 
+.c2 .fi-text-input_hintText_p {
+  display: block;
+  margin-bottom: 10px;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .c2 .fi-text-input_input {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -480,6 +489,15 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   line-height: 20px;
 }
 
+.c2 .fi-text-input_hintText_p {
+  display: block;
+  margin-bottom: 10px;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .c2 .fi-text-input_input {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -743,6 +761,15 @@ exports[`snapshots match minimal implementation 1`] = `
   font-weight: 600;
   font-size: 14px;
   line-height: 20px;
+}
+
+.c2 .fi-text-input_hintText_p {
+  display: block;
+  margin-bottom: 10px;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 .c2 .fi-text-input_input {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -305,7 +305,7 @@ exports[`snapshots match error status with statustext 1`] = `
       />
     </div>
     <span
-      class="c6 fi-text-input_statusText_span"
+      class="c6 fi-text-input_statusText"
       id="test-id2-statusText"
     >
       This is a status text

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`snapshots match error status with statustext 1`] = `
   flex-direction: column;
 }
 
-.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
+.c2 .fi-text-input_statusText_container .fi-text-input_statusText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -197,7 +197,7 @@ exports[`snapshots match error status with statustext 1`] = `
   line-height: 20px;
 }
 
-.c2 .fi-text-input_hintText_p {
+.c2 .fi-text-input_hintText {
   display: block;
   color: hsl(0,0%,16%);
   margin-bottom: 10px;
@@ -267,7 +267,7 @@ exports[`snapshots match error status with statustext 1`] = `
   border-color: hsl(3,59%,48%);
 }
 
-.c2.fi-text-input--error .fi-text-input_statusText_span {
+.c2.fi-text-input--error .fi-text-input_statusText {
   margin-top: 5px;
   color: hsl(3,59%,48%);
 }
@@ -490,7 +490,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   flex-direction: column;
 }
 
-.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
+.c2 .fi-text-input_statusText_container .fi-text-input_statusText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -499,7 +499,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   line-height: 20px;
 }
 
-.c2 .fi-text-input_hintText_p {
+.c2 .fi-text-input_hintText {
   display: block;
   color: hsl(0,0%,16%);
   margin-bottom: 10px;
@@ -569,7 +569,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   border-color: hsl(3,59%,48%);
 }
 
-.c2.fi-text-input--error .fi-text-input_statusText_span {
+.c2.fi-text-input--error .fi-text-input_statusText {
   margin-top: 5px;
   color: hsl(3,59%,48%);
 }
@@ -774,7 +774,7 @@ exports[`snapshots match minimal implementation 1`] = `
   flex-direction: column;
 }
 
-.c2 .fi-text-input_statusText_container .fi-text-input_statusText_span {
+.c2 .fi-text-input_statusText_container .fi-text-input_statusText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -783,7 +783,7 @@ exports[`snapshots match minimal implementation 1`] = `
   line-height: 20px;
 }
 
-.c2 .fi-text-input_hintText_p {
+.c2 .fi-text-input_hintText {
   display: block;
   color: hsl(0,0%,16%);
   margin-bottom: 10px;
@@ -853,7 +853,7 @@ exports[`snapshots match minimal implementation 1`] = `
   border-color: hsl(3,59%,48%);
 }
 
-.c2.fi-text-input--error .fi-text-input_statusText_span {
+.c2.fi-text-input--error .fi-text-input_statusText {
   margin-top: 5px;
   color: hsl(3,59%,48%);
 }

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -598,7 +598,6 @@ exports[`snapshots match hidden label with placeholder 1`] = `
       class="c5 fi-text-input_container"
     >
       <input
-        aria-describedby=""
         class="c6 fi-text-input_input"
         data-testid="textinput1"
         id="test-id1"
@@ -882,7 +881,6 @@ exports[`snapshots match minimal implementation 1`] = `
       class="c4 fi-text-input_container"
     >
       <input
-        aria-describedby=""
         class="c5 fi-text-input_input"
         data-testid="textinput"
         id="test-id"

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -282,7 +282,7 @@ exports[`snapshots match error status with statustext 1`] = `
 }
 
 <label
-  class="c0 fi-text-input_label c1 c2 fi-text-input--error"
+  class="c0 fi-text-input_label c1 fi-text-input c2 fi-text-input--error"
 >
   <p
     class="c3 fi-paragraph fi-text-input_label-p"
@@ -584,7 +584,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 }
 
 <label
-  class="c0 fi-text-input_label c1 c2"
+  class="c0 fi-text-input_label c1 fi-text-input c2"
 >
   <span
     class="c3 c4 fi-visually-hidden"
@@ -868,7 +868,7 @@ exports[`snapshots match minimal implementation 1`] = `
 }
 
 <label
-  class="c0 fi-text-input_label c1 c2"
+  class="c0 fi-text-input_label c1 fi-text-input c2"
 >
   <p
     class="c3 fi-paragraph fi-text-input_label-p"


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
- `hintText` prop for the TextInput
- Able to give `type` to TextInput: ```'text' | 'email' | 'number' | 'password' | 'tel' | 'url'```
- More tests added.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
These changes were made because those were wanted by the designs and users of the library. 

Now user is able to give some different **type** than the previous `text` if it is needed. Not every type is supported as it makes no sense to give e.g _checkbox_ or _button_ as types because we have separate component for those.

Tests were added to increase test coverage and to hopefully help in future to catch some possible bugs.

## How Has This Been Tested?

## Screenshots
![image](https://user-images.githubusercontent.com/53757053/89033230-0811b500-d33f-11ea-8f4a-b30c85144723.png)


## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

Feature
- TextInput now has `hintText` and `type` props.