### PR TITLE
[Fix] Checkbox's hintText style for font

### DIFF
--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -143,7 +143,7 @@ export const baseStyles = withSuomifiTheme(
     & .fi-checkbox_hintText {
       display: block;
       padding-left: ${theme.spacing.l};
-      font-size: ${theme.typography.bodyTextSmall};
+      ${theme.typography.bodyTextSmall};
       color: ${theme.colors.depthDark1};
     }
 

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`Calling render with the same component on the same container does not r
 .c1 .fi-checkbox_hintText {
   display: block;
   padding-left: 25px;
-  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Checkbox's hintText had problem with the style for font. Snapshot test updated accordingly.



## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

It was not having any visual glitch in the styles, but still an error in the styles that might later come as a problem or just needless to have error that was fixable.

## How Has This Been Tested?

Tested locally in the styleguidist.

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

Fix
- Checkbox's hintText style for font fixed.
