### PR TITLE
[BugFix] Upgrade suomifi-icons to latest 1.0.1.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13134,9 +13134,9 @@ suomifi-design-tokens@^2.0.0:
   integrity sha512-5jBQSmWlQJoIjyytG6JWB8ILhlWY0x416eO9iH4KxXuPpy7GeA+oyfabdsgPWFUPge0oOlO98A6qtLNZnsT9iA==
 
 suomifi-icons@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-1.0.0.tgz#ab6a4c00526b7c355656b557aa566cbe30ae7d73"
-  integrity sha512-5OcASRIwiYIXYtaCag96SBVsycDIifOpEem0WkqpNd/Xo3D/y8teG89nYLGuedsmmPIrOEJS+8IyJZ9E313HkQ==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-1.0.1.tgz#6f6df2e382d0abb4c14fef2417b3378860400ae7"
+  integrity sha512-POcr+qdaMlRckEtLFC47wvovPDxMEfqC+O390aZGVRQKztP15PqpgvHZgjh7vkR3fMP3jcvNv3FV1JSyb5kQXw==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

Upgrade suomifi-icons to latest 1.0.1 version and fix related security issues.

## Related Issue

suomifi-icons had vulnerable dependencies which have now been fixed.

## How Has This Been Tested?

Tested using a create react app project, SSR template project and styleguidist build.

## Release notes
- Suomifi-icons upgraded to 1.0.1