### PR TITLE
[BugFix] discard passProps tokens for unStyled Button

### DIFF
--- a/src/core/Button/UnstyledButton.tsx
+++ b/src/core/Button/UnstyledButton.tsx
@@ -9,7 +9,7 @@ const baseClassName = 'fi-button';
 
 export const UnstyledButton = styled(
   (props: ButtonProps & InternalTokensProp) => {
-    const { className, ...passProps } = props;
+    const { className, tokens, ...passProps } = props;
     return (
       <Button {...passProps} className={classnames(className, baseClassName)} />
     );

--- a/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -409,7 +409,6 @@ exports[`calling render with the same component on the same container does not r
     aria-disabled="false"
     class="c3 c4 fi-button c5 fi-expander-group_all-button fi-button"
     tabindex="0"
-    tokens="[object Object]"
     type="button"
   >
     Open all

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -409,7 +409,6 @@ exports[`snapshot testing 1`] = `
     aria-disabled="false"
     class="c3 c4 fi-button c5 fi-expander-group_all-button fi-button"
     tabindex="0"
-    tokens="[object Object]"
     type="button"
   >
     Open all


### PR DESCRIPTION
## Description
Tokens prop is now discarded for unstyled Button variant.

## Related Issue
Tokens object was passed to DOM when provided to unstyled variant of button.

## Motivation and Context
All buttons accept the tokens prop, but unstyled Button variant does not utilize it. In some cases it is dynamically passed anyways, so the best approach is just to remove it before render to keep the Button API's consistent.

## How Has This Been Tested?
Tested with Create React App TS and SSR template test projects.

## Release notes
- Tokens prop is now discarded for unstyled Button variant.