### PR TITLE
[Feature] Add name prop to form component APIs

### DIFF
--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -57,6 +57,7 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   visualPlaceholder?: string;
   /** Input container div to define custom styling */
   inputContainerProps?: HtmlDivProps;
+  /** A custom element to be passed to the component. Will be rendered after the input */
   children?: ReactNode;
   /** Hint text to be shown below the component */
   hintText?: string;
@@ -66,6 +67,8 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
    * @default text
    */
   type?: InputType;
+  name?: string;
+  value?: string;
 }
 
 class BaseTextInput extends Component<TextInputProps> {

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -67,8 +67,8 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
    * @default text
    */
   type?: InputType;
+  /** Input name */
   name?: string;
-  value?: string;
 }
 
 class BaseTextInput extends Component<TextInputProps> {

--- a/src/components/Form/Textarea.tsx
+++ b/src/components/Form/Textarea.tsx
@@ -61,6 +61,8 @@ export interface TextareaProps extends HtmlTextareaProps {
    * @default uuidV4
    */
   id?: string;
+  /** Input name */
+  name?: string;
 }
 
 export class Textarea extends Component<TextareaProps> {

--- a/src/components/Form/Toggle.tsx
+++ b/src/components/Form/Toggle.tsx
@@ -20,6 +20,8 @@ export interface ToggleInputProps {
   className?: string;
   /** Disable Button usage */
   disabled?: boolean;
+  /** Input name */
+  name?: string;
   'aria-label'?: string;
   'aria-labelledby'?: string;
 }

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -99,8 +99,7 @@ describe('props', () => {
       const namedInput = getByTestId('input-name') as HTMLInputElement;
 
       it('has the given name attribute', () => {
-        fireEvent.change(namedInput, { target: { name: 'newName' } });
-        expect(namedInput.name).toBe('newName');
+        expect(namedInput.name).toBe('test-name');
       });
     });
 

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -87,6 +87,23 @@ describe('props', () => {
       });
     });
 
+    describe('name', () => {
+      const textInput = (
+        <TextInput
+          labelText="Test input"
+          name="test-name"
+          data-testid="input-name"
+        />
+      );
+      const { getByTestId } = render(textInput);
+      const namedInput = getByTestId('input-name') as HTMLInputElement;
+
+      it('has the given name attribute', () => {
+        fireEvent.change(namedInput, { target: { name: 'newName' } });
+        expect(namedInput.name).toBe('newName');
+      });
+    });
+
     describe('number', () => {
       const textInput = (
         <TextInput

--- a/src/core/Form/Textarea/Textarea.test.tsx
+++ b/src/core/Form/Textarea/Textarea.test.tsx
@@ -216,12 +216,10 @@ describe('props', () => {
   describe('name', () => {
     it('has the given name attribute', () => {
       const { getByRole } = render(
-        <Textarea labelText="label" resize="vertical" />,
+        <Textarea labelText="label" resize="vertical" name="test-name" />,
       );
       const textarea = getByRole('textbox') as HTMLInputElement;
-
-      fireEvent.change(textarea, { target: { name: 'newName' } });
-      expect(textarea.name).toBe('newName');
+      expect(textarea.name).toBe('test-name');
     });
   });
 });

--- a/src/core/Form/Textarea/Textarea.test.tsx
+++ b/src/core/Form/Textarea/Textarea.test.tsx
@@ -213,4 +213,15 @@ describe('props', () => {
       expect(textarea).toHaveStyle('resize: none');
     });
   });
+  describe('name', () => {
+    it('has the given name attribute', () => {
+      const { getByRole } = render(
+        <Textarea labelText="label" resize="vertical" />,
+      );
+      const textarea = getByRole('textbox') as HTMLInputElement;
+
+      fireEvent.change(textarea, { target: { name: 'newName' } });
+      expect(textarea.name).toBe('newName');
+    });
+  });
 });

--- a/src/core/Form/Toggle/Toggle.test.tsx
+++ b/src/core/Form/Toggle/Toggle.test.tsx
@@ -96,7 +96,5 @@ describe('name', () => {
 
   it('has the given name attribute', () => {
     expect(namedToggle.name).toBe('testToggle');
-    fireEvent.change(namedToggle, { target: { name: 'newName' } });
-    expect(namedToggle.name).toBe('newName');
   });
 });

--- a/src/core/Form/Toggle/Toggle.test.tsx
+++ b/src/core/Form/Toggle/Toggle.test.tsx
@@ -88,3 +88,15 @@ describe.each([['withInput'], ['default']])(
     );
   },
 );
+
+describe('name', () => {
+  const toggle = <Toggle.withInput toggleInputProps={{ name: 'testToggle' }} />;
+  const { getByRole } = render(toggle);
+  const namedToggle = getByRole('checkbox') as HTMLInputElement;
+
+  it('has the given name attribute', () => {
+    expect(namedToggle.name).toBe('testToggle');
+    fireEvent.change(namedToggle, { target: { name: 'newName' } });
+    expect(namedToggle.name).toBe('newName');
+  });
+});


### PR DESCRIPTION
## Description
This PR adds name property to form components that didn't previously have them.
ToggleInput is not really a form component, but is a checkbox under the hood, so name prop was added for that as well.

Also added documentation for the children prop in TextInput.

## Motivation and Context
Form elements should support different ways of using them, and those ways should be documented. With the addition of documentation for the name prop the support for a classic way of building a form is effectively conveyed.

## How Has This Been Tested?
Running locally & automated tests.

## Release notes
Added name property to form component APIs.
