### PR TITLE
[Feature] Add logger warning to checkbox when name or value props have an empty value

### DIFF
--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -128,11 +128,11 @@ export class Checkbox extends Component<CheckboxProps> {
     }
 
     if (
-      ('name' in this.props && name === '') ||
-      ('value' in this.props && value === '')
+      ('name' in this.props && (typeof name !== 'string' || name === '')) ||
+      ('value' in this.props && (typeof value !== 'string' || value === ''))
     ) {
       logger.warn(
-        'Name or value props should not have empty values. Provide valid values.',
+        'Name and value props should have non-empty values if provided.',
       );
     }
 

--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -127,6 +127,15 @@ export class Checkbox extends Component<CheckboxProps> {
       );
     }
 
+    if (
+      ('name' in this.props && name === '') ||
+      ('value' in this.props && value === '')
+    ) {
+      logger.warn(
+        'Name or value props should not have empty values. Provide valid values.',
+      );
+    }
+
     const id = idGenerator(propId);
     const statusTextId = `${idGenerator(propId)}-statusText`;
     const hintTextId = `${idGenerator(propId)}-hintText`;


### PR DESCRIPTION
## Description
This PR adds a logger warning to checkbox when either name or value props have an empty value.

## Motivation and Context
Name and/or value props having empty values can lead to issues. Therefore it should be avoided. To help that, the library should warn the developer when an empty value for those props is given.

## How Has This Been Tested?
Tested by running locally and manually giving the props different values as well as with automated tests.

## Release notes
Added empty value or name warning to checkbox.
