### PR TITLE
[Feature] Aria-invalid attributes

### DIFF
--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -148,6 +148,7 @@ export class Checkbox extends Component<CheckboxProps> {
       id,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
+      'aria-invalid': status === 'error',
       checked: !!checkedState,
       className: checkboxBaseClassNames.input,
       onChange: this.handleClick,

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -30,6 +30,8 @@ type Label = 'hidden' | 'visible';
 
 type InputType = 'text' | 'email' | 'number' | 'password' | 'tel' | 'url';
 
+type TextInputStatus = 'default' | 'error' | 'success';
+
 export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   /** Custom classname for the input to extend or customize */
   className?: string;
@@ -61,6 +63,11 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   children?: ReactNode;
   /** Hint text to be shown below the component */
   hintText?: string;
+  /**
+   * 'default' | 'error' | 'success'
+   * @default default
+   */
+  status?: TextInputStatus;
   /** Status text to be shown below the component and hint text. Use e.g. for validation error */
   statusText?: string;
   /** 'text' | 'email' | 'number' | 'password' | 'tel' | 'url'
@@ -82,6 +89,7 @@ class BaseTextInput extends Component<TextInputProps> {
       labelTextProps,
       inputContainerProps,
       children,
+      status,
       statusText,
       hintText,
       visualPlaceholder,
@@ -132,6 +140,7 @@ class BaseTextInput extends Component<TextInputProps> {
               type={type}
               {...getDescribedBy()}
               placeholder={visualPlaceholder}
+              {...{ 'aria-invalid': status === 'error' }}
             />
             {children}
           </HtmlDiv>

--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -102,18 +102,6 @@ class BaseTextInput extends Component<TextInputProps> {
     const generatedStatusTextId = `${idGenerator(propId)}-statusText`;
     const generatedHintTextId = `${idGenerator(propId)}-hintText`;
 
-    const getDescribedBy = () => {
-      if (statusText || hintText) {
-        return {
-          'aria-describedby': [
-            ...(statusText ? [generatedStatusTextId] : []),
-            ...(hintText ? [generatedHintTextId] : []),
-          ].join(' '),
-        };
-      }
-      return {};
-    };
-
     return (
       <HtmlLabel
         {...labelProps}
@@ -138,7 +126,6 @@ class BaseTextInput extends Component<TextInputProps> {
               {...passProps}
               className={classnames(inputBaseClassName, inputClassName)}
               type={type}
-              {...getDescribedBy()}
               placeholder={visualPlaceholder}
               {...{ 'aria-invalid': status === 'error' }}
             />

--- a/src/components/Form/Textarea.tsx
+++ b/src/components/Form/Textarea.tsx
@@ -161,6 +161,7 @@ export class Textarea extends Component<TextareaProps> {
           disabled={disabled}
           defaultValue={children}
           placeholder={visualPlaceholder}
+          {...{ 'aria-invalid': status === 'error' }}
           {...getDescribedBy()}
           {...passProps}
           {...onClickProps}

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -80,6 +80,7 @@ class DefaultCheckbox extends Component<CheckboxProps> {
         disabled={disabled}
         onClick={this.handleClick}
         {...passProps}
+        status={status}
         className={classnames(baseClassName, className, {
           [checkboxClassNames.error]: status === 'error' && !disabled,
           [checkboxClassNames.checked]: checkedState && !disabled,

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -230,6 +230,7 @@ exports[`props children has matching snapshot 1`] = `
 >
   <input
     aria-describedby=""
+    aria-invalid="false"
     class="c2 fi-checkbox_input"
     id="test"
     type="checkbox"

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -295,6 +295,7 @@ exports[`calling render with the same component on the same container does not r
       class="c4 fi-search-input_input-container fi-text-input_container"
     >
       <input
+        aria-invalid="false"
         class="c5 fi-text-input_input fi-search-input_input"
         data-testid="textinput"
         id="test-id"

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -17,15 +17,8 @@ export const textInputClassNames = {
   error: `${baseClassName}--error`,
   success: `${baseClassName}--success`,
 };
-type TextInputStatus = 'default' | 'error' | 'success';
 
-export interface TextInputProps extends CompTextInputProps, TokensProp {
-  /**
-   * 'default' | 'error' | 'success'
-   * @default default
-   */
-  status?: TextInputStatus;
-}
+export interface TextInputProps extends CompTextInputProps, TokensProp {}
 
 const StyledTextInput = styled(
   ({
@@ -39,6 +32,7 @@ const StyledTextInput = styled(
     return (
       <CompTextInput
         {...passProps}
+        status={status}
         labelTextProps={{
           ...labelTextProps,
           className: classnames(

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -296,7 +296,6 @@ exports[`snapshots match error status with statustext 1`] = `
       class="c4 fi-text-input_container"
     >
       <input
-        aria-describedby="test-id2-statusText"
         aria-invalid="true"
         class="c5 fi-text-input_input"
         data-testid="textinput2"

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -297,6 +297,7 @@ exports[`snapshots match error status with statustext 1`] = `
     >
       <input
         aria-describedby="test-id2-statusText"
+        aria-invalid="true"
         class="c5 fi-text-input_input"
         data-testid="textinput2"
         id="test-id2"
@@ -598,6 +599,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
       class="c5 fi-text-input_container"
     >
       <input
+        aria-invalid="false"
         class="c6 fi-text-input_input"
         data-testid="textinput1"
         id="test-id1"
@@ -881,6 +883,7 @@ exports[`snapshots match minimal implementation 1`] = `
       class="c4 fi-text-input_container"
     >
       <input
+        aria-invalid="false"
         class="c5 fi-text-input_input"
         data-testid="textinput"
         id="test-id"

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -42,6 +42,7 @@ export class Textarea extends Component<TextareaProps> {
           [textareaClassNames.disabled]: !!disabled,
           [textareaClassNames.error]: status === 'error' && !disabled,
         })}
+        status={status}
         {...passProps}
       >
         {children}

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -266,6 +266,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
     </p>
   </label>
   <textarea
+    aria-invalid="false"
     class="c5 fi-textarea_textarea"
     id="just-for-snapshot-to-be-same"
   />


### PR DESCRIPTION
## Description
This PR adds aria-invalid attributes to inputs that already have the status prop. Aria-invalid is set to true when status equals "error".

Additionally, redundant aria-describedby attributes have been removed TextInput and those are now only read once by screenreaders.

## Motivation and Context
Cases where there are errors are now natively announced by screen readers. This is a better practice than only relying on error messages.

## How Has This Been Tested?
Tested with Mac OS Safari, Chrome and Firefox browsers using VoiceOver and Windows Chrome, Firefox and Edge browsers using NVDA.

## Release notes
- Form components with status now also use aria-invalid to communicate errors.
- TextInput labels and texts are not read twice any more.