### PR TITLE
[Feature] Text input icon support

### DIFF
--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -244,6 +244,22 @@ exports[`calling render with the same component on the same container does not r
   box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
 }
 
+.c2.fi-text-input_with-icon .fi-text-input_container {
+  position: relative;
+}
+
+.c2.fi-text-input_with-icon .fi-text-input_input {
+  padding-right: 40px;
+}
+
+.c2.fi-text-input_with-icon .fi-icon {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  top: 10px;
+  right: 10px;
+}
+
 .c2.fi-text-input--error .fi-text-input_input {
   border-color: hsl(3,59%,48%);
 }

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../../theme';
 import { input, inputContainer, font } from '../../theme/reset';
+import { math } from 'polished';
 
 export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
@@ -43,6 +44,26 @@ export const baseStyles = withSuomifiTheme(
     :focus {
       box-shadow: ${theme.shadows.actionElementBoxShadow};
     }
+    }
+    
+  &.fi-text-input_with-icon {
+    & .fi-text-input_container {
+    position: relative;
+    }
+
+    & .fi-text-input_input{
+    padding-right: ${math(
+      `${theme.spacing.insetXl} * 2 + ${theme.spacing.insetM}`,
+    )};
+    }
+
+    & .fi-icon{
+        position: absolute;
+        width: 18px;
+        height: 18px;
+        top: ${theme.spacing.insetL};
+        right: ${theme.spacing.insetL};
+      }
     }
 
   &.fi-text-input--error {

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -4,7 +4,6 @@ import { TextInput } from 'suomifi-ui-components';
   <TextInput
     onBlur={(event) => console.log(event.target.value)}
     labelText="TextInput with visible label"
-    icon="search"
   />
   <TextInput
     onBlur={(event) => console.log(event.target.value)}
@@ -80,6 +79,11 @@ import { TextInput } from 'suomifi-ui-components';
     labelText="TextInput with password"
     type="password"
     defaultValue="password"
+  />
+  <TextInput
+    labelText="TextInput with an icon"
+    icon="mapLocation"
+    iconProps={{ fill: 'red' }}
   />
 </>;
 ```

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -4,6 +4,7 @@ import { TextInput } from 'suomifi-ui-components';
   <TextInput
     onBlur={(event) => console.log(event.target.value)}
     labelText="TextInput with visible label"
+    icon="search"
   />
   <TextInput
     onBlur={(event) => console.log(event.target.value)}

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -177,4 +177,21 @@ describe('props', () => {
       expect(inputField).toHaveAttribute('placeholder', 'Enter text here');
     });
   });
+
+  describe('icon', () => {
+    it('should have the correct classname when icon prop is given', () => {
+      const { container } = render(
+        <TextInput labelText="Test input" icon="close" />,
+      );
+      expect(container.firstChild).toHaveClass('fi-text-input_with-icon');
+    });
+
+    it('should have an icon element when one is specified', () => {
+      const { container } = render(
+        <TextInput labelText="Test input" icon="close" />,
+      );
+      const icon = container.querySelector('.fi-icon');
+      expect(container.contains(icon)).toBeTruthy();
+    });
+  });
 });

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -71,9 +71,14 @@ const StyledTextInput = styled(
  */
 export class TextInput extends Component<TextInputProps> {
   render() {
-    const { children, icon, iconProps, ...passProps } = withSuomifiDefaultProps(
-      this.props,
-    );
+    const { children, ...passProps } = withSuomifiDefaultProps(this.props);
+
+    const icon = this.props.icon || this.props.iconProps?.icon;
+
+    const iconProps = {
+      ...this.props.iconProps,
+      icon,
+    };
 
     return (
       <StyledTextInput
@@ -83,7 +88,7 @@ export class TextInput extends Component<TextInputProps> {
         })}
       >
         {children}
-        {icon && <Icon {...iconProps} icon={icon} />}
+        {icon && <Icon {...iconProps} />}
       </StyledTextInput>
     );
   }

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -71,24 +71,30 @@ const StyledTextInput = styled(
  */
 export class TextInput extends Component<TextInputProps> {
   render() {
-    const { children, ...passProps } = withSuomifiDefaultProps(this.props);
-
-    const icon = this.props.icon || this.props.iconProps?.icon;
-
-    const iconProps = {
-      ...this.props.iconProps,
+    const {
+      children,
       icon,
+      iconProps,
+      className,
+      ...passProps
+    } = withSuomifiDefaultProps(this.props);
+
+    const prioritizedIcon = icon || iconProps?.icon;
+
+    const newIconProps = {
+      ...iconProps,
+      icon: prioritizedIcon,
     };
 
     return (
       <StyledTextInput
         {...passProps}
-        className={classnames({
-          [textInputClassNames.icon]: icon !== undefined,
+        className={classnames(className, {
+          [textInputClassNames.icon]: prioritizedIcon !== undefined,
         })}
       >
         {children}
-        {icon && <Icon {...iconProps} />}
+        {prioritizedIcon && <Icon {...newIconProps} />}
       </StyledTextInput>
     );
   }

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -79,22 +79,22 @@ export class TextInput extends Component<TextInputProps> {
       ...passProps
     } = withSuomifiDefaultProps(this.props);
 
-    const prioritizedIcon = icon || iconProps?.icon;
+    const resolvedIcon = icon || iconProps?.icon;
 
     const newIconProps = {
       ...iconProps,
-      icon: prioritizedIcon,
+      icon: resolvedIcon,
     };
 
     return (
       <StyledTextInput
         {...passProps}
         className={classnames(className, {
-          [textInputClassNames.icon]: prioritizedIcon !== undefined,
+          [textInputClassNames.icon]: resolvedIcon !== undefined,
         })}
       >
         {children}
-        {prioritizedIcon && <Icon {...newIconProps} />}
+        {resolvedIcon && <Icon {...newIconProps} />}
       </StyledTextInput>
     );
   }

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -8,6 +8,9 @@ import {
   TextInputProps as CompTextInputProps,
 } from '../../../components/Form/TextInput';
 import classnames from 'classnames';
+import { Icon, IconProps, BaseIconKeys } from '../../Icon/Icon';
+import { Omit } from '../../../utils/typescript';
+
 const baseClassName = 'fi-text-input';
 
 export const textInputClassNames = {
@@ -16,9 +19,13 @@ export const textInputClassNames = {
   inputContainer: `${baseClassName}_container`,
   error: `${baseClassName}--error`,
   success: `${baseClassName}--success`,
+  icon: `${baseClassName}_with-icon`,
 };
 
-export interface TextInputProps extends CompTextInputProps, TokensProp {}
+export interface TextInputProps extends CompTextInputProps, TokensProp {
+  icon?: BaseIconKeys;
+  iconProps?: Omit<IconProps, 'icon'>;
+}
 
 const StyledTextInput = styled(
   ({
@@ -64,8 +71,20 @@ const StyledTextInput = styled(
  */
 export class TextInput extends Component<TextInputProps> {
   render() {
-    const { ...passProps } = withSuomifiDefaultProps(this.props);
+    const { children, icon, iconProps, ...passProps } = withSuomifiDefaultProps(
+      this.props,
+    );
 
-    return <StyledTextInput {...passProps} />;
+    return (
+      <StyledTextInput
+        {...passProps}
+        className={classnames({
+          [textInputClassNames.icon]: icon !== undefined,
+        })}
+      >
+        {children}
+        {icon && <Icon {...iconProps} icon={icon} />}
+      </StyledTextInput>
+    );
   }
 }

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -263,6 +263,22 @@ exports[`snapshots match error status with statustext 1`] = `
   box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
 }
 
+.c2.fi-text-input_with-icon .fi-text-input_container {
+  position: relative;
+}
+
+.c2.fi-text-input_with-icon .fi-text-input_input {
+  padding-right: 40px;
+}
+
+.c2.fi-text-input_with-icon .fi-icon {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  top: 10px;
+  right: 10px;
+}
+
 .c2.fi-text-input--error .fi-text-input_input {
   border-color: hsl(3,59%,48%);
 }
@@ -565,6 +581,22 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
 }
 
+.c2.fi-text-input_with-icon .fi-text-input_container {
+  position: relative;
+}
+
+.c2.fi-text-input_with-icon .fi-text-input_input {
+  padding-right: 40px;
+}
+
+.c2.fi-text-input_with-icon .fi-icon {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  top: 10px;
+  right: 10px;
+}
+
 .c2.fi-text-input--error .fi-text-input_input {
   border-color: hsl(3,59%,48%);
 }
@@ -847,6 +879,22 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c2 .fi-text-input_input:focus {
   box-shadow: 0 1px 2px 0 rgba(0,53,122,0.1) inset;
+}
+
+.c2.fi-text-input_with-icon .fi-text-input_container {
+  position: relative;
+}
+
+.c2.fi-text-input_with-icon .fi-text-input_input {
+  padding-right: 40px;
+}
+
+.c2.fi-text-input_with-icon .fi-icon {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  top: 10px;
+  right: 10px;
 }
 
 .c2.fi-text-input--error .fi-text-input_input {


### PR DESCRIPTION
## Description
This PR implements support for using icons inside the text input component. User can give the icon name as well as any preferred icon props to the component. Those get passed to the corresponding elements. The necessary styling is also applied when an icon is given.

## Motivation and Context
Text input with an icon is part of the designs for this component, but it hasn't been implemented until now.

## How Has This Been Tested?
So far only tested by running locally.

## Release notes
Added support for icons inside text inputs.
