### PR TITLE
[Bugfix] Disabled chip color and cursor

### DIFF
--- a/src/core/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip.baseStyles.tsx
@@ -13,13 +13,18 @@ const removableStyles = ({ theme }: SuomifiThemeProp) => css`
 `;
 
 const disabledStyles = ({ theme }: SuomifiThemeProp) => css`
-  &.fi-chip--disabled.fi-chip {
-    background: ${theme.colors.depthBase};
-    &:hover,
-    &:active {
+  &.fi-chip--disabled {
+    &.fi-chip {
+      ${disabledCursor}
       background: ${theme.colors.depthBase};
+      &:hover,
+      &:active {
+        background: ${theme.colors.depthBase};
+      }
     }
-    ${disabledCursor}
+    & .fi-chip--icon {
+      ${disabledCursor}
+    }
   }
 `;
 

--- a/src/core/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip.baseStyles.tsx
@@ -14,10 +14,10 @@ const removableStyles = ({ theme }: SuomifiThemeProp) => css`
 
 const disabledStyles = ({ theme }: SuomifiThemeProp) => css`
   &.fi-chip--disabled.fi-chip {
-    background: ${theme.colors.depthLight1};
+    background: ${theme.colors.depthBase};
     &:hover,
     &:active {
-      background: ${theme.colors.depthLight1};
+      background: ${theme.colors.depthBase};
     }
     ${disabledCursor}
   }

--- a/src/core/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/__snapshots__/Chip.test.tsx.snap
@@ -164,13 +164,17 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-chip--disabled.fi-chip {
-  background: hsl(202,7%,80%);
   cursor: not-allowed;
+  background: hsl(202,7%,67%);
 }
 
 .c1.fi-chip--disabled.fi-chip:hover,
 .c1.fi-chip--disabled.fi-chip:active {
-  background: hsl(202,7%,80%);
+  background: hsl(202,7%,67%);
+}
+
+.c1.fi-chip--disabled .fi-chip--icon {
+  cursor: not-allowed;
 }
 
 <div>
@@ -355,13 +359,17 @@ exports[`classnames should match snapshot 1`] = `
 }
 
 .c1.fi-chip--disabled.fi-chip {
-  background: hsl(202,7%,80%);
   cursor: not-allowed;
+  background: hsl(202,7%,67%);
 }
 
 .c1.fi-chip--disabled.fi-chip:hover,
 .c1.fi-chip--disabled.fi-chip:active {
-  background: hsl(202,7%,80%);
+  background: hsl(202,7%,67%);
+}
+
+.c1.fi-chip--disabled .fi-chip--icon {
+  cursor: not-allowed;
 }
 
 <div>
@@ -542,13 +550,17 @@ exports[`disabled should match snapshot 1`] = `
 }
 
 .c1.fi-chip--disabled.fi-chip {
-  background: hsl(202,7%,80%);
   cursor: not-allowed;
+  background: hsl(202,7%,67%);
 }
 
 .c1.fi-chip--disabled.fi-chip:hover,
 .c1.fi-chip--disabled.fi-chip:active {
-  background: hsl(202,7%,80%);
+  background: hsl(202,7%,67%);
+}
+
+.c1.fi-chip--disabled .fi-chip--icon {
+  cursor: not-allowed;
 }
 
 <div>


### PR DESCRIPTION
## Description
This PR fixes a couple of small bugs in the chip component:

- The background color of the disabled variant now has the correct color token (darker than previously)
- The disabled cursor now applies to the icon as well, if one is present.

## Motivation and Context

Components should match the designs and not have bugs.

## How Has This Been Tested?
Tested by running locally and checking visually.

## Release notes
Disabled chip now has correct color
