### PR TITLE
[Bugfix] Disabled text input icon color

### DIFF
--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -306,6 +306,10 @@ exports[`calling render with the same component on the same container does not r
   background-color: hsl(202,7%,97%);
 }
 
+.c2.fi-text-input--disabled .fi-icon {
+  fill: hsl(202,7%,67%);
+}
+
 .c2.fi-search-input {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -105,6 +105,9 @@ export const baseStyles = withSuomifiTheme(
       color: ${theme.colors.depthBase};
       background-color: ${theme.colors.depthLight3};
     }
+    & .fi-icon{
+      fill: ${theme.colors.depthBase};
+    }
   }
 `,
 );

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -325,6 +325,10 @@ exports[`snapshots match error status with statustext 1`] = `
   background-color: hsl(202,7%,97%);
 }
 
+.c2.fi-text-input--disabled .fi-icon {
+  fill: hsl(202,7%,67%);
+}
+
 <div
   class="c0 c1 fi-text-input c2 fi-text-input--error"
 >
@@ -675,6 +679,10 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   background-color: hsl(202,7%,97%);
 }
 
+.c2.fi-text-input--disabled .fi-icon {
+  fill: hsl(202,7%,67%);
+}
+
 <div
   class="c0 c1 fi-text-input c2"
 >
@@ -1005,6 +1013,10 @@ exports[`snapshots match minimal implementation 1`] = `
 .c2.fi-text-input--disabled .fi-text-input_input {
   color: hsl(202,7%,67%);
   background-color: hsl(202,7%,97%);
+}
+
+.c2.fi-text-input--disabled .fi-icon {
+  fill: hsl(202,7%,67%);
 }
 
 <div


### PR DESCRIPTION
## Description
Text input icon color was unaffected in disabled styles, which made it stand out and take away from the visual cue of the input being disabled. This PR applies a style to set the icon color to a lighter one when the component is disabled.

## How Has This Been Tested?
Tested in styleguidist in local environment.

## Release notes
Apply disabled styles to text input icon as well
