### PR TITLE
[Feature] Update readme to cover alternative css imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ And include **required** styles and fonts from `dist/main.css` as best suited fo
 import 'suomifi-ui-components/dist/main.css';
 ```
 
-This stylesheet contains styles required by Reach UI, which is used by this library in a few places, as well as the default font for the library. If you already use Reach UI in your project or cannot import the CSS file for some reason (e.g. CSP for fonts), you can also import the styles directly from Reach UI by following [their instructions](https://reach.tech/styling/).
+This stylesheet contains the default fonts for the library as well as Reach UI peer dependency styles.
 
-In this case, however, you need to import the font separately e.g. by adding the following entry to your application's CSS.
+If you already use Reach UI in your project or cannot import the CSS file for some reason (e.g. CSP for fonts), you can also import the styles directly from Reach UI by following [their instructions](https://reach.tech/styling/). In this case you need to import the font separately e.g. by adding the following entry to your application's CSS.
 
 ```javascript
 @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300:400,600&display=swap');

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ And include **required** styles and fonts from `dist/main.css` as best suited fo
 import 'suomifi-ui-components/dist/main.css';
 ```
 
+This stylesheet contains styles required by Reach UI, which is used by this library in a few places, as well as the default font for the library. If you already use Reach UI in your project or cannot import the CSS file for some reason (e.g. CSP for fonts), you can also import the styles directly from Reach UI by following [their instructions](https://reach.tech/styling/).
+
+In this case, however, you need to import the font separately e.g. by adding the following entry to your application's CSS.
+
+```javascript
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300:400,600&display=swap');
+```
+
 ### Peer dependencies
 
 You should also install the following dependencies, if your project does not already have them.


### PR DESCRIPTION
## Description
The readme section instructed the user to add our custom CSS file in order to make the library work as intended. This is not the only way, so this PR adds a mention of alternative ways of implementing the necessary styles.

## Motivation and Context
The issue was brought up by a developer using the library.

## How Has This Been Tested?
Running locally.

## Release notes
-Update readme on implementing required styles
