### PR TITLE
[Feature] Text input optionalText prop

### DIFF
--- a/src/components/Form/TextInput.tsx
+++ b/src/components/Form/TextInput.tsx
@@ -25,6 +25,7 @@ const textInputClassNames = {
   statusText: `${baseClassName}_statusText`,
   statusTextContainer: `${baseClassName}_statusText_container`,
   hintText: `${baseClassName}_hintText`,
+  optionalText: `${baseClassName}_optionalText`,
 };
 
 export interface TextInputLabelProps extends HtmlLabelProps {}
@@ -79,6 +80,8 @@ export interface TextInputProps extends Omit<HtmlInputProps, 'type'> {
   name?: string;
   /** Set components width to 100% */
   fullWidth?: boolean;
+  /** Optional text that is shown after labelText. Will be wrapped in parentheses. */
+  optionalText?: string;
 }
 
 class BaseTextInput extends Component<TextInputProps> {
@@ -91,6 +94,7 @@ class BaseTextInput extends Component<TextInputProps> {
       labelTextProps,
       inputContainerProps,
       children,
+      optionalText,
       status,
       statusText,
       hintText,
@@ -120,9 +124,19 @@ class BaseTextInput extends Component<TextInputProps> {
           )}
         >
           {hideLabel ? (
-            <VisuallyHidden>{labelText}</VisuallyHidden>
+            <VisuallyHidden>
+              {labelText}
+              {optionalText && `(${optionalText})`}
+            </VisuallyHidden>
           ) : (
-            <Paragraph {...labelTextProps}>{labelText}</Paragraph>
+            <Paragraph {...labelTextProps}>
+              {labelText}
+              {optionalText && (
+                <HtmlSpan className={textInputClassNames.optionalText}>
+                  {` (${optionalText})`}
+                </HtmlSpan>
+              )}
+            </Paragraph>
           )}
           {hintText && (
             <Paragraph

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -142,6 +142,13 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(0,0%,16%);
 }
 
+.c2 .fi-text-input_optionalText {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .c2 .fi-text-input_input-element-container > input:focus {
   outline-color: hsl(23,82%,53%);
   outline-width: 4px;

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -29,6 +29,10 @@ export const baseStyles = withSuomifiTheme(
     color: ${theme.colors.blackBase};
   }
 
+  & .fi-text-input_optionalText {
+        ${theme.typography.bodyTextSmall};
+  }
+
   & .fi-text-input_input-element-container {
     ${inputContainer({ theme })}
   }

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -148,6 +148,16 @@ describe('props', () => {
     });
   });
 
+  describe('optionalText', () => {
+    it('should have element and correct classname for it', () => {
+      const { getByText } = render(
+        <TextInput labelText="label" optionalText="Optional" />,
+      );
+      const optionalText = getByText('(Optional)');
+      expect(optionalText).toHaveClass('fi-text-input_optionalText');
+    });
+  });
+
   describe('labelMode', () => {
     it('should be visible by default', () => {
       const { getByText } = render(<TextInput labelText="Test input" />);

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -161,6 +161,13 @@ exports[`snapshots match error status with statustext 1`] = `
   color: hsl(0,0%,16%);
 }
 
+.c2 .fi-text-input_optionalText {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .c2 .fi-text-input_input-element-container > input:focus {
   outline-color: hsl(23,82%,53%);
   outline-width: 4px;
@@ -515,6 +522,13 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   color: hsl(0,0%,16%);
 }
 
+.c2 .fi-text-input_optionalText {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .c2 .fi-text-input_input-element-container > input:focus {
   outline-color: hsl(23,82%,53%);
   outline-width: 4px;
@@ -849,6 +863,13 @@ exports[`snapshots match minimal implementation 1`] = `
   line-height: 1.5;
   font-weight: 600;
   color: hsl(0,0%,16%);
+}
+
+.c2 .fi-text-input_optionalText {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 .c2 .fi-text-input_input-element-container > input:focus {


### PR DESCRIPTION
## Description
This PR implements optionalText prop for text input. The implementation is similar to that in Textarea. Through the prop the user of the component can mark the field optional with the text of their choice.

## Motivation and Context
This feature is part of the design, so it needed to be implemented.

## How Has This Been Tested?
Automated tests and running locally in styleguidist.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/54316341/95300446-d7db1b00-0887-11eb-891a-81d461243412.png)

## Release notes
-Added a way to mark text input as an optional field
