### PR TITLE
[Feature] Create separate styling for selected items in dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -25,7 +25,7 @@ export const dropdownClassNames = {
   button: `${baseClassName}_button`,
   popover: `${baseClassName}_popover`,
   item: `${baseClassName}_item`,
-  actionMenuItem: `${baseClassName}_actionMenuItem`,
+  noSelectedStyles: `${baseClassName}_noSelectedStyles`,
 };
 
 export interface DropdownLabelProps extends HtmlLabelProps {}
@@ -202,7 +202,7 @@ export class Dropdown extends Component<DropdownProps> {
 
     const passDropdownItemProps = {
       className: classnames(dropdownClassNames.item, dropdownItemClassName, {
-        [dropdownClassNames.actionMenuItem]: alwaysShowVisualPlaceholder,
+        [dropdownClassNames.noSelectedStyles]: alwaysShowVisualPlaceholder,
       }),
     };
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -25,7 +25,7 @@ export const dropdownClassNames = {
   button: `${baseClassName}_button`,
   popover: `${baseClassName}_popover`,
   item: `${baseClassName}_item`,
-  noSelectedStyles: `${baseClassName}_noSelectedStyles`,
+  noSelectedStyles: `${baseClassName}--noSelectedStyles`,
 };
 
 export interface DropdownLabelProps extends HtmlLabelProps {}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -25,6 +25,7 @@ export const dropdownClassNames = {
   button: `${baseClassName}_button`,
   popover: `${baseClassName}_popover`,
   item: `${baseClassName}_item`,
+  actionMenuItem: `${baseClassName}_actionMenuItem`,
 };
 
 export interface DropdownLabelProps extends HtmlLabelProps {}
@@ -200,7 +201,9 @@ export class Dropdown extends Component<DropdownProps> {
     };
 
     const passDropdownItemProps = {
-      className: classnames(dropdownClassNames.item, dropdownItemClassName),
+      className: classnames(dropdownClassNames.item, dropdownItemClassName, {
+        [dropdownClassNames.actionMenuItem]: alwaysShowVisualPlaceholder,
+      }),
     };
 
     const onChange = (newValue: string) => {

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -80,7 +80,7 @@ export const listboxPopoverStyles = withSuomifiTheme(
       background-color: ${theme.colors.highlightLight3};
       border: 0;
 
-      &.fi-dropdown_actionMenuItem {
+      &.fi-dropdown_noSelectedStyles {
         background-color: ${theme.colors.whiteBase};
         ${theme.typography.actionElementInnerText}
       }

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -45,63 +45,62 @@ export const baseStyles = withSuomifiTheme(
 
 export const listboxPopoverStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
-  &[data-reach-listbox-popover].fi-dropdown_popover {
-    ${element({ theme })}
-    ${theme.typography.actionElementInnerText}
-    margin-top: -1px;
-    padding: 0;
-    box-sizing: border-box;
-    font-size: 100%;
-    border: 0;
-    background-color: ${theme.colors.whiteBase};
-    border-color: ${theme.colors.depthLight1};
-    border-style: solid;
-    border-width: 0 1px 1px 1px;
-    border-radius: 0px 0px ${theme.radius.basic} ${theme.radius.basic};
-    overflow: hidden;
-    &:focus-within {
-      outline: 0;
-      box-shadow: none;
-    }
-  }
-  
-  & [data-reach-listbox-list] {
-    border: 0;
-    padding: 0;
-    margin: 0;
-    white-space: normal;
-    word-break: break-word;
-    overflow-wrap: break-word;
-  }
-
-  & [data-reach-listbox-option][data-current].fi-dropdown_item {
-    ${theme.typography.actionElementInnerTextBold}
-      color: ${theme.colors.blackBase};
-      background-image: none;
-      background-color: ${theme.colors.highlightLight3};
-      border: 0;
-
-      &.fi-dropdown_actionMenuItem{
-      background-color: ${theme.colors.whiteBase};
+    &[data-reach-listbox-popover].fi-dropdown_popover {
+      ${element({ theme })}
       ${theme.typography.actionElementInnerText}
+      margin-top: -1px;
+      padding: 0;
+      box-sizing: border-box;
+      font-size: 100%;
+      border: 0;
+      background-color: ${theme.colors.whiteBase};
+      border-color: ${theme.colors.depthLight1};
+      border-style: solid;
+      border-width: 0 1px 1px 1px;
+      border-radius: 0px 0px ${theme.radius.basic} ${theme.radius.basic};
+      overflow: hidden;
+      &:focus-within {
+        outline: 0;
+        box-shadow: none;
+      }
     }
-  }
 
-  & [data-reach-listbox-option].fi-dropdown_item {
-    ${element({ theme })}
-    ${theme.typography.actionElementInnerText}
-    line-height: 1.5;
-    padding: ${theme.spacing.insetM};
-    border: 0;
-    &[aria-selected='true'] {
-      color: ${theme.colors.blackBase};
+    & [data-reach-listbox-list] {
+      border: 0;
+      padding: 0;
+      margin: 0;
+      white-space: normal;
+      word-break: break-word;
+      overflow-wrap: break-word;
+    }
+
+    & [data-reach-listbox-option][data-current].fi-dropdown_item {
+      ${theme.typography.actionElementInnerTextBold}
       background-image: none;
       background-color: ${theme.colors.highlightLight3};
       border: 0;
+
+      &.fi-dropdown_actionMenuItem {
+        background-color: ${theme.colors.whiteBase};
+        ${theme.typography.actionElementInnerText}
+      }
     }
-    &:focus {
-      outline: 0;
+
+    & [data-reach-listbox-option].fi-dropdown_item {
+      ${element({ theme })}
+      ${theme.typography.actionElementInnerText}
+      line-height: 1.5;
+      padding: ${theme.spacing.insetM};
+      border: 0;
+      &[aria-selected='true'] {
+        color: ${theme.colors.blackBase};
+        background-image: none;
+        background-color: ${theme.colors.highlightLight3};
+        border: 0;
+      }
+      &:focus {
+        outline: 0;
+      }
     }
-  }
-`,
+  `,
 );

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -74,6 +74,19 @@ export const listboxPopoverStyles = withSuomifiTheme(
     overflow-wrap: break-word;
   }
 
+  & [data-reach-listbox-option][data-current].fi-dropdown_item {
+    ${theme.typography.actionElementInnerTextBold}
+      color: ${theme.colors.blackBase};
+      background-image: none;
+      background-color: ${theme.colors.highlightLight3};
+      border: 0;
+
+      &.fi-dropdown_actionMenuItem{
+      background-color: ${theme.colors.whiteBase};
+      ${theme.typography.actionElementInnerText}
+    }
+  }
+
   & [data-reach-listbox-option].fi-dropdown_item {
     ${element({ theme })}
     ${theme.typography.actionElementInnerText}
@@ -81,7 +94,6 @@ export const listboxPopoverStyles = withSuomifiTheme(
     padding: ${theme.spacing.insetM};
     border: 0;
     &[aria-selected='true'] {
-      ${theme.typography.actionElementInnerText}
       color: ${theme.colors.blackBase};
       background-image: none;
       background-color: ${theme.colors.highlightLight3};

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -80,7 +80,7 @@ export const listboxPopoverStyles = withSuomifiTheme(
       background-color: ${theme.colors.highlightLight3};
       border: 0;
 
-      &.fi-dropdown_noSelectedStyles {
+      &.fi-dropdown--noSelectedStyles {
         background-color: ${theme.colors.whiteBase};
         ${theme.typography.actionElementInnerText}
       }


### PR DESCRIPTION
## Description
This PR adds a styling for the currently selected item in dropdown.

## Motivation and Context
Previously the styling was tied to the hover styles, which meant that hovering over an option in the dropdown made the selected style disappear. The styling also didn't match the current designs. This PR fixes both of those issues.

## How Has This Been Tested?
Tested by running locally in styleguidist.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/54316341/95548545-ff5bf000-0a0d-11eb-8f4b-591bc0ab9591.png)


## Release notes
-Improve styling of selected element in dropdown
