### PR TITLE
[Feature] Dropdown disabled state

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -91,6 +91,8 @@ export interface DropdownProps {
   'aria-labelledby'?: string;
   /** Custom classname to extend or customize */
   className?: string;
+  /** Disable component */
+  disabled?: boolean;
   /** Properties given to dropdown's Button-component, className etc. */
   dropdownButtonProps?: OptionalListboxButtonProps;
   /** Properties given to dropdown's popover-component, className etc. */
@@ -143,6 +145,7 @@ export class Dropdown extends Component<DropdownProps> {
     const {
       id: propId,
       name,
+      disabled = false,
       children,
       labelProps,
       labelText,
@@ -247,7 +250,7 @@ export class Dropdown extends Component<DropdownProps> {
             <Paragraph {...labelTextProps}>{labelText}</Paragraph>
           )}
         </HtmlLabel>
-        <ListboxInput {...listboxInputProps}>
+        <ListboxInput disabled={disabled} {...listboxInputProps}>
           <ListboxButton {...passDropdownButtonProps}>
             {listboxDisplayValue}
           </ListboxButton>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -26,6 +26,7 @@ export const dropdownClassNames = {
   popover: `${baseClassName}_popover`,
   item: `${baseClassName}_item`,
   noSelectedStyles: `${baseClassName}--noSelectedStyles`,
+  disabled: `${baseClassName}--disabled`,
 };
 
 export interface DropdownLabelProps extends HtmlLabelProps {}
@@ -145,7 +146,7 @@ export class Dropdown extends Component<DropdownProps> {
     const {
       id: propId,
       name,
-      disabled = false,
+      disabled,
       children,
       labelProps,
       labelText,
@@ -191,6 +192,9 @@ export class Dropdown extends Component<DropdownProps> {
       className: classnames(
         dropdownClassNames.button,
         dropdownButtonProps.className,
+        {
+          [dropdownClassNames.disabled]: !!disabled,
+        },
       ),
       ...buttonAriaLabelledByOverride,
     };
@@ -220,6 +224,7 @@ export class Dropdown extends Component<DropdownProps> {
 
     const listboxInputProps = {
       'aria-labelledby': ariaLabelledByIds,
+      disabled,
       onChange,
       name,
       value: selectedValue || '',
@@ -250,7 +255,7 @@ export class Dropdown extends Component<DropdownProps> {
             <Paragraph {...labelTextProps}>{labelText}</Paragraph>
           )}
         </HtmlLabel>
-        <ListboxInput disabled={disabled} {...listboxInputProps}>
+        <ListboxInput {...listboxInputProps}>
           <ListboxButton {...passDropdownButtonProps}>
             {listboxDisplayValue}
           </ListboxButton>

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -1,9 +1,13 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../theme';
+import { DropdownProps } from './Dropdown';
 import { element, inputButton, font } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
-  ({ theme }: TokensAndTheme) => css`
+  ({
+    theme,
+    disabled,
+  }: TokensAndTheme & Omit<DropdownProps, 'labelText'>) => css`
     & .fi-dropdown_label-p {
       margin-bottom: ${theme.spacing.insetM};
       ${font({ theme })('actionElementInnerTextBold')};
@@ -22,7 +26,7 @@ export const baseStyles = withSuomifiTheme(
       line-height: 1.5;
       background-color: ${theme.colors.whiteBase};
       box-shadow: ${theme.shadows.actionElementBoxShadow};
-      cursor: pointer;
+      cursor: ${disabled ? 'not-allowed' : 'pointer'};
       &:before {
         content: '';
         position: absolute;

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -1,13 +1,9 @@
 import { css } from 'styled-components';
 import { withSuomifiTheme, TokensAndTheme } from '../theme';
-import { DropdownProps } from './Dropdown';
 import { element, inputButton, font } from '../theme/reset';
 
 export const baseStyles = withSuomifiTheme(
-  ({
-    theme,
-    disabled,
-  }: TokensAndTheme & Omit<DropdownProps, 'labelText'>) => css`
+  ({ theme }: TokensAndTheme) => css`
     & .fi-dropdown_label-p {
       margin-bottom: ${theme.spacing.insetM};
       ${font({ theme })('actionElementInnerTextBold')};
@@ -26,7 +22,7 @@ export const baseStyles = withSuomifiTheme(
       line-height: 1.5;
       background-color: ${theme.colors.whiteBase};
       box-shadow: ${theme.shadows.actionElementBoxShadow};
-      cursor: ${disabled ? 'not-allowed' : 'pointer'};
+      cursor: pointer;
       &:before {
         content: '';
         position: absolute;
@@ -47,7 +43,7 @@ export const baseStyles = withSuomifiTheme(
         background-color: ${theme.colors.depthLight3};
         color: ${theme.colors.depthBase};
         opacity: 1;
-        cursor: 'not-allowed';
+        cursor: not-allowed;
         &:before {
           border-color: ${theme.colors.depthBase} transparent transparent
             transparent;

--- a/src/core/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown.baseStyles.tsx
@@ -43,6 +43,16 @@ export const baseStyles = withSuomifiTheme(
           transparent;
         border-width: 0 4px 6px 4px;
       }
+      &.fi-dropdown--disabled {
+        background-color: ${theme.colors.depthLight3};
+        color: ${theme.colors.depthBase};
+        opacity: 1;
+        cursor: 'not-allowed';
+        &:before {
+          border-color: ${theme.colors.depthBase} transparent transparent
+            transparent;
+        }
+      }
     }
   `,
 );

--- a/src/core/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown.md
@@ -1,6 +1,5 @@
 ```js
 import { Dropdown } from 'suomifi-ui-components';
-
 <Dropdown
   name="Dropdown"
   labelText="Dropdown label"
@@ -18,20 +17,34 @@ import { Dropdown } from 'suomifi-ui-components';
 
 ```js
 import { Dropdown } from 'suomifi-ui-components';
+<>
+  <Dropdown
+    name="Dropdown"
+    visualPlaceholder="Dropdown with visually hidden label"
+    labelText="Dropdown label"
+    labelMode="hidden"
+  >
+    <Dropdown.item value={'dropdown-item-1'}>
+      Dropdown Item 1
+    </Dropdown.item>
+    <Dropdown.item value={'dropdown-item-2'}>
+      Dropdown Item 2
+    </Dropdown.item>
+  </Dropdown>
 
-<Dropdown
-  name="Dropdown"
-  visualPlaceholder="Dropdown with visually hidden label"
-  labelText="Dropdown label"
-  labelMode="hidden"
->
-  <Dropdown.item value={'dropdown-item-1'}>
-    Dropdown Item 1
-  </Dropdown.item>
-  <Dropdown.item value={'dropdown-item-2'}>
-    Dropdown Item 2
-  </Dropdown.item>
-</Dropdown>;
+  <Dropdown
+    labelText="Disabled dropdown"
+    defaultValue={'dropdown-item-2'}
+    disabled
+  >
+    <Dropdown.item value={'dropdown-item-1'}>
+      Dropdown Item 1
+    </Dropdown.item>
+    <Dropdown.item value={'dropdown-item-2'}>
+      Dropdown Item 2
+    </Dropdown.item>
+  </Dropdown>
+</>;
 ```
 
 ```js

--- a/src/core/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown.test.tsx
@@ -50,6 +50,16 @@ describe('Basic dropdown', () => {
     expect(input).toHaveAttribute('name', 'dropdown-test');
   });
 
+  it('should have disabled styles when disabled', async () => {
+    const { findByRole } = render(
+      <Dropdown labelText="Dropdown" disabled>
+        <Dropdown.item value={'item-1'}>Item 1</Dropdown.item>
+      </Dropdown>,
+    );
+    const button = await findByRole('button');
+    expect(button).toHaveClass('fi-dropdown--disabled');
+  });
+
   it('should match snapshot', async () => {
     const promise = Promise.resolve();
     const { container } = render(BasicDropdown);

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -162,6 +162,17 @@ exports[`Basic dropdown should match snapshot 1`] = `
   border-width: 0 4px 6px 4px;
 }
 
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  cursor: 'not-allowed';
+}
+
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown"
@@ -368,6 +379,17 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 .c1 [data-reach-listbox-button].fi-dropdown_button[aria-expanded='true']:before {
   border-color: transparent transparent hsl(202,7%,40%) transparent;
   border-width: 0 4px 6px 4px;
+}
+
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  cursor: 'not-allowed';
+}
+
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
 }
 
 <div>
@@ -579,6 +601,17 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   border-width: 0 4px 6px 4px;
 }
 
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  cursor: 'not-allowed';
+}
+
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown"
@@ -787,6 +820,17 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   border-width: 0 4px 6px 4px;
 }
 
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  cursor: 'not-allowed';
+}
+
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown"
@@ -981,6 +1025,17 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 .c1 [data-reach-listbox-button].fi-dropdown_button[aria-expanded='true']:before {
   border-color: transparent transparent hsl(202,7%,40%) transparent;
   border-width: 0 4px 6px 4px;
+}
+
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  cursor: 'not-allowed';
+}
+
+.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
 }
 
 <div>

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   background-color: hsl(202,7%,97%);
   color: hsl(202,7%,67%);
   opacity: 1;
-  cursor: 'not-allowed';
+  cursor: not-allowed;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
@@ -385,7 +385,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   background-color: hsl(202,7%,97%);
   color: hsl(202,7%,67%);
   opacity: 1;
-  cursor: 'not-allowed';
+  cursor: not-allowed;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
@@ -605,7 +605,7 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   background-color: hsl(202,7%,97%);
   color: hsl(202,7%,67%);
   opacity: 1;
-  cursor: 'not-allowed';
+  cursor: not-allowed;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
@@ -824,7 +824,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   background-color: hsl(202,7%,97%);
   color: hsl(202,7%,67%);
   opacity: 1;
-  cursor: 'not-allowed';
+  cursor: not-allowed;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
@@ -1031,7 +1031,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   background-color: hsl(202,7%,97%);
   color: hsl(202,7%,67%);
   opacity: 1;
-  cursor: 'not-allowed';
+  cursor: not-allowed;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -193,14 +193,14 @@ exports[`Basic dropdown should match snapshot 1`] = `
       data-reach-listbox-input=""
       data-state="closed"
       data-value=""
-      id="listbox-input--19"
+      id="listbox-input--25"
     >
       <span
         aria-haspopup="listbox"
         aria-labelledby="test-id-label"
         class="fi-dropdown_button"
         data-reach-listbox-button=""
-        id="button--listbox-input--19"
+        id="button--listbox-input--25"
         role="button"
         tabindex="0"
       >
@@ -413,14 +413,14 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
       data-reach-listbox-input=""
       data-state="closed"
       data-value="item-2"
-      id="listbox-input--51"
+      id="listbox-input--57"
     >
       <span
         aria-haspopup="listbox"
-        aria-labelledby="test-id-label button--listbox-input--51"
+        aria-labelledby="test-id-label button--listbox-input--57"
         class="fi-dropdown_button"
         data-reach-listbox-button=""
-        id="button--listbox-input--51"
+        id="button--listbox-input--57"
         role="button"
         tabindex="0"
       >
@@ -632,14 +632,14 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
       data-reach-listbox-input=""
       data-state="closed"
       data-value="item-2"
-      id="listbox-input--63"
+      id="listbox-input--69"
     >
       <span
         aria-haspopup="listbox"
-        aria-labelledby="test-id-label button--listbox-input--63"
+        aria-labelledby="test-id-label button--listbox-input--69"
         class="fi-dropdown_button"
         data-reach-listbox-button=""
-        id="button--listbox-input--63"
+        id="button--listbox-input--69"
         role="button"
         tabindex="0"
       >
@@ -851,14 +851,14 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
       data-reach-listbox-input=""
       data-state="closed"
       data-value=""
-      id="listbox-input--75"
+      id="listbox-input--81"
     >
       <span
         aria-haspopup="listbox"
         aria-labelledby="additional-label-id test-id-label"
         class="fi-dropdown_button"
         data-reach-listbox-button=""
-        id="button--listbox-input--75"
+        id="button--listbox-input--81"
         role="button"
         tabindex="0"
       >
@@ -1058,14 +1058,14 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
       data-reach-listbox-input=""
       data-state="closed"
       data-value=""
-      id="listbox-input--31"
+      id="listbox-input--37"
     >
       <span
         aria-haspopup="listbox"
         aria-labelledby="test-id-label"
         class="fi-dropdown_button"
         data-reach-listbox-button=""
-        id="button--listbox-input--31"
+        id="button--listbox-input--37"
         role="button"
         tabindex="0"
       >


### PR DESCRIPTION
## Description
This PR implements disabled prop and the corresponding styling for the dropdown component.

## Motivation and Context
Being able to disable a component is one of the key functions of any input component and needs to be supported.

## How Has This Been Tested?
Only tested by running locally in styleguidist.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/54316341/96081286-a97dc100-0ec1-11eb-8b8e-264e50aaf94a.png)

## Release notes
-Added disabled prop for Dropdown component