### PR TITLE
[Bugfix] Move Chip example inline styling to wrapping element

### DIFF
--- a/src/core/Chip/Chip.md
+++ b/src/core/Chip/Chip.md
@@ -7,14 +7,11 @@ const removeAction = () => {
 
 <>
   <div>
-    <Chip
-      removable
-      actionLabel="Deselect"
-      onClick={removeAction}
-      style={{ marginRight: '10px' }}
-    >
-      Removable chip 1
-    </Chip>
+    <span style={{ marginRight: '10px' }}>
+      <Chip removable actionLabel="Deselect" onClick={removeAction}>
+        Removable chip 1
+      </Chip>
+    </span>
 
     <Chip removable actionLabel="Deselect" onClick={removeAction}>
       Removable chip 2


### PR DESCRIPTION
## Description
The Chip component styleguidist example used inline styles, which are not actually supported by the component. This PR removes the bad practice from the example by moving the inline style to a wrapping span element.

## Motivation and Context
We shouldn't demonstrate unsupported uses of the components.

## How Has This Been Tested?
Tested by running locally.

## Release notes
-Fixed unsupported use of inline styles from Chip example
