### PR TITLE
[Fix] LanguageMenu text wrapping

### DIFF
--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -13,11 +13,12 @@ export const baseStyles = withSuomifiTheme(
       &.fi-language-menu-language_button {
         ${element({ theme })}
         ${theme.typography.actionElementInnerTextBold}
-      padding: 9px ${theme.spacing.xs};
+        padding: 9px ${theme.spacing.xs};
         line-height: 24px;
         background-color: ${theme.colors.whiteBase};
         border: 1px solid transparent;
         border-radius: ${theme.radius.basic};
+        word-break: break-word;
         & > .fi-language-menu-language_icon {
           height: 1em;
           width: 1em;

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -93,12 +93,14 @@ export const languageMenuPopoverStyles = withSuomifiTheme(
     & [data-reach-menu-items] {
       border: 0;
       padding: 0;
+      white-space: normal;
     }
 
     & [data-reach-menu-item].fi-language-menu_item {
       ${element({ theme })}
       ${theme.typography.bodyText}
-    &[data-selected] {
+      word-break: break-word;
+      &[data-selected] {
         ${theme.typography.bodyText}
         color: ${theme.colors.blackBase};
         background-color: ${theme.colors.highlightLight3};

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -86,7 +86,7 @@ const LanguageMenuPopoverPosition = (
     top: `${targetRect.top + targetRect.height + window.pageYOffset}px`,
     maxWidth: `${Math.max(
       targetRect.width,
-      targetRect.width + targetRect.left - 20,
+      targetRect.width + targetRect.left - 30,
     )}px`,
     minWidth: `${targetRect.width - 2}px`,
   };

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -85,6 +85,7 @@ const LanguageMenuPopoverPosition = (
     // eslint-disable-next-line no-undef
     top: `${targetRect.top + targetRect.height + window.pageYOffset}px`,
     maxWidth: `${targetRect.width + targetRect.left - 20}px`,
+    minWidth: `${targetRect.width - 20}px`,
   };
 };
 

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -84,6 +84,7 @@ const LanguageMenuPopoverPosition = (
     left: `${targetRect.left - popoverRect.width + targetRect.width}px`,
     // eslint-disable-next-line no-undef
     top: `${targetRect.top + targetRect.height + window.pageYOffset}px`,
+    maxWidth: `${targetRect.width + targetRect.left - 20}px`,
   };
 };
 

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -84,8 +84,11 @@ const LanguageMenuPopoverPosition = (
     left: `${targetRect.left - popoverRect.width + targetRect.width}px`,
     // eslint-disable-next-line no-undef
     top: `${targetRect.top + targetRect.height + window.pageYOffset}px`,
-    maxWidth: `${targetRect.width + targetRect.left - 20}px`,
-    minWidth: `${targetRect.width - 20}px`,
+    maxWidth: `${Math.max(
+      targetRect.width,
+      targetRect.width + targetRect.left - 20,
+    )}px`,
+    minWidth: `${targetRect.width - 2}px`,
   };
 };
 

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`calling render with the same component on the same container does not r
   background-color: hsl(0,0%,100%);
   border: 1px solid transparent;
   border-radius: 2px;
+  word-break: break-word;
 }
 
 .c1 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button > .fi-language-menu-language_icon {


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Long text will now wrap more nicely in the **LanguageMenu**
* In the button that opens the menu
* ...and in the opened menu

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Long text was not wrapping as wanted on the LanguageMenu.

## How Has This Been Tested?

- Locally in styleguidist

## Screenshots:
<img width="770" alt="LanguageMenu_wrap" src="https://user-images.githubusercontent.com/53757053/97837234-77a09300-1ce6-11eb-8592-5d159786345e.png">

_In the screenshot the area circled shows the gap that is intentionally left on the left side, so that menu is not "touching" the edge._

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

Fix wrapping of long text in the LanguageMenu (#408)