### PR TITLE
Feature/expander title checkbox

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -114,6 +114,7 @@ module.exports = {
                 'Expander/Expander',
                 'ExpanderGroup/ExpanderGroup',
                 'ExpanderTitle/ExpanderTitle',
+                'ExpanderTitleButton/ExpanderTitleButton',
                 'ExpanderContent/ExpanderContent',
               ]),
             },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:updatesnapshots": "tsdx test --u",
     "lint": "npm-run-all lint:tsdx-lint lint:stylelint",
     "lint:tsdx-lint": "tsdx lint src",
-    "lint:stylelint": "stylelint ./src/**/*.{ts,tsx}",
+    "lint:stylelint": "stylelint \"./src/**/*.{ts,tsx}\"",
     "prettier": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "prettier:check": "prettier-check \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "validate": "npm-run-all test lint prettier:check",

--- a/src/core/Expander/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander/Expander.baseStyles.tsx
@@ -17,7 +17,6 @@ export const baseStyles = withSuomifiTheme(
       display: block;
       width: 100%;
       max-width: 100%;
-      overflow: hidden;
 
       &:before {
         background-color: ${theme.colors.highlightLight4};

--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -20,7 +20,10 @@ import {
 } from 'suomifi-ui-components';
 
 <Expander className="expander-test" defaultOpen={true}>
-  <ExpanderTitle>
+  <ExpanderTitle
+    ariaOpenText="open expander"
+    ariaCloseText="close expander"
+  >
     <Checkbox hintText="Checkbox hint text">Checkbox label</Checkbox>
   </ExpanderTitle>
   <ExpanderContent>Test expander</ExpanderContent>

--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -6,7 +6,9 @@ import {
 } from 'suomifi-ui-components';
 
 <Expander className="expander-test" defaultOpen={true}>
-  <ExpanderTitleButton>Test expander</ExpanderTitleButton>
+  <ExpanderTitleButton asHeading="h3">
+    Test expander
+  </ExpanderTitleButton>
   <ExpanderContent>Test expander</ExpanderContent>
 </Expander>;
 ```

--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -14,6 +14,22 @@ import {
 ```jsx
 import {
   Expander,
+  ExpanderTitle,
+  ExpanderContent,
+  Checkbox
+} from 'suomifi-ui-components';
+
+<Expander className="expander-test" defaultOpen={true}>
+  <ExpanderTitle>
+    <Checkbox hintText="Checkbox hint text">Checkbox label</Checkbox>
+  </ExpanderTitle>
+  <ExpanderContent>Test expander</ExpanderContent>
+</Expander>;
+```
+
+```jsx
+import {
+  Expander,
   ExpanderGroup,
   ExpanderTitleButton,
   ExpanderContent
@@ -59,16 +75,7 @@ const [expanderThreeOpen, setExpanderThreeOpen] = React.useState(
   false
 );
 
-const [showExpander, setShowExpander] = React.useState(false);
-
 <>
-  <button
-    onClick={() => {
-      setShowExpander(!showExpander);
-    }}
-  >
-    {showExpander ? 'Hide' : 'Show'}
-  </button>
   <ExpanderGroup
     OpenAllText="Open all"
     AriaOpenAllText="Open all expanders"
@@ -83,12 +90,6 @@ const [showExpander, setShowExpander] = React.useState(false);
       <ExpanderTitleButton>Test expander 2</ExpanderTitleButton>
       <ExpanderContent>Test expander content 2</ExpanderContent>
     </Expander>
-    {!!showExpander && (
-      <Expander>
-        <ExpanderTitleButton>Test expander X</ExpanderTitleButton>
-        <ExpanderContent>Test expander content X</ExpanderContent>
-      </Expander>
-    )}
     <Expander
       open={expanderThreeOpen}
       onOpenChange={(open) => {

--- a/src/core/Expander/Expander/Expander.test.tsx
+++ b/src/core/Expander/Expander/Expander.test.tsx
@@ -130,9 +130,9 @@ describe('defaultOpen', () => {
   it('gives the classname to expander title and icon', () => {
     const { getByTestId } = render(DefaultOpenExpander());
     const div = getByTestId('expander-open-by-default-title');
-    expect(div).toHaveClass('fi-expander_title--open');
+    expect(div).toHaveClass('fi-expander_title-button--open');
     expect(div.querySelector('svg')).toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
 
@@ -144,10 +144,10 @@ describe('defaultOpen', () => {
     const buttonToClick = getByRole('button');
     const titleDiv = getByTestId('expander-open-by-default-title');
     fireEvent.click(buttonToClick);
-    expect(titleDiv).toHaveClass('fi-expander_title');
-    expect(titleDiv).not.toHaveClass('fi-expander_title--open');
+    expect(titleDiv).toHaveClass('fi-expander_title-button');
+    expect(titleDiv).not.toHaveClass('fi-expander_title-button--open');
     expect(buttonToClick.querySelector('svg')).not.toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
 });
@@ -180,10 +180,10 @@ describe('open', () => {
   it('open-classnames should be found ', async () => {
     const { getByTestId } = render(ControlledExpander());
     const div = getByTestId('expander-title-id');
-    expect(div).toHaveClass('fi-expander_title--open');
+    expect(div).toHaveClass('fi-expander_title-button--open');
 
     expect(div.querySelector('svg')).toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
 
@@ -196,10 +196,10 @@ describe('open', () => {
     fireEvent.click(button);
     expect(mockClickHandler).toHaveBeenCalledTimes(1);
     const div = getByTestId('expander-title-id');
-    expect(div).toHaveClass('fi-expander_title--open');
+    expect(div).toHaveClass('fi-expander_title-button--open');
 
     expect(button.querySelector('svg')).toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
 });

--- a/src/core/Expander/Expander/Expander.test.tsx
+++ b/src/core/Expander/Expander/Expander.test.tsx
@@ -55,33 +55,6 @@ describe('Basic expander', () => {
   it('should not have basic accessibility issues', axeTest(TestExpander));
 });
 
-describe('ExpanderTitleButton Aria attributes', () => {
-  const TestExpanderWithProps = (titleProps: ExpanderTitleButtonProps) => {
-    return (
-      <Expander className="expander-test">
-        <ExpanderTitleButton
-          {...titleProps}
-          {...{ 'data-testid': 'expander-title' }}
-        />
-        <ExpanderContent>Test expander content</ExpanderContent>
-      </Expander>
-    );
-  };
-
-  it('should be passed to title button', () => {
-    const TestExpander = TestExpanderWithProps({
-      ariaCloseText: 'click to close expander',
-      ariaOpenText: 'click to open expander',
-      children: 'Test expander',
-    });
-    const { getByText, getByRole } = render(TestExpander);
-    const button = getByRole('button');
-    expect(getByText('click to open expander')).toBeTruthy();
-    fireEvent.click(button);
-    expect(getByText('click to close expander')).toBeTruthy();
-  });
-});
-
 describe('Custom id', () => {
   const ExpanderWithCustomId = (
     <Expander id="test-id" {...{ 'data-testid': 'expander-custom-id' }}>
@@ -101,18 +74,6 @@ describe('Custom id', () => {
     const div = getByTestId('expander-custom-id');
     expect(div).toHaveAttribute('id', 'test-id');
   });
-
-  it('is passed on to title', () => {
-    const { getByTestId } = render(ExpanderWithCustomId);
-    const div = getByTestId('expander-custom-id-title');
-    expect(div).toHaveAttribute('id', 'test-id_title');
-  });
-
-  it('is passed on to content', () => {
-    const { getByTestId } = render(ExpanderWithCustomId);
-    const div = getByTestId('expander-custom-id-content');
-    expect(div).toHaveAttribute('id', 'test-id_content');
-  });
 });
 
 describe('defaultOpen', () => {
@@ -127,15 +88,6 @@ describe('defaultOpen', () => {
     </Expander>
   );
 
-  it('gives the classname to expander title and icon', () => {
-    const { getByTestId } = render(DefaultOpenExpander());
-    const div = getByTestId('expander-open-by-default-title');
-    expect(div).toHaveClass('fi-expander_title-button--open');
-    expect(div.querySelector('svg')).toHaveClass(
-      'fi-expander_title-button-icon--open',
-    );
-  });
-
   it('classnames will be removed when clicked', () => {
     const mockClickHandler = jest.fn();
     const { getByTestId, getByRole } = render(
@@ -146,9 +98,6 @@ describe('defaultOpen', () => {
     fireEvent.click(buttonToClick);
     expect(titleDiv).toHaveClass('fi-expander_title-button');
     expect(titleDiv).not.toHaveClass('fi-expander_title-button--open');
-    expect(buttonToClick.querySelector('svg')).not.toHaveClass(
-      'fi-expander_title-button-icon--open',
-    );
   });
 });
 
@@ -181,10 +130,6 @@ describe('open', () => {
     const { getByTestId } = render(ControlledExpander());
     const div = getByTestId('expander-title-id');
     expect(div).toHaveClass('fi-expander_title-button--open');
-
-    expect(div.querySelector('svg')).toHaveClass(
-      'fi-expander_title-button-icon--open',
-    );
   });
 
   it('is clicked. Should not change as it is controlled outside', async () => {
@@ -197,9 +142,5 @@ describe('open', () => {
     expect(mockClickHandler).toHaveBeenCalledTimes(1);
     const div = getByTestId('expander-title-id');
     expect(div).toHaveClass('fi-expander_title-button--open');
-
-    expect(button.querySelector('svg')).toHaveClass(
-      'fi-expander_title-button-icon--open',
-    );
   });
 });

--- a/src/core/Expander/Expander/Expander.tsx
+++ b/src/core/Expander/Expander/Expander.tsx
@@ -222,4 +222,4 @@ export class Expander extends Component<ExpanderProps> {
   }
 }
 
-export { ExpanderConsumer };
+export { ExpanderConsumer, ExpanderProvider };

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Basic expander shoud match snapshot 1`] = `
-.c3 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -27,25 +27,25 @@ exports[`Basic expander shoud match snapshot 1`] = `
   cursor: pointer;
 }
 
-.c3:-moz-focusring {
+.c4:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
-.c3::-moz-focus-inner {
+.c4::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
 
-.c3::-webkit-file-upload-button {
+.c4::-webkit-file-upload-button {
   -webkit-appearance: button;
   font: inherit;
 }
 
-.c3::-webkit-inner-spin-button {
+.c4::-webkit-inner-spin-button {
   height: auto;
 }
 
-.c3::-webkit-outer-spin-button {
+.c4::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -73,7 +73,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   white-space: normal;
 }
 
-.c4 {
+.c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -325,33 +325,41 @@ exports[`Basic expander shoud match snapshot 1`] = `
     class="c0 c2 fi-expander_title-button"
     data-testid="expander-title"
   >
-    <button
-      aria-controls="4_content"
-      aria-expanded="false"
-      class="c3 fi-expander_title-button_button"
-      id="4_title"
-      type="button"
+    <span
+      class="c3"
     >
-      Test expander
-      <span
-        class="c4 c5 fi-visually-hidden"
+      <button
+        aria-controls="4_content"
+        aria-expanded="false"
+        class="c4 fi-expander_title-button_button"
+        type="button"
       >
-        click to open expander
-      </span>
-      <svg
-        aria-hidden="true"
-        class="fi-icon c6 fi-expander_title-button-icon"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="0 0 24 24"
-        width="1em"
-      >
-        <path
-          d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
-        />
-      </svg>
-    </button>
+        <span
+          class="c3"
+          id="4_title"
+        >
+          Test expander
+        </span>
+        <span
+          class="c3 c5 fi-visually-hidden"
+        >
+          click to open expander
+        </span>
+        <svg
+          aria-hidden="true"
+          class="fi-icon c6 fi-expander_title-button-icon"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+          />
+        </svg>
+      </button>
+    </span>
   </div>
   <div
     aria-hidden="true"

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -132,7 +132,6 @@ exports[`Basic expander shoud match snapshot 1`] = `
   display: block;
   width: 100%;
   max-width: 100%;
-  overflow: hidden;
 }
 
 .c1:before {
@@ -156,6 +155,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   background-color: hsl(0,0%,100%);
+  border-radius: inherit;
   position: relative;
   visibility: hidden;
   display: block;
@@ -181,6 +181,8 @@ exports[`Basic expander shoud match snapshot 1`] = `
   visibility: visible;
   height: 10%;
   overflow: visible;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
   animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
 }
@@ -205,10 +207,13 @@ exports[`Basic expander shoud match snapshot 1`] = `
   max-width: 100%;
   min-height: 60px;
   background-color: hsl(212,63%,98%);
+  border-radius: inherit;
 }
 
 .c2.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .c2 .fi-expander_title-button_button {
@@ -285,7 +290,6 @@ exports[`Basic expander shoud match snapshot 1`] = `
   content: none;
 }
 
-.c2 .fi-expander_title-button_button,
 .c2 .fi-expander_title-button_button * {
   cursor: pointer;
 }
@@ -354,6 +358,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
     aria-labelledby="4_title"
     class="c0 c7 fi-expander_content"
     id="4_content"
+    role="region"
   >
     Test expander content
   </div>

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -207,11 +207,11 @@ exports[`Basic expander shoud match snapshot 1`] = `
   background-color: hsl(212,63%,98%);
 }
 
-.c2.fi-expander_title--open {
+.c2.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
 }
 
-.c2 .fi-expander_title-button {
+.c2 .fi-expander_title-button_button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -241,27 +241,27 @@ exports[`Basic expander shoud match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  color: hsl(212,63%,45%);
-  display: block;
   font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
+  color: hsl(212,63%,45%);
+  display: inline-block;
   width: 100%;
   max-width: 100%;
   min-height: 60px;
   padding: 17px 60px 16px 20px;
 }
 
-.c2 .fi-expander_title-button:focus {
+.c2 .fi-expander_title-button_button:focus {
   outline: 0;
 }
 
-.c2 .fi-expander_title-button:focus-within {
+.c2 .fi-expander_title-button_button:focus-within {
   outline: 0;
 }
 
-.c2 .fi-expander_title-button:focus-within:after {
+.c2 .fi-expander_title-button_button:focus-within:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -277,37 +277,37 @@ exports[`Basic expander shoud match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c2 .fi-expander_title-button:not(:focus-visible) {
+.c2 .fi-expander_title-button_button:not(:focus-visible) {
   outline: 0;
 }
 
-.c2 .fi-expander_title-button:not(:focus-visible):after {
+.c2 .fi-expander_title-button_button:not(:focus-visible):after {
   content: none;
 }
 
-.c2 .fi-expander_title-button,
-.c2 .fi-expander_title-button * {
+.c2 .fi-expander_title-button_button,
+.c2 .fi-expander_title-button_button * {
   cursor: pointer;
 }
 
-.c2 .fi-expander_title-button:hover,
-.c2 .fi-expander_title-button:active,
-.c2 .fi-expander_title-button:focus,
-.c2 .fi-expander_title-button:focus-within {
+.c2 .fi-expander_title-button_button:hover,
+.c2 .fi-expander_title-button_button:active,
+.c2 .fi-expander_title-button_button:focus,
+.c2 .fi-expander_title-button_button:focus-within {
   cursor: pointer;
 }
 
-.c2 .fi-expander_title-icon {
+.c2 .fi-expander_title-button-icon {
   position: absolute;
-  height: 20px;
-  width: 20px;
   top: 0;
   right: 0;
+  height: 20px;
+  width: 20px;
   margin: 20px;
 }
 
-.c2 .fi-expander_title--open .fi-expander_title-icon,
-.c2 .fi-expander_title-icon--open {
+.c2 .fi-expander_title-button--open .fi-expander_title-button-icon,
+.c2 .fi-expander_title-button-icon--open {
   -webkit-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
   transform: rotate(-180deg);
@@ -318,13 +318,13 @@ exports[`Basic expander shoud match snapshot 1`] = `
   id="4"
 >
   <div
-    class="c0 c2 fi-expander_title"
+    class="c0 c2 fi-expander_title-button"
     data-testid="expander-title"
   >
     <button
       aria-controls="4_content"
       aria-expanded="false"
-      class="c3 fi-expander_title-button"
+      class="c3 fi-expander_title-button_button"
       id="4_title"
       type="button"
     >
@@ -336,7 +336,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
       </span>
       <svg
         aria-hidden="true"
-        class="fi-icon c6 fi-expander_title-icon"
+        class="fi-icon c6 fi-expander_title-button-icon"
         fill="currentColor"
         focusable="false"
         height="1em"

--- a/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
@@ -11,6 +11,7 @@ export const baseStyles = withSuomifiTheme(
       ${element({ theme })}
       ${font({ theme })('bodyText')}
       background-color: ${theme.colors.whiteBase};
+      border-radius: inherit;
       position: relative;
       visibility: hidden;
       display: block;
@@ -32,6 +33,8 @@ export const baseStyles = withSuomifiTheme(
         visibility: visible;
         height: 10%;
         overflow: visible;
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
         /* This is very robust - cannot animate dynamic height with height-definition */
         animation: fi-expander_content-anim ${theme.transitions.basicTime}
           ${theme.transitions.basicTimingFunction} 1 forwards;

--- a/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
@@ -17,14 +17,17 @@ export const baseStyles = withSuomifiTheme(
       height: 0;
       overflow: hidden;
       word-break: break-word;
+
       transform: scaleY(0);
       transform-origin: top;
       transition: all ${`${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction}`};
       will-change: transition, height;
+
       &:not(.fi-expander_content--no-padding) {
         padding: 0 ${theme.spacing.insetXl};
       }
+
       &.fi-expander_content--open {
         visibility: visible;
         height: 10%;

--- a/src/core/Expander/ExpanderContent/ExpanderContent.test.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.test.tsx
@@ -1,0 +1,141 @@
+/* eslint-disable no-shadow */
+import React, { ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import { ExpanderProviderState, ExpanderProvider } from '../Expander/Expander';
+import { ExpanderContent, ExpanderContentProps } from './ExpanderContent';
+
+/**
+ * A custom render to setup providers. Extends regular
+ * render options with `providerProps` to allow injecting
+ * different scenarios to test with.
+ *
+ * @see https://testing-library.com/docs/react-testing-library/setup#custom-render
+ */
+const customRender = (
+  ui: ReactNode,
+  {
+    providerProps,
+    ...renderOptions
+  }: { providerProps: ExpanderProviderState; [key: string]: any },
+) => {
+  const rendered = render(
+    <ExpanderProvider value={providerProps}>{ui}</ExpanderProvider>,
+    renderOptions,
+  );
+  return {
+    ...rendered,
+    rerender: (
+      ui: ReactNode,
+      {
+        providerProps,
+        ...renderOptions
+      }: { providerProps: ExpanderProviderState },
+    ) =>
+      customRender(ui, {
+        providerProps,
+        container: rendered.container,
+        ...renderOptions,
+      }),
+  };
+};
+
+const providerProps: ExpanderProviderState = {
+  onToggleExpander: () => null,
+  open: false,
+  titleId: 'test-id_title',
+  contentId: 'test-id_content',
+};
+
+describe('Basic ExpanderContent', () => {
+  const TestExpanderContentWithProps = (
+    props?: Partial<ExpanderContentProps>,
+  ) => (
+    <ExpanderContent {...{ 'data-testid': 'expander-content' }} {...props}>
+      {props?.children ? props.children : 'Expander content'}
+    </ExpanderContent>
+  );
+
+  it('render with the same component on the same container does not remount', () => {
+    const { rerender, getByTestId } = customRender(
+      TestExpanderContentWithProps(),
+      {
+        providerProps,
+      },
+    );
+    expect(getByTestId('expander-content').textContent).toBe(
+      'Expander content',
+    );
+    // re-render the same component with different props
+    rerender(
+      TestExpanderContentWithProps({ children: 'Expander content two' }),
+      {
+        providerProps: { ...providerProps },
+      },
+    );
+    expect(getByTestId('expander-content').textContent).toBe(
+      'Expander content two',
+    );
+  });
+
+  it('shoud match snapshot', () => {
+    const expanderRenderer = customRender(TestExpanderContentWithProps(), {
+      providerProps,
+    });
+    const { container } = expanderRenderer;
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('Custom id', () => {
+  const TestExpanderContentWithProps = (props?: ExpanderContentProps) => (
+    <ExpanderContent {...{ 'data-testid': 'expander-content' }} {...props}>
+      {props?.children ? props.children : 'Expander content'}
+    </ExpanderContent>
+  );
+
+  it('is passed on to content', () => {
+    const { getByTestId } = customRender(TestExpanderContentWithProps(), {
+      providerProps,
+    });
+    const div = getByTestId('expander-content');
+    expect(div).toHaveAttribute('id', 'test-id_content');
+    expect(div).toHaveAttribute('aria-labelledby', 'test-id_title');
+  });
+});
+
+describe('Provider open property', () => {
+  const TestExpanderContentWithProps = (props?: ExpanderContentProps) => (
+    <ExpanderContent {...{ 'data-testid': 'expander-content' }} {...props}>
+      {props?.children ? props.children : 'Expander content'}
+    </ExpanderContent>
+  );
+
+  it('sets contents visible when true', () => {
+    const { getByTestId } = customRender(TestExpanderContentWithProps(), {
+      providerProps: { ...providerProps, open: true },
+    });
+    const div = getByTestId('expander-content');
+    expect(div).toHaveClass('fi-expander_content--open');
+  });
+
+  it('hides contents when false', () => {
+    const { getByTestId, rerender } = customRender(
+      TestExpanderContentWithProps(),
+      {
+        providerProps: {
+          ...providerProps,
+          open: false,
+        },
+      },
+    );
+    rerender(TestExpanderContentWithProps(), {
+      providerProps: {
+        ...providerProps,
+        open: false,
+      },
+    });
+    const contentDiv = getByTestId('expander-content');
+    expect(contentDiv).toHaveClass('fi-expander_content');
+    expect(contentDiv).not.toHaveClass('fi-expander_content--open');
+  });
+});

--- a/src/core/Expander/ExpanderContent/ExpanderContent.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.tsx
@@ -42,6 +42,7 @@ class BaseExpanderContent extends Component<InternalExpanderContentProps> {
     } = this.props;
     return (
       <HtmlDiv
+        role="region"
         {...passProps}
         id={consumer.contentId}
         {...{

--- a/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
+++ b/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Basic ExpanderContent shoud match snapshot 1`] = `
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c1 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: hsl(0,0%,100%);
+  position: relative;
+  visibility: hidden;
+  display: block;
+  height: 0;
+  overflow: hidden;
+  word-break: break-word;
+  -webkit-transform: scaleY(0);
+  -ms-transform: scaleY(0);
+  transform: scaleY(0);
+  -webkit-transform-origin: top;
+  -ms-transform-origin: top;
+  transform-origin: top;
+  -webkit-transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
+  transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
+  will-change: transition,height;
+}
+
+.c1:not(.fi-expander_content--no-padding) {
+  padding: 0 16px;
+}
+
+.c1.fi-expander_content--open {
+  visibility: visible;
+  height: 10%;
+  overflow: visible;
+  -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
+  animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
+}
+
+.c1.fi-expander_content--open:not(.fi-expander_content--no-padding) {
+  padding-top: 0;
+  padding-right: 20px;
+  padding-bottom: 20px;
+  padding-left: 20px;
+}
+
+<div
+  aria-hidden="true"
+  aria-labelledby="test-id_title"
+  class="c0 c1 fi-expander_content"
+  data-testid="expander-content"
+  id="test-id_content"
+>
+  Expander content
+</div>
+`;

--- a/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
+++ b/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   background-color: hsl(0,0%,100%);
+  border-radius: inherit;
   position: relative;
   visibility: hidden;
   display: block;
@@ -66,6 +67,8 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
   visibility: visible;
   height: 10%;
   overflow: visible;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
   animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
 }
@@ -83,6 +86,7 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
   class="c0 c1 fi-expander_content"
   data-testid="expander-content"
   id="test-id_content"
+  role="region"
 >
   Expander content
 </div>

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -25,15 +25,16 @@ export const baseStyles = withSuomifiTheme(
         & .fi-icon {
           color: ${theme.colors.highlightBase};
         }
-
+        & > {
+          border-radius: 0;
+        }
         &:first-child {
-          border-radius: ${theme.radius.basic} ${theme.radius.basic} 0 0;
           border-top: none;
+          border-radius: ${theme.radius.basic} ${theme.radius.basic} 0 0;
         }
         &:last-child {
           border-radius: 0 0 ${theme.radius.basic} ${theme.radius.basic};
         }
-
         &.fi-expander--open {
           border-top: none;
           &:not(:first-of-type) {
@@ -41,14 +42,6 @@ export const baseStyles = withSuomifiTheme(
           }
           &:not(:last-of-type) {
             margin-bottom: ${theme.spacing.insetXl};
-          }
-          &:first-child,
-          &:first-child:before {
-            border-radius: ${theme.radius.basic} ${theme.radius.basic} 0 0;
-          }
-          &:last-child,
-          &:last-child:before {
-            border-radius: 0 0 ${theme.radius.basic} ${theme.radius.basic};
           }
           & + .fi-expander {
             border-top: none;

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
@@ -129,19 +129,19 @@ describe('default behaviour', () => {
     const { getByTestId } = render(DefaultGroup);
     const titleDiv = getByTestId('expander-title-2');
     const button = getByTestId('expander-title-2-button');
-    expect(titleDiv).not.toHaveClass('fi-expander_title--open');
+    expect(titleDiv).not.toHaveClass('fi-expander_title-button--open');
     expect(button.querySelector('svg')).not.toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
     fireEvent.click(button);
-    expect(titleDiv).toHaveClass('fi-expander_title--open');
+    expect(titleDiv).toHaveClass('fi-expander_title-button--open');
     expect(button.querySelector('svg')).toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
     fireEvent.click(button);
-    expect(titleDiv).not.toHaveClass('fi-expander_title--open');
+    expect(titleDiv).not.toHaveClass('fi-expander_title-button--open');
     expect(button.querySelector('svg')).not.toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
   it('open/close all should have providedTexts and screen reader texts', async () => {
@@ -182,9 +182,9 @@ describe('defaultOpen', () => {
       ]),
     );
     const titleDiv = getByTestId('expander-title-2');
-    expect(titleDiv).toHaveClass('fi-expander_title--open');
+    expect(titleDiv).toHaveClass('fi-expander_title-button--open');
     expect(titleDiv.querySelector('svg')).toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
 
@@ -221,10 +221,10 @@ describe('defaultOpen', () => {
     );
     const button = getByTestId('expander-title-2-button');
     const titleDiv = getByTestId('expander-title-2');
-    expect(titleDiv).toHaveClass('fi-expander_title--open');
+    expect(titleDiv).toHaveClass('fi-expander_title-button--open');
     fireEvent.click(button);
     expect(button.querySelector('svg')).not.toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
 });
@@ -288,10 +288,10 @@ describe('open', () => {
       ]),
     );
     const titleDiv = getByTestId('expander-title-2');
-    expect(titleDiv).toHaveClass('fi-expander_title--open');
+    expect(titleDiv).toHaveClass('fi-expander_title-button--open');
 
     expect(titleDiv.querySelector('svg')).toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
 
@@ -326,15 +326,15 @@ describe('open', () => {
     );
     const button = getByTestId('expander-title-2-button');
     const titleDiv = getByTestId('expander-title-2');
-    expect(titleDiv).toHaveClass('fi-expander_title--open');
+    expect(titleDiv).toHaveClass('fi-expander_title-button--open');
     expect(titleDiv.querySelector('svg')).toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
     fireEvent.click(button);
     expect(mockClickHandler).toHaveBeenCalledTimes(1);
-    expect(titleDiv).toHaveClass('fi-expander_title--open');
+    expect(titleDiv).toHaveClass('fi-expander_title-button--open');
     expect(titleDiv.querySelector('svg')).toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
 
@@ -377,16 +377,16 @@ describe('open', () => {
     );
     const titleDiv = getByTestId('expander-title-2');
     const button = getByTestId('expander-title-2-button');
-    expect(titleDiv).not.toHaveClass('fi-expander_title--open');
+    expect(titleDiv).not.toHaveClass('fi-expander_title-button--open');
     expect(button.querySelector('svg')).not.toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
     const openAllButton = getByTestId('open-all-button');
 
     fireEvent.click(openAllButton);
-    expect(titleDiv).not.toHaveClass('fi-expander_title--open');
+    expect(titleDiv).not.toHaveClass('fi-expander_title-button--open');
     expect(button.querySelector('svg')).not.toHaveClass(
-      'fi-expander_title-icon--open',
+      'fi-expander_title-button-icon--open',
     );
   });
 });

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -467,28 +467,36 @@ exports[`Basic expander group should match snapshot 1`] = `
         class="c0 c6 fi-expander_title-button"
         data-testid="expander-title-1"
       >
-        <button
-          aria-controls="id-first_content"
-          aria-expanded="false"
-          class="c2 fi-expander_title-button_button"
-          id="id-first_title"
-          type="button"
+        <span
+          class="c3"
         >
-          First
-          <svg
-            aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-button-icon"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
+          <button
+            aria-controls="id-first_content"
+            aria-expanded="false"
+            class="c2 fi-expander_title-button_button"
+            type="button"
           >
-            <path
-              d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
-            />
-          </svg>
-        </button>
+            <span
+              class="c3"
+              id="id-first_title"
+            >
+              First
+            </span>
+            <svg
+              aria-hidden="true"
+              class="fi-icon c7 fi-expander_title-button-icon"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <path
+                d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
       <div
         aria-hidden="true"
@@ -508,28 +516,36 @@ exports[`Basic expander group should match snapshot 1`] = `
         class="c0 c6 fi-expander_title-button"
         data-testid="expander-title-2"
       >
-        <button
-          aria-controls="id-second_content"
-          aria-expanded="false"
-          class="c2 fi-expander_title-button_button"
-          id="id-second_title"
-          type="button"
+        <span
+          class="c3"
         >
-          Second
-          <svg
-            aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-button-icon"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
+          <button
+            aria-controls="id-second_content"
+            aria-expanded="false"
+            class="c2 fi-expander_title-button_button"
+            type="button"
           >
-            <path
-              d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
-            />
-          </svg>
-        </button>
+            <span
+              class="c3"
+              id="id-second_title"
+            >
+              Second
+            </span>
+            <svg
+              aria-hidden="true"
+              class="fi-icon c7 fi-expander_title-button-icon"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <path
+                d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
       <div
         aria-hidden="true"

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -141,9 +141,13 @@ exports[`Basic expander group should match snapshot 1`] = `
   color: hsl(212,63%,45%);
 }
 
+.c1 > .fi-expander-group_expanders .fi-expander > {
+  border-radius: 0;
+}
+
 .c1 > .fi-expander-group_expanders .fi-expander:first-child {
-  border-radius: 2px 2px 0 0;
   border-top: none;
+  border-radius: 2px 2px 0 0;
 }
 
 .c1 > .fi-expander-group_expanders .fi-expander:last-child {
@@ -160,16 +164,6 @@ exports[`Basic expander group should match snapshot 1`] = `
 
 .c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:last-of-type) {
   margin-bottom: 16px;
-}
-
-.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:first-child,
-.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:first-child:before {
-  border-radius: 2px 2px 0 0;
-}
-
-.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:last-child,
-.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:last-child:before {
-  border-radius: 0 0 2px 2px;
 }
 
 .c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open + .fi-expander {
@@ -258,7 +252,6 @@ exports[`Basic expander group should match snapshot 1`] = `
   display: block;
   width: 100%;
   max-width: 100%;
-  overflow: hidden;
 }
 
 .c5:before {
@@ -282,6 +275,7 @@ exports[`Basic expander group should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   background-color: hsl(0,0%,100%);
+  border-radius: inherit;
   position: relative;
   visibility: hidden;
   display: block;
@@ -307,6 +301,8 @@ exports[`Basic expander group should match snapshot 1`] = `
   visibility: visible;
   height: 10%;
   overflow: visible;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
   animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
 }
@@ -331,10 +327,13 @@ exports[`Basic expander group should match snapshot 1`] = `
   max-width: 100%;
   min-height: 60px;
   background-color: hsl(212,63%,98%);
+  border-radius: inherit;
 }
 
 .c6.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .c6 .fi-expander_title-button_button {
@@ -411,7 +410,6 @@ exports[`Basic expander group should match snapshot 1`] = `
   content: none;
 }
 
-.c6 .fi-expander_title-button_button,
 .c6 .fi-expander_title-button_button * {
   cursor: pointer;
 }
@@ -497,6 +495,7 @@ exports[`Basic expander group should match snapshot 1`] = `
         aria-labelledby="id-first_title"
         class="c0 c8 fi-expander_content"
         id="id-first_content"
+        role="region"
       >
         First content
       </div>
@@ -537,6 +536,7 @@ exports[`Basic expander group should match snapshot 1`] = `
         aria-labelledby="id-second_title"
         class="c0 c8 fi-expander_content"
         id="id-second_content"
+        role="region"
       >
         Second content
       </div>

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -333,11 +333,11 @@ exports[`Basic expander group should match snapshot 1`] = `
   background-color: hsl(212,63%,98%);
 }
 
-.c6.fi-expander_title--open {
+.c6.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
 }
 
-.c6 .fi-expander_title-button {
+.c6 .fi-expander_title-button_button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -367,27 +367,27 @@ exports[`Basic expander group should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  color: hsl(212,63%,45%);
-  display: block;
   font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
+  color: hsl(212,63%,45%);
+  display: inline-block;
   width: 100%;
   max-width: 100%;
   min-height: 60px;
   padding: 17px 60px 16px 20px;
 }
 
-.c6 .fi-expander_title-button:focus {
+.c6 .fi-expander_title-button_button:focus {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button:focus-within {
+.c6 .fi-expander_title-button_button:focus-within {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button:focus-within:after {
+.c6 .fi-expander_title-button_button:focus-within:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -403,37 +403,37 @@ exports[`Basic expander group should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c6 .fi-expander_title-button:not(:focus-visible) {
+.c6 .fi-expander_title-button_button:not(:focus-visible) {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button:not(:focus-visible):after {
+.c6 .fi-expander_title-button_button:not(:focus-visible):after {
   content: none;
 }
 
-.c6 .fi-expander_title-button,
-.c6 .fi-expander_title-button * {
+.c6 .fi-expander_title-button_button,
+.c6 .fi-expander_title-button_button * {
   cursor: pointer;
 }
 
-.c6 .fi-expander_title-button:hover,
-.c6 .fi-expander_title-button:active,
-.c6 .fi-expander_title-button:focus,
-.c6 .fi-expander_title-button:focus-within {
+.c6 .fi-expander_title-button_button:hover,
+.c6 .fi-expander_title-button_button:active,
+.c6 .fi-expander_title-button_button:focus,
+.c6 .fi-expander_title-button_button:focus-within {
   cursor: pointer;
 }
 
-.c6 .fi-expander_title-icon {
+.c6 .fi-expander_title-button-icon {
   position: absolute;
-  height: 20px;
-  width: 20px;
   top: 0;
   right: 0;
+  height: 20px;
+  width: 20px;
   margin: 20px;
 }
 
-.c6 .fi-expander_title--open .fi-expander_title-icon,
-.c6 .fi-expander_title-icon--open {
+.c6 .fi-expander_title-button--open .fi-expander_title-button-icon,
+.c6 .fi-expander_title-button-icon--open {
   -webkit-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
   transform: rotate(-180deg);
@@ -466,20 +466,20 @@ exports[`Basic expander group should match snapshot 1`] = `
       id="id-first"
     >
       <div
-        class="c0 c6 fi-expander_title"
+        class="c0 c6 fi-expander_title-button"
         data-testid="expander-title-1"
       >
         <button
           aria-controls="id-first_content"
           aria-expanded="false"
-          class="c2 fi-expander_title-button"
+          class="c2 fi-expander_title-button_button"
           id="id-first_title"
           type="button"
         >
           First
           <svg
             aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-icon"
+            class="fi-icon c7 fi-expander_title-button-icon"
             fill="currentColor"
             focusable="false"
             height="1em"
@@ -506,20 +506,20 @@ exports[`Basic expander group should match snapshot 1`] = `
       id="id-second"
     >
       <div
-        class="c0 c6 fi-expander_title"
+        class="c0 c6 fi-expander_title-button"
         data-testid="expander-title-2"
       >
         <button
           aria-controls="id-second_content"
           aria-expanded="false"
-          class="c2 fi-expander_title-button"
+          class="c2 fi-expander_title-button_button"
           id="id-second_title"
           type="button"
         >
           Second
           <svg
             aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-icon"
+            class="fi-icon c7 fi-expander_title-button-icon"
             fill="currentColor"
             focusable="false"
             height="1em"

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
@@ -18,12 +18,15 @@ export const expanderTitleBaseStyles = withSuomifiTheme(
       max-width: 100%;
       min-height: 60px;
       background-color: ${theme.colors.highlightLight4};
+      border-radius: inherit;
       padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
       white-space: break-word;
       word-wrap: break-word;
 
       &.fi-expander_title--open {
         background-color: ${theme.colors.whiteBase};
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
       }
 
       & .fi-expander_title-button {
@@ -50,8 +53,6 @@ export const expanderTitleBaseStyles = withSuomifiTheme(
           }
         }
         ${noMouseFocus}
-        &,
-
         & * {
           cursor: pointer;
         }

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
@@ -28,7 +28,6 @@ export const expanderTitleBaseStyles = withSuomifiTheme(
 
       & .fi-expander_title-button {
         ${button({ theme })}
-        ${font({ theme })('bodyText')}
         font-size: ${theme.typography.bodySemiBold};
         color: ${theme.colors.highlightBase};
         display: inline-block;

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
@@ -125,16 +125,17 @@ describe('Custom id', () => {
     </ExpanderTitle>
   );
 
-  it('is passed on to button', () => {
-    const { getByRole } = customRender(TestExpanderWithProps(), {
+  it('is passed on to content and set to button aria-controls', () => {
+    const { getByRole, getByText } = customRender(TestExpanderWithProps(), {
       providerProps: {
         ...providerProps,
         titleId: 'test-id_title',
         contentId: 'test-id_content',
       },
     });
+    const span = getByText('Expander title button');
+    expect(span).toHaveAttribute('id', 'test-id_title');
     const button = getByRole('button');
-    expect(button).toHaveAttribute('id', 'test-id_title');
     expect(button).toHaveAttribute('aria-controls', 'test-id_content');
   });
 });

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 import React, { ReactNode } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ExpanderProviderState, ExpanderProvider } from '../Expander/Expander';
@@ -14,27 +13,27 @@ import { ExpanderTitle, ExpanderTitleProps } from './ExpanderTitle';
 const customRender = (
   ui: ReactNode,
   {
-    providerProps,
+    providerProps: origProviderProps,
     ...renderOptions
   }: { providerProps: ExpanderProviderState; [key: string]: any },
 ) => {
   const rendered = render(
-    <ExpanderProvider value={providerProps}>{ui}</ExpanderProvider>,
+    <ExpanderProvider value={origProviderProps}>{ui}</ExpanderProvider>,
     renderOptions,
   );
   return {
     ...rendered,
     rerender: (
-      ui: ReactNode,
+      rerenderUi: ReactNode,
       {
         providerProps,
-        ...renderOptions
+        ...rerenderOptions
       }: { providerProps: ExpanderProviderState },
     ) =>
-      customRender(ui, {
+      customRender(rerenderUi, {
         providerProps,
         container: rendered.container,
-        ...renderOptions,
+        ...rerenderOptions,
       }),
   };
 };

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
@@ -1,0 +1,209 @@
+/* eslint-disable no-shadow */
+import React, { ReactNode } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ExpanderProviderState, ExpanderProvider } from '../Expander/Expander';
+import { ExpanderTitle, ExpanderTitleProps } from './ExpanderTitle';
+
+/**
+ * A custom render to setup providers. Extends regular
+ * render options with `providerProps` to allow injecting
+ * different scenarios to test with.
+ *
+ * @see https://testing-library.com/docs/react-testing-library/setup#custom-render
+ */
+const customRender = (
+  ui: ReactNode,
+  {
+    providerProps,
+    ...renderOptions
+  }: { providerProps: ExpanderProviderState; [key: string]: any },
+) => {
+  const rendered = render(
+    <ExpanderProvider value={providerProps}>{ui}</ExpanderProvider>,
+    renderOptions,
+  );
+  return {
+    ...rendered,
+    rerender: (
+      ui: ReactNode,
+      {
+        providerProps,
+        ...renderOptions
+      }: { providerProps: ExpanderProviderState },
+    ) =>
+      customRender(ui, {
+        providerProps,
+        container: rendered.container,
+        ...renderOptions,
+      }),
+  };
+};
+
+const providerProps: ExpanderProviderState = {
+  onToggleExpander: () => null,
+  open: false,
+  titleId: undefined,
+  contentId: undefined,
+};
+
+describe('Basic ExpanderTitle', () => {
+  const TestExpanderWithProps = (props?: Partial<ExpanderTitleProps>) => (
+    <ExpanderTitle
+      {...{ 'data-testid': 'expander-title' }}
+      {...props}
+      ariaOpenText="open expander"
+      ariaCloseText="close expander"
+    >
+      {props?.children ? props.children : 'Expander title button'}
+    </ExpanderTitle>
+  );
+
+  it('render with the same component on the same container does not remount', () => {
+    const { rerender, getByTestId } = customRender(TestExpanderWithProps(), {
+      providerProps,
+    });
+    expect(getByTestId('expander-title').textContent).toBe(
+      'Expander title buttonopen expander',
+    );
+    // re-render the same component with different props
+    rerender(TestExpanderWithProps({ children: 'Expander title button two' }), {
+      providerProps: { ...providerProps },
+    });
+    expect(getByTestId('expander-title').textContent).toBe(
+      'Expander title button twoopen expander',
+    );
+  });
+
+  it('shoud match snapshot', () => {
+    const expanderRenderer = customRender(TestExpanderWithProps(), {
+      providerProps: {
+        ...providerProps,
+        titleId: 'test-id_title',
+        contentId: 'test-id_content',
+      },
+    });
+    const { container } = expanderRenderer;
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('Aria attributes', () => {
+  const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
+    <ExpanderTitle
+      ariaCloseText="click to close expander"
+      ariaOpenText="click to open expander"
+      {...{ 'data-testid': 'expander-title' }}
+      {...props}
+    >
+      {props?.children ? props.children : 'Expander title button'}
+    </ExpanderTitle>
+  );
+
+  it('should be passed to title button', () => {
+    const { getByText, rerender } = customRender(TestExpanderWithProps(), {
+      providerProps,
+    });
+    expect(getByText('click to open expander')).toBeTruthy();
+    const adjustedProviderProps = {
+      ...providerProps,
+      open: true,
+    };
+    rerender(TestExpanderWithProps(), {
+      providerProps: adjustedProviderProps,
+    });
+    expect(getByText('click to close expander')).toBeTruthy();
+  });
+});
+
+describe('Custom id', () => {
+  const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
+    <ExpanderTitle
+      {...props}
+      ariaCloseText="click to close expander"
+      ariaOpenText="click to open expander"
+    >
+      {props?.children ? props.children : 'Expander title button'}
+    </ExpanderTitle>
+  );
+
+  it('is passed on to button', () => {
+    const { getByRole } = customRender(TestExpanderWithProps(), {
+      providerProps: {
+        ...providerProps,
+        titleId: 'test-id_title',
+        contentId: 'test-id_content',
+      },
+    });
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('id', 'test-id_title');
+    expect(button).toHaveAttribute('aria-controls', 'test-id_content');
+  });
+});
+
+describe('Provider open property', () => {
+  const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
+    <ExpanderTitle
+      {...{ 'data-testid': 'expander-open-by-default-title' }}
+      ariaCloseText="click to close expander"
+      ariaOpenText="click to open expander"
+      {...props}
+    >
+      {props?.children ? props.children : 'Test expander open by default'}
+    </ExpanderTitle>
+  );
+
+  it('correlates with aria-expanded attribute', () => {
+    const { getByRole, rerender } = customRender(TestExpanderWithProps(), {
+      providerProps: { ...providerProps, open: true },
+    });
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    rerender(TestExpanderWithProps(), {
+      providerProps: {
+        ...providerProps,
+        open: false,
+      },
+    });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('gives the classname to expander title and icon', () => {
+    const { getByTestId } = customRender(TestExpanderWithProps(), {
+      providerProps: { ...providerProps, open: true },
+    });
+    const div = getByTestId('expander-open-by-default-title');
+    expect(div).toHaveClass('fi-expander_title--open');
+    expect(div.querySelector('svg')).toHaveClass(
+      'fi-expander_title-icon--open',
+    );
+  });
+
+  it('will remove open classnames when false', () => {
+    const mockClickHandler = jest.fn();
+    const { getByTestId, getByRole, rerender } = customRender(
+      TestExpanderWithProps(),
+      {
+        providerProps: {
+          ...providerProps,
+          open: true,
+          onToggleExpander: mockClickHandler,
+        },
+      },
+    );
+    const buttonToClick = getByRole('button');
+    fireEvent.click(buttonToClick);
+    expect(mockClickHandler).toHaveBeenCalledTimes(1);
+    rerender(TestExpanderWithProps(), {
+      providerProps: {
+        ...providerProps,
+        open: false,
+      },
+    });
+    const titleDiv = getByTestId('expander-open-by-default-title');
+    expect(titleDiv).toHaveClass('fi-expander_title');
+    expect(titleDiv).not.toHaveClass('fi-expander_title--open');
+    expect(buttonToClick.querySelector('svg')).not.toHaveClass(
+      'fi-expander_title-icon--open',
+    );
+  });
+});

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -1,0 +1,112 @@
+import React, { Component, ReactNode } from 'react';
+import { default as styled } from 'styled-components';
+import classnames from 'classnames';
+import { withSuomifiDefaultProps } from '../../theme/utils';
+import { TokensProp, InternalTokensProp } from '../../theme';
+import {
+  HtmlDiv,
+  HtmlButton,
+  HtmlButtonProps,
+  HtmlDivProps,
+} from '../../../reset';
+import { expanderTitleBaseStyles } from './ExpanderTitle.baseStyles';
+import { Icon } from '../../Icon/Icon';
+import { ExpanderConsumer, ExpanderTitleBaseProps } from '../Expander/Expander';
+import { VisuallyHidden } from '../../../components';
+
+const baseClassName = 'fi-expander';
+const titleClassName = `${baseClassName}_title`;
+const titleOpenClassName = `${titleClassName}--open`;
+const titleButtonClassName = `${titleClassName}-button`;
+const iconClassName = `${titleClassName}-icon`;
+const iconOpenClassName = `${iconClassName}--open`;
+
+export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'classname'> {
+  /** Custom classname to extend or customize */
+  className?: string;
+  /** Title for Expander */
+  children?: ReactNode;
+  /** Additional text for closed expanders toggle button. E.g."open expander". */
+  ariaOpenText: string;
+  /** Additional text for open expanders toggle button. E.g."close expander". */
+  ariaCloseText: string;
+  /** Properties for title open/close toggle button */
+  toggleButtonProps?: Omit<
+    HtmlButtonProps,
+    | 'onClick'
+    | 'onMouseDown'
+    | 'onMouseUp'
+    | 'onKeyPress'
+    | 'onKeyUp'
+    | 'onKeyDown'
+  >;
+}
+
+export interface InternalExpanderTitleProps
+  extends ExpanderTitleProps,
+    ExpanderTitleBaseProps {}
+
+class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
+  render() {
+    const {
+      ariaCloseText,
+      ariaOpenText,
+      children,
+      className,
+      toggleButtonProps,
+      consumer,
+      ...passProps
+    } = this.props;
+
+    return (
+      <HtmlDiv
+        {...passProps}
+        className={classnames(className, titleClassName, {
+          [titleOpenClassName]: !!consumer.open,
+        })}
+      >
+        {children}
+        <HtmlButton
+          {...toggleButtonProps}
+          onClick={consumer.onToggleExpander}
+          aria-expanded={!!consumer.open}
+          className={titleButtonClassName}
+          id={consumer.titleId}
+          {...{ 'aria-controls': `${consumer.contentId}` }}
+        >
+          <VisuallyHidden>
+            {!!consumer.open ? ariaCloseText : ariaOpenText}
+          </VisuallyHidden>
+          <Icon
+            icon="chevronDown"
+            className={classnames(iconClassName, {
+              [iconOpenClassName]: consumer.open,
+            })}
+          />
+        </HtmlButton>
+      </HtmlDiv>
+    );
+  }
+}
+
+const StyledExpanderTitle = styled(
+  ({ tokens, ...passProps }: ExpanderTitleProps & InternalTokensProp) => {
+    return (
+      <ExpanderConsumer>
+        {(consumer) => <BaseExpanderTitle consumer={consumer} {...passProps} />}
+      </ExpanderConsumer>
+    );
+  },
+)`
+  ${(props) => expanderTitleBaseStyles(props)};
+`;
+
+/**
+ * <i class="semantics" />
+ * Expander title for focusable content and toggle button for content visiblity
+ */
+export class ExpanderTitle extends Component<ExpanderTitleProps & TokensProp> {
+  render() {
+    return <StyledExpanderTitle {...withSuomifiDefaultProps(this.props)} />;
+  }
+}

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -14,11 +14,10 @@ import { Icon } from '../../Icon/Icon';
 import { ExpanderConsumer, ExpanderTitleBaseProps } from '../Expander/Expander';
 import { VisuallyHidden } from '../../../components';
 
-const baseClassName = 'fi-expander';
-const titleClassName = `${baseClassName}_title`;
-const titleOpenClassName = `${titleClassName}--open`;
-const titleButtonClassName = `${titleClassName}-button`;
-const iconClassName = `${titleClassName}-icon`;
+const baseClassName = 'fi-expander_title';
+const titleOpenClassName = `${baseClassName}--open`;
+const titleButtonClassName = `${baseClassName}-button`;
+const iconClassName = `${baseClassName}-icon`;
 const iconOpenClassName = `${iconClassName}--open`;
 
 export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'classname'> {
@@ -42,7 +41,7 @@ export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'classname'> {
   >;
 }
 
-export interface InternalExpanderTitleProps
+interface InternalExpanderTitleProps
   extends ExpanderTitleProps,
     ExpanderTitleBaseProps {}
 
@@ -61,7 +60,7 @@ class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
     return (
       <HtmlDiv
         {...passProps}
-        className={classnames(className, titleClassName, {
+        className={classnames(className, baseClassName, {
           [titleOpenClassName]: !!consumer.open,
         })}
       >

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -8,6 +8,7 @@ import {
   HtmlButton,
   HtmlButtonProps,
   HtmlDivProps,
+  HtmlSpan,
 } from '../../../reset';
 import { expanderTitleBaseStyles } from './ExpanderTitle.baseStyles';
 import { Icon } from '../../Icon/Icon';
@@ -64,13 +65,12 @@ class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
           [titleOpenClassName]: !!consumer.open,
         })}
       >
-        {children}
+        <HtmlSpan id={consumer.titleId}>{children}</HtmlSpan>
         <HtmlButton
           {...toggleButtonProps}
           onClick={consumer.onToggleExpander}
           aria-expanded={!!consumer.open}
           className={titleButtonClassName}
-          id={consumer.titleId}
           {...{ 'aria-controls': `${consumer.contentId}` }}
         >
           <VisuallyHidden>

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -20,7 +20,7 @@ const titleButtonClassName = `${baseClassName}-button`;
 const iconClassName = `${baseClassName}-icon`;
 const iconOpenClassName = `${iconClassName}--open`;
 
-export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'classname'> {
+export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'className'> {
   /** Custom classname to extend or customize */
   className?: string;
   /** Title for Expander */

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
-.c2 {
+.c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -27,25 +27,25 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   cursor: pointer;
 }
 
-.c2:-moz-focusring {
+.c3:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
-.c2::-moz-focus-inner {
+.c3::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
 
-.c2::-webkit-file-upload-button {
+.c3::-webkit-file-upload-button {
   -webkit-appearance: button;
   font: inherit;
 }
 
-.c2::-webkit-inner-spin-button {
+.c3::-webkit-inner-spin-button {
   height: auto;
 }
 
-.c2::-webkit-outer-spin-button {
+.c3::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -73,7 +73,7 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   white-space: normal;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -243,16 +243,20 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   class="c0 c1 fi-expander_title"
   data-testid="expander-title"
 >
-  Expander title button
+  <span
+    class="c2"
+    id="test-id_title"
+  >
+    Expander title button
+  </span>
   <button
     aria-controls="test-id_content"
     aria-expanded="false"
-    class="c2 fi-expander_title-button"
-    id="test-id_title"
+    class="c3 fi-expander_title-button"
     type="button"
   >
     <span
-      class="c3 c4 fi-visually-hidden"
+      class="c2 c4 fi-visually-hidden"
     >
       open expander
     </span>

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   max-width: 100%;
   min-height: 60px;
   background-color: hsl(212,63%,98%);
+  border-radius: inherit;
   padding: 17px 60px 16px 20px;
   white-space: break-word;
   word-wrap: break-word;
@@ -146,6 +147,8 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
 
 .c1.fi-expander_title--open {
   background-color: hsl(0,0%,100%);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .c1 .fi-expander_title-button {
@@ -212,7 +215,6 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   content: none;
 }
 
-.c1 .fi-expander_title-button,
 .c1 .fi-expander_title-button * {
   cursor: pointer;
 }

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -1,0 +1,272 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+  cursor: pointer;
+}
+
+.c2:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c2::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c2::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c2::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c2::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c5 {
+  display: inline-block;
+  vertical-align: baseline;
+}
+
+.c1 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  position: relative;
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  min-height: 60px;
+  background-color: hsl(212,63%,98%);
+  padding: 17px 60px 16px 20px;
+  white-space: break-word;
+  word-wrap: break-word;
+}
+
+.c1.fi-expander_title--open {
+  background-color: hsl(0,0%,100%);
+}
+
+.c1 .fi-expander_title-button {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(212,63%,45%);
+  display: inline-block;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 44px;
+  height: 44px;
+  padding: 12px;
+  margin: 13px;
+}
+
+.c1 .fi-expander_title-button:focus {
+  outline: 0;
+}
+
+.c1 .fi-expander_title-button:focus-within {
+  outline: 0;
+}
+
+.c1 .fi-expander_title-button:focus-within:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+.c1 .fi-expander_title-button:not(:focus-visible) {
+  outline: 0;
+}
+
+.c1 .fi-expander_title-button:not(:focus-visible):after {
+  content: none;
+}
+
+.c1 .fi-expander_title-button,
+.c1 .fi-expander_title-button * {
+  cursor: pointer;
+}
+
+.c1 .fi-expander_title-button:hover,
+.c1 .fi-expander_title-button:active,
+.c1 .fi-expander_title-button:focus,
+.c1 .fi-expander_title-button:focus-within {
+  cursor: pointer;
+}
+
+.c1 .fi-expander_title-icon {
+  position: relative;
+  height: 20px;
+  width: 20px;
+}
+
+.c1 .fi-expander_title--open .fi-expander_title-icon,
+.c1 .fi-expander_title-icon--open {
+  -webkit-transform: rotate(-180deg);
+  -ms-transform: rotate(-180deg);
+  transform: rotate(-180deg);
+}
+
+<div
+  class="c0 c1 fi-expander_title"
+  data-testid="expander-title"
+>
+  Expander title button
+  <button
+    aria-controls="test-id_content"
+    aria-expanded="false"
+    class="c2 fi-expander_title-button"
+    id="test-id_title"
+    type="button"
+  >
+    <span
+      class="c3 c4 fi-visually-hidden"
+    >
+      open expander
+    </span>
+    <svg
+      aria-hidden="true"
+      class="fi-icon c5 fi-expander_title-icon"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="0 0 24 24"
+      width="1em"
+    >
+      <path
+        d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+      />
+    </svg>
+  </button>
+</div>
+`;

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
@@ -10,8 +10,6 @@ export const expanderTitleButtonBaseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme & Partial<ExpanderTitleButtonProps>) => {
     return css`
       ${element({ theme })}
-      ${font({ theme })('bodyText')}
-      font-size: ${theme.typography.bodySemiBold};
       position: relative;
       display: block;
       width: 100%;
@@ -30,6 +28,7 @@ export const expanderTitleButtonBaseStyles = withSuomifiTheme(
         color: ${theme.colors.highlightBase};
         display: inline-block;
         width: 100%;
+        max-width: 100%;
         min-height: 60px;
         padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
 
@@ -55,12 +54,9 @@ export const expanderTitleButtonBaseStyles = withSuomifiTheme(
         position: absolute;
         top: 0;
         right: 0;
-      }
-
-      & .fi-expander_title-button-icon {
-        margin: ${theme.spacing.m};
         height: 20px;
         width: 20px;
+        margin: ${theme.spacing.m};
       }
 
       & .fi-expander_title-button--open .fi-expander_title-button-icon,

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
@@ -16,9 +16,12 @@ export const expanderTitleButtonBaseStyles = withSuomifiTheme(
       max-width: 100%;
       min-height: 60px;
       background-color: ${theme.colors.highlightLight4};
+      border-radius: inherit;
 
       &.fi-expander_title-button--open {
         background-color: ${theme.colors.whiteBase};
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
       }
 
       & .fi-expander_title-button_button {
@@ -43,7 +46,6 @@ export const expanderTitleButtonBaseStyles = withSuomifiTheme(
           }
         }
         ${noMouseFocus}
-        &,
         & * {
           cursor: pointer;
         }

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
@@ -4,10 +4,10 @@ import { element, button, font } from '../../theme/reset';
 import { allStates } from '../../../utils/css';
 import { absoluteFocus, noMouseFocus } from '../../theme/utils';
 
-import { ExpanderTitleProps } from './ExpanderTitle';
+import { ExpanderTitleButtonProps } from './ExpanderTitleButton';
 
-export const expanderTitleBaseStyles = withSuomifiTheme(
-  ({ theme }: TokensAndTheme & Partial<ExpanderTitleProps>) => {
+export const expanderTitleButtonBaseStyles = withSuomifiTheme(
+  ({ theme }: TokensAndTheme & Partial<ExpanderTitleButtonProps>) => {
     return css`
       ${element({ theme })}
       ${font({ theme })('bodyText')}
@@ -18,27 +18,20 @@ export const expanderTitleBaseStyles = withSuomifiTheme(
       max-width: 100%;
       min-height: 60px;
       background-color: ${theme.colors.highlightLight4};
-      padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
-      white-space: break-word;
-      word-wrap: break-word;
 
-      &.fi-expander_title--open {
+      &.fi-expander_title-button--open {
         background-color: ${theme.colors.whiteBase};
       }
 
-      & .fi-expander_title-button {
+      & .fi-expander_title-button_button {
         ${button({ theme })}
         ${font({ theme })('bodyText')}
         font-size: ${theme.typography.bodySemiBold};
         color: ${theme.colors.highlightBase};
         display: inline-block;
-        position: absolute;
-        right: 0;
-        top: 0;
-        width: 44px;
-        height: 44px;
-        padding: 12px;
-        margin: 13px;
+        width: 100%;
+        min-height: 60px;
+        padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
 
         &:focus {
           outline: 0;
@@ -52,20 +45,26 @@ export const expanderTitleBaseStyles = withSuomifiTheme(
         }
         ${noMouseFocus}
         &,
-
         & * {
           cursor: pointer;
         }
         ${allStates('cursor: pointer;')}
       }
 
-      & .fi-expander_title-icon {
-        position: relative;
+      & .fi-expander_title-button-icon {
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+
+      & .fi-expander_title-button-icon {
+        margin: ${theme.spacing.m};
         height: 20px;
         width: 20px;
       }
-      & .fi-expander_title--open .fi-expander_title-icon,
-      & .fi-expander_title-icon--open {
+
+      & .fi-expander_title-button--open .fi-expander_title-button-icon,
+      & .fi-expander_title-button-icon--open {
         transform: rotate(-180deg);
       }
     `;

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.test.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.test.tsx
@@ -1,0 +1,201 @@
+/* eslint-disable no-shadow */
+import React, { ReactNode } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ExpanderProviderState, ExpanderProvider } from '../Expander/Expander';
+import {
+  ExpanderTitleButton,
+  ExpanderTitleButtonProps,
+} from './ExpanderTitleButton';
+
+/**
+ * A custom render to setup providers. Extends regular
+ * render options with `providerProps` to allow injecting
+ * different scenarios to test with.
+ *
+ * @see https://testing-library.com/docs/react-testing-library/setup#custom-render
+ */
+const customRender = (
+  ui: ReactNode,
+  {
+    providerProps,
+    ...renderOptions
+  }: { providerProps: ExpanderProviderState; [key: string]: any },
+) => {
+  const rendered = render(
+    <ExpanderProvider value={providerProps}>{ui}</ExpanderProvider>,
+    renderOptions,
+  );
+  return {
+    ...rendered,
+    rerender: (
+      ui: ReactNode,
+      {
+        providerProps,
+        ...renderOptions
+      }: { providerProps: ExpanderProviderState },
+    ) =>
+      customRender(ui, {
+        providerProps,
+        container: rendered.container,
+        ...renderOptions,
+      }),
+  };
+};
+
+const providerProps: ExpanderProviderState = {
+  onToggleExpander: () => null,
+  open: false,
+  titleId: undefined,
+  contentId: undefined,
+};
+
+describe('Basic ExpanderTitleButton', () => {
+  const TestExpanderWithProps = (props?: ExpanderTitleButtonProps) => (
+    <ExpanderTitleButton {...{ 'data-testid': 'expander-title' }} {...props}>
+      {props?.children ? props.children : 'Expander title button'}
+    </ExpanderTitleButton>
+  );
+
+  it('render with the same component on the same container does not remount', () => {
+    const { rerender, getByTestId } = customRender(TestExpanderWithProps(), {
+      providerProps,
+    });
+    expect(getByTestId('expander-title').textContent).toBe(
+      'Expander title button',
+    );
+    // re-render the same component with different props
+    rerender(TestExpanderWithProps({ children: 'Expander title button two' }), {
+      providerProps: { ...providerProps },
+    });
+    expect(getByTestId('expander-title').textContent).toBe(
+      'Expander title button two',
+    );
+  });
+
+  it('shoud match snapshot', () => {
+    const expanderRenderer = customRender(TestExpanderWithProps(), {
+      providerProps: {
+        ...providerProps,
+        titleId: 'test-id_title',
+        contentId: 'test-id_content',
+      },
+    });
+    const { container } = expanderRenderer;
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});
+
+describe('Aria attributes', () => {
+  const TestExpanderWithProps = (props?: ExpanderTitleButtonProps) => (
+    <ExpanderTitleButton
+      ariaCloseText="click to close expander"
+      ariaOpenText="click to open expander"
+      {...{ 'data-testid': 'expander-title' }}
+      {...props}
+    >
+      {props?.children ? props.children : 'Expander title button'}
+    </ExpanderTitleButton>
+  );
+
+  it('should be passed to title button', () => {
+    const { getByText, rerender } = customRender(TestExpanderWithProps(), {
+      providerProps,
+    });
+    expect(getByText('click to open expander')).toBeTruthy();
+    const adjustedProviderProps = {
+      ...providerProps,
+      open: true,
+    };
+    rerender(TestExpanderWithProps(), {
+      providerProps: adjustedProviderProps,
+    });
+    expect(getByText('click to close expander')).toBeTruthy();
+  });
+});
+
+describe('Custom id', () => {
+  const TestExpanderWithProps = (props?: ExpanderTitleButtonProps) => (
+    <ExpanderTitleButton {...props}>
+      {props?.children ? props.children : 'Expander title button'}
+    </ExpanderTitleButton>
+  );
+
+  it('is passed on to button', () => {
+    const { getByRole } = customRender(TestExpanderWithProps(), {
+      providerProps: {
+        ...providerProps,
+        titleId: 'test-id_title',
+        contentId: 'test-id_content',
+      },
+    });
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('id', 'test-id_title');
+    expect(button).toHaveAttribute('aria-controls', 'test-id_content');
+  });
+});
+
+describe('Provider open property', () => {
+  const TestExpanderWithProps = (props?: ExpanderTitleButtonProps) => (
+    <ExpanderTitleButton
+      {...{ 'data-testid': 'expander-open-by-default-title' }}
+      {...props}
+    >
+      {props?.children ? props.children : 'Test expander open by default'}
+    </ExpanderTitleButton>
+  );
+
+  it('correlates with aria-expanded attribute', () => {
+    const { getByRole, rerender } = customRender(TestExpanderWithProps(), {
+      providerProps: { ...providerProps, open: true },
+    });
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    rerender(TestExpanderWithProps(), {
+      providerProps: {
+        ...providerProps,
+        open: false,
+      },
+    });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('gives the classname to expander title and icon', () => {
+    const { getByTestId } = customRender(TestExpanderWithProps(), {
+      providerProps: { ...providerProps, open: true },
+    });
+    const div = getByTestId('expander-open-by-default-title');
+    expect(div).toHaveClass('fi-expander_title-button--open');
+    expect(div.querySelector('svg')).toHaveClass(
+      'fi-expander_title-button-icon--open',
+    );
+  });
+
+  it('will remove open classnames when false', () => {
+    const mockClickHandler = jest.fn();
+    const { getByTestId, getByRole, rerender } = customRender(
+      TestExpanderWithProps(),
+      {
+        providerProps: {
+          ...providerProps,
+          open: true,
+          onToggleExpander: mockClickHandler,
+        },
+      },
+    );
+    const buttonToClick = getByRole('button');
+    fireEvent.click(buttonToClick);
+    expect(mockClickHandler).toHaveBeenCalledTimes(1);
+    rerender(TestExpanderWithProps(), {
+      providerProps: {
+        ...providerProps,
+        open: false,
+      },
+    });
+    const titleDiv = getByTestId('expander-open-by-default-title');
+    expect(titleDiv).toHaveClass('fi-expander_title-button');
+    expect(titleDiv).not.toHaveClass('fi-expander_title-button--open');
+    expect(buttonToClick.querySelector('svg')).not.toHaveClass(
+      'fi-expander_title-button-icon--open',
+    );
+  });
+});

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.test.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-shadow */
 import React, { ReactNode } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ExpanderProviderState, ExpanderProvider } from '../Expander/Expander';
@@ -17,27 +16,27 @@ import {
 const customRender = (
   ui: ReactNode,
   {
-    providerProps,
+    providerProps: origProviderProps,
     ...renderOptions
   }: { providerProps: ExpanderProviderState; [key: string]: any },
 ) => {
   const rendered = render(
-    <ExpanderProvider value={providerProps}>{ui}</ExpanderProvider>,
+    <ExpanderProvider value={origProviderProps}>{ui}</ExpanderProvider>,
     renderOptions,
   );
   return {
     ...rendered,
     rerender: (
-      ui: ReactNode,
+      rerenderUi: ReactNode,
       {
         providerProps,
-        ...renderOptions
+        ...rerenderOptions
       }: { providerProps: ExpanderProviderState },
     ) =>
-      customRender(ui, {
+      customRender(rerenderUi, {
         providerProps,
         container: rendered.container,
-        ...renderOptions,
+        ...rerenderOptions,
       }),
   };
 };

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.test.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.test.tsx
@@ -84,6 +84,28 @@ describe('Basic ExpanderTitleButton', () => {
   });
 });
 
+describe('As heading', () => {
+  const TestExpanderWithProps = (props?: ExpanderTitleButtonProps) => (
+    <ExpanderTitleButton
+      ariaCloseText="click to close expander"
+      ariaOpenText="click to open expander"
+      {...props}
+    >
+      {props?.children ? props.children : 'Expander title button'}
+    </ExpanderTitleButton>
+  );
+
+  it('should wrap the button to h-element', () => {
+    const { getByRole } = customRender(
+      TestExpanderWithProps({ asHeading: 'h2' }),
+      {
+        providerProps,
+      },
+    );
+    expect(getByRole('heading')).toBeTruthy();
+  });
+});
+
 describe('Aria attributes', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleButtonProps) => (
     <ExpanderTitleButton
@@ -119,16 +141,17 @@ describe('Custom id', () => {
     </ExpanderTitleButton>
   );
 
-  it('is passed on to button', () => {
-    const { getByRole } = customRender(TestExpanderWithProps(), {
+  it('is passed on to content and set to button aria-controls', () => {
+    const { getByRole, getByText } = customRender(TestExpanderWithProps(), {
       providerProps: {
         ...providerProps,
         titleId: 'test-id_title',
         contentId: 'test-id_content',
       },
     });
+    const span = getByText('Expander title button');
+    expect(span).toHaveAttribute('id', 'test-id_title');
     const button = getByRole('button');
-    expect(button).toHaveAttribute('id', 'test-id_title');
     expect(button).toHaveAttribute('aria-controls', 'test-id_content');
   });
 });

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
@@ -3,7 +3,7 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { withSuomifiDefaultProps } from '../../theme/utils';
 import { TokensProp, InternalTokensProp } from '../../theme';
-import { HtmlDiv, HtmlButton, HtmlButtonProps } from '../../../reset';
+import { HtmlDiv, HtmlButton, HtmlButtonProps, HtmlSpan } from '../../../reset';
 import { expanderTitleButtonBaseStyles } from './ExpanderTitleButton.baseStyles';
 import { Icon } from '../../Icon/Icon';
 import { ExpanderConsumer, ExpanderTitleBaseProps } from '../Expander/Expander';
@@ -20,6 +20,8 @@ export interface ExpanderTitleButtonProps {
   className?: string;
   /** Title for Expander */
   children?: ReactNode;
+  /** Wrap the title button inside a heading tag */
+  asHeading?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   /** Additional text for closed expanders toggle button. E.g."open expander". */
   ariaOpenText?: string;
   /** Additional text for open expanders toggle button. E.g."close expander". */
@@ -47,6 +49,7 @@ class BaseExpanderTitleButton extends Component<
     const {
       ariaCloseText,
       ariaOpenText,
+      asHeading,
       children,
       className,
       toggleButtonProps,
@@ -61,27 +64,28 @@ class BaseExpanderTitleButton extends Component<
           [titleOpenClassName]: !!consumer.open,
         })}
       >
-        <HtmlButton
-          {...toggleButtonProps}
-          onClick={consumer.onToggleExpander}
-          aria-expanded={!!consumer.open}
-          className={titleButtonClassName}
-          id={consumer.titleId}
-          {...{ 'aria-controls': `${consumer.contentId}` }}
-        >
-          {children}
-          {(!!ariaCloseText || !!ariaOpenText) && (
-            <VisuallyHidden>
-              {!!consumer.open ? ariaCloseText : ariaOpenText}
-            </VisuallyHidden>
-          )}
-          <Icon
-            icon="chevronDown"
-            className={classnames(iconClassName, {
-              [iconOpenClassName]: consumer.open,
-            })}
-          />
-        </HtmlButton>
+        <HtmlSpan {...(!!asHeading ? { as: asHeading } : {})}>
+          <HtmlButton
+            {...toggleButtonProps}
+            onClick={consumer.onToggleExpander}
+            aria-expanded={!!consumer.open}
+            className={titleButtonClassName}
+            {...{ 'aria-controls': `${consumer.contentId}` }}
+          >
+            <HtmlSpan id={consumer.titleId}>{children}</HtmlSpan>
+            {(!!ariaCloseText || !!ariaOpenText) && (
+              <VisuallyHidden>
+                {!!consumer.open ? ariaCloseText : ariaOpenText}
+              </VisuallyHidden>
+            )}
+            <Icon
+              icon="chevronDown"
+              className={classnames(iconClassName, {
+                [iconOpenClassName]: consumer.open,
+              })}
+            />
+          </HtmlButton>
+        </HtmlSpan>
       </HtmlDiv>
     );
   }

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
@@ -9,11 +9,10 @@ import { Icon } from '../../Icon/Icon';
 import { ExpanderConsumer, ExpanderTitleBaseProps } from '../Expander/Expander';
 import { VisuallyHidden } from '../../../components';
 
-const baseClassName = 'fi-expander';
-const titleClassName = `${baseClassName}_title-button`;
-const titleOpenClassName = `${titleClassName}--open`;
-const titleButtonClassName = `${titleClassName}_button`;
-const iconClassName = `${titleClassName}-icon`;
+const baseClassName = 'fi-expander_title-button';
+const titleOpenClassName = `${baseClassName}--open`;
+const titleButtonClassName = `${baseClassName}_button`;
+const iconClassName = `${baseClassName}-icon`;
 const iconOpenClassName = `${iconClassName}--open`;
 
 export interface ExpanderTitleButtonProps {
@@ -37,7 +36,7 @@ export interface ExpanderTitleButtonProps {
   >;
 }
 
-export interface InternalExpanderTitleButtonProps
+interface InternalExpanderTitleButtonProps
   extends ExpanderTitleButtonProps,
     ExpanderTitleBaseProps {}
 
@@ -58,7 +57,7 @@ class BaseExpanderTitleButton extends Component<
     return (
       <HtmlDiv
         {...passProps}
-        className={classnames(className, titleClassName, {
+        className={classnames(className, baseClassName, {
           [titleOpenClassName]: !!consumer.open,
         })}
       >

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
@@ -4,19 +4,21 @@ import classnames from 'classnames';
 import { withSuomifiDefaultProps } from '../../theme/utils';
 import { TokensProp, InternalTokensProp } from '../../theme';
 import { HtmlDiv, HtmlButton, HtmlButtonProps } from '../../../reset';
-import { expanderTitleButtonBaseStyles } from './ExpanderTitle.baseStyles';
+import { expanderTitleButtonBaseStyles } from './ExpanderTitleButton.baseStyles';
 import { Icon } from '../../Icon/Icon';
 import { ExpanderConsumer, ExpanderTitleBaseProps } from '../Expander/Expander';
 import { VisuallyHidden } from '../../../components';
 
 const baseClassName = 'fi-expander';
-const titleClassName = `${baseClassName}_title`;
+const titleClassName = `${baseClassName}_title-button`;
 const titleOpenClassName = `${titleClassName}--open`;
-const titleButtonClassName = `${titleClassName}-button`;
+const titleButtonClassName = `${titleClassName}_button`;
 const iconClassName = `${titleClassName}-icon`;
 const iconOpenClassName = `${iconClassName}--open`;
 
 export interface ExpanderTitleButtonProps {
+  /** Custom classname to extend or customize */
+  className?: string;
   /** Title for Expander */
   children?: ReactNode;
   /** Additional text for closed expanders toggle button. E.g."open expander". */
@@ -102,7 +104,7 @@ const StyledExpanderTitle = styled(
 
 /**
  * <i class="semantics" />
- * Expander title for content and toggle for content visiblity
+ * Expander title button for static title content and toggle for content visiblity
  */
 export class ExpanderTitleButton extends Component<
   ExpanderTitleButtonProps & TokensProp

--- a/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
-.c2 {
+.c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -27,25 +27,25 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   cursor: pointer;
 }
 
-.c2:-moz-focusring {
+.c3:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
-.c2::-moz-focus-inner {
+.c3::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
 
-.c2::-webkit-file-upload-button {
+.c3::-webkit-file-upload-button {
   -webkit-appearance: button;
   font: inherit;
 }
 
-.c2::-webkit-inner-spin-button {
+.c3::-webkit-inner-spin-button {
   height: auto;
 }
 
-.c2::-webkit-outer-spin-button {
+.c3::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -73,7 +73,31 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   white-space: normal;
 }
 
-.c3 {
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4 {
   display: inline-block;
   vertical-align: baseline;
 }
@@ -200,27 +224,35 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   class="c0 c1 fi-expander_title-button"
   data-testid="expander-title"
 >
-  <button
-    aria-controls="test-id_content"
-    aria-expanded="false"
-    class="c2 fi-expander_title-button_button"
-    id="test-id_title"
-    type="button"
+  <span
+    class="c2"
   >
-    Expander title button
-    <svg
-      aria-hidden="true"
-      class="fi-icon c3 fi-expander_title-button-icon"
-      fill="currentColor"
-      focusable="false"
-      height="1em"
-      viewBox="0 0 24 24"
-      width="1em"
+    <button
+      aria-controls="test-id_content"
+      aria-expanded="false"
+      class="c3 fi-expander_title-button_button"
+      type="button"
     >
-      <path
-        d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
-      />
-    </svg>
-  </button>
+      <span
+        class="c2"
+        id="test-id_title"
+      >
+        Expander title button
+      </span>
+      <svg
+        aria-hidden="true"
+        class="fi-icon c4 fi-expander_title-button-icon"
+        fill="currentColor"
+        focusable="false"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+      >
+        <path
+          d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+        />
+      </svg>
+    </button>
+  </span>
 </div>
 `;

--- a/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
@@ -1,0 +1,224 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+  cursor: pointer;
+}
+
+.c2:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c2::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c2::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c2::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c2::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3 {
+  display: inline-block;
+  vertical-align: baseline;
+}
+
+.c1 {
+  color: hsl(0,0%,16%);
+  position: relative;
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  min-height: 60px;
+  background-color: hsl(212,63%,98%);
+}
+
+.c1.fi-expander_title-button--open {
+  background-color: hsl(0,0%,100%);
+}
+
+.c1 .fi-expander_title-button_button {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(212,63%,45%);
+  display: inline-block;
+  width: 100%;
+  max-width: 100%;
+  min-height: 60px;
+  padding: 17px 60px 16px 20px;
+}
+
+.c1 .fi-expander_title-button_button:focus {
+  outline: 0;
+}
+
+.c1 .fi-expander_title-button_button:focus-within {
+  outline: 0;
+}
+
+.c1 .fi-expander_title-button_button:focus-within:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+.c1 .fi-expander_title-button_button:not(:focus-visible) {
+  outline: 0;
+}
+
+.c1 .fi-expander_title-button_button:not(:focus-visible):after {
+  content: none;
+}
+
+.c1 .fi-expander_title-button_button,
+.c1 .fi-expander_title-button_button * {
+  cursor: pointer;
+}
+
+.c1 .fi-expander_title-button_button:hover,
+.c1 .fi-expander_title-button_button:active,
+.c1 .fi-expander_title-button_button:focus,
+.c1 .fi-expander_title-button_button:focus-within {
+  cursor: pointer;
+}
+
+.c1 .fi-expander_title-button-icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 20px;
+  width: 20px;
+  margin: 20px;
+}
+
+.c1 .fi-expander_title-button--open .fi-expander_title-button-icon,
+.c1 .fi-expander_title-button-icon--open {
+  -webkit-transform: rotate(-180deg);
+  -ms-transform: rotate(-180deg);
+  transform: rotate(-180deg);
+}
+
+<div
+  class="c0 c1 fi-expander_title-button"
+  data-testid="expander-title"
+>
+  <button
+    aria-controls="test-id_content"
+    aria-expanded="false"
+    class="c2 fi-expander_title-button_button"
+    id="test-id_title"
+    type="button"
+  >
+    Expander title button
+    <svg
+      aria-hidden="true"
+      class="fi-icon c3 fi-expander_title-button-icon"
+      fill="currentColor"
+      focusable="false"
+      height="1em"
+      viewBox="0 0 24 24"
+      width="1em"
+    >
+      <path
+        d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+      />
+    </svg>
+  </button>
+</div>
+`;

--- a/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
@@ -86,10 +86,13 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   max-width: 100%;
   min-height: 60px;
   background-color: hsl(212,63%,98%);
+  border-radius: inherit;
 }
 
 .c1.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .c1 .fi-expander_title-button_button {
@@ -166,7 +169,6 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   content: none;
 }
 
-.c1 .fi-expander_title-button_button,
 .c1 .fi-expander_title-button_button * {
   cursor: pointer;
 }

--- a/src/core/Expander/index.ts
+++ b/src/core/Expander/index.ts
@@ -10,4 +10,8 @@ export {
 export {
   ExpanderTitleButton,
   ExpanderTitleButtonProps,
-} from './ExpanderTitle/ExpanderTitleButton';
+} from './ExpanderTitleButton/ExpanderTitleButton';
+export {
+  ExpanderTitle,
+  ExpanderTitleProps,
+} from './ExpanderTitle/ExpanderTitle';

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -333,11 +333,11 @@ exports[`snapshot testing 1`] = `
   background-color: hsl(212,63%,98%);
 }
 
-.c6.fi-expander_title--open {
+.c6.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
 }
 
-.c6 .fi-expander_title-button {
+.c6 .fi-expander_title-button_button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -367,27 +367,27 @@ exports[`snapshot testing 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  color: hsl(212,63%,45%);
-  display: block;
   font-size: font-family:'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
+  color: hsl(212,63%,45%);
+  display: inline-block;
   width: 100%;
   max-width: 100%;
   min-height: 60px;
   padding: 17px 60px 16px 20px;
 }
 
-.c6 .fi-expander_title-button:focus {
+.c6 .fi-expander_title-button_button:focus {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button:focus-within {
+.c6 .fi-expander_title-button_button:focus-within {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button:focus-within:after {
+.c6 .fi-expander_title-button_button:focus-within:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -403,37 +403,37 @@ exports[`snapshot testing 1`] = `
   z-index: 9999;
 }
 
-.c6 .fi-expander_title-button:not(:focus-visible) {
+.c6 .fi-expander_title-button_button:not(:focus-visible) {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button:not(:focus-visible):after {
+.c6 .fi-expander_title-button_button:not(:focus-visible):after {
   content: none;
 }
 
-.c6 .fi-expander_title-button,
-.c6 .fi-expander_title-button * {
+.c6 .fi-expander_title-button_button,
+.c6 .fi-expander_title-button_button * {
   cursor: pointer;
 }
 
-.c6 .fi-expander_title-button:hover,
-.c6 .fi-expander_title-button:active,
-.c6 .fi-expander_title-button:focus,
-.c6 .fi-expander_title-button:focus-within {
+.c6 .fi-expander_title-button_button:hover,
+.c6 .fi-expander_title-button_button:active,
+.c6 .fi-expander_title-button_button:focus,
+.c6 .fi-expander_title-button_button:focus-within {
   cursor: pointer;
 }
 
-.c6 .fi-expander_title-icon {
+.c6 .fi-expander_title-button-icon {
   position: absolute;
-  height: 20px;
-  width: 20px;
   top: 0;
   right: 0;
+  height: 20px;
+  width: 20px;
   margin: 20px;
 }
 
-.c6 .fi-expander_title--open .fi-expander_title-icon,
-.c6 .fi-expander_title-icon--open {
+.c6 .fi-expander_title-button--open .fi-expander_title-button-icon,
+.c6 .fi-expander_title-button-icon--open {
   -webkit-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
   transform: rotate(-180deg);
@@ -466,19 +466,19 @@ exports[`snapshot testing 1`] = `
       id="id-expander-1"
     >
       <div
-        class="c0 c6 fi-expander_title"
+        class="c0 c6 fi-expander_title-button"
       >
         <button
           aria-controls="id-expander-1_content"
           aria-expanded="false"
-          class="c2 fi-expander_title-button"
+          class="c2 fi-expander_title-button_button"
           id="id-expander-1_title"
           type="button"
         >
           Test expander 1
           <svg
             aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-icon"
+            class="fi-icon c7 fi-expander_title-button-icon"
             fill="currentColor"
             focusable="false"
             height="1em"
@@ -497,19 +497,19 @@ exports[`snapshot testing 1`] = `
       id="id-expander-2"
     >
       <div
-        class="c0 c6 fi-expander_title"
+        class="c0 c6 fi-expander_title-button"
       >
         <button
           aria-controls="id-expander-2_content"
           aria-expanded="false"
-          class="c2 fi-expander_title-button"
+          class="c2 fi-expander_title-button_button"
           id="id-expander-2_title"
           type="button"
         >
           Test expander 2
           <svg
             aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-icon"
+            class="fi-icon c7 fi-expander_title-button-icon"
             fill="currentColor"
             focusable="false"
             height="1em"
@@ -536,19 +536,19 @@ exports[`snapshot testing 1`] = `
       id="id-expander-3"
     >
       <div
-        class="c0 c6 fi-expander_title"
+        class="c0 c6 fi-expander_title-button"
       >
         <button
           aria-controls="id-expander-3_content"
           aria-expanded="false"
-          class="c2 fi-expander_title-button"
+          class="c2 fi-expander_title-button_button"
           id="id-expander-3_title"
           type="button"
         >
           Test expander 3
           <svg
             aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-icon"
+            class="fi-icon c7 fi-expander_title-button-icon"
             fill="currentColor"
             focusable="false"
             height="1em"

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -146,9 +146,13 @@ exports[`snapshot testing 1`] = `
   color: hsl(1,2%,3%);
 }
 
+.c1 > .fi-expander-group_expanders .fi-expander > {
+  border-radius: 0;
+}
+
 .c1 > .fi-expander-group_expanders .fi-expander:first-child {
-  border-radius: 2px 2px 0 0;
   border-top: none;
+  border-radius: 2px 2px 0 0;
 }
 
 .c1 > .fi-expander-group_expanders .fi-expander:last-child {
@@ -165,16 +169,6 @@ exports[`snapshot testing 1`] = `
 
 .c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:last-of-type) {
   margin-bottom: 16px;
-}
-
-.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:first-child,
-.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:first-child:before {
-  border-radius: 2px 2px 0 0;
-}
-
-.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:last-child,
-.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:last-child:before {
-  border-radius: 0 0 2px 2px;
 }
 
 .c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open + .fi-expander {
@@ -263,7 +257,6 @@ exports[`snapshot testing 1`] = `
   display: block;
   width: 100%;
   max-width: 100%;
-  overflow: hidden;
 }
 
 .c5:before {
@@ -287,6 +280,7 @@ exports[`snapshot testing 1`] = `
   line-height: 1.5;
   font-weight: 400;
   background-color: hsl(0,0%,100%);
+  border-radius: inherit;
   position: relative;
   visibility: hidden;
   display: block;
@@ -312,6 +306,8 @@ exports[`snapshot testing 1`] = `
   visibility: visible;
   height: 10%;
   overflow: visible;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
   animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
 }
@@ -331,10 +327,13 @@ exports[`snapshot testing 1`] = `
   max-width: 100%;
   min-height: 60px;
   background-color: hsl(212,63%,98%);
+  border-radius: inherit;
 }
 
 .c6.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .c6 .fi-expander_title-button_button {
@@ -411,7 +410,6 @@ exports[`snapshot testing 1`] = `
   content: none;
 }
 
-.c6 .fi-expander_title-button_button,
 .c6 .fi-expander_title-button_button * {
   cursor: pointer;
 }
@@ -527,6 +525,7 @@ exports[`snapshot testing 1`] = `
         aria-labelledby="id-expander-2_title"
         class="c0 c8 fi-expander_content"
         id="id-expander-2_content"
+        role="region"
       >
         Test expander content 2
       </div>
@@ -566,6 +565,7 @@ exports[`snapshot testing 1`] = `
         aria-labelledby="id-expander-3_title"
         class="c0 c8 fi-expander_content"
         id="id-expander-3_content"
+        role="region"
       >
         Test expander content 3
       </div>

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -466,28 +466,36 @@ exports[`snapshot testing 1`] = `
       <div
         class="c0 c6 fi-expander_title-button"
       >
-        <button
-          aria-controls="id-expander-1_content"
-          aria-expanded="false"
-          class="c2 fi-expander_title-button_button"
-          id="id-expander-1_title"
-          type="button"
+        <span
+          class="c3"
         >
-          Test expander 1
-          <svg
-            aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-button-icon"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
+          <button
+            aria-controls="id-expander-1_content"
+            aria-expanded="false"
+            class="c2 fi-expander_title-button_button"
+            type="button"
           >
-            <path
-              d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
-            />
-          </svg>
-        </button>
+            <span
+              class="c3"
+              id="id-expander-1_title"
+            >
+              Test expander 1
+            </span>
+            <svg
+              aria-hidden="true"
+              class="fi-icon c7 fi-expander_title-button-icon"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <path
+                d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
     </div>
     <div
@@ -497,28 +505,36 @@ exports[`snapshot testing 1`] = `
       <div
         class="c0 c6 fi-expander_title-button"
       >
-        <button
-          aria-controls="id-expander-2_content"
-          aria-expanded="false"
-          class="c2 fi-expander_title-button_button"
-          id="id-expander-2_title"
-          type="button"
+        <span
+          class="c3"
         >
-          Test expander 2
-          <svg
-            aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-button-icon"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
+          <button
+            aria-controls="id-expander-2_content"
+            aria-expanded="false"
+            class="c2 fi-expander_title-button_button"
+            type="button"
           >
-            <path
-              d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
-            />
-          </svg>
-        </button>
+            <span
+              class="c3"
+              id="id-expander-2_title"
+            >
+              Test expander 2
+            </span>
+            <svg
+              aria-hidden="true"
+              class="fi-icon c7 fi-expander_title-button-icon"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <path
+                d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
       <div
         aria-hidden="true"
@@ -537,28 +553,36 @@ exports[`snapshot testing 1`] = `
       <div
         class="c0 c6 fi-expander_title-button"
       >
-        <button
-          aria-controls="id-expander-3_content"
-          aria-expanded="false"
-          class="c2 fi-expander_title-button_button"
-          id="id-expander-3_title"
-          type="button"
+        <span
+          class="c3"
         >
-          Test expander 3
-          <svg
-            aria-hidden="true"
-            class="fi-icon c7 fi-expander_title-button-icon"
-            fill="currentColor"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
+          <button
+            aria-controls="id-expander-3_content"
+            aria-expanded="false"
+            class="c2 fi-expander_title-button_button"
+            type="button"
           >
-            <path
-              d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
-            />
-          </svg>
-        </button>
+            <span
+              class="c3"
+              id="id-expander-3_title"
+            >
+              Test expander 3
+            </span>
+            <svg
+              aria-hidden="true"
+              class="fi-icon c7 fi-expander_title-button-icon"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <path
+                d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+              />
+            </svg>
+          </button>
+        </span>
       </div>
       <div
         aria-hidden="true"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -60,6 +60,8 @@ export {
   ExpanderContentProps,
   ExpanderTitleButton,
   ExpanderTitleButtonProps,
+  ExpanderTitle,
+  ExpanderTitleProps,
 } from './core/Expander/';
 export { Paragraph, ParagraphProps } from './core/Paragraph/Paragraph';
 export { Text, TextProps } from './core/Text/Text';


### PR DESCRIPTION
## Description

This PR introduces ExpanderTitle as a variant for ExpanderTitleButton. ExpanderTitle only has open / close button on the far right of the title to support focusable content on the remaining title area. This makes it possible to use the expander with common use cases like checkbox in the expander title.

In addition, most of the Expander related tests are rearranged or refactored so that each component now have separate test files.

## Motivation and Context

There was a clear need to support focusable content on the expander title and the variant with whole title are as button did not work with these use cases.

## How Has This Been Tested?

Tested with Styleguidist, CRA TypeScript, SSR application by using VoiceOver with Chrome, Firefox and Safari and by using NVDA with Chrome, Firefox, Edge and IE.

## Screenshots (if appropriate):

![Screenshot 2020-12-10 at 7 49 47](https://user-images.githubusercontent.com/53744258/101727006-563c7f00-3abc-11eb-88ab-0fae717f0f09.png)

## Release notes
- ExpanderTitle component to support interactive content on expander titles.
