### PR TITLE
[Bugfix] Remove native internet explorer pseudo elements from text input

### DIFF
--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -42,6 +42,16 @@ export const baseStyles = withSuomifiTheme(
         color: ${theme.colors.depthDark2};
         opacity: 1;
       }
+      &::-ms-clear {
+        display: none;
+        width: 0;
+        height: 0;
+      }
+      &::-ms-reveal {
+        display: none;
+        width: 0;
+        height: 0;
+      }
     }
 
     &.fi-text-input_with-icon {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -233,6 +233,18 @@ exports[`snapshots match error status with statustext 1`] = `
   opacity: 1;
 }
 
+.c1 .fi-text-input_input::-ms-clear {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.c1 .fi-text-input_input::-ms-reveal {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 .c1.fi-text-input_with-icon .fi-text-input_input-element-container {
   position: relative;
 }
@@ -522,6 +534,18 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   opacity: 1;
 }
 
+.c1 .fi-text-input_input::-ms-clear {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.c1 .fi-text-input_input::-ms-reveal {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 .c1.fi-text-input_with-icon .fi-text-input_input-element-container {
   position: relative;
 }
@@ -790,6 +814,18 @@ exports[`snapshots match minimal implementation 1`] = `
   font-style: italic;
   color: hsl(201,7%,46%);
   opacity: 1;
+}
+
+.c1 .fi-text-input_input::-ms-clear {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.c1 .fi-text-input_input::-ms-reveal {
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 .c1.fi-text-input_with-icon .fi-text-input_input-element-container {


### PR DESCRIPTION
## Description
This PR removes the clear button and "show password" pseudo elements for text/password input in Internet Explorer.

## Motivation and Context
These elements are not part of the design and are not shown in other browsers. This PR will put IE behavior in line with other browsers and the design.

## How Has This Been Tested?
Tested by automated tests and by running in design system site.

## Screenshots (if appropriate):
Input in internet explorer before the change:
![image](https://user-images.githubusercontent.com/54316341/103981525-9f025900-518a-11eb-9cb0-67ec243007c5.png)

Input in internet explorer after the change:
![image](https://user-images.githubusercontent.com/54316341/103981469-85f9a800-518a-11eb-8d1f-c5cfbb9c9951.png)

## Release notes
*Remove Internet Explorer native pseudo elements from text input
