### PR TITLE
[Bugfix] Box sizing inheritance

### DIFF
--- a/src/core/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/core/Block/__snapshots__/Block.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`calling render with the same component on the same container does not r
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -24,6 +24,11 @@ exports[`calling render with the same component on the same container does not r
   text-decoration: underline;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c4:hover,
 .c4:active,
 .c4:focus,
@@ -54,6 +59,11 @@ exports[`calling render with the same component on the same container does not r
   display: list-item;
 }
 
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -73,6 +83,11 @@ exports[`calling render with the same component on the same container does not r
   cursor: inherit;
   display: block;
   max-width: 100%;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -101,6 +116,11 @@ exports[`calling render with the same component on the same container does not r
   padding-left: 40px;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -123,6 +143,11 @@ exports[`calling render with the same component on the same container does not r
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c7::before,
+.c7::after {
+  box-sizing: border-box;
 }
 
 .c6 {

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`Button variant default should match snapshot 1`] = `
   height: auto;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -319,6 +324,11 @@ exports[`Button variant inverted should match snapshot 1`] = `
 
 .c0::-webkit-outer-spin-button {
   height: auto;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -593,6 +603,11 @@ exports[`Button variant secondary should match snapshot 1`] = `
   height: auto;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -865,6 +880,11 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
   height: auto;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -1135,6 +1155,11 @@ exports[`Button variant tertiary match snapshot 1`] = `
 
 .c0::-webkit-outer-spin-button {
   height: auto;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
 }
 
 .c1 {

--- a/src/core/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/__snapshots__/Chip.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`children should match snapshot 1`] = `
   height: auto;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -71,6 +76,11 @@ exports[`children should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -237,6 +247,11 @@ exports[`classnames should match snapshot 1`] = `
   height: auto;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -259,6 +274,11 @@ exports[`classnames should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -421,6 +441,11 @@ exports[`disabled should match snapshot 1`] = `
   height: auto;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -443,6 +468,11 @@ exports[`disabled should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {

--- a/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -21,6 +21,11 @@ exports[`Basic dropdown should match snapshot 1`] = `
   max-width: 100%;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -45,6 +50,11 @@ exports[`Basic dropdown should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -67,6 +77,11 @@ exports[`Basic dropdown should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 .fi-dropdown_label-p {
@@ -237,6 +252,11 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   max-width: 100%;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -261,6 +281,11 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -283,6 +308,11 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 .fi-dropdown_label-p {
@@ -454,6 +484,11 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   max-width: 100%;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -478,6 +513,11 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -500,6 +540,11 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 .fi-dropdown_label-p {
@@ -670,6 +715,11 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   max-width: 100%;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -694,6 +744,11 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -716,6 +771,11 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 .fi-dropdown_label-p {
@@ -886,6 +946,11 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   max-width: 100%;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -908,6 +973,11 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
 }
 
 .c3 {

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`Basic expander shoud match snapshot 1`] = `
   height: auto;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -73,6 +78,11 @@ exports[`Basic expander shoud match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -95,6 +105,11 @@ exports[`Basic expander shoud match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c5 {

--- a/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
+++ b/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`Basic expander group should match snapshot 1`] = `
   height: auto;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -73,6 +78,11 @@ exports[`Basic expander group should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -95,6 +105,11 @@ exports[`Basic expander group should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c4 {

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   height: auto;
 }
 
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -73,6 +78,11 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -95,6 +105,11 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c4 {

--- a/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   height: auto;
 }
 
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -73,6 +78,11 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -95,6 +105,11 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c4 {

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`props children has matching snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -53,6 +58,11 @@ exports[`props children has matching snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -71,6 +81,11 @@ exports[`props children has matching snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 {

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`snapshot matches 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -53,6 +58,11 @@ exports[`snapshot matches 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -75,6 +85,11 @@ exports[`snapshot matches 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c2.fi-label-text .fi-label-text_label-span {

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -42,6 +42,7 @@ export const baseStyles = withSuomifiTheme(
             border-radius: 50%;
             border: 1px solid ${theme.colors.depthDark3};
             background: transparent;
+            box-sizing: content-box;
           }
           /* Radio input circle when selected */
           &::after {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`children should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -53,6 +58,11 @@ exports[`children should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -71,6 +81,11 @@ exports[`children should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -273,6 +288,11 @@ exports[`className should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -301,6 +321,11 @@ exports[`className should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -319,6 +344,11 @@ exports[`className should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -521,6 +551,11 @@ exports[`disabled should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -549,6 +584,11 @@ exports[`disabled should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -567,6 +607,11 @@ exports[`disabled should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -770,6 +815,11 @@ exports[`hintText should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -798,6 +848,11 @@ exports[`hintText should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -816,6 +871,11 @@ exports[`hintText should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c4 {
@@ -840,6 +900,11 @@ exports[`hintText should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -1049,6 +1114,11 @@ exports[`id should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1077,6 +1147,11 @@ exports[`id should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1095,6 +1170,11 @@ exports[`id should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -1297,6 +1377,11 @@ exports[`name should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1325,6 +1410,11 @@ exports[`name should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1343,6 +1433,11 @@ exports[`name should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -1546,6 +1641,11 @@ exports[`value should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1574,6 +1674,11 @@ exports[`value should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1592,6 +1697,11 @@ exports[`value should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -1794,6 +1904,11 @@ exports[`variant should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1822,6 +1937,11 @@ exports[`variant should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1840,6 +1960,11 @@ exports[`variant should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1 {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -126,6 +126,7 @@ exports[`children should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -373,6 +374,7 @@ exports[`className should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -620,6 +622,7 @@ exports[`disabled should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -892,6 +895,7 @@ exports[`hintText should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -1146,6 +1150,7 @@ exports[`id should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -1393,6 +1398,7 @@ exports[`name should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -1641,6 +1647,7 @@ exports[`value should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -1888,6 +1895,7 @@ exports[`variant should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`default, with only required props should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -53,6 +58,11 @@ exports[`default, with only required props should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -71,6 +81,11 @@ exports[`default, with only required props should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -95,6 +110,11 @@ exports[`default, with only required props should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -390,6 +410,11 @@ exports[`props className should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -418,6 +443,11 @@ exports[`props className should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -436,6 +466,11 @@ exports[`props className should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -460,6 +495,11 @@ exports[`props className should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -755,6 +795,11 @@ exports[`props defaultValue should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -783,6 +828,11 @@ exports[`props defaultValue should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -801,6 +851,11 @@ exports[`props defaultValue should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -825,6 +880,11 @@ exports[`props defaultValue should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -1121,6 +1181,11 @@ exports[`props hintText should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1149,6 +1214,11 @@ exports[`props hintText should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1167,6 +1237,11 @@ exports[`props hintText should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -1191,6 +1266,11 @@ exports[`props hintText should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -1492,6 +1572,11 @@ exports[`props id should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1520,6 +1605,11 @@ exports[`props id should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1538,6 +1628,11 @@ exports[`props id should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -1562,6 +1657,11 @@ exports[`props id should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -1857,6 +1957,11 @@ exports[`props label should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1885,6 +1990,11 @@ exports[`props label should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1903,6 +2013,11 @@ exports[`props label should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -1927,6 +2042,11 @@ exports[`props label should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -2222,6 +2342,11 @@ exports[`props labelMode should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2250,6 +2375,11 @@ exports[`props labelMode should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
 .c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2268,6 +2398,11 @@ exports[`props labelMode should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -2292,6 +2427,11 @@ exports[`props labelMode should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c3 {
@@ -2599,6 +2739,11 @@ exports[`props name should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2627,6 +2772,11 @@ exports[`props name should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2645,6 +2795,11 @@ exports[`props name should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -2669,6 +2824,11 @@ exports[`props name should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {
@@ -2964,6 +3124,11 @@ exports[`props value should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2992,6 +3157,11 @@ exports[`props value should match snapshot 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -3010,6 +3180,11 @@ exports[`props value should match snapshot 1`] = `
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
 }
 
 .c2 {
@@ -3034,6 +3209,11 @@ exports[`props value should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
 }
 
 .c1 {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c3.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -555,6 +556,7 @@ exports[`props className should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c3.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -919,6 +921,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c3.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -1284,6 +1287,7 @@ exports[`props hintText should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c3.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -1654,6 +1658,7 @@ exports[`props id should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c3.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -2018,6 +2023,7 @@ exports[`props label should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c3.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -2394,6 +2400,7 @@ exports[`props labelMode should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c4.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -2758,6 +2765,7 @@ exports[`props name should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c3.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {
@@ -3122,6 +3130,7 @@ exports[`props value should match snapshot 1`] = `
   border-radius: 50%;
   border: 1px solid hsl(201,7%,58%);
   background: transparent;
+  box-sizing: content-box;
 }
 
 .c3.fi-radio-button .fi-radio-button_input + .fi-radio-button_label::after {

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`snapshot should have matching default structure 1`] = `
   height: auto;
 }
 
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -71,6 +76,11 @@ exports[`snapshot should have matching default structure 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
 }
 
 .c4 {
@@ -101,6 +111,11 @@ exports[`snapshot should have matching default structure 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -123,6 +138,11 @@ exports[`snapshot should have matching default structure 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c6 {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`snapshots match error status with statustext 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -53,6 +58,11 @@ exports[`snapshots match error status with statustext 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -75,6 +85,11 @@ exports[`snapshots match error status with statustext 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c2.fi-label-text .fi-label-text_label-span {
@@ -338,6 +353,11 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -366,6 +386,11 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   opacity: 0.54;
 }
 
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -388,6 +413,11 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c4 {
@@ -632,6 +662,11 @@ exports[`snapshots match minimal implementation 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -660,6 +695,11 @@ exports[`snapshots match minimal implementation 1`] = `
   opacity: 0.54;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -682,6 +722,11 @@ exports[`snapshots match minimal implementation 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c2.fi-label-text .fi-label-text_label-span {

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`snapshot default structure should match snapshot 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -47,6 +52,11 @@ exports[`snapshot default structure should match snapshot 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c4 {
@@ -75,6 +85,11 @@ exports[`snapshot default structure should match snapshot 1`] = `
 .c4::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
 }
 
 .c2.fi-label-text .fi-label-text_label-span {

--- a/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/core/Form/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`Toggle variant default:  calling render with the same component on the 
   height: auto;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -71,6 +76,11 @@ exports[`Toggle variant default:  calling render with the same component on the 
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c1.fi-toggle--disabled {
@@ -528,6 +538,11 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   opacity: 0.54;
 }
 
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -546,6 +561,11 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   background: none;
   cursor: inherit;
   max-width: 100%;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
 }
 
 .c4 {
@@ -570,6 +590,11 @@ exports[`Toggle variant withInput:  calling render with the same component on th
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
 }
 
 .c1 {

--- a/src/core/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/core/Heading/__snapshots__/Heading.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`calling render with the same component on the same container does not r
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`calling render with the same component on the same container does not r
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   display: inline-block;
   vertical-align: baseline;

--- a/src/core/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link.baseStyles.ts
@@ -35,7 +35,8 @@ export const externalStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
     & .fi-link_icon {
       padding-left: ${theme.spacing.insetXs};
-      transform: translateY(0.1em);
+      font-size: 16px;
+      box-sizing: content-box;
     }
   `,
 );

--- a/src/core/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/__snapshots__/Link.test.tsx.snap
@@ -24,6 +24,11 @@ exports[`calling render with the same component on the same container does not r
   text-decoration: underline;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c0:hover,
 .c0:active,
 .c0:focus,

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -24,6 +24,11 @@ exports[`calling render with the same component on the same container does not r
   text-decoration: underline;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c0:hover,
 .c0:active,
 .c0:focus,
@@ -56,6 +61,11 @@ exports[`calling render with the same component on the same container does not r
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c5 {

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -77,9 +77,8 @@ exports[`calling render with the same component on the same container does not r
 
 .c2 .fi-link_icon {
   padding-left: 4px;
-  -webkit-transform: translateY(0.1em);
-  -ms-transform: translateY(0.1em);
-  transform: translateY(0.1em);
+  font-size: 16px;
+  box-sizing: content-box;
 }
 
 .c1 {

--- a/src/core/Paragraph/__snapshots__/Paragraph.test.tsx.snap
+++ b/src/core/Paragraph/__snapshots__/Paragraph.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`calling render with the same component on the same container does not r
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;

--- a/src/core/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/core/Text/__snapshots__/Text.test.tsx.snap
@@ -25,6 +25,11 @@ exports[`calling render with the same component on the same container does not r
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -91,6 +96,11 @@ exports[`calling render with the same component on the same container does not r
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c4 {

--- a/src/core/theme/__snapshots__/tokens.test.tsx.snap
+++ b/src/core/theme/__snapshots__/tokens.test.tsx.snap
@@ -49,6 +49,11 @@ exports[`snapshot testing 1`] = `
   height: auto;
 }
 
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -73,6 +78,11 @@ exports[`snapshot testing 1`] = `
   white-space: normal;
 }
 
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -95,6 +105,11 @@ exports[`snapshot testing 1`] = `
   word-wrap: normal;
   word-break: normal;
   white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
 }
 
 .c7 {

--- a/src/reset/utils/index.ts
+++ b/src/reset/utils/index.ts
@@ -16,6 +16,11 @@ const common = css`
   color: inherit;
   background: none;
   cursor: inherit;
+
+  ::before,
+  ::after {
+    box-sizing: border-box;
+  }
 `;
 
 const resets = {


### PR DESCRIPTION
## Description
This PR fixes a couple of reported issues where global styles caused inherited box-size CSS rules to cause some issues with radiobutton and external link. External link icon size was also wrong. That was fixed in the process.

## Motivation and Context
This was a reported bug, which, while it was caused by a global rule in a different project, was easier to fix on our end.

## How Has This Been Tested?
Tested in styleguidist in chrome.

## Release notes
-External link and RadioButton pseudo elements now have explicitly set box-size.
