### PR TITLE
[BugFix] Add resolution for react-styleguidist immer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     }
   ],
   "resolutions": {
-    "tsdx/jest": "26.6.3"
+    "tsdx/jest": "26.6.3",
+    "react-styleguidist/**/immer": "^8.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7088,10 +7088,10 @@ ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@7.0.9:
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
-  integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
+immer@7.0.9, immer@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 import-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Description
This PR adds resolution for react-styleguidist - react-devtools - immer to fix security issue. The resolution is added for all styleguidist immer sub-dependencies (react-styleguidist/**/immer) and sets the immer version to ^8.0.1.

## Related Issue
Dependabot security alert.

## Motivation and Context
There is no updated version of styleguidist available, so a temporary resolution for immer is needed.

## How Has This Been Tested?
Tested with styleguidist build using Mac OS and Chrome. This only concerns the styleguide.

## Release notes
- Set styleguidist immer sub-dependency resolution to ^8.0.1