### PR TITLE
[Feature] SearchInput auto id

### DIFF
--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -7,11 +7,16 @@ export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
     &.fi-search-input {
       ${font({ theme })('bodyText')}
-      display: inline-block;
       width: 290px;
     }
 
     & .fi-search-input {
+      &_wrapper {
+        width: 100%;
+        min-width: 105px;
+        display: inline-block;
+      }
+
       &_functionality-container {
         position: relative;
       }

--- a/src/core/Form/SearchInput/SearchInput.md
+++ b/src/core/Form/SearchInput/SearchInput.md
@@ -23,7 +23,7 @@ const sharedProps = {
 
   <SearchInput
     {...sharedProps}
-    inputContainerProps={{ style: { width: '250px' } }}
+    wrapperProps={{ style: { width: '250px' } }}
     labelMode="hidden"
   />
 

--- a/src/core/Form/SearchInput/SearchInput.test.tsx
+++ b/src/core/Form/SearchInput/SearchInput.test.tsx
@@ -4,11 +4,7 @@ import { axeTest } from '../../../utils/test/axe';
 
 import { SearchInput, SearchInputProps } from './SearchInput';
 
-const TestSearchInput = (
-  props: Partial<SearchInputProps> = {
-    id: 'test-id',
-  },
-) => {
+const TestSearchInput = (props: Partial<SearchInputProps> = {}) => {
   const {
     labelText,
     clearButtonLabel,
@@ -49,7 +45,7 @@ describe('props', () => {
     });
 
     it('should have label text with correct class and for id', () => {
-      const { getByText } = render(TestSearchInput());
+      const { getByText } = render(TestSearchInput({ id: 'test-id' }));
       const label = getByText('Test search input').closest('label');
       expect(label).toHaveClass('fi-label-text');
       expect(label).toHaveAttribute('for', 'test-id');

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import {
   HtmlInputWithRef,
   HtmlInputProps,
+  HtmlSpan,
   HtmlDiv,
   HtmlDivProps,
   HtmlButton,
@@ -85,6 +86,7 @@ const searchInputClassNames = {
   fullWidth: `${baseClassName}--full-width`,
   error: `${baseClassName}--error`,
   notEmpty: `${baseClassName}--not-empty`,
+  styleWrapper: `${baseClassName}_wrapper`,
   inputElement: `${baseClassName}_input`,
   inputElementContainer: `${baseClassName}_input-element-container`,
   functionalityContainer: `${baseClassName}_functionality-container`,
@@ -208,66 +210,70 @@ class BaseSearchInput extends Component<SearchInputProps> {
           [searchInputClassNames.fullWidth]: fullWidth,
         })}
       >
-        <LabelText htmlFor={id} labelMode={labelMode} as="label">
-          {labelText}
-        </LabelText>
-        <Debounce waitFor={this.props.debounce}>
-          {(debouncer: Function, cancelDebounce: Function) => (
-            <HtmlDiv className={searchInputClassNames.functionalityContainer}>
-              <HtmlDiv className={searchInputClassNames.inputElementContainer}>
-                <HtmlInputWithRef
-                  {...passProps}
-                  {...getConditionalAriaProp('aria-describedby', [
-                    !!statusText ? statusTextId : undefined,
-                    ariaDescribedBy,
-                  ])}
-                  forwardRef={this.inputRef}
-                  aria-invalid={status === 'error'}
-                  id={id}
-                  className={searchInputClassNames.inputElement}
-                  type="search"
-                  role="searchbox"
-                  value={this.state.value}
-                  placeholder={visualPlaceholder}
-                  onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                    const eventValue = event.currentTarget.value;
-                    conditionalSetState(eventValue);
-                    if (propOnChange) {
-                      debouncer(propOnChange, eventValue);
-                    }
+        <HtmlSpan className={searchInputClassNames.styleWrapper}>
+          <LabelText htmlFor={id} labelMode={labelMode} as="label">
+            {labelText}
+          </LabelText>
+          <Debounce waitFor={this.props.debounce}>
+            {(debouncer: Function, cancelDebounce: Function) => (
+              <HtmlDiv className={searchInputClassNames.functionalityContainer}>
+                <HtmlDiv
+                  className={searchInputClassNames.inputElementContainer}
+                >
+                  <HtmlInputWithRef
+                    {...passProps}
+                    {...getConditionalAriaProp('aria-describedby', [
+                      !!statusText ? statusTextId : undefined,
+                      ariaDescribedBy,
+                    ])}
+                    forwardRef={this.inputRef}
+                    aria-invalid={status === 'error'}
+                    id={id}
+                    className={searchInputClassNames.inputElement}
+                    type="search"
+                    role="searchbox"
+                    value={this.state.value}
+                    placeholder={visualPlaceholder}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                      const eventValue = event.currentTarget.value;
+                      conditionalSetState(eventValue);
+                      if (propOnChange) {
+                        debouncer(propOnChange, eventValue);
+                      }
+                    }}
+                    onKeyPress={onKeyPress}
+                    onKeyDown={onKeyDown}
+                  />
+                </HtmlDiv>
+                <HtmlButton
+                  {...clearButtonProps}
+                  onClick={() => {
+                    onClear();
+                    cancelDebounce();
                   }}
-                  onKeyPress={onKeyPress}
-                  onKeyDown={onKeyDown}
-                />
+                >
+                  <VisuallyHidden>{clearButtonLabel}</VisuallyHidden>
+                  <Icon
+                    aria-hidden={true}
+                    icon="close"
+                    className={searchInputClassNames.clearIcon}
+                  />
+                </HtmlButton>
+                <HtmlButton {...searchButtonDerivedProps}>
+                  <VisuallyHidden>{searchButtonLabel}</VisuallyHidden>
+                  <Icon
+                    aria-hidden={true}
+                    icon="search"
+                    className={searchInputClassNames.searchIcon}
+                  />
+                </HtmlButton>
               </HtmlDiv>
-              <HtmlButton
-                {...clearButtonProps}
-                onClick={() => {
-                  onClear();
-                  cancelDebounce();
-                }}
-              >
-                <VisuallyHidden>{clearButtonLabel}</VisuallyHidden>
-                <Icon
-                  aria-hidden={true}
-                  icon="close"
-                  className={searchInputClassNames.clearIcon}
-                />
-              </HtmlButton>
-              <HtmlButton {...searchButtonDerivedProps}>
-                <VisuallyHidden>{searchButtonLabel}</VisuallyHidden>
-                <Icon
-                  aria-hidden={true}
-                  icon="search"
-                  className={searchInputClassNames.searchIcon}
-                />
-              </HtmlButton>
-            </HtmlDiv>
-          )}
-        </Debounce>
-        <StatusText id={statusTextId} status={status}>
-          {statusText}
-        </StatusText>
+            )}
+          </Debounce>
+          <StatusText id={statusTextId} status={status}>
+            {statusText}
+          </StatusText>
+        </HtmlSpan>
       </HtmlDiv>
     );
   }

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -40,8 +40,8 @@ export interface SearchInputProps
     TokensProp {
   /** SearchInput container div class name for custom styling. */
   className?: string;
-  /** SearchInput container div props */
-  inputContainerProps?: Omit<HtmlDivProps, 'className'>;
+  /** SearchInput wrapping div element props */
+  wrapperProps?: Omit<HtmlDivProps, 'className'>;
   /** Label text */
   labelText: string;
   /** Hide or show label. Label element is always present, but can be visually hidden.
@@ -129,7 +129,7 @@ class BaseSearchInput extends Component<SearchInputProps> {
       clearButtonLabel,
       searchButtonLabel,
       searchButtonProps,
-      inputContainerProps,
+      wrapperProps,
       onChange: propOnChange,
       onSearch: propOnSearch,
       children,
@@ -203,7 +203,7 @@ class BaseSearchInput extends Component<SearchInputProps> {
 
     return (
       <HtmlDiv
-        {...inputContainerProps}
+        {...wrapperProps}
         className={classnames(className, baseClassName, {
           [searchInputClassNames.error]: status === 'error',
           [searchInputClassNames.notEmpty]: !!this.state.value,

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`snapshot should have matching default structure 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -140,8 +140,8 @@ exports[`snapshot should have matching default structure 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -157,7 +157,7 @@ exports[`snapshot should have matching default structure 1`] = `
   overflow: hidden;
 }
 
-.c2.fi-label-text .fi-label-text_label-span {
+.c3.fi-label-text .fi-label-text_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -176,7 +176,7 @@ exports[`snapshot should have matching default structure 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c2.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -202,8 +202,13 @@ exports[`snapshot should have matching default structure 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  display: inline-block;
   width: 290px;
+}
+
+.c1 .fi-search-input_wrapper {
+  width: 100%;
+  min-width: 105px;
+  display: inline-block;
 }
 
 .c1 .fi-search-input_functionality-container {
@@ -460,82 +465,86 @@ exports[`snapshot should have matching default structure 1`] = `
 <div
   class="c0 c1 fi-search-input"
 >
-  <label
-    class="c0 c2 fi-label-text"
-    for="1"
+  <span
+    class="c2 fi-search-input_wrapper"
   >
-    <span
-      class="c3 fi-label-text_label-span"
+    <label
+      class="c0 c3 fi-label-text"
+      for="1"
     >
-      Test search input
-    </span>
-  </label>
-  <div
-    class="c0 fi-search-input_functionality-container"
-  >
+      <span
+        class="c2 fi-label-text_label-span"
+      >
+        Test search input
+      </span>
+    </label>
     <div
-      class="c0 fi-search-input_input-element-container"
+      class="c0 fi-search-input_functionality-container"
     >
-      <input
-        aria-invalid="false"
-        class="c4 fi-search-input_input"
-        data-testid="searchinput"
-        id="1"
-        role="searchbox"
-        type="search"
-        value=""
-      />
+      <div
+        class="c0 fi-search-input_input-element-container"
+      >
+        <input
+          aria-invalid="false"
+          class="c4 fi-search-input_input"
+          data-testid="searchinput"
+          id="1"
+          role="searchbox"
+          type="search"
+          value=""
+        />
+      </div>
+      <button
+        aria-hidden="true"
+        class="c5 fi-search-input_button fi-search-input_button-clear"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="c2 c6 fi-visually-hidden"
+        >
+          Clear
+        </span>
+        <svg
+          aria-hidden="true"
+          class="fi-icon c7 fi-search-input_button-clear-icon"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M12 13.45L4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45z"
+          />
+        </svg>
+      </button>
+      <button
+        aria-hidden="true"
+        class="c5 fi-search-input_button fi-search-input_button-search"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="c2 c6 fi-visually-hidden"
+        >
+          Search
+        </span>
+        <svg
+          aria-hidden="true"
+          class="fi-icon c7 fi-search-input_button-search-icon"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M9 2C5.14 2 2 5.141 2 9.001 2 12.86 5.14 16 9 16s7-3.14 7-6.999C16 5.141 12.86 2 9 2m7.029 12.615l7.678 7.678a.999.999 0 11-1.414 1.414l-7.678-7.678A8.957 8.957 0 019 18c-4.962 0-9-4.037-9-8.999C0 4.038 4.038 0 9 0s9 4.038 9 9.001a8.955 8.955 0 01-1.971 5.614z"
+          />
+        </svg>
+      </button>
     </div>
-    <button
-      aria-hidden="true"
-      class="c5 fi-search-input_button fi-search-input_button-clear"
-      tabindex="-1"
-      type="button"
-    >
-      <span
-        class="c3 c6 fi-visually-hidden"
-      >
-        Clear
-      </span>
-      <svg
-        aria-hidden="true"
-        class="fi-icon c7 fi-search-input_button-clear-icon"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="0 0 24 24"
-        width="1em"
-      >
-        <path
-          d="M12 13.45L4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45z"
-        />
-      </svg>
-    </button>
-    <button
-      aria-hidden="true"
-      class="c5 fi-search-input_button fi-search-input_button-search"
-      tabindex="-1"
-      type="button"
-    >
-      <span
-        class="c3 c6 fi-visually-hidden"
-      >
-        Search
-      </span>
-      <svg
-        aria-hidden="true"
-        class="fi-icon c7 fi-search-input_button-search-icon"
-        fill="currentColor"
-        focusable="false"
-        height="1em"
-        viewBox="0 0 24 24"
-        width="1em"
-      >
-        <path
-          d="M9 2C5.14 2 2 5.141 2 9.001 2 12.86 5.14 16 9 16s7-3.14 7-6.999C16 5.141 12.86 2 9 2m7.029 12.615l7.678 7.678a.999.999 0 11-1.414 1.414l-7.678-7.678A8.957 8.957 0 019 18c-4.962 0-9-4.037-9-8.999C0 4.038 4.038 0 9 0s9 4.038 9 9.001a8.955 8.955 0 01-1.971 5.614z"
-        />
-      </svg>
-    </button>
-  </div>
+  </span>
 </div>
 `;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -462,7 +462,7 @@ exports[`snapshot should have matching default structure 1`] = `
 >
   <label
     class="c0 c2 fi-label-text"
-    for="test-id"
+    for="1"
   >
     <span
       class="c3 fi-label-text_label-span"
@@ -480,7 +480,7 @@ exports[`snapshot should have matching default structure 1`] = `
         aria-invalid="false"
         class="c4 fi-search-input_input"
         data-testid="searchinput"
-        id="test-id"
+        id="1"
         role="searchbox"
         type="search"
         value=""


### PR DESCRIPTION
## Description
This PR adds AutoId for SearchInput and replaces the old uuid implementation. By doing so SSR support is improved and the id mismatch between server and client no longer happens.

In addition, this PR introduces an intermediate style wrapper so that it is now possible to add margin/display etc styles directly to SearchInput without breaking the component.

## Motivation and Context
SSR Should be fully supported to allow faster page loads and hydration on client side. Positioning the components should be possible without the danger of breaking the internal layout and styles and this can be achieved by adding an additional style wrapper inside the component.

## How Has This Been Tested?
Tested with Mac OS and VoiceOver using Firefox, Safari and Chrome and with Win10 and NVDA using Chrome, Firefox and Edge.

## Release notes
**SearchInput**
- Add better support for SSR by replacing uuid with AutoId
- Add support for styling SearchInput directly without breaking the component's internal layout
- Breaking change: rename inputContainerProps to wrapperProps