### PR TITLE
[BreakingChange] Text input AutoId, aria util and styling

### DIFF
--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -77,15 +77,17 @@ export const baseStyles = withSuomifiTheme(
     &.fi-text-input--error {
       & .fi-text-input_input {
         border: 2px solid ${theme.colors.alertBase};
-        height: 38px;
         padding-left: ${math(`${theme.spacing.insetL} - 1`)};
+        padding-top: 7px;
+        padding-bottom: 7px;
       }
     }
     &.fi-text-input--success {
       & .fi-text-input_input {
         border: 2px solid ${theme.colors.successBase};
-        height: 38px;
         padding-left: ${math(`${theme.spacing.insetL} - 1`)};
+        padding-top: 7px;
+        padding-bottom: 7px;
       }
     }
     &.fi-text-input--disabled {

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -81,7 +81,7 @@ export const baseStyles = withSuomifiTheme(
     &.fi-text-input--error {
       & .fi-text-input_input {
         border: 2px solid ${theme.colors.alertBase};
-        padding-left: ${math(`${theme.spacing.insetL} - 1`)};
+        padding-left: 9px;
         padding-top: 7px;
         padding-bottom: 7px;
       }
@@ -89,7 +89,7 @@ export const baseStyles = withSuomifiTheme(
     &.fi-text-input--success {
       & .fi-text-input_input {
         border: 2px solid ${theme.colors.successBase};
-        padding-left: ${math(`${theme.spacing.insetL} - 1`)};
+        padding-left: 9px;
         padding-top: 7px;
         padding-bottom: 7px;
       }

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -76,12 +76,16 @@ export const baseStyles = withSuomifiTheme(
 
     &.fi-text-input--error {
       & .fi-text-input_input {
-        border-color: ${theme.colors.alertBase};
+        border: 2px solid ${theme.colors.alertBase};
+        height: 38px;
+        padding-left: ${math(`${theme.spacing.insetL} - 1`)};
       }
     }
     &.fi-text-input--success {
       & .fi-text-input_input {
-        border-color: ${theme.colors.successBase};
+        border: 2px solid ${theme.colors.successBase};
+        height: 38px;
+        padding-left: ${math(`${theme.spacing.insetL} - 1`)};
       }
     }
     &.fi-text-input--disabled {

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -8,8 +8,12 @@ export const baseStyles = withSuomifiTheme(
   ({ theme }: TokensAndTheme) => css`
     &.fi-text-input {
       ${font({ theme })('bodyText')}
-      display: inline-block;
       width: 290px;
+    }
+
+    &_wrapper {
+      width: 100%;
+      display: inline-block;
     }
 
     & .fi-text-input_input-element-container {

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -75,7 +75,7 @@ import { TextInput, Button } from 'suomifi-ui-components';
 <>
   <TextInput
     labelText="Test TextInput with fixed custom width of 250px"
-    inputContainerProps={{ style: { width: '250px' } }}
+    wrapperProps={{ style: { width: '250px' } }}
   />
 
   <TextInput labelText="Test TextInput with 100% width" fullWidth />

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -16,7 +16,7 @@ import { HintText } from '../HintText/HintText';
 import classnames from 'classnames';
 import { Icon, IconProps, BaseIconKeys } from '../../Icon/Icon';
 import { Omit } from '../../../utils/typescript';
-import { idGenerator } from '../../../utils/uuid';
+import { AutoId } from '../../../utils/AutoId';
 import { Debounce } from '../../utils/Debounce/Debounce';
 
 const baseClassName = 'fi-text-input';
@@ -86,17 +86,14 @@ export interface TextInputProps
 }
 
 class BaseTextInput extends Component<TextInputProps> {
-  private id: string;
-
   private hintTextId: string;
 
   private statusTextId: string;
 
   constructor(props: TextInputProps) {
     super(props);
-    this.id = `${idGenerator(props.id)}`;
-    this.hintTextId = `${this.id}-hintText`;
-    this.statusTextId = `${this.id}-statusText`;
+    this.hintTextId = `${props.id}-hintText`;
+    this.statusTextId = `${props.id}-statusText`;
   }
 
   render() {
@@ -152,7 +149,7 @@ class BaseTextInput extends Component<TextInputProps> {
         })}
       >
         <LabelText
-          htmlFor={this.id}
+          htmlFor={id}
           labelMode={labelMode}
           as="label"
           optionalText={optionalText}
@@ -165,7 +162,7 @@ class BaseTextInput extends Component<TextInputProps> {
             {(debouncer: Function) => (
               <HtmlInput
                 {...passProps}
-                id={this.id}
+                id={id}
                 className={textInputClassNames.inputElement}
                 type={type}
                 placeholder={visualPlaceholder}
@@ -205,6 +202,11 @@ const StyledTextInput = styled(
  */
 export class TextInput extends Component<TextInputProps> {
   render() {
-    return <StyledTextInput {...withSuomifiDefaultProps(this.props)} />;
+    const { id: propId, ...passProps } = withSuomifiDefaultProps(this.props);
+    return (
+      <AutoId id={propId}>
+        {(id) => <StyledTextInput id={id} {...passProps} />}
+      </AutoId>
+    );
   }
 }

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -6,6 +6,7 @@ import {
   HtmlInputProps,
   HtmlDiv,
   HtmlDivProps,
+  HtmlSpan,
 } from '../../../reset';
 import { TokensProp, InternalTokensProp } from '../../theme';
 import { baseStyles } from './TextInput.baseStyles';
@@ -15,7 +16,6 @@ import { InputStatus } from '../types';
 import { HintText } from '../HintText/HintText';
 import classnames from 'classnames';
 import { Icon, IconProps, BaseIconKeys } from '../../Icon/Icon';
-import { Omit } from '../../../utils/typescript';
 import { AutoId } from '../../../utils/AutoId';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
@@ -30,6 +30,7 @@ export const textInputClassNames = {
   icon: `${baseClassName}_with-icon`,
   inputElementContainer: `${baseClassName}_input-element-container`,
   inputElement: `${baseClassName}_input`,
+  styleWrapper: `${baseClassName}_wrapper`,
 };
 
 type TextInputValue = string | number | undefined;
@@ -39,8 +40,8 @@ export interface TextInputProps
     TokensProp {
   /** TextInput container div class name for custom styling. */
   className?: string;
-  /** TextInput container div props */
-  inputContainerProps?: Omit<HtmlDivProps, 'className'>;
+  /** TextInput wrapping div element props */
+  wrapperProps?: Omit<HtmlDivProps, 'className'>;
   /** Disable input usage */
   disabled?: boolean;
   /** Event handler to execute when clicked */
@@ -103,7 +104,7 @@ class BaseTextInput extends Component<TextInputProps> {
       labelText,
       labelMode,
       onChange: propOnChange,
-      inputContainerProps,
+      wrapperProps,
       optionalText,
       status,
       statusText,
@@ -127,7 +128,7 @@ class BaseTextInput extends Component<TextInputProps> {
 
     return (
       <HtmlDiv
-        {...inputContainerProps}
+        {...wrapperProps}
         className={classnames(baseClassName, className, {
           [textInputClassNames.disabled]: !!passProps.disabled,
           [textInputClassNames.icon]: resolvedIcon !== undefined,
@@ -136,44 +137,46 @@ class BaseTextInput extends Component<TextInputProps> {
           [textInputClassNames.fullWidth]: fullWidth,
         })}
       >
-        <LabelText
-          htmlFor={id}
-          labelMode={labelMode}
-          as="label"
-          optionalText={optionalText}
-        >
-          {labelText}
-        </LabelText>
-        <HintText id={this.hintTextId}>{hintText}</HintText>
-        <HtmlDiv className={textInputClassNames.inputElementContainer}>
-          <Debounce waitFor={this.props.debounce}>
-            {(debouncer: Function) => (
-              <HtmlInput
-                {...passProps}
-                id={id}
-                className={textInputClassNames.inputElement}
-                type={type}
-                placeholder={visualPlaceholder}
-                {...{ 'aria-invalid': status === 'error' }}
-                {...getConditionalAriaProp('aria-describedby', [
-                  statusText ? this.statusTextId : undefined,
-                  hintText ? this.hintTextId : undefined,
-                  ariaDescribedBy,
-                ])}
-                onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                  if (propOnChange) {
-                    const eventValue = event.currentTarget.value;
-                    debouncer(propOnChange, eventValue);
-                  }
-                }}
-              />
-            )}
-          </Debounce>
-          {resolvedIcon && <Icon {...newIconProps} />}
-        </HtmlDiv>
-        <StatusText id={this.statusTextId} status={status}>
-          {statusText}
-        </StatusText>
+        <HtmlSpan className={textInputClassNames.styleWrapper}>
+          <LabelText
+            htmlFor={id}
+            labelMode={labelMode}
+            as="label"
+            optionalText={optionalText}
+          >
+            {labelText}
+          </LabelText>
+          <HintText id={this.hintTextId}>{hintText}</HintText>
+          <HtmlDiv className={textInputClassNames.inputElementContainer}>
+            <Debounce waitFor={this.props.debounce}>
+              {(debouncer: Function) => (
+                <HtmlInput
+                  {...passProps}
+                  id={id}
+                  className={textInputClassNames.inputElement}
+                  type={type}
+                  placeholder={visualPlaceholder}
+                  {...{ 'aria-invalid': status === 'error' }}
+                  {...getConditionalAriaProp('aria-describedby', [
+                    statusText ? this.statusTextId : undefined,
+                    hintText ? this.hintTextId : undefined,
+                    ariaDescribedBy,
+                  ])}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                    if (propOnChange) {
+                      const eventValue = event.currentTarget.value;
+                      debouncer(propOnChange, eventValue);
+                    }
+                  }}
+                />
+              )}
+            </Debounce>
+            {resolvedIcon && <Icon {...newIconProps} />}
+          </HtmlDiv>
+          <StatusText id={this.statusTextId} status={status}>
+            {statusText}
+          </StatusText>
+        </HtmlSpan>
       </HtmlDiv>
     );
   }

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -156,8 +156,8 @@ class BaseTextInput extends Component<TextInputProps> {
                 placeholder={visualPlaceholder}
                 {...{ 'aria-invalid': status === 'error' }}
                 {...getConditionalAriaProp('aria-describedby', [
-                  this.statusTextId,
-                  this.hintTextId,
+                  statusText ? this.statusTextId : undefined,
+                  hintText ? this.hintTextId : undefined,
                   ariaDescribedBy,
                 ])}
                 onChange={(event: ChangeEvent<HTMLInputElement>) => {

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -88,16 +88,6 @@ export interface TextInputProps
 }
 
 class BaseTextInput extends Component<TextInputProps> {
-  private hintTextId: string;
-
-  private statusTextId: string;
-
-  constructor(props: TextInputProps) {
-    super(props);
-    this.hintTextId = `${props.id}-hintText`;
-    this.statusTextId = `${props.id}-statusText`;
-  }
-
   render() {
     const {
       className,
@@ -119,12 +109,10 @@ class BaseTextInput extends Component<TextInputProps> {
       ...passProps
     } = this.props;
 
-    const resolvedIcon = icon || iconProps?.icon;
+    const resolvedIcon: BaseIconKeys = icon || iconProps?.icon;
 
-    const newIconProps = {
-      ...iconProps,
-      icon: resolvedIcon,
-    };
+    const hintTextId = `${id}-hintText`;
+    const statusTextId = `${id}-statusText`;
 
     return (
       <HtmlDiv
@@ -146,7 +134,7 @@ class BaseTextInput extends Component<TextInputProps> {
           >
             {labelText}
           </LabelText>
-          <HintText id={this.hintTextId}>{hintText}</HintText>
+          <HintText id={hintTextId}>{hintText}</HintText>
           <HtmlDiv className={textInputClassNames.inputElementContainer}>
             <Debounce waitFor={this.props.debounce}>
               {(debouncer: Function) => (
@@ -158,22 +146,21 @@ class BaseTextInput extends Component<TextInputProps> {
                   placeholder={visualPlaceholder}
                   {...{ 'aria-invalid': status === 'error' }}
                   {...getConditionalAriaProp('aria-describedby', [
-                    statusText ? this.statusTextId : undefined,
-                    hintText ? this.hintTextId : undefined,
+                    statusText ? statusTextId : undefined,
+                    hintText ? hintTextId : undefined,
                     ariaDescribedBy,
                   ])}
                   onChange={(event: ChangeEvent<HTMLInputElement>) => {
                     if (propOnChange) {
-                      const eventValue = event.currentTarget.value;
-                      debouncer(propOnChange, eventValue);
+                      debouncer(propOnChange, event.currentTarget.value);
                     }
                   }}
                 />
               )}
             </Debounce>
-            {resolvedIcon && <Icon {...newIconProps} />}
+            {resolvedIcon && <Icon {...{ iconProps, icon: resolvedIcon }} />}
           </HtmlDiv>
-          <StatusText id={this.statusTextId} status={status}>
+          <StatusText id={statusTextId} status={status}>
             {statusText}
           </StatusText>
         </HtmlSpan>

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -18,6 +18,7 @@ import { Icon, IconProps, BaseIconKeys } from '../../Icon/Icon';
 import { Omit } from '../../../utils/typescript';
 import { AutoId } from '../../../utils/AutoId';
 import { Debounce } from '../../utils/Debounce/Debounce';
+import { getConditionalAriaProp } from '../../../utils/aria';
 
 const baseClassName = 'fi-text-input';
 export const textInputClassNames = {
@@ -124,19 +125,6 @@ class BaseTextInput extends Component<TextInputProps> {
       icon: resolvedIcon,
     };
 
-    const getDescribedBy = () => {
-      if (statusText || hintText || ariaDescribedBy) {
-        return {
-          'aria-describedby': [
-            ...(statusText ? [this.statusTextId] : []),
-            ...(hintText ? [this.hintTextId] : []),
-            ...(ariaDescribedBy ? [ariaDescribedBy] : []),
-          ].join(' '),
-        };
-      }
-      return {};
-    };
-
     return (
       <HtmlDiv
         {...inputContainerProps}
@@ -167,7 +155,11 @@ class BaseTextInput extends Component<TextInputProps> {
                 type={type}
                 placeholder={visualPlaceholder}
                 {...{ 'aria-invalid': status === 'error' }}
-                {...getDescribedBy()}
+                {...getConditionalAriaProp('aria-describedby', [
+                  this.statusTextId,
+                  this.hintTextId,
+                  ariaDescribedBy,
+                ])}
                 onChange={(event: ChangeEvent<HTMLInputElement>) => {
                   if (propOnChange) {
                     const eventValue = event.currentTarget.value;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -277,11 +277,17 @@ exports[`snapshots match error status with statustext 1`] = `
 }
 
 .c1.fi-text-input--error .fi-text-input_input {
-  border-color: hsl(3,59%,48%);
+  border: 2px solid hsl(3,59%,48%);
+  padding-left: 9px;
+  padding-top: 7px;
+  padding-bottom: 7px;
 }
 
 .c1.fi-text-input--success .fi-text-input_input {
-  border-color: hsl(166,90%,34%);
+  border: 2px solid hsl(166,90%,34%);
+  padding-left: 9px;
+  padding-top: 7px;
+  padding-bottom: 7px;
 }
 
 .c1.fi-text-input--disabled .fi-text-input_input {
@@ -593,11 +599,17 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 }
 
 .c1.fi-text-input--error .fi-text-input_input {
-  border-color: hsl(3,59%,48%);
+  border: 2px solid hsl(3,59%,48%);
+  padding-left: 9px;
+  padding-top: 7px;
+  padding-bottom: 7px;
 }
 
 .c1.fi-text-input--success .fi-text-input_input {
-  border-color: hsl(166,90%,34%);
+  border: 2px solid hsl(166,90%,34%);
+  padding-left: 9px;
+  padding-top: 7px;
+  padding-bottom: 7px;
 }
 
 .c1.fi-text-input--disabled .fi-text-input_input {
@@ -890,11 +902,17 @@ exports[`snapshots match minimal implementation 1`] = `
 }
 
 .c1.fi-text-input--error .fi-text-input_input {
-  border-color: hsl(3,59%,48%);
+  border: 2px solid hsl(3,59%,48%);
+  padding-left: 9px;
+  padding-top: 7px;
+  padding-bottom: 7px;
 }
 
 .c1.fi-text-input--success .fi-text-input_input {
-  border-color: hsl(166,90%,34%);
+  border: 2px solid hsl(166,90%,34%);
+  padding-left: 9px;
+  padding-top: 7px;
+  padding-bottom: 7px;
 }
 
 .c1.fi-text-input--disabled .fi-text-input_input {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`snapshots match error status with statustext 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -87,12 +87,12 @@ exports[`snapshots match error status with statustext 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
-.c2.fi-label-text .fi-label-text_label-span {
+.c3.fi-label-text .fi-label-text_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -111,7 +111,7 @@ exports[`snapshots match error status with statustext 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c2.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -156,8 +156,12 @@ exports[`snapshots match error status with statustext 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  display: inline-block;
   width: 290px;
+}
+
+.c1_wrapper {
+  width: 100%;
+  display: inline-block;
 }
 
 .c1 .fi-text-input_input-element-container > input:focus {
@@ -302,34 +306,38 @@ exports[`snapshots match error status with statustext 1`] = `
 <div
   class="c0 fi-text-input c1 fi-text-input--error"
 >
-  <label
-    class="c0 c2 fi-label-text"
-    for="test-id2"
-  >
-    <span
-      class="c3 fi-label-text_label-span"
-    >
-      Test input
-    </span>
-  </label>
-  <div
-    class="c0 fi-text-input_input-element-container"
-  >
-    <input
-      aria-describedby="test-id2-statusText"
-      aria-invalid="true"
-      class="c4 fi-text-input_input"
-      data-testid="textinput2"
-      id="test-id2"
-      placeholder="Test TextInput"
-      type="text"
-    />
-  </div>
   <span
-    class="c3 c5 fi-status-text fi-status-text--error"
-    id="test-id2-statusText"
+    class="c2 fi-text-input_wrapper"
   >
-    This is a status text
+    <label
+      class="c0 c3 fi-label-text"
+      for="test-id2"
+    >
+      <span
+        class="c2 fi-label-text_label-span"
+      >
+        Test input
+      </span>
+    </label>
+    <div
+      class="c0 fi-text-input_input-element-container"
+    >
+      <input
+        aria-describedby="test-id2-statusText"
+        aria-invalid="true"
+        class="c4 fi-text-input_input"
+        data-testid="textinput2"
+        id="test-id2"
+        placeholder="Test TextInput"
+        type="text"
+      />
+    </div>
+    <span
+      class="c2 c5 fi-status-text fi-status-text--error"
+      id="test-id2-statusText"
+    >
+      This is a status text
+    </span>
   </span>
 </div>
 `;
@@ -397,7 +405,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -421,8 +429,8 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -438,7 +446,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   overflow: hidden;
 }
 
-.c2.fi-label-text .fi-label-text_label-span {
+.c3.fi-label-text .fi-label-text_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -457,7 +465,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c2.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -478,8 +486,12 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  display: inline-block;
   width: 290px;
+}
+
+.c1_wrapper {
+  width: 100%;
+  display: inline-block;
 }
 
 .c1 .fi-text-input_input-element-container > input:focus {
@@ -624,28 +636,32 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 <div
   class="c0 fi-text-input c1"
 >
-  <label
-    class="c0 c2 fi-label-text"
-    for="test-id1"
+  <span
+    class="c2 fi-text-input_wrapper"
   >
-    <span
-      class="c3 c4 fi-visually-hidden"
+    <label
+      class="c0 c3 fi-label-text"
+      for="test-id1"
     >
-      Test input
-    </span>
-  </label>
-  <div
-    class="c0 fi-text-input_input-element-container"
-  >
-    <input
-      aria-invalid="false"
-      class="c5 fi-text-input_input"
-      data-testid="textinput1"
-      id="test-id1"
-      placeholder="Test TextInput"
-      type="text"
-    />
-  </div>
+      <span
+        class="c2 c4 fi-visually-hidden"
+      >
+        Test input
+      </span>
+    </label>
+    <div
+      class="c0 fi-text-input_input-element-container"
+    >
+      <input
+        aria-invalid="false"
+        class="c5 fi-text-input_input"
+        data-testid="textinput1"
+        id="test-id1"
+        placeholder="Test TextInput"
+        type="text"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -712,7 +728,7 @@ exports[`snapshots match minimal implementation 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -736,12 +752,12 @@ exports[`snapshots match minimal implementation 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
-.c2.fi-label-text .fi-label-text_label-span {
+.c3.fi-label-text .fi-label-text_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -760,7 +776,7 @@ exports[`snapshots match minimal implementation 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c2.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -781,8 +797,12 @@ exports[`snapshots match minimal implementation 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  display: inline-block;
   width: 290px;
+}
+
+.c1_wrapper {
+  width: 100%;
+  display: inline-block;
 }
 
 .c1 .fi-text-input_input-element-container > input:focus {
@@ -927,26 +947,30 @@ exports[`snapshots match minimal implementation 1`] = `
 <div
   class="c0 fi-text-input c1"
 >
-  <label
-    class="c0 c2 fi-label-text"
-    for="test-id"
+  <span
+    class="c2 fi-text-input_wrapper"
   >
-    <span
-      class="c3 fi-label-text_label-span"
+    <label
+      class="c0 c3 fi-label-text"
+      for="test-id"
     >
-      Test input
-    </span>
-  </label>
-  <div
-    class="c0 fi-text-input_input-element-container"
-  >
-    <input
-      aria-invalid="false"
-      class="c4 fi-text-input_input"
-      data-testid="textinput"
-      id="test-id"
-      type="text"
-    />
-  </div>
+      <span
+        class="c2 fi-label-text_label-span"
+      >
+        Test input
+      </span>
+    </label>
+    <div
+      class="c0 fi-text-input_input-element-container"
+    >
+      <input
+        aria-invalid="false"
+        class="c4 fi-text-input_input"
+        data-testid="textinput"
+        id="test-id"
+        type="text"
+      />
+    </div>
+  </span>
 </div>
 `;


### PR DESCRIPTION
## Description
This PR implements AutoId, aria util, style wrapper and fixes non-neutral status border width. 

## Motivation and Context
Style wrapper safeguards against alignment issues and ensures the integrity of the component. AutoId helps with server side rendering by ensuring the ID on the server and client side match. Internal aria util ensures the conditional aria props are put in place in a clean manner. Border was previously 1px wide for all states, but in designs it is 2px for the error and success statuses. 

## How Has This Been Tested?
Tested by running in styleguidist and by automated tests.

## Release notes
Text Input
* **Breaking change**: inputContainerProps renamed to wrapperProps
* Error and success status border width now 2px
