### PR TITLE
[Bugfix] Add missing spread operator to TextInput icon props

### DIFF
--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -158,7 +158,7 @@ class BaseTextInput extends Component<TextInputProps> {
                 />
               )}
             </Debounce>
-            {resolvedIcon && <Icon {...{ iconProps, icon: resolvedIcon }} />}
+            {resolvedIcon && <Icon {...{ ...iconProps, icon: resolvedIcon }} />}
           </HtmlDiv>
           <StatusText id={statusTextId} status={status}>
             {statusText}


### PR DESCRIPTION
## Description
This PR addresses an issue where a missing spread operator caused icon props not to be conveyed to the icon component within a TextInput correctly.

## Motivation and Context
This bug was found after merging recent changes to the TextInput component. It's an easy fix, so it was decided to fix it asap.

## How Has This Been Tested?
Tested in styleguidist in chrome

## Release notes
#### Text Input
* Fixed a recent bug that caused icon props to not work correctly
