### PR TITLE
Fix SSR issue with AutoId.

### DIFF
--- a/src/utils/AutoId.tsx
+++ b/src/utils/AutoId.tsx
@@ -44,5 +44,5 @@ export const AutoId = ({
   children: (passedId: string) => JSX.Element;
 }) => {
   const generatedId = useGeneratedId(id);
-  return generatedId ? children(generatedId) : null;
+  return children(!!generatedId ? generatedId : '');
 };


### PR DESCRIPTION
## Description
This PR fixes AutoId issues with Server Side Rendering. Current implementation returns no children wrapped in AutoId when rendering in server for dehydrate/rehydrate. Desired behaviour would be to render the DOM in server, as closely to what is rendered in client, as possible. In this case, ids should be empty when rendered on server and patched in place with hooks on client. Current behaviour does not break anything, but may cause additional renders on client.

## Motivation and Context
To enable efficient rendering and utilisation of SSR, rendered DOM's should match between server and client, with the exception of portals and and content that has to be positioned based on rendered content.

## How Has This Been Tested?
Tested with Styleguidist, Create React App TypeScript project and SSR test project on Mac OS and Chrome. Also DOM contents were manually inspected after the change.

## Release notes
- Fix AutoId SSR issue and return children always, also on server but with empty string as id.