### PR TITLE
[Feature] Button secondary noborder styles and button link variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "polished": "4.0.5",
     "react-popper": "2.2.4",
     "react-svg": "11.2.1",
-    "suomifi-design-tokens": "^3.0.0",
+    "suomifi-design-tokens": "3.1.0",
     "suomifi-icons": "^2.0.0",
     "uuid": "8.3.2"
   },

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -75,15 +75,23 @@ const linkStyles = css`
   &.fi-button--link {
     color: ${theme.colors.highlightBase};
     ${secondary}
-    background: ${theme.gradients.highlightLight3ToHighlightLight2};
+    background: ${theme.gradients.depthSecondaryToDepthSecondaryDark1};
     border: none;
 
     &:hover {
-      background: ${theme.colors.highlightLight3};
+      background: ${theme.gradients.highlightLight4ToDepthSecondary};
     }
 
     &:active {
       background: ${theme.gradients.depthLight3ToDepthLight2};
+    }
+
+    &.fi-button--disabled,
+    &[disabled],
+    &:disabled {
+      color: ${theme.colors.depthBase};
+      background: none;
+      background-color: ${theme.colors.depthLight3};
     }
   }
 `;

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -64,7 +64,7 @@ const secondaryStyles = css`
 `;
 
 const secondaryNoBorderStyles = css`
-  &.fi-button--secondaryNoBorder {
+  &.fi-button--secondary-noborder {
     ${secondary}
     border: none;
     background-color: transparent;

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -64,7 +64,7 @@ const secondaryStyles = css`
 `;
 
 const secondaryNoBorderStyles = css`
-  &.fi-button--secondary-noborder {
+  &.fi-button--secondaryNoBorder {
     ${secondary}
     border: none;
     background-color: transparent;

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -67,11 +67,13 @@ const secondaryNoBorderStyles = css`
   &.fi-button--secondary-noborder {
     ${secondary}
     border: none;
+    background-color: transparent;
   }
 `;
 
-const tertiaryStyles = css`
-  &.fi-button--tertiary {
+const linkStyles = css`
+  &.fi-button--link {
+    color: ${theme.colors.highlightBase};
     ${secondary}
     background: ${theme.gradients.highlightLight3ToHighlightLight2};
     border: none;
@@ -136,7 +138,7 @@ export const baseStyles = css`
   ${invertedStyles}
   ${secondaryStyles}
   ${secondaryNoBorderStyles}
-  ${tertiaryStyles}
+  ${linkStyles}
 
   & > .fi-button_icon {
     width: 16px;

--- a/src/core/Button/Button.md
+++ b/src/core/Button/Button.md
@@ -87,6 +87,7 @@ import { Button } from 'suomifi-ui-components';
   <Button variant="secondary" disabled fullWidth icon="login">
     Secondary Button disabled fullWidth icon="login"
   </Button>
+
   <Button variant="secondaryNoBorder">
     Borderless secondary Button
   </Button>

--- a/src/core/Button/Button.md
+++ b/src/core/Button/Button.md
@@ -87,16 +87,15 @@ import { Button } from 'suomifi-ui-components';
   <Button variant="secondary" disabled fullWidth icon="login">
     Secondary Button disabled fullWidth icon="login"
   </Button>
-
-  <Button variant="secondaryNoborder">
+  <Button variant="secondary-noborder">
     Borderless secondary Button
   </Button>
 
-  <Button variant="secondaryNoborder" icon="login">
+  <Button variant="secondary-noborder" icon="login">
     Borderless secondary Button icon="login"
   </Button>
 
-  <Button variant="secondaryNoborder" disabled icon="login">
+  <Button variant="secondary-noborder" disabled icon="login">
     Borderless secondary Button disabled icon="login"
   </Button>
 </>;
@@ -106,10 +105,10 @@ import { Button } from 'suomifi-ui-components';
 import { Button } from 'suomifi-ui-components';
 
 <>
-  <Button variant="tertiary">Tertiary Button</Button>
+  <Button variant="link">Link Button</Button>
 
-  <Button variant="tertiary" disabled icon="login">
-    Tertiary Button disabled icon="login"
+  <Button variant="link" disabled icon="login">
+    Link Button disabled icon="login"
   </Button>
 </>;
 ```

--- a/src/core/Button/Button.md
+++ b/src/core/Button/Button.md
@@ -87,15 +87,15 @@ import { Button } from 'suomifi-ui-components';
   <Button variant="secondary" disabled fullWidth icon="login">
     Secondary Button disabled fullWidth icon="login"
   </Button>
-  <Button variant="secondary-noborder">
+  <Button variant="secondaryNoBorder">
     Borderless secondary Button
   </Button>
 
-  <Button variant="secondary-noborder" icon="login">
+  <Button variant="secondaryNoBorder" icon="login">
     Borderless secondary Button icon="login"
   </Button>
 
-  <Button variant="secondary-noborder" disabled icon="login">
+  <Button variant="secondaryNoBorder" disabled icon="login">
     Borderless secondary Button disabled icon="login"
   </Button>
 </>;

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -67,9 +67,9 @@ describe('Button variant', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('secondary-noborder should match snapshot', () => {
+  it('secondaryNoBorder should match snapshot', () => {
     const { container } = render(
-      <Button variant="secondary-noborder">Secondary-noborder button</Button>,
+      <Button variant="secondaryNoBorder">secondaryNoBorder button</Button>,
     );
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -74,10 +74,8 @@ describe('Button variant', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('tertiary match snapshot', () => {
-    const { container } = render(
-      <Button variant="tertiary">Tertiary button</Button>,
-    );
+  it('link match snapshot', () => {
+    const { container } = render(<Button variant="link">Link button</Button>);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -145,8 +145,6 @@ const StyledButton = styled(
 /**
  * <i class="semantics" />
  * Use for inside Application onClick events.<br />
- * When using Button secondaryNoborder variant with other than white background,<br />
- * define styles background color for all needed states (:hover, :active, :disabled)<br /><br />
  */
 export const Button = forwardRef(
   (props: ButtonProps, ref: React.RefObject<HTMLButtonElement>) => (

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -10,12 +10,12 @@ type ButtonVariant =
   | 'inverted'
   | 'secondary'
   | 'secondary-noborder'
-  | 'tertiary';
+  | 'link';
 
 interface InternalButtonProps
   extends Omit<HtmlButtonProps, 'aria-disabled' | 'onClick'> {
   /**
-   * 'default' | 'inverted' | 'secondary' | 'secondary-noborder' | 'tertiary'
+   * 'default' | 'inverted' | 'secondary' | 'secondary-noborder' | 'link'
    * @default default
    */
   variant?: ButtonVariant;

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -9,13 +9,13 @@ type ButtonVariant =
   | 'default'
   | 'inverted'
   | 'secondary'
-  | 'secondary-noborder'
+  | 'secondaryNoBorder'
   | 'link';
 
 interface InternalButtonProps
   extends Omit<HtmlButtonProps, 'aria-disabled' | 'onClick'> {
   /**
-   * 'default' | 'inverted' | 'secondary' | 'secondary-noborder' | 'link'
+   * 'default' | 'inverted' | 'secondary' | 'secondaryNoBorder' | 'link'
    * @default default
    */
   variant?: ButtonVariant;

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -101,7 +101,11 @@ class BaseButton extends Component<ButtonProps & InnerRef> {
           disabled={!!disabled}
           className={classnames(baseClassName, className, {
             [disabledClassName]: !!disabled || !!ariaDisabled,
-            [`${baseClassName}--${variant}`]: variant !== 'default',
+            [`${baseClassName}--inverted`]: variant === 'inverted',
+            [`${baseClassName}--secondary`]: variant === 'secondary',
+            [`${baseClassName}--secondary-noborder`]:
+              variant === 'secondaryNoBorder',
+            [`${baseClassName}--link`]: variant === 'link',
             [fullWidthClassName]: fullWidth,
           })}
         >

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`Button variant default should match snapshot 1`] = `
 }
 
 .c1.fi-button--secondary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary:active {
@@ -190,10 +190,11 @@ exports[`Button variant default should match snapshot 1`] = `
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
   border: none;
+  background-color: transparent;
 }
 
 .c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary-noborder:active {
@@ -211,28 +212,29 @@ exports[`Button variant default should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--tertiary {
+.c1.fi-button--link {
+  color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
-  background: linear-gradient(0deg,hsl(212,63%,90%),hsl(212,63%,95%));
+  background: linear-gradient(0deg,hsl(215,100%,97%),hsl(215,100%,95%));
   border: none;
 }
 
-.c1.fi-button--tertiary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+.c1.fi-button--link:hover {
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--tertiary:active {
+.c1.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--tertiary.fi-button--disabled,
-.c1.fi-button--tertiary[disabled],
-.c1.fi-button--tertiary:disabled {
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -240,12 +242,20 @@ exports[`Button variant default should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--tertiary:hover {
-  background: hsl(212,63%,95%);
+.c1.fi-button--link:hover {
+  background: linear-gradient(0deg,hsl(212,63%,98%),hsl(215,100%,97%));
 }
 
-.c1.fi-button--tertiary:active {
+.c1.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
+}
+
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
+  color: hsl(202,7%,67%);
+  background: none;
+  background-color: hsl(202,7%,97%);
 }
 
 .c1 > .fi-button_icon {
@@ -442,7 +452,7 @@ exports[`Button variant inverted should match snapshot 1`] = `
 }
 
 .c1.fi-button--secondary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary:active {
@@ -467,10 +477,11 @@ exports[`Button variant inverted should match snapshot 1`] = `
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
   border: none;
+  background-color: transparent;
 }
 
 .c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary-noborder:active {
@@ -488,28 +499,29 @@ exports[`Button variant inverted should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--tertiary {
+.c1.fi-button--link {
+  color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
-  background: linear-gradient(0deg,hsl(212,63%,90%),hsl(212,63%,95%));
+  background: linear-gradient(0deg,hsl(215,100%,97%),hsl(215,100%,95%));
   border: none;
 }
 
-.c1.fi-button--tertiary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+.c1.fi-button--link:hover {
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--tertiary:active {
+.c1.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--tertiary.fi-button--disabled,
-.c1.fi-button--tertiary[disabled],
-.c1.fi-button--tertiary:disabled {
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -517,12 +529,20 @@ exports[`Button variant inverted should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--tertiary:hover {
-  background: hsl(212,63%,95%);
+.c1.fi-button--link:hover {
+  background: linear-gradient(0deg,hsl(212,63%,98%),hsl(215,100%,97%));
 }
 
-.c1.fi-button--tertiary:active {
+.c1.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
+}
+
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
+  color: hsl(202,7%,67%);
+  background: none;
+  background-color: hsl(202,7%,97%);
 }
 
 .c1 > .fi-button_icon {
@@ -551,6 +571,293 @@ exports[`Button variant inverted should match snapshot 1`] = `
   type="button"
 >
   Inverted button
+</button>
+`;
+
+exports[`Button variant link match snapshot 1`] = `
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+  cursor: pointer;
+}
+
+.c0:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c0::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c0::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c0::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c0::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c1 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 10px 20px;
+  min-height: 40px;
+  color: hsl(0,0%,100%);
+  background: linear-gradient(0deg,hsl(212,63%,37%) 0%,hsl(212,63%,45%) 100%);
+  border-radius: 2px;
+  text-align: center;
+  text-shadow: 0 1px 1px rgba(0,53,122,0.5);
+  cursor: pointer;
+}
+
+.c1:focus {
+  outline: none;
+  position: relative;
+}
+
+.c1:focus::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+.c1:hover {
+  background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+}
+
+.c1:active {
+  background: hsl(212,63%,37%);
+}
+
+.c1.fi-button--disabled,
+.c1[disabled],
+.c1:disabled {
+  text-shadow: 0 1px 1px rgba(41,41,41,0.5);
+  background: linear-gradient(0deg,hsl(202,7%,67%) 0%,hsl(202,7%,80%) 100%);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  cursor: not-allowed;
+}
+
+.c1.fi-button--disabled::after {
+  border: none;
+  box-shadow: none;
+}
+
+.c1.fi-button--fullwidth {
+  display: block;
+  width: 100%;
+}
+
+.c1.fi-button--inverted {
+  background: none;
+  background-color: hsl(212,63%,45%);
+  border: 1px solid hsl(0,0%,100%);
+  text-shadow: none;
+}
+
+.c1.fi-button--inverted:hover {
+  background: linear-gradient(-180deg,rgba(255,255,255,0.1) 0%,rgba(255,255,255,0) 100%);
+}
+
+.c1.fi-button--inverted:active {
+  background: none;
+  background-color: hsl(212,63%,45%);
+}
+
+.c1.fi-button--inverted.fi-button--disabled,
+.c1.fi-button--inverted[disabled],
+.c1.fi-button--inverted:disabled {
+  opacity: 0.41;
+  background: none;
+  background-color: none;
+}
+
+.c1.fi-button--secondary {
+  color: hsl(212,63%,45%);
+  background: none;
+  background-color: hsl(0,0%,100%);
+  border: 1px solid hsl(212,63%,45%);
+  text-shadow: none;
+}
+
+.c1.fi-button--secondary:hover {
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+}
+
+.c1.fi-button--secondary:active {
+  background: none;
+  background-color: hsl(202,7%,93%);
+}
+
+.c1.fi-button--secondary.fi-button--disabled,
+.c1.fi-button--secondary[disabled],
+.c1.fi-button--secondary:disabled {
+  color: hsl(202,7%,67%);
+  text-shadow: none;
+  background: none;
+  background-color: hsl(212,63%,98%);
+  border-color: hsl(202,7%,67%);
+}
+
+.c1.fi-button--secondary-noborder {
+  color: hsl(212,63%,45%);
+  background: none;
+  background-color: hsl(0,0%,100%);
+  border: 1px solid hsl(212,63%,45%);
+  text-shadow: none;
+  border: none;
+  background-color: transparent;
+}
+
+.c1.fi-button--secondary-noborder:hover {
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+}
+
+.c1.fi-button--secondary-noborder:active {
+  background: none;
+  background-color: hsl(202,7%,93%);
+}
+
+.c1.fi-button--secondary-noborder.fi-button--disabled,
+.c1.fi-button--secondary-noborder[disabled],
+.c1.fi-button--secondary-noborder:disabled {
+  color: hsl(202,7%,67%);
+  text-shadow: none;
+  background: none;
+  background-color: hsl(212,63%,98%);
+  border-color: hsl(202,7%,67%);
+}
+
+.c1.fi-button--link {
+  color: hsl(212,63%,45%);
+  color: hsl(212,63%,45%);
+  background: none;
+  background-color: hsl(0,0%,100%);
+  border: 1px solid hsl(212,63%,45%);
+  text-shadow: none;
+  background: linear-gradient(0deg,hsl(215,100%,97%),hsl(215,100%,95%));
+  border: none;
+}
+
+.c1.fi-button--link:hover {
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+}
+
+.c1.fi-button--link:active {
+  background: none;
+  background-color: hsl(202,7%,93%);
+}
+
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
+  color: hsl(202,7%,67%);
+  text-shadow: none;
+  background: none;
+  background-color: hsl(212,63%,98%);
+  border-color: hsl(202,7%,67%);
+}
+
+.c1.fi-button--link:hover {
+  background: linear-gradient(0deg,hsl(212,63%,98%),hsl(215,100%,97%));
+}
+
+.c1.fi-button--link:active {
+  background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
+}
+
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
+  color: hsl(202,7%,67%);
+  background: none;
+  background-color: hsl(202,7%,97%);
+}
+
+.c1 > .fi-button_icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+}
+
+.c1 > .fi-button_icon.fi-button_icon--right {
+  margin-right: 0;
+  margin-left: 8px;
+}
+
+.c1.fi-button--disabled > .fi-button_icon {
+  cursor: not-allowed;
+}
+
+<button
+  aria-disabled="false"
+  class="c0 fi-button c1 fi-button--link"
+  tabindex="0"
+  type="button"
+>
+  Link button
 </button>
 `;
 
@@ -719,7 +1026,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
 }
 
 .c1.fi-button--secondary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary:active {
@@ -744,10 +1051,11 @@ exports[`Button variant secondary should match snapshot 1`] = `
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
   border: none;
+  background-color: transparent;
 }
 
 .c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary-noborder:active {
@@ -765,28 +1073,29 @@ exports[`Button variant secondary should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--tertiary {
+.c1.fi-button--link {
+  color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
-  background: linear-gradient(0deg,hsl(212,63%,90%),hsl(212,63%,95%));
+  background: linear-gradient(0deg,hsl(215,100%,97%),hsl(215,100%,95%));
   border: none;
 }
 
-.c1.fi-button--tertiary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+.c1.fi-button--link:hover {
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--tertiary:active {
+.c1.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--tertiary.fi-button--disabled,
-.c1.fi-button--tertiary[disabled],
-.c1.fi-button--tertiary:disabled {
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -794,12 +1103,20 @@ exports[`Button variant secondary should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--tertiary:hover {
-  background: hsl(212,63%,95%);
+.c1.fi-button--link:hover {
+  background: linear-gradient(0deg,hsl(212,63%,98%),hsl(215,100%,97%));
 }
 
-.c1.fi-button--tertiary:active {
+.c1.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
+}
+
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
+  color: hsl(202,7%,67%);
+  background: none;
+  background-color: hsl(202,7%,97%);
 }
 
 .c1 > .fi-button_icon {
@@ -996,7 +1313,7 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
 }
 
 .c1.fi-button--secondary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary:active {
@@ -1021,10 +1338,11 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
   border: none;
+  background-color: transparent;
 }
 
 .c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary-noborder:active {
@@ -1042,28 +1360,29 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--tertiary {
+.c1.fi-button--link {
+  color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
-  background: linear-gradient(0deg,hsl(212,63%,90%),hsl(212,63%,95%));
+  background: linear-gradient(0deg,hsl(215,100%,97%),hsl(215,100%,95%));
   border: none;
 }
 
-.c1.fi-button--tertiary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+.c1.fi-button--link:hover {
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--tertiary:active {
+.c1.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--tertiary.fi-button--disabled,
-.c1.fi-button--tertiary[disabled],
-.c1.fi-button--tertiary:disabled {
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1071,12 +1390,20 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--tertiary:hover {
-  background: hsl(212,63%,95%);
+.c1.fi-button--link:hover {
+  background: linear-gradient(0deg,hsl(212,63%,98%),hsl(215,100%,97%));
 }
 
-.c1.fi-button--tertiary:active {
+.c1.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
+}
+
+.c1.fi-button--link.fi-button--disabled,
+.c1.fi-button--link[disabled],
+.c1.fi-button--link:disabled {
+  color: hsl(202,7%,67%);
+  background: none;
+  background-color: hsl(202,7%,97%);
 }
 
 .c1 > .fi-button_icon {
@@ -1105,282 +1432,5 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
   type="button"
 >
   Secondary-noborder button
-</button>
-`;
-
-exports[`Button variant tertiary match snapshot 1`] = `
-.c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  overflow: visible;
-  text-transform: none;
-  -webkit-appearance: button;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline-block;
-  max-width: 100%;
-  cursor: pointer;
-}
-
-.c0:-moz-focusring {
-  outline: 1px dotted ButtonText;
-}
-
-.c0::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-
-.c0::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  font: inherit;
-}
-
-.c0::-webkit-inner-spin-button {
-  height: auto;
-}
-
-.c0::-webkit-outer-spin-button {
-  height: auto;
-}
-
-.c0::before,
-.c0::after {
-  box-sizing: border-box;
-}
-
-.c1 {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 20px;
-  padding: 10px 20px;
-  min-height: 40px;
-  color: hsl(0,0%,100%);
-  background: linear-gradient(0deg,hsl(212,63%,37%) 0%,hsl(212,63%,45%) 100%);
-  border-radius: 2px;
-  text-align: center;
-  text-shadow: 0 1px 1px rgba(0,53,122,0.5);
-  cursor: pointer;
-}
-
-.c1:focus {
-  outline: none;
-  position: relative;
-}
-
-.c1:focus::after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
-}
-
-.c1:hover {
-  background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
-}
-
-.c1:active {
-  background: hsl(212,63%,37%);
-}
-
-.c1.fi-button--disabled,
-.c1[disabled],
-.c1:disabled {
-  text-shadow: 0 1px 1px rgba(41,41,41,0.5);
-  background: linear-gradient(0deg,hsl(202,7%,67%) 0%,hsl(202,7%,80%) 100%);
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  cursor: not-allowed;
-}
-
-.c1.fi-button--disabled::after {
-  border: none;
-  box-shadow: none;
-}
-
-.c1.fi-button--fullwidth {
-  display: block;
-  width: 100%;
-}
-
-.c1.fi-button--inverted {
-  background: none;
-  background-color: hsl(212,63%,45%);
-  border: 1px solid hsl(0,0%,100%);
-  text-shadow: none;
-}
-
-.c1.fi-button--inverted:hover {
-  background: linear-gradient(-180deg,rgba(255,255,255,0.1) 0%,rgba(255,255,255,0) 100%);
-}
-
-.c1.fi-button--inverted:active {
-  background: none;
-  background-color: hsl(212,63%,45%);
-}
-
-.c1.fi-button--inverted.fi-button--disabled,
-.c1.fi-button--inverted[disabled],
-.c1.fi-button--inverted:disabled {
-  opacity: 0.41;
-  background: none;
-  background-color: none;
-}
-
-.c1.fi-button--secondary {
-  color: hsl(212,63%,45%);
-  background: none;
-  background-color: hsl(0,0%,100%);
-  border: 1px solid hsl(212,63%,45%);
-  text-shadow: none;
-}
-
-.c1.fi-button--secondary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
-}
-
-.c1.fi-button--secondary:active {
-  background: none;
-  background-color: hsl(202,7%,93%);
-}
-
-.c1.fi-button--secondary.fi-button--disabled,
-.c1.fi-button--secondary[disabled],
-.c1.fi-button--secondary:disabled {
-  color: hsl(202,7%,67%);
-  text-shadow: none;
-  background: none;
-  background-color: hsl(212,63%,98%);
-  border-color: hsl(202,7%,67%);
-}
-
-.c1.fi-button--secondary-noborder {
-  color: hsl(212,63%,45%);
-  background: none;
-  background-color: hsl(0,0%,100%);
-  border: 1px solid hsl(212,63%,45%);
-  text-shadow: none;
-  border: none;
-}
-
-.c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
-}
-
-.c1.fi-button--secondary-noborder:active {
-  background: none;
-  background-color: hsl(202,7%,93%);
-}
-
-.c1.fi-button--secondary-noborder.fi-button--disabled,
-.c1.fi-button--secondary-noborder[disabled],
-.c1.fi-button--secondary-noborder:disabled {
-  color: hsl(202,7%,67%);
-  text-shadow: none;
-  background: none;
-  background-color: hsl(212,63%,98%);
-  border-color: hsl(202,7%,67%);
-}
-
-.c1.fi-button--tertiary {
-  color: hsl(212,63%,45%);
-  background: none;
-  background-color: hsl(0,0%,100%);
-  border: 1px solid hsl(212,63%,45%);
-  text-shadow: none;
-  background: linear-gradient(0deg,hsl(212,63%,90%),hsl(212,63%,95%));
-  border: none;
-}
-
-.c1.fi-button--tertiary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
-}
-
-.c1.fi-button--tertiary:active {
-  background: none;
-  background-color: hsl(202,7%,93%);
-}
-
-.c1.fi-button--tertiary.fi-button--disabled,
-.c1.fi-button--tertiary[disabled],
-.c1.fi-button--tertiary:disabled {
-  color: hsl(202,7%,67%);
-  text-shadow: none;
-  background: none;
-  background-color: hsl(212,63%,98%);
-  border-color: hsl(202,7%,67%);
-}
-
-.c1.fi-button--tertiary:hover {
-  background: hsl(212,63%,95%);
-}
-
-.c1.fi-button--tertiary:active {
-  background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
-}
-
-.c1 > .fi-button_icon {
-  width: 16px;
-  height: 16px;
-  margin-right: 8px;
-  vertical-align: middle;
-  -webkit-transform: translateY(-0.1em);
-  -ms-transform: translateY(-0.1em);
-  transform: translateY(-0.1em);
-}
-
-.c1 > .fi-button_icon.fi-button_icon--right {
-  margin-right: 0;
-  margin-left: 8px;
-}
-
-.c1.fi-button--disabled > .fi-button_icon {
-  cursor: not-allowed;
-}
-
-<button
-  aria-disabled="false"
-  class="c0 fi-button c1 fi-button--tertiary"
-  tabindex="0"
-  type="button"
->
-  Tertiary button
 </button>
 `;

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`Button variant default should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondaryNoBorder {
+.c1.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -193,18 +193,18 @@ exports[`Button variant default should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondaryNoBorder:hover {
+.c1.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondaryNoBorder:active {
+.c1.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondaryNoBorder.fi-button--disabled,
-.c1.fi-button--secondaryNoBorder[disabled],
-.c1.fi-button--secondaryNoBorder:disabled {
+.c1.fi-button--secondary-noborder.fi-button--disabled,
+.c1.fi-button--secondary-noborder[disabled],
+.c1.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -470,7 +470,7 @@ exports[`Button variant inverted should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondaryNoBorder {
+.c1.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -480,18 +480,18 @@ exports[`Button variant inverted should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondaryNoBorder:hover {
+.c1.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondaryNoBorder:active {
+.c1.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondaryNoBorder.fi-button--disabled,
-.c1.fi-button--secondaryNoBorder[disabled],
-.c1.fi-button--secondaryNoBorder:disabled {
+.c1.fi-button--secondary-noborder.fi-button--disabled,
+.c1.fi-button--secondary-noborder[disabled],
+.c1.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -757,7 +757,7 @@ exports[`Button variant link match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondaryNoBorder {
+.c1.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -767,18 +767,18 @@ exports[`Button variant link match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondaryNoBorder:hover {
+.c1.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondaryNoBorder:active {
+.c1.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondaryNoBorder.fi-button--disabled,
-.c1.fi-button--secondaryNoBorder[disabled],
-.c1.fi-button--secondaryNoBorder:disabled {
+.c1.fi-button--secondary-noborder.fi-button--disabled,
+.c1.fi-button--secondary-noborder[disabled],
+.c1.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1044,7 +1044,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondaryNoBorder {
+.c1.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -1054,18 +1054,18 @@ exports[`Button variant secondary should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondaryNoBorder:hover {
+.c1.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondaryNoBorder:active {
+.c1.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondaryNoBorder.fi-button--disabled,
-.c1.fi-button--secondaryNoBorder[disabled],
-.c1.fi-button--secondaryNoBorder:disabled {
+.c1.fi-button--secondary-noborder.fi-button--disabled,
+.c1.fi-button--secondary-noborder[disabled],
+.c1.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1331,7 +1331,7 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondaryNoBorder {
+.c1.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -1341,18 +1341,18 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondaryNoBorder:hover {
+.c1.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondaryNoBorder:active {
+.c1.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondaryNoBorder.fi-button--disabled,
-.c1.fi-button--secondaryNoBorder[disabled],
-.c1.fi-button--secondaryNoBorder:disabled {
+.c1.fi-button--secondary-noborder.fi-button--disabled,
+.c1.fi-button--secondary-noborder[disabled],
+.c1.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1427,7 +1427,7 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
 
 <button
   aria-disabled="false"
-  class="c0 fi-button c1 fi-button--secondaryNoBorder"
+  class="c0 fi-button c1 fi-button--secondary-noborder"
   tabindex="0"
   type="button"
 >

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`Button variant default should match snapshot 1`] = `
 }
 
 .c1.fi-button--secondary:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary:active {
@@ -183,7 +183,7 @@ exports[`Button variant default should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondary-noborder {
+.c1.fi-button--secondaryNoBorder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -193,18 +193,18 @@ exports[`Button variant default should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+.c1.fi-button--secondaryNoBorder:hover {
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondary-noborder:active {
+.c1.fi-button--secondaryNoBorder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondary-noborder.fi-button--disabled,
-.c1.fi-button--secondary-noborder[disabled],
-.c1.fi-button--secondary-noborder:disabled {
+.c1.fi-button--secondaryNoBorder.fi-button--disabled,
+.c1.fi-button--secondaryNoBorder[disabled],
+.c1.fi-button--secondaryNoBorder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -224,7 +224,7 @@ exports[`Button variant default should match snapshot 1`] = `
 }
 
 .c1.fi-button--link:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--link:active {
@@ -452,7 +452,7 @@ exports[`Button variant inverted should match snapshot 1`] = `
 }
 
 .c1.fi-button--secondary:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary:active {
@@ -470,7 +470,7 @@ exports[`Button variant inverted should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondary-noborder {
+.c1.fi-button--secondaryNoBorder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -480,18 +480,18 @@ exports[`Button variant inverted should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+.c1.fi-button--secondaryNoBorder:hover {
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondary-noborder:active {
+.c1.fi-button--secondaryNoBorder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondary-noborder.fi-button--disabled,
-.c1.fi-button--secondary-noborder[disabled],
-.c1.fi-button--secondary-noborder:disabled {
+.c1.fi-button--secondaryNoBorder.fi-button--disabled,
+.c1.fi-button--secondaryNoBorder[disabled],
+.c1.fi-button--secondaryNoBorder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -511,7 +511,7 @@ exports[`Button variant inverted should match snapshot 1`] = `
 }
 
 .c1.fi-button--link:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--link:active {
@@ -739,7 +739,7 @@ exports[`Button variant link match snapshot 1`] = `
 }
 
 .c1.fi-button--secondary:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary:active {
@@ -757,7 +757,7 @@ exports[`Button variant link match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondary-noborder {
+.c1.fi-button--secondaryNoBorder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -767,18 +767,18 @@ exports[`Button variant link match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+.c1.fi-button--secondaryNoBorder:hover {
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondary-noborder:active {
+.c1.fi-button--secondaryNoBorder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondary-noborder.fi-button--disabled,
-.c1.fi-button--secondary-noborder[disabled],
-.c1.fi-button--secondary-noborder:disabled {
+.c1.fi-button--secondaryNoBorder.fi-button--disabled,
+.c1.fi-button--secondaryNoBorder[disabled],
+.c1.fi-button--secondaryNoBorder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -798,7 +798,7 @@ exports[`Button variant link match snapshot 1`] = `
 }
 
 .c1.fi-button--link:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--link:active {
@@ -1026,7 +1026,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
 }
 
 .c1.fi-button--secondary:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary:active {
@@ -1044,7 +1044,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondary-noborder {
+.c1.fi-button--secondaryNoBorder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -1054,18 +1054,18 @@ exports[`Button variant secondary should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+.c1.fi-button--secondaryNoBorder:hover {
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondary-noborder:active {
+.c1.fi-button--secondaryNoBorder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondary-noborder.fi-button--disabled,
-.c1.fi-button--secondary-noborder[disabled],
-.c1.fi-button--secondary-noborder:disabled {
+.c1.fi-button--secondaryNoBorder.fi-button--disabled,
+.c1.fi-button--secondaryNoBorder[disabled],
+.c1.fi-button--secondaryNoBorder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1085,7 +1085,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
 }
 
 .c1.fi-button--link:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--link:active {
@@ -1148,7 +1148,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
 </button>
 `;
 
-exports[`Button variant secondary-noborder should match snapshot 1`] = `
+exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1313,7 +1313,7 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
 }
 
 .c1.fi-button--secondary:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--secondary:active {
@@ -1331,7 +1331,7 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--secondary-noborder {
+.c1.fi-button--secondaryNoBorder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -1341,18 +1341,18 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c1.fi-button--secondary-noborder:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+.c1.fi-button--secondaryNoBorder:hover {
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c1.fi-button--secondary-noborder:active {
+.c1.fi-button--secondaryNoBorder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--secondary-noborder.fi-button--disabled,
-.c1.fi-button--secondary-noborder[disabled],
-.c1.fi-button--secondary-noborder:disabled {
+.c1.fi-button--secondaryNoBorder.fi-button--disabled,
+.c1.fi-button--secondaryNoBorder[disabled],
+.c1.fi-button--secondaryNoBorder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1372,7 +1372,7 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
 }
 
 .c1.fi-button--link:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c1.fi-button--link:active {
@@ -1427,10 +1427,10 @@ exports[`Button variant secondary-noborder should match snapshot 1`] = `
 
 <button
   aria-disabled="false"
-  class="c0 fi-button c1 fi-button--secondary-noborder"
+  class="c0 fi-button c1 fi-button--secondaryNoBorder"
   tabindex="0"
   type="button"
 >
-  Secondary-noborder button
+  secondaryNoBorder button
 </button>
 `;

--- a/src/core/Colors/__snapshots__/Colors.test.tsx.snap
+++ b/src/core/Colors/__snapshots__/Colors.test.tsx.snap
@@ -990,7 +990,7 @@ exports[`check that snapshot matches 1`] = `
   height: 196px;
   max-width: 100%;
   color: #000;
-  border-bottom: 4px solid hsl(215,100%,91%);
+  border-bottom: 4px solid hsl(215,100%,95%);
   cursor: pointer;
   z-index: 2;
   position: relative;
@@ -2949,19 +2949,19 @@ exports[`check that snapshot matches 1`] = `
   </figure>
   <figure
     class="c12"
-    color="hsl(215, 100%, 91%)"
+    color="hsl(215, 100%, 95%)"
     tabindex="0"
   >
     <figcaption>
       <div
         class="fi-color__name"
       >
-        hsl(215, 100%, 91%)
+        hsl(215, 100%, 95%)
       </div>
       <div
         class="fi-color__name fi-color__name--hex"
       >
-        #d1e4ff
+        #e5f0ff
       </div>
       <div
         class="fi-color__name fi-color__name--key"
@@ -2970,11 +2970,11 @@ exports[`check that snapshot matches 1`] = `
       </div>
     </figcaption>
     <svg
-      aria-label="hsl(215, 100%, 91%)"
+      aria-label="hsl(215, 100%, 95%)"
       role="img"
     >
       <rect
-        fill="hsl(215, 100%, 91%)"
+        fill="hsl(215, 100%, 95%)"
       >
         <title>
           depthSecondaryDark1

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -659,7 +659,7 @@ exports[`Basic modal should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c8.fi-button--secondaryNoBorder {
+.c8.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -669,18 +669,18 @@ exports[`Basic modal should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c8.fi-button--secondaryNoBorder:hover {
+.c8.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c8.fi-button--secondaryNoBorder:active {
+.c8.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c8.fi-button--secondaryNoBorder.fi-button--disabled,
-.c8.fi-button--secondaryNoBorder[disabled],
-.c8.fi-button--secondaryNoBorder:disabled {
+.c8.fi-button--secondary-noborder.fi-button--disabled,
+.c8.fi-button--secondary-noborder[disabled],
+.c8.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -641,7 +641,7 @@ exports[`Basic modal should match snapshot 1`] = `
 }
 
 .c8.fi-button--secondary:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c8.fi-button--secondary:active {
@@ -659,7 +659,7 @@ exports[`Basic modal should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c8.fi-button--secondary-noborder {
+.c8.fi-button--secondaryNoBorder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -669,18 +669,18 @@ exports[`Basic modal should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c8.fi-button--secondary-noborder:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+.c8.fi-button--secondaryNoBorder:hover {
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c8.fi-button--secondary-noborder:active {
+.c8.fi-button--secondaryNoBorder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c8.fi-button--secondary-noborder.fi-button--disabled,
-.c8.fi-button--secondary-noborder[disabled],
-.c8.fi-button--secondary-noborder:disabled {
+.c8.fi-button--secondaryNoBorder.fi-button--disabled,
+.c8.fi-button--secondaryNoBorder[disabled],
+.c8.fi-button--secondaryNoBorder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -700,7 +700,7 @@ exports[`Basic modal should match snapshot 1`] = `
 }
 
 .c8.fi-button--link:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c8.fi-button--link:active {

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -641,7 +641,7 @@ exports[`Basic modal should match snapshot 1`] = `
 }
 
 .c8.fi-button--secondary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c8.fi-button--secondary:active {
@@ -666,10 +666,11 @@ exports[`Basic modal should match snapshot 1`] = `
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
   border: none;
+  background-color: transparent;
 }
 
 .c8.fi-button--secondary-noborder:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c8.fi-button--secondary-noborder:active {
@@ -687,28 +688,29 @@ exports[`Basic modal should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c8.fi-button--tertiary {
+.c8.fi-button--link {
+  color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
-  background: linear-gradient(0deg,hsl(212,63%,90%),hsl(212,63%,95%));
+  background: linear-gradient(0deg,hsl(215,100%,97%),hsl(215,100%,95%));
   border: none;
 }
 
-.c8.fi-button--tertiary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+.c8.fi-button--link:hover {
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
-.c8.fi-button--tertiary:active {
+.c8.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c8.fi-button--tertiary.fi-button--disabled,
-.c8.fi-button--tertiary[disabled],
-.c8.fi-button--tertiary:disabled {
+.c8.fi-button--link.fi-button--disabled,
+.c8.fi-button--link[disabled],
+.c8.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -716,12 +718,20 @@ exports[`Basic modal should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c8.fi-button--tertiary:hover {
-  background: hsl(212,63%,95%);
+.c8.fi-button--link:hover {
+  background: linear-gradient(0deg,hsl(212,63%,98%),hsl(215,100%,97%));
 }
 
-.c8.fi-button--tertiary:active {
+.c8.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
+}
+
+.c8.fi-button--link.fi-button--disabled,
+.c8.fi-button--link[disabled],
+.c8.fi-button--link:disabled {
+  color: hsl(202,7%,67%);
+  background: none;
+  background-color: hsl(202,7%,97%);
 }
 
 .c8 > .fi-button_icon {

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -321,7 +321,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 }
 
 .c4.fi-button--secondary:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c4.fi-button--secondary:active {
@@ -339,7 +339,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c4.fi-button--secondary-noborder {
+.c4.fi-button--secondaryNoBorder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -349,18 +349,18 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c4.fi-button--secondary-noborder:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+.c4.fi-button--secondaryNoBorder:hover {
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c4.fi-button--secondary-noborder:active {
+.c4.fi-button--secondaryNoBorder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c4.fi-button--secondary-noborder.fi-button--disabled,
-.c4.fi-button--secondary-noborder[disabled],
-.c4.fi-button--secondary-noborder:disabled {
+.c4.fi-button--secondaryNoBorder.fi-button--disabled,
+.c4.fi-button--secondaryNoBorder[disabled],
+.c4.fi-button--secondaryNoBorder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -380,7 +380,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 }
 
 .c4.fi-button--link:hover {
-  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
+  background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
 .c4.fi-button--link:active {

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -339,7 +339,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c4.fi-button--secondaryNoBorder {
+.c4.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -349,18 +349,18 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   background-color: transparent;
 }
 
-.c4.fi-button--secondaryNoBorder:hover {
+.c4.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,rgba(255,255,255,0) 100%);
 }
 
-.c4.fi-button--secondaryNoBorder:active {
+.c4.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c4.fi-button--secondaryNoBorder.fi-button--disabled,
-.c4.fi-button--secondaryNoBorder[disabled],
-.c4.fi-button--secondaryNoBorder:disabled {
+.c4.fi-button--secondary-noborder.fi-button--disabled,
+.c4.fi-button--secondary-noborder[disabled],
+.c4.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -321,7 +321,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 }
 
 .c4.fi-button--secondary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c4.fi-button--secondary:active {
@@ -346,10 +346,11 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
   border: none;
+  background-color: transparent;
 }
 
 .c4.fi-button--secondary-noborder:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
 .c4.fi-button--secondary-noborder:active {
@@ -367,28 +368,29 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c4.fi-button--tertiary {
+.c4.fi-button--link {
+  color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
   border: 1px solid hsl(212,63%,45%);
   text-shadow: none;
-  background: linear-gradient(0deg,hsl(212,63%,90%),hsl(212,63%,95%));
+  background: linear-gradient(0deg,hsl(215,100%,97%),hsl(215,100%,95%));
   border: none;
 }
 
-.c4.fi-button--tertiary:hover {
-  background: linear-gradient(0deg,hsl(202,7%,93%) 0%,hsl(0,0%,100%) 100%);
+.c4.fi-button--link:hover {
+  background: linear-gradient(-180deg,#ecedee 0%,rgba(255,255,255,0) 100%);
 }
 
-.c4.fi-button--tertiary:active {
+.c4.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c4.fi-button--tertiary.fi-button--disabled,
-.c4.fi-button--tertiary[disabled],
-.c4.fi-button--tertiary:disabled {
+.c4.fi-button--link.fi-button--disabled,
+.c4.fi-button--link[disabled],
+.c4.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -396,12 +398,20 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c4.fi-button--tertiary:hover {
-  background: hsl(212,63%,95%);
+.c4.fi-button--link:hover {
+  background: linear-gradient(0deg,hsl(212,63%,98%),hsl(215,100%,97%));
 }
 
-.c4.fi-button--tertiary:active {
+.c4.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
+}
+
+.c4.fi-button--link.fi-button--disabled,
+.c4.fi-button--link[disabled],
+.c4.fi-button--link:disabled {
+  color: hsl(202,7%,67%);
+  background: none;
+  background-color: hsl(202,7%,97%);
 }
 
 .c4 > .fi-button_icon {

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -106,7 +106,9 @@ export const gradients = {
   whiteBaseNegative: `linear-gradient(-180deg, ${alphaHex(0.1)(
     colors.whiteBase,
   )} 0%, ${alphaHex(0)(colors.whiteBase)} 100%)`,
-  whiteBaseToDepthLight2: `linear-gradient(0deg, ${colors.depthLight2} 0%, ${colors.whiteBase} 100%)`,
+  whiteBaseToDepthLight2: `linear-gradient(-180deg, ${alphaHex(1)(
+    colors.depthLight2,
+  )} 0%, ${alphaHex(0)(colors.whiteBase)} 100%)`,
   highlightLight3ToHighlightLight2: `linear-gradient(0deg, ${colors.highlightLight2}, ${colors.highlightLight3})`,
   depthLight3ToDepthLight2: `linear-gradient(0deg, ${colors.depthLight2}, ${colors.depthLight3})`,
 };

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -111,6 +111,8 @@ export const gradients = {
   )} 0%, ${alphaHex(0)(colors.whiteBase)} 100%)`,
   highlightLight3ToHighlightLight2: `linear-gradient(0deg, ${colors.highlightLight2}, ${colors.highlightLight3})`,
   depthLight3ToDepthLight2: `linear-gradient(0deg, ${colors.depthLight2}, ${colors.depthLight3})`,
+  depthSecondaryToDepthSecondaryDark1: `linear-gradient(0deg, ${colors.depthSecondary}, ${colors.depthSecondaryDark1})`,
+  highlightLight4ToDepthSecondary: `linear-gradient(0deg, ${colors.highlightLight4}, ${colors.depthSecondary})`,
 };
 
 export const outlines = {

--- a/src/core/theme/colors.ts
+++ b/src/core/theme/colors.ts
@@ -106,9 +106,9 @@ export const gradients = {
   whiteBaseNegative: `linear-gradient(-180deg, ${alphaHex(0.1)(
     colors.whiteBase,
   )} 0%, ${alphaHex(0)(colors.whiteBase)} 100%)`,
-  whiteBaseToDepthLight2: `linear-gradient(-180deg, ${alphaHex(1)(
-    colors.depthLight2,
-  )} 0%, ${alphaHex(0)(colors.whiteBase)} 100%)`,
+  whiteBaseToDepthLight2: `linear-gradient(-180deg, ${
+    colors.depthLight2
+  } 0%, ${alphaHex(0)(colors.whiteBase)} 100%)`,
   highlightLight3ToHighlightLight2: `linear-gradient(0deg, ${colors.highlightLight2}, ${colors.highlightLight3})`,
   depthLight3ToDepthLight2: `linear-gradient(0deg, ${colors.depthLight2}, ${colors.depthLight3})`,
   depthSecondaryToDepthSecondaryDark1: `linear-gradient(0deg, ${colors.depthSecondary}, ${colors.depthSecondaryDark1})`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12915,10 +12915,10 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-suomifi-design-tokens@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-3.0.0.tgz#e84b665b62234edbbc449f9ec8de96e23dcb308c"
-  integrity sha512-fbwY0XPI71K5BOrjICsmm7bVwWYsOCFYW48ZzKQtKCNCPEqdSkfh63C8CXDjYoEJNKW0gfR7dsHMHNhDzAhfdg==
+suomifi-design-tokens@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-3.1.0.tgz#ebaacb5851c206953e41a75a8be37b01e1693dae"
+  integrity sha512-TcyimLgcKwCO8b2sNm84El+DYBgu0v4QiJISiWValGdAt7U+HCoaY1ImpBsOVfuiKfZsiJPvRd0k7OgNVbN1oQ==
 
 suomifi-icons@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
This PR replaces the button tertiary variant with link variant. It also adjusts the button secondary noborder styles to work on different backgrounds. To make these changes, suomifi-design-tokens dependency was updated to get the recently updated color token values.

## Motivation and Context
The implementation differed from the designs, and there were requests from the projects using the library to make button secondary noborder compatible with other background colors than white.

## How Has This Been Tested?
Automated tests and running locally in Windows using Chrome, Firefox and Edge.

## Screenshots (if appropriate):
secondary noborder hover styles with colored background
![image](https://user-images.githubusercontent.com/54316341/111962240-bb136680-8afa-11eb-9c9f-deb968f0601f.png)


## Release notes
### Breaking changes:
* Button tertiary variant replaced by link button variant
* Button secondary-noborder variant renamed to secondaryNoBorder
* depthSecondaryDark1 color token value changed
### Other changes:
* suomifi-design-tokens dependency updated to latest available
* Button secondaryNoBorder variant hover styles changed

