### PR TITLE
Fix/chip props and styles

### DIFF
--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -19,23 +19,11 @@ export const baseChipBaseStyles = css`
 
   &.fi-chip {
     border-radius: 14px;
-    padding-top: ${theme.spacing.insetXxs};
-    padding-right: 22px;
-    padding-bottom: ${theme.spacing.insetXxs};
-    padding-left: ${theme.spacing.insetL};
+    padding: ${theme.spacing.insetXxs} ${theme.spacing.insetL};
     color: ${theme.colors.whiteBase};
     background: ${theme.colors.highlightBase};
     max-height: 28px;
     display: inline-block;
-    position: relative;
-
-    & .fi-chip--icon {
-      position: absolute;
-      top: 8px;
-      right: 10px;
-      height: 12px;
-      width: 12px;
-    }
 
     & .fi-chip--content {
       display: inline-block;
@@ -56,9 +44,6 @@ export const baseChipBaseStyles = css`
       &:active {
         background: ${theme.colors.depthBase};
       }
-    }
-    & .fi-chip--icon {
-      cursor: not-allowed;
     }
   }
 `;

--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -19,16 +19,22 @@ export const baseChipBaseStyles = css`
 
   &.fi-chip {
     border-radius: 14px;
-    padding: ${theme.spacing.insetXxs} ${theme.spacing.insetL};
+    padding-top: ${theme.spacing.insetXxs};
+    padding-right: 22px;
+    padding-bottom: ${theme.spacing.insetXxs};
+    padding-left: ${theme.spacing.insetL};
     color: ${theme.colors.whiteBase};
     background: ${theme.colors.highlightBase};
     max-height: 28px;
     display: inline-block;
+    position: relative;
 
     & .fi-chip--icon {
+      position: absolute;
+      top: 8px;
+      right: 10px;
       height: 12px;
       width: 12px;
-      transform: translateY(-0.35em);
     }
 
     & .fi-chip--content {

--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -32,7 +32,6 @@ export const baseChipBaseStyles = css`
       overflow: hidden;
       text-overflow: ellipsis;
       line-height: 1.5em;
-      vertical-align: center;
     }
   }
 

--- a/src/core/Chip/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip/Chip.baseStyles.tsx
@@ -16,9 +16,29 @@ export const baseStyles = css`
   }
 
   &.fi-chip--removable {
+    padding-top: ${theme.spacing.insetXxs};
+    padding-right: 22px;
+    padding-bottom: ${theme.spacing.insetXxs};
+    padding-left: ${theme.spacing.insetL};
+    position: relative;
+
+    & .fi-chip--icon {
+      position: absolute;
+      top: 8px;
+      right: 10px;
+      height: 12px;
+      width: 12px;
+    }
+
     & .fi-chip--content {
       max-width: 248px;
       margin-right: ${theme.spacing.xs};
+    }
+  }
+
+  &.fi-chip--disabled {
+    & .fi-chip--icon {
+      cursor: not-allowed;
     }
   }
 `;

--- a/src/core/Chip/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip/Chip.baseStyles.tsx
@@ -34,11 +34,11 @@ export const baseStyles = css`
       max-width: 248px;
       margin-right: ${theme.spacing.xs};
     }
-  }
 
-  &.fi-chip--disabled {
-    & .fi-chip--icon {
-      cursor: not-allowed;
+    &.fi-chip--disabled {
+      & .fi-chip--icon {
+        cursor: not-allowed;
+      }
     }
   }
 `;

--- a/src/core/Chip/Chip/Chip.md
+++ b/src/core/Chip/Chip/Chip.md
@@ -24,11 +24,15 @@ const chipStyle = {
     </Chip>
     <Chip
       style={chipStyle}
+      removable
       actionLabel="Log referenced element"
       ref={exampleRef}
-      onClick={() => console.log(exampleRef.current)}
+      onClick={() => {
+        console.log(exampleRef.current);
+        removeAction();
+      }}
     >
-      Chip with ref
+      Removable chip with ref
     </Chip>
   </div>
   <div>

--- a/src/core/Chip/Chip/Chip.md
+++ b/src/core/Chip/Chip/Chip.md
@@ -29,7 +29,7 @@ const chipStyle = {
       ref={exampleRef}
       onClick={() => console.log(exampleRef.current)}
     >
-      Removable chip with ref
+      Chip with ref
     </Chip>
   </div>
   <div>

--- a/src/core/Chip/Chip/Chip.md
+++ b/src/core/Chip/Chip/Chip.md
@@ -7,20 +7,23 @@ const removeAction = () => {
 };
 
 const exampleRef = React.createRef();
-
+const chipStyle = {
+  display: 'inline-block',
+  marginRight: '10px',
+  marginBottom: '24px'
+};
 <>
   <div>
-    <span style={{ marginRight: '10px' }}>
-      <Chip
-        removable
-        actionLabel="Deselect item"
-        onClick={removeAction}
-      >
-        Removable chip
-      </Chip>
-    </span>
-
     <Chip
+      style={chipStyle}
+      removable
+      actionLabel="Deselect item"
+      onClick={removeAction}
+    >
+      Removable chip
+    </Chip>
+    <Chip
+      style={chipStyle}
       removable
       actionLabel="Log referenced element"
       ref={exampleRef}

--- a/src/core/Chip/Chip/Chip.md
+++ b/src/core/Chip/Chip/Chip.md
@@ -24,7 +24,6 @@ const chipStyle = {
     </Chip>
     <Chip
       style={chipStyle}
-      removable
       actionLabel="Log referenced element"
       ref={exampleRef}
       onClick={() => console.log(exampleRef.current)}

--- a/src/core/Chip/Chip/Chip.tsx
+++ b/src/core/Chip/Chip/Chip.tsx
@@ -22,7 +22,7 @@ interface InternalChipProps
   extends BaseChipProps,
     Omit<
       HtmlButtonProps,
-      'forwardedRef' | 'disabled' | 'onClick' | 'children'
+      'forwardedRef' | 'disabled' | 'onClick' | 'children' | 'as'
     > {
   /**
    * Event handler to execute when clicked

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -124,23 +124,11 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
-  position: relative;
-}
-
-.c1.fi-chip .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  height: 12px;
-  width: 12px;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -163,10 +151,6 @@ exports[`children should match snapshot 1`] = `
   background: hsl(202,7%,67%);
 }
 
-.c1.fi-chip--disabled .fi-chip--icon {
-  cursor: not-allowed;
-}
-
 .c1.fi-chip--button {
   cursor: pointer;
 }
@@ -179,9 +163,29 @@ exports[`children should match snapshot 1`] = `
   background: hsl(212,63%,37%);
 }
 
+.c1.fi-chip--removable {
+  padding-top: 2px;
+  padding-right: 22px;
+  padding-bottom: 2px;
+  padding-left: 10px;
+  position: relative;
+}
+
+.c1.fi-chip--removable .fi-chip--icon {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  height: 12px;
+  width: 12px;
+}
+
 .c1.fi-chip--removable .fi-chip--content {
   max-width: 248px;
   margin-right: 10px;
+}
+
+.c1.fi-chip--disabled .fi-chip--icon {
+  cursor: not-allowed;
 }
 
 <div>
@@ -326,23 +330,11 @@ exports[`classnames should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
-  position: relative;
-}
-
-.c1.fi-chip .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  height: 12px;
-  width: 12px;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -365,10 +357,6 @@ exports[`classnames should match snapshot 1`] = `
   background: hsl(202,7%,67%);
 }
 
-.c1.fi-chip--disabled .fi-chip--icon {
-  cursor: not-allowed;
-}
-
 .c1.fi-chip--button {
   cursor: pointer;
 }
@@ -381,9 +369,29 @@ exports[`classnames should match snapshot 1`] = `
   background: hsl(212,63%,37%);
 }
 
+.c1.fi-chip--removable {
+  padding-top: 2px;
+  padding-right: 22px;
+  padding-bottom: 2px;
+  padding-left: 10px;
+  position: relative;
+}
+
+.c1.fi-chip--removable .fi-chip--icon {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  height: 12px;
+  width: 12px;
+}
+
 .c1.fi-chip--removable .fi-chip--content {
   max-width: 248px;
   margin-right: 10px;
+}
+
+.c1.fi-chip--disabled .fi-chip--icon {
+  cursor: not-allowed;
 }
 
 <div>
@@ -524,23 +532,11 @@ exports[`disabled should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
-  position: relative;
-}
-
-.c1.fi-chip .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  height: 12px;
-  width: 12px;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -563,10 +559,6 @@ exports[`disabled should match snapshot 1`] = `
   background: hsl(202,7%,67%);
 }
 
-.c1.fi-chip--disabled .fi-chip--icon {
-  cursor: not-allowed;
-}
-
 .c1.fi-chip--button {
   cursor: pointer;
 }
@@ -579,9 +571,29 @@ exports[`disabled should match snapshot 1`] = `
   background: hsl(212,63%,37%);
 }
 
+.c1.fi-chip--removable {
+  padding-top: 2px;
+  padding-right: 22px;
+  padding-bottom: 2px;
+  padding-left: 10px;
+  position: relative;
+}
+
+.c1.fi-chip--removable .fi-chip--icon {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  height: 12px;
+  width: 12px;
+}
+
 .c1.fi-chip--removable .fi-chip--content {
   max-width: 248px;
   margin-right: 10px;
+}
+
+.c1.fi-chip--disabled .fi-chip--icon {
+  cursor: not-allowed;
 }
 
 <div>

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -124,19 +124,23 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding: 2px 10px;
+  padding-top: 2px;
+  padding-right: 22px;
+  padding-bottom: 2px;
+  padding-left: 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
+  position: relative;
 }
 
 .c1.fi-chip .fi-chip--icon {
+  position: absolute;
+  top: 8px;
+  right: 10px;
   height: 12px;
   width: 12px;
-  -webkit-transform: translateY(-0.35em);
-  -ms-transform: translateY(-0.35em);
-  transform: translateY(-0.35em);
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -322,19 +326,23 @@ exports[`classnames should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding: 2px 10px;
+  padding-top: 2px;
+  padding-right: 22px;
+  padding-bottom: 2px;
+  padding-left: 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
+  position: relative;
 }
 
 .c1.fi-chip .fi-chip--icon {
+  position: absolute;
+  top: 8px;
+  right: 10px;
   height: 12px;
   width: 12px;
-  -webkit-transform: translateY(-0.35em);
-  -ms-transform: translateY(-0.35em);
-  transform: translateY(-0.35em);
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -516,19 +524,23 @@ exports[`disabled should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding: 2px 10px;
+  padding-top: 2px;
+  padding-right: 22px;
+  padding-bottom: 2px;
+  padding-left: 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
+  position: relative;
 }
 
 .c1.fi-chip .fi-chip--icon {
+  position: absolute;
+  top: 8px;
+  right: 10px;
   height: 12px;
   width: 12px;
-  -webkit-transform: translateY(-0.35em);
-  -ms-transform: translateY(-0.35em);
-  transform: translateY(-0.35em);
 }
 
 .c1.fi-chip .fi-chip--content {

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -138,7 +138,6 @@ exports[`children should match snapshot 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: 1.5em;
-  vertical-align: center;
 }
 
 .c1.fi-chip--disabled.fi-chip {
@@ -184,7 +183,7 @@ exports[`children should match snapshot 1`] = `
   margin-right: 10px;
 }
 
-.c1.fi-chip--disabled .fi-chip--icon {
+.c1.fi-chip--removable.fi-chip--disabled .fi-chip--icon {
   cursor: not-allowed;
 }
 
@@ -344,7 +343,6 @@ exports[`classnames should match snapshot 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: 1.5em;
-  vertical-align: center;
 }
 
 .c1.fi-chip--disabled.fi-chip {
@@ -390,7 +388,7 @@ exports[`classnames should match snapshot 1`] = `
   margin-right: 10px;
 }
 
-.c1.fi-chip--disabled .fi-chip--icon {
+.c1.fi-chip--removable.fi-chip--disabled .fi-chip--icon {
   cursor: not-allowed;
 }
 
@@ -546,7 +544,6 @@ exports[`disabled should match snapshot 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: 1.5em;
-  vertical-align: center;
 }
 
 .c1.fi-chip--disabled.fi-chip {
@@ -592,7 +589,7 @@ exports[`disabled should match snapshot 1`] = `
   margin-right: 10px;
 }
 
-.c1.fi-chip--disabled .fi-chip--icon {
+.c1.fi-chip--removable.fi-chip--disabled .fi-chip--icon {
   cursor: not-allowed;
 }
 

--- a/src/core/Chip/StaticChip/StaticChip.md
+++ b/src/core/Chip/StaticChip/StaticChip.md
@@ -2,12 +2,18 @@
 import { StaticChip } from 'suomifi-ui-components';
 import React from 'react';
 
+const chipStyle = {
+  display: 'inline-block',
+  marginRight: '10px',
+  marginBottom: '24px'
+};
+
 <>
   <div>
-    <span style={{ marginRight: '10px' }}>
-      <StaticChip>Basic static chip</StaticChip>
-    </span>
-    <StaticChip disabled>Disabled static chip</StaticChip>
+    <StaticChip style={chipStyle}>Basic static chip</StaticChip>
+    <StaticChip style={chipStyle} disabled>
+      Disabled static chip
+    </StaticChip>
   </div>
   <StaticChip>
     StaticChip with a long content that doesn't fit into the

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -85,7 +85,6 @@ exports[`children should match snapshot 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: 1.5em;
-  vertical-align: center;
 }
 
 .c1.fi-chip--disabled.fi-chip {
@@ -200,7 +199,6 @@ exports[`classnames should match snapshot 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: 1.5em;
-  vertical-align: center;
 }
 
 .c1.fi-chip--disabled.fi-chip {
@@ -311,7 +309,6 @@ exports[`disabled should match snapshot 1`] = `
   overflow: hidden;
   text-overflow: ellipsis;
   line-height: 1.5em;
-  vertical-align: center;
 }
 
 .c1.fi-chip--disabled.fi-chip {

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -71,23 +71,11 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
-  position: relative;
-}
-
-.c1.fi-chip .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  height: 12px;
-  width: 12px;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -108,10 +96,6 @@ exports[`children should match snapshot 1`] = `
 .c1.fi-chip--disabled.fi-chip:hover,
 .c1.fi-chip--disabled.fi-chip:active {
   background: hsl(202,7%,67%);
-}
-
-.c1.fi-chip--disabled .fi-chip--icon {
-  cursor: not-allowed;
 }
 
 <div>
@@ -202,23 +186,11 @@ exports[`classnames should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
-  position: relative;
-}
-
-.c1.fi-chip .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  height: 12px;
-  width: 12px;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -239,10 +211,6 @@ exports[`classnames should match snapshot 1`] = `
 .c1.fi-chip--disabled.fi-chip:hover,
 .c1.fi-chip--disabled.fi-chip:active {
   background: hsl(202,7%,67%);
-}
-
-.c1.fi-chip--disabled .fi-chip--icon {
-  cursor: not-allowed;
 }
 
 <div>
@@ -329,23 +297,11 @@ exports[`disabled should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
-  position: relative;
-}
-
-.c1.fi-chip .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
-  height: 12px;
-  width: 12px;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -366,10 +322,6 @@ exports[`disabled should match snapshot 1`] = `
 .c1.fi-chip--disabled.fi-chip:hover,
 .c1.fi-chip--disabled.fi-chip:active {
   background: hsl(202,7%,67%);
-}
-
-.c1.fi-chip--disabled .fi-chip--icon {
-  cursor: not-allowed;
 }
 
 <div>

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -71,19 +71,23 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding: 2px 10px;
+  padding-top: 2px;
+  padding-right: 22px;
+  padding-bottom: 2px;
+  padding-left: 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
+  position: relative;
 }
 
 .c1.fi-chip .fi-chip--icon {
+  position: absolute;
+  top: 8px;
+  right: 10px;
   height: 12px;
   width: 12px;
-  -webkit-transform: translateY(-0.35em);
-  -ms-transform: translateY(-0.35em);
-  transform: translateY(-0.35em);
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -198,19 +202,23 @@ exports[`classnames should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding: 2px 10px;
+  padding-top: 2px;
+  padding-right: 22px;
+  padding-bottom: 2px;
+  padding-left: 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
+  position: relative;
 }
 
 .c1.fi-chip .fi-chip--icon {
+  position: absolute;
+  top: 8px;
+  right: 10px;
   height: 12px;
   width: 12px;
-  -webkit-transform: translateY(-0.35em);
-  -ms-transform: translateY(-0.35em);
-  transform: translateY(-0.35em);
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -321,19 +329,23 @@ exports[`disabled should match snapshot 1`] = `
 
 .c1.fi-chip {
   border-radius: 14px;
-  padding: 2px 10px;
+  padding-top: 2px;
+  padding-right: 22px;
+  padding-bottom: 2px;
+  padding-left: 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
   display: inline-block;
+  position: relative;
 }
 
 .c1.fi-chip .fi-chip--icon {
+  position: absolute;
+  top: 8px;
+  right: 10px;
   height: 12px;
   width: 12px;
-  -webkit-transform: translateY(-0.35em);
-  -ms-transform: translateY(-0.35em);
-  transform: translateY(-0.35em);
 }
 
 .c1.fi-chip .fi-chip--content {


### PR DESCRIPTION
## Description
This PR fixes Chip remove icon alignment issue with Safari and removes support for as-prop. Examples were updated and improved.

Also minor refactoring of styles was done to have better isolation between variants.

## Related Issue
The remove icon for Chip was not aligned according designs in Safari. As-prop made it possible to replace the chip button/div component with other elements which is not desired for this component.

## Motivation and Context
Components should look and behave the same way with all supported browsers. This fix is needed to align styles in Safari with rest of the supported browsers. Also changing the chip semantics with as-prop is not desired for this component.

## How Has This Been Tested?
Tested with CRA-TS project using MacOS with Safari, Firefox and Chrome.

## Screenshots (if appropriate):
![Screenshot 2021-03-22 at 14 31 31](https://user-images.githubusercontent.com/53744258/112109337-1a847b80-8bba-11eb-8ddd-fb3d828ba983.png)
![Screenshot 2021-03-23 at 9 27 37](https://user-images.githubusercontent.com/53744258/112109338-1b1d1200-8bba-11eb-9118-44a500a2f748.png)


## Release notes
- Chip
  - Breaking changes: as prop is now removed
  - Remove icon is now properly aligned in Safari