### PR TITLE
[Fix] Remove uuid dependency, type definitions and util

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,8 +141,7 @@
     "react-popper": "2.2.4",
     "react-svg": "11.2.1",
     "suomifi-design-tokens": "3.1.0",
-    "suomifi-icons": "^2.0.0",
-    "uuid": "8.3.2"
+    "suomifi-icons": "^2.0.0"
   },
   "peerDependencies": {
     "@types/styled-components": ">=5.1.4",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@types/react": "17.0.0",
     "@types/react-dom": "17.0.0",
     "@types/styled-components": "5.1.7",
-    "@types/uuid": "8.3.0",
     "@types/warning": "3.0.0",
     "@typescript-eslint/eslint-plugin": "4.11.1",
     "@typescript-eslint/parser": "4.11.1",

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,8 +1,0 @@
-import { v4 as uuid } from 'uuid';
-export { uuid };
-
-/**
- * Generate unique ID if given id is not defined
- * @param {String} id use this first if set
- */
-export const idGenerator = (id?: string) => (!!id ? id : uuid());

--- a/yarn.lock
+++ b/yarn.lock
@@ -13746,11 +13746,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,11 +2362,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/uuid@8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
-  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
-
 "@types/warning@3.0.0", "@types/warning@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"


### PR DESCRIPTION
## Description
This PR removes the uuid dependency, its type definitions and related util from the library.

## Motivation and Context
uuid seems to be replaced by AutoId in all cases, which means uuid dependency, type definitions and util can be removed from the library.

## How Has This Been Tested?
Tested by running locally in styleguidist on Chrome. I found no instances of the generateId util based on the uuid, so it should be safe to remove.

## Release notes
* uuid removed from dependencies
