### PR TITLE
[Fix] Text component color prop

### DIFF
--- a/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -357,7 +357,6 @@ exports[`Basic ToggleButton should match snapshot 1`] = `
     </span>
     <span
       class="c0 fi-text c5 fi-text--body"
-      color="blackBase"
     >
       TestToggle
     </span>

--- a/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
@@ -383,7 +383,6 @@ exports[`Basic ToggleInput should match snapshot 1`] = `
     </span>
     <span
       class="c0 fi-text c6 fi-text--body"
-      color="blackBase"
     >
       TestToggle
     </span>

--- a/src/core/Text/Text.baseStyles.ts
+++ b/src/core/Text/Text.baseStyles.ts
@@ -1,11 +1,12 @@
 import { css } from 'styled-components';
 import { defaultThemeTokens as theme } from '../theme';
 import { element, font } from '../theme/reset';
+import { TextProps } from './Text';
 
-export const baseStyles = css`
+export const baseStyles = ({ color }: TextProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  color: ${theme.colors.blackBase};
+  color: ${!!color ? theme.colors[color] : theme.colors.blackBase};
 
   &.fi-text {
     &--bold {

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -24,7 +24,13 @@ export interface TextProps extends CompTextProps {
 }
 
 const StyledText = styled(
-  ({ variant = 'body', smallScreen, className, ...passProps }: TextProps) => (
+  ({
+    variant = 'body',
+    smallScreen,
+    className,
+    color,
+    ...passProps
+  }: TextProps) => (
     <CompText
       {...passProps}
       className={classnames(className, [`${baseClassName}--${variant}`], {
@@ -33,7 +39,7 @@ const StyledText = styled(
     />
   ),
 )`
-  ${baseStyles};
+  ${(props) => baseStyles(props)};
 `;
 
 /**


### PR DESCRIPTION
## Description
This PR fixes the broken color prop in the Text component. The color prop was not passed on or utilized in any way after the recent tokens revamp.

## Motivation and Context
This was an obvious bug that needed to be fixed asap.

## How Has This Been Tested?
Tested by running locally in styleguidist in Chrome.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/54316341/114396243-04a91b80-9ba6-11eb-90fe-1a91567dcd5c.png)


## Release notes
### Text:
* Fix broken color prop