### PR TITLE
Fix/modal mobile focus lock

### DIFF
--- a/src/core/Modal/Modal/Modal.baseStyles.tsx
+++ b/src/core/Modal/Modal/Modal.baseStyles.tsx
@@ -8,8 +8,8 @@ export const baseStyles = css`
   &.fi-modal {
     ${element(theme)}
     ${font(theme)('actionElementInnerTextBold')}
-    width: 100vw;
-    height: 100vh;
+    width: 100%;
+    height: 100%;
     position: fixed;
     top: 0;
     left: 0;
@@ -20,8 +20,8 @@ export const baseStyles = css`
 
     & .fi-modal_overlay {
       background-color: ${alphaHex(0.5)(theme.colors.blackBase)};
-      width: 100vw;
-      height: 100vh;
+      width: 100%;
+      height: 100%;
       display: flex;
       flex-direction: column;
       justify-content: center;
@@ -33,7 +33,7 @@ export const baseStyles = css`
       background-color: ${theme.colors.whiteBase};
       border-top: ${theme.spacing.insetXs} solid ${theme.colors.highlightBase};
       overflow: hidden;
-      max-height: calc(100vh - 50px);
+      max-height: calc(100% - 50px);
       min-height: 230px;
       width: 800px;
       flex: 0 1 auto;

--- a/src/core/Modal/Modal/Modal.test.tsx
+++ b/src/core/Modal/Modal/Modal.test.tsx
@@ -39,6 +39,119 @@ describe('Basic modal', () => {
   it('should not have basic accessibility issues', axeTest(BasicModal()));
 });
 
+describe('Modal sibling DOM nodes', () => {
+  const ModalWithSiblings = () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <>
+        <div data-testid="test-sibling">Test content</div>
+        <div
+          data-testid="test-sibling-with-aria-hidden-true"
+          aria-hidden="true"
+        >
+          Test content with Aria-hidden true
+        </div>
+        <div
+          data-testid="test-sibling-with-aria-hidden-false"
+          aria-hidden="false"
+        >
+          Test content with Aria-hidden false
+        </div>
+        <div data-testid="portal-containing-node">
+          <Modal
+            data-testid="modal"
+            visible={open}
+            usePortal={false}
+            onEscKeyDown={() => setOpen(false)}
+          >
+            <ModalContent>
+              <ModalTitle>Test modal</ModalTitle>
+              <p>Some test text</p>
+            </ModalContent>
+            <ModalFooter>
+              <Button>OK</Button>
+            </ModalFooter>
+          </Modal>
+          <div data-testid="test-sibling-inside-portal-node">
+            Test siblign inside portal node
+          </div>
+          <div
+            data-testid="test-sibling-inside-portal-node-aria-hidden-true"
+            aria-hidden="true"
+          >
+            Test siblign inside portal node aria hidden true
+          </div>
+          <div
+            data-testid="test-sibling-inside-portal-node-aria-hidden-false"
+            aria-hidden="false"
+          >
+            Test siblign inside portal node aria-hidden false
+          </div>
+        </div>
+      </>
+    );
+  };
+
+  it('containing the modal should not be aria-hidden', () => {
+    const { getByTestId, baseElement } = render(<ModalWithSiblings />);
+    expect(baseElement).not.toHaveAttribute('aria-hidden');
+    expect(getByTestId('portal-containing-node')).not.toHaveAttribute(
+      'aria-hidden',
+    );
+    expect(getByTestId('modal')).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('not containing the modal should be aria-hidden', () => {
+    const { getByTestId } = render(<ModalWithSiblings />);
+    expect(getByTestId('test-sibling')).toHaveAttribute('aria-hidden', 'true');
+    expect(getByTestId('test-sibling-with-aria-hidden-true')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+    expect(getByTestId('test-sibling-with-aria-hidden-false')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+    expect(getByTestId('test-sibling-inside-portal-node')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+    expect(
+      getByTestId('test-sibling-inside-portal-node-aria-hidden-true'),
+    ).toHaveAttribute('aria-hidden', 'true');
+    expect(
+      getByTestId('test-sibling-inside-portal-node-aria-hidden-false'),
+    ).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should preserve aria-hidden state after closing modal', () => {
+    const { getByTestId } = render(<ModalWithSiblings />);
+    fireEvent.keyDown(getByTestId('modal'), {
+      key: 'Esc',
+      code: 27,
+      charCode: 27,
+    });
+    expect(getByTestId('test-sibling')).not.toHaveAttribute('aria-hidden');
+    expect(getByTestId('test-sibling-with-aria-hidden-true')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+    expect(getByTestId('test-sibling-with-aria-hidden-false')).toHaveAttribute(
+      'aria-hidden',
+      'false',
+    );
+    expect(getByTestId('test-sibling-inside-portal-node')).not.toHaveAttribute(
+      'aria-hidden',
+    );
+    expect(
+      getByTestId('test-sibling-inside-portal-node-aria-hidden-true'),
+    ).toHaveAttribute('aria-hidden', 'true');
+    expect(
+      getByTestId('test-sibling-inside-portal-node-aria-hidden-false'),
+    ).toHaveAttribute('aria-hidden', 'false');
+  });
+});
+
 describe('Modal variant', () => {
   const ModalWithProps = (props?: Partial<ModalProps>) => (
     <Modal visible={true} usePortal={false} {...props}>

--- a/src/core/Modal/Modal/Modal.test.tsx
+++ b/src/core/Modal/Modal/Modal.test.tsx
@@ -48,16 +48,22 @@ describe('Modal sibling DOM nodes', () => {
         <div
           data-testid="test-sibling-with-aria-hidden-true"
           aria-hidden="true"
+          role="presentation"
         >
           Test content with Aria-hidden true
         </div>
         <div
           data-testid="test-sibling-with-aria-hidden-false"
           aria-hidden="false"
+          role="presentation"
         >
           Test content with Aria-hidden false
         </div>
-        <div data-testid="portal-containing-node">
+        <div
+          data-testid="portal-containing-node"
+          aria-hidden="false"
+          role="button"
+        >
           <Modal
             data-testid="modal"
             visible={open}
@@ -78,12 +84,14 @@ describe('Modal sibling DOM nodes', () => {
           <div
             data-testid="test-sibling-inside-portal-node-aria-hidden-true"
             aria-hidden="true"
+            role="button"
           >
             Test siblign inside portal node aria hidden true
           </div>
           <div
             data-testid="test-sibling-inside-portal-node-aria-hidden-false"
             aria-hidden="false"
+            role="button"
           >
             Test siblign inside portal node aria-hidden false
           </div>
@@ -95,8 +103,9 @@ describe('Modal sibling DOM nodes', () => {
   it('containing the modal should not be aria-hidden', () => {
     const { getByTestId, baseElement } = render(<ModalWithSiblings />);
     expect(baseElement).not.toHaveAttribute('aria-hidden');
-    expect(getByTestId('portal-containing-node')).not.toHaveAttribute(
+    expect(getByTestId('portal-containing-node')).toHaveAttribute(
       'aria-hidden',
+      'false',
     );
     expect(getByTestId('modal')).not.toHaveAttribute('aria-hidden');
   });
@@ -124,7 +133,7 @@ describe('Modal sibling DOM nodes', () => {
     ).toHaveAttribute('aria-hidden', 'true');
   });
 
-  it('should preserve aria-hidden state after closing modal', () => {
+  it('should preserve aria-hidden and role state after closing modal', () => {
     const { getByTestId } = render(<ModalWithSiblings />);
     fireEvent.keyDown(getByTestId('modal'), {
       key: 'Esc',
@@ -136,9 +145,25 @@ describe('Modal sibling DOM nodes', () => {
       'aria-hidden',
       'true',
     );
+    expect(getByTestId('test-sibling-with-aria-hidden-true')).toHaveAttribute(
+      'role',
+      'presentation',
+    );
     expect(getByTestId('test-sibling-with-aria-hidden-false')).toHaveAttribute(
       'aria-hidden',
       'false',
+    );
+    expect(getByTestId('test-sibling-with-aria-hidden-false')).toHaveAttribute(
+      'role',
+      'presentation',
+    );
+    expect(getByTestId('portal-containing-node')).toHaveAttribute(
+      'aria-hidden',
+      'false',
+    );
+    expect(getByTestId('portal-containing-node')).toHaveAttribute(
+      'role',
+      'button',
     );
     expect(getByTestId('test-sibling-inside-portal-node')).not.toHaveAttribute(
       'aria-hidden',
@@ -147,8 +172,14 @@ describe('Modal sibling DOM nodes', () => {
       getByTestId('test-sibling-inside-portal-node-aria-hidden-true'),
     ).toHaveAttribute('aria-hidden', 'true');
     expect(
+      getByTestId('test-sibling-inside-portal-node-aria-hidden-true'),
+    ).toHaveAttribute('role', 'button');
+    expect(
       getByTestId('test-sibling-inside-portal-node-aria-hidden-false'),
     ).toHaveAttribute('aria-hidden', 'false');
+    expect(
+      getByTestId('test-sibling-inside-portal-node-aria-hidden-false'),
+    ).toHaveAttribute('role', 'button');
   });
 });
 

--- a/src/core/Modal/Modal/Modal.tsx
+++ b/src/core/Modal/Modal/Modal.tsx
@@ -138,14 +138,14 @@ class BaseModal extends Component<ModalProps> {
   };
 
   private getNodePrevState = (node: HTMLElement): null | PrevState => {
-    const ariaDisabledPrevState = node.getAttribute('aria-hidden');
+    const ariaHiddenPrevState = node.getAttribute('aria-hidden');
     const rolePrevState = node.getAttribute('role');
     const prevState: PrevState = {};
     if (
-      typeof ariaDisabledPrevState === 'string' &&
-      ariaDisabledPrevState.length > 0
+      typeof ariaHiddenPrevState === 'string' &&
+      ariaHiddenPrevState.length > 0
     ) {
-      prevState['aria-hidden'] = ariaDisabledPrevState;
+      prevState['aria-hidden'] = ariaHiddenPrevState;
     }
     if (typeof rolePrevState === 'string' && rolePrevState.length > 0) {
       prevState.role = rolePrevState;
@@ -308,8 +308,8 @@ const StyledModal = styled(BaseModal)`
  * <i class="semantics" />
  * Use for showing modal content.
  * Props other than specified explicitly are passed on to outermost content div.
- * NOTE: Modal modifies body element styles and sibling DOM element aria-hidden properties.
- * It assumes aria-hidden for sibling DOM nodes remains unchanged while Modal is visilbe.
+ * NOTE: Modal modifies body element styles and sibling DOM node aria-hidden and parent DOM node role properties.
+ * It assumes aria-hidden for sibling DOM nodes and role for parent DOM nodes remains unchanged while Modal is visilbe.
  */
 export class Modal extends Component<ModalProps> {
   render() {

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -54,35 +54,6 @@ exports[`Basic modal should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -109,6 +80,35 @@ exports[`Basic modal should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -784,19 +784,21 @@ exports[`Basic modal should match snapshot 1`] = `
 }
 
 <div
-  aria-describedby="3_title"
-  aria-modal="true"
   class="c0 c1 fi-modal fi-modal--no-portal"
-  role="dialog"
+  role="presentation"
 >
   <div
-    class="c2 fi-modal_overlay"
+    class="c0 fi-modal_overlay"
+    role="presentation"
   >
     <div
+      aria-describedby="3_title"
+      aria-modal="true"
       class="c2 fi-modal_content-container"
+      role="dialog"
     >
       <div
-        class="c2 fi-modal_content c3"
+        class="c0 fi-modal_content c3"
       >
         <h2
           class="c4 fi-heading c5 c6 fi-modal_title fi-heading--h3"
@@ -809,10 +811,10 @@ exports[`Basic modal should match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="c2 c7 fi-modal_footer"
+        class="c0 c7 fi-modal_footer"
       >
         <div
-          class="c2 fi-modal_footer_content"
+          class="c0 fi-modal_footer_content"
         >
           <button
             aria-disabled="false"
@@ -824,10 +826,10 @@ exports[`Basic modal should match snapshot 1`] = `
           </button>
         </div>
         <div
-          class="c2 fi-modal_footer_content-gradient-overlay"
+          class="c0 fi-modal_footer_content-gradient-overlay"
         >
           <div
-            class="c2 fi-modal_footer_content-gradient"
+            class="c0 fi-modal_footer_content-gradient"
           />
         </div>
       </div>

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -156,8 +156,8 @@ exports[`Basic modal should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   position: fixed;
   top: 0;
   left: 0;
@@ -169,8 +169,8 @@ exports[`Basic modal should match snapshot 1`] = `
 
 .c1.fi-modal .fi-modal_overlay {
   background-color: rgba(41,41,41,0.5);
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -193,7 +193,7 @@ exports[`Basic modal should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   border-top: 4px solid hsl(212,63%,45%);
   overflow: hidden;
-  max-height: calc(100vh - 50px);
+  max-height: calc(100% - 50px);
   min-height: 230px;
   width: 800px;
   -webkit-flex: 0 1 auto;

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -1,35 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Basic ModalContent should match snapshot 1`] = `
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -56,6 +27,35 @@ exports[`Basic ModalContent should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -463,19 +463,21 @@ exports[`Basic ModalContent should match snapshot 1`] = `
 }
 
 <div
-  aria-describedby="5_title"
-  aria-modal="true"
   class="c0 c1 fi-modal fi-modal--no-portal"
-  role="dialog"
+  role="presentation"
 >
   <div
-    class="c2 fi-modal_overlay"
+    class="c0 fi-modal_overlay"
+    role="presentation"
   >
     <div
+      aria-describedby="5_title"
+      aria-modal="true"
       class="c2 fi-modal_content-container"
+      role="dialog"
     >
       <div
-        class="c2 fi-modal_content c3"
+        class="c0 fi-modal_content c3"
         data-testid="modal-content-id"
       >
         <h2

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -103,8 +103,8 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   position: fixed;
   top: 0;
   left: 0;
@@ -116,8 +116,8 @@ exports[`Basic ModalContent should match snapshot 1`] = `
 
 .c1.fi-modal .fi-modal_overlay {
   background-color: rgba(41,41,41,0.5);
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -140,7 +140,7 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   border-top: 4px solid hsl(212,63%,45%);
   overflow: hidden;
-  max-height: calc(100vh - 50px);
+  max-height: calc(100% - 50px);
   min-height: 230px;
   width: 800px;
   -webkit-flex: 0 1 auto;

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -54,35 +54,6 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -109,6 +80,35 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -464,22 +464,24 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 }
 
 <div
-  aria-describedby="3_title"
-  aria-modal="true"
   class="c0 c1 fi-modal fi-modal--no-portal"
-  role="dialog"
+  role="presentation"
 >
   <div
-    class="c2 fi-modal_overlay"
+    class="c0 fi-modal_overlay"
+    role="presentation"
   >
     <div
+      aria-describedby="3_title"
+      aria-modal="true"
       class="c2 fi-modal_content-container"
+      role="dialog"
     >
       <div
-        class="c2 c3 fi-modal_footer"
+        class="c0 c3 fi-modal_footer"
       >
         <div
-          class="c2 fi-modal_footer_content"
+          class="c0 fi-modal_footer_content"
           data-testid="modal-footer-id"
         >
           <button
@@ -500,10 +502,10 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
           </button>
         </div>
         <div
-          class="c2 fi-modal_footer_content-gradient-overlay"
+          class="c0 fi-modal_footer_content-gradient-overlay"
         >
           <div
-            class="c2 fi-modal_footer_content-gradient"
+            class="c0 fi-modal_footer_content-gradient"
           />
         </div>
       </div>

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -127,8 +127,8 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   position: fixed;
   top: 0;
   left: 0;
@@ -140,8 +140,8 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 
 .c1.fi-modal .fi-modal_overlay {
   background-color: rgba(41,41,41,0.5);
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -164,7 +164,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   border-top: 4px solid hsl(212,63%,45%);
   overflow: hidden;
-  max-height: calc(100vh - 50px);
+  max-height: calc(100% - 50px);
   min-height: 230px;
   width: 800px;
   -webkit-flex: 0 1 auto;


### PR DESCRIPTION
## Description
This PR introduces fixes for Modal for browsers not properly supporting aria-dialog property. Sibling DOM nodes are now aria-hidden when the modal is open and parent nodes have a role of presentation.

## Related Issue
Previously some browser and screenreader combinations allowed navigating to elements hidden beneath the Modal. This should no longer be possible.

There are some caveats though, an existing issue with iOS and Safari allows screenreader to read number of pages from the main document below the modal. This issue is reproducible with many other library implementation as well and there seems to be no feasible workaround. The bugs have been reported to Apple and Material-UI.

## Motivation and Context
Android and iOS users should be supported as those with Safari and Chrome form the majority of mobile users using a screen reader. Most of the issues (excluding the above mentioned) have now been fixed.

## How Has This Been Tested?
Tested using styleguidist build with Mac OS, Windows, iOS and Android with Chrome, Safari, Edge and Firefox.

## Release notes
- Fixes for Modal Accessibility with mobile devices