### PR TITLE
Fix/expander styles and aria support

### DIFF
--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -44,10 +44,10 @@ import {
 } from 'suomifi-ui-components';
 
 <ExpanderGroup
-  OpenAllText="Open all"
-  AriaOpenAllText="Open all expanders"
-  CloseAllText="Close all"
-  AriaCloseAllText="Close all expanders"
+  openAllText="Open all"
+  ariaOpenAllText="Open all expanders"
+  closeAllText="Close all"
+  ariaCloseAllText="Close all expanders"
 >
   <Expander>
     <ExpanderTitleButton>Test expander 1</ExpanderTitleButton>
@@ -85,10 +85,10 @@ const [expanderThreeOpen, setExpanderThreeOpen] = React.useState(
 
 <>
   <ExpanderGroup
-    OpenAllText="Open all"
-    AriaOpenAllText="Open all expanders"
-    CloseAllText="Close all"
-    AriaCloseAllText="Close all expanders"
+    openAllText="Open all"
+    ariaOpenAllText="Open all expanders"
+    closeAllText="Close all"
+    ariaCloseAllText="Close all expanders"
   >
     <Expander>
       <ExpanderTitleButton>Test expander 1</ExpanderTitleButton>

--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -25,8 +25,11 @@ import {
   <ExpanderTitle
     ariaOpenText="open expander"
     ariaCloseText="close expander"
+    toggleButtonAriaDescribedBy="checkbox-id"
   >
-    <Checkbox hintText="Checkbox hint text">Checkbox label</Checkbox>
+    <Checkbox hintText="Checkbox hint text" id="checkbox-id">
+      Checkbox label
+    </Checkbox>
   </ExpanderTitle>
   <ExpanderContent>Test expander</ExpanderContent>
 </Expander>;

--- a/src/core/Expander/Expander/Expander.test.tsx
+++ b/src/core/Expander/Expander/Expander.test.tsx
@@ -20,28 +20,20 @@ describe('Basic expander', () => {
   );
 
   const TestExpander = TestExpanderWithProps({
-    ariaCloseText: 'click to close expander',
-    ariaOpenText: 'click to open expander',
     children: 'Test expander',
   });
 
   it('render with the same component on the same container does not remount', () => {
     const { getByTestId, rerender } = render(TestExpander);
-    expect(getByTestId('expander-title').textContent).toBe(
-      'Test expanderclick to open expander',
-    );
+    expect(getByTestId('expander-title').textContent).toBe('Test expander');
 
     // re-render the same component with different props
     rerender(
       TestExpanderWithProps({
-        ariaCloseText: 'click to close expander',
-        ariaOpenText: 'click to open expander',
         children: 'Test expander two',
       }),
     );
-    expect(getByTestId('expander-title').textContent).toBe(
-      'Test expander twoclick to open expander',
-    );
+    expect(getByTestId('expander-title').textContent).toBe('Test expander two');
   });
 
   it('shoud match snapshot', () => {

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -194,8 +194,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
 
 .c7.fi-expander_content--open {
   visibility: visible;
-  height: 10%;
-  overflow: visible;
+  height: auto;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -112,18 +112,6 @@ exports[`Basic expander shoud match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-}
-
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -154,7 +142,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   opacity: 0;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -188,11 +176,11 @@ exports[`Basic expander shoud match snapshot 1`] = `
   will-change: transition,height;
 }
 
-.c7:not(.fi-expander_content--no-padding) {
+.c6:not(.fi-expander_content--no-padding) {
   padding: 0 16px;
 }
 
-.c7.fi-expander_content--open {
+.c6.fi-expander_content--open {
   visibility: visible;
   height: auto;
   border-top-left-radius: 0;
@@ -201,23 +189,23 @@ exports[`Basic expander shoud match snapshot 1`] = `
   animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
 }
 
-.c7.fi-expander_content--open:not(.fi-expander_content--no-padding) {
+.c6.fi-expander_content--open:not(.fi-expander_content--no-padding) {
   padding-top: 0;
   padding-right: 20px;
   padding-bottom: 20px;
   padding-left: 20px;
 }
 
-.c6 {
+.c5 {
   display: inline-block;
   vertical-align: baseline;
 }
 
-.c6.fi-icon--cursor-pointer {
+.c5.fi-icon--cursor-pointer {
   cursor: pointer;
 }
 
-.c6.fi-icon--cursor-pointer * {
+.c5.fi-icon--cursor-pointer * {
   cursor: inherit;
 }
 
@@ -358,14 +346,9 @@ exports[`Basic expander shoud match snapshot 1`] = `
         >
           Test expander
         </span>
-        <span
-          class="c3 c5 fi-visually-hidden"
-        >
-          click to open expander
-        </span>
         <svg
           aria-hidden="true"
-          class="fi-icon c6 fi-expander_title-button-icon"
+          class="fi-icon c5 fi-expander_title-button-icon"
           fill="currentColor"
           focusable="false"
           height="1em"
@@ -382,7 +365,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="4_title"
-    class="c0 c7 fi-expander_content"
+    class="c0 c6 fi-expander_content"
     id="4_content"
     role="region"
   >

--- a/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
@@ -27,8 +27,7 @@ export const baseStyles = css`
 
   &.fi-expander_content--open {
     visibility: visible;
-    height: 10%;
-    overflow: visible;
+    height: auto;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     /* This is very robust - cannot animate dynamic height with height-definition */

--- a/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
+++ b/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
@@ -70,8 +70,7 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
 
 .c1.fi-expander_content--open {
   visibility: visible;
-  height: 10%;
-  overflow: visible;
+  height: auto;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
@@ -35,10 +35,10 @@ const TestExpanderGroup = (
   expanderGroupProps?: Partial<ExpanderGroupProps>,
 ) => (
   <ExpanderGroup
-    OpenAllText="Open all"
-    CloseAllText="Close all"
-    AriaOpenAllText="Open all expanders"
-    AriaCloseAllText="Close all expanders"
+    openAllText="Open all"
+    closeAllText="Close all"
+    ariaOpenAllText="Open all expanders"
+    ariaCloseAllText="Close all expanders"
     {...expanderGroupProps}
   >
     {expanderData.map((d, index) =>

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -153,6 +153,7 @@ class BaseExpanderGroup extends Component<ExpanderGroupProps> {
             toggleAllButtonProps?.className,
             openAllButtonClassName,
           )}
+          aria-expanded={allOpen}
         >
           <HtmlSpan aria-hidden={true}>
             {allOpen ? CloseAllText : OpenAllText}

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -13,13 +13,13 @@ export interface ExpanderGroupProps {
   /** Expanders and optionally, other ReactNodes */
   children: ReactNode;
   /** 'Open all' button text */
-  OpenAllText: string;
+  openAllText: string;
   /** 'Close all' button text */
-  CloseAllText: string;
+  closeAllText: string;
   /** 'Open all' button text for screen readers, hides OpenAllText for screen readers if provided */
-  AriaOpenAllText?: string;
+  ariaOpenAllText?: string;
   /** 'Close all' button text for screen readers, hides CloseAllText for screen readers if provided */
-  AriaCloseAllText?: string;
+  ariaCloseAllText?: string;
   /** Custom classname to extend or customize */
   className?: string;
   /** Open/Close all button props */
@@ -131,10 +131,10 @@ class BaseExpanderGroup extends Component<ExpanderGroupProps> {
     const {
       className,
       children,
-      OpenAllText,
-      AriaOpenAllText,
-      CloseAllText,
-      AriaCloseAllText,
+      openAllText,
+      ariaOpenAllText,
+      closeAllText,
+      ariaCloseAllText,
       toggleAllButtonProps,
       ...passProps
     } = this.props;
@@ -156,12 +156,12 @@ class BaseExpanderGroup extends Component<ExpanderGroupProps> {
           aria-expanded={allOpen}
         >
           <HtmlSpan aria-hidden={true}>
-            {allOpen ? CloseAllText : OpenAllText}
+            {allOpen ? closeAllText : openAllText}
           </HtmlSpan>
           <VisuallyHidden>
             {allOpen
-              ? AriaCloseAllText || CloseAllText
-              : AriaOpenAllText || OpenAllText}
+              ? ariaCloseAllText || closeAllText
+              : ariaOpenAllText || openAllText}
           </VisuallyHidden>
         </HtmlButton>
         <HtmlDiv className={expandersContainerClassName}>

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -314,8 +314,7 @@ exports[`Basic expander group should match snapshot 1`] = `
 
 .c8.fi-expander_content--open {
   visibility: visible;
-  height: 10%;
-  overflow: visible;
+  height: auto;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
@@ -460,6 +459,7 @@ exports[`Basic expander group should match snapshot 1`] = `
   class="c0 c1 fi-expander-group"
 >
   <button
+    aria-expanded="false"
     class="c2 fi-expander-group_all-button"
     type="button"
   >

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
@@ -52,8 +52,13 @@ describe('Basic ExpanderTitle', () => {
       {...props}
       ariaOpenText="open expander"
       ariaCloseText="close expander"
+      toggleButtonAriaDescribedBy="title-id"
     >
-      {props?.children ? props.children : 'Expander title button'}
+      {props?.children ? (
+        props.children
+      ) : (
+        <span id="title-id">Expander title button</span>
+      )}
     </ExpanderTitle>
   );
 
@@ -91,17 +96,26 @@ describe('Aria attributes', () => {
     <ExpanderTitle
       ariaCloseText="click to close expander"
       ariaOpenText="click to open expander"
+      toggleButtonAriaDescribedBy="title-id"
       {...{ 'data-testid': 'expander-title' }}
       {...props}
     >
-      {props?.children ? props.children : 'Expander title button'}
+      {props?.children ? (
+        props.children
+      ) : (
+        <span id="title-id">Expander title button</span>
+      )}
     </ExpanderTitle>
   );
 
   it('should be passed to title button', () => {
-    const { getByText, rerender } = customRender(TestExpanderWithProps(), {
-      providerProps,
-    });
+    const { getByText, getByRole, rerender } = customRender(
+      TestExpanderWithProps(),
+      {
+        providerProps,
+      },
+    );
+    expect(getByRole('button')).toHaveAttribute('aria-describedby', 'title-id');
     expect(getByText('click to open expander')).toBeTruthy();
     const adjustedProviderProps = {
       ...providerProps,
@@ -120,8 +134,13 @@ describe('Custom id', () => {
       {...props}
       ariaCloseText="click to close expander"
       ariaOpenText="click to open expander"
+      toggleButtonAriaDescribedBy="title-id"
     >
-      {props?.children ? props.children : 'Expander title button'}
+      {props?.children ? (
+        props.children
+      ) : (
+        <span id="title-id">Expander title button</span>
+      )}
     </ExpanderTitle>
   );
 
@@ -134,7 +153,7 @@ describe('Custom id', () => {
       },
     });
     const span = getByText('Expander title button');
-    expect(span).toHaveAttribute('id', 'test-id_title');
+    expect(span.parentElement).toHaveAttribute('id', 'test-id_title');
     const button = getByRole('button');
     expect(button).toHaveAttribute('aria-controls', 'test-id_content');
   });
@@ -146,9 +165,14 @@ describe('Provider open property', () => {
       {...{ 'data-testid': 'expander-open-by-default-title' }}
       ariaCloseText="click to close expander"
       ariaOpenText="click to open expander"
+      toggleButtonAriaDescribedBy="title-id"
       {...props}
     >
-      {props?.children ? props.children : 'Test expander open by default'}
+      {props?.children ? (
+        props.children
+      ) : (
+        <span id="title-id">Test expander open by default</span>
+      )}
     </ExpanderTitle>
   );
 

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -24,11 +24,11 @@ export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'className'> {
   className?: string;
   /** Title for Expander */
   children?: ReactNode;
-  /** Informative text for collapsed expander toggle button. E.g."open expander". */
+  /** Screen reader action label for collapsed expander toggle button. E.g."open expander". */
   ariaOpenText: string;
-  /** Informative text for expanded expander toggle button. E.g."close expander". */
+  /** Screen reader action label for expanded expander toggle button. E.g."close expander". */
   ariaCloseText: string;
-  /** Description id for expander toggle button for referencing expander title. */
+  /** Expander title id for screen reader reference in expander toggle button. */
   toggleButtonAriaDescribedBy: string;
   /** Properties for title open/close toggle button */
   toggleButtonProps?: Omit<

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -24,10 +24,12 @@ export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'className'> {
   className?: string;
   /** Title for Expander */
   children?: ReactNode;
-  /** Additional text for closed expanders toggle button. E.g."open expander". */
+  /** Informative text for collapsed expander toggle button. E.g."open expander". */
   ariaOpenText: string;
-  /** Additional text for open expanders toggle button. E.g."close expander". */
+  /** Informative text for expanded expander toggle button. E.g."close expander". */
   ariaCloseText: string;
+  /** Description id for expander toggle button for referencing expander title. */
+  toggleButtonAriaDescribedBy: string;
   /** Properties for title open/close toggle button */
   toggleButtonProps?: Omit<
     HtmlButtonProps,
@@ -51,6 +53,7 @@ class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
       ariaOpenText,
       children,
       className,
+      toggleButtonAriaDescribedBy,
       toggleButtonProps,
       consumer,
       ...passProps
@@ -70,6 +73,7 @@ class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
           aria-expanded={!!consumer.open}
           className={titleButtonClassName}
           aria-controls={consumer.contentId}
+          aria-describedby={toggleButtonAriaDescribedBy}
         >
           <VisuallyHidden>
             {!!consumer.open ? ariaCloseText : ariaOpenText}

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -275,10 +275,15 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
     class="c2"
     id="test-id_title"
   >
-    Expander title button
+    <span
+      id="title-id"
+    >
+      Expander title button
+    </span>
   </span>
   <button
     aria-controls="test-id_content"
+    aria-describedby="title-id"
     aria-expanded="false"
     class="c3 fi-expander_title-button"
     type="button"

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.test.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.test.tsx
@@ -86,11 +86,7 @@ describe('Basic ExpanderTitleButton', () => {
 
 describe('As heading', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleButtonProps) => (
-    <ExpanderTitleButton
-      ariaCloseText="click to close expander"
-      ariaOpenText="click to open expander"
-      {...props}
-    >
+    <ExpanderTitleButton {...props}>
       {props?.children ? props.children : 'Expander title button'}
     </ExpanderTitleButton>
   );
@@ -103,34 +99,6 @@ describe('As heading', () => {
       },
     );
     expect(getByRole('heading')).toBeTruthy();
-  });
-});
-
-describe('Aria attributes', () => {
-  const TestExpanderWithProps = (props?: ExpanderTitleButtonProps) => (
-    <ExpanderTitleButton
-      ariaCloseText="click to close expander"
-      ariaOpenText="click to open expander"
-      {...{ 'data-testid': 'expander-title' }}
-      {...props}
-    >
-      {props?.children ? props.children : 'Expander title button'}
-    </ExpanderTitleButton>
-  );
-
-  it('should be passed to title button', () => {
-    const { getByText, rerender } = customRender(TestExpanderWithProps(), {
-      providerProps,
-    });
-    expect(getByText('click to open expander')).toBeTruthy();
-    const adjustedProviderProps = {
-      ...providerProps,
-      open: true,
-    };
-    rerender(TestExpanderWithProps(), {
-      providerProps: adjustedProviderProps,
-    });
-    expect(getByText('click to close expander')).toBeTruthy();
   });
 });
 

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
@@ -3,7 +3,6 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv, HtmlButton, HtmlButtonProps, HtmlSpan } from '../../../reset';
 import { Icon } from '../../Icon/Icon';
-import { VisuallyHidden } from '../../../components';
 import { ExpanderConsumer, ExpanderTitleBaseProps } from '../Expander/Expander';
 import { expanderTitleButtonBaseStyles } from './ExpanderTitleButton.baseStyles';
 
@@ -20,10 +19,6 @@ export interface ExpanderTitleButtonProps {
   children?: ReactNode;
   /** Wrap the title button inside a heading tag */
   asHeading?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-  /** Additional text for closed expanders toggle button. E.g."open expander". */
-  ariaOpenText?: string;
-  /** Additional text for open expanders toggle button. E.g."close expander". */
-  ariaCloseText?: string;
   /** Properties for title open/close toggle button */
   toggleButtonProps?: Omit<
     HtmlButtonProps,
@@ -43,8 +38,6 @@ interface InternalExpanderTitleButtonProps
 class BaseExpanderTitleButton extends Component<InternalExpanderTitleButtonProps> {
   render() {
     const {
-      ariaCloseText,
-      ariaOpenText,
       asHeading,
       children,
       className,
@@ -69,11 +62,6 @@ class BaseExpanderTitleButton extends Component<InternalExpanderTitleButtonProps
             aria-controls={consumer.contentId}
           >
             <HtmlSpan id={consumer.titleId}>{children}</HtmlSpan>
-            {(!!ariaCloseText || !!ariaOpenText) && (
-              <VisuallyHidden>
-                {!!consumer.open ? ariaCloseText : ariaOpenText}
-              </VisuallyHidden>
-            )}
             <Icon
               icon="chevronDown"
               className={classnames(iconClassName, {


### PR DESCRIPTION
## Description
This PR improves Expander accessibility features and fixes minor style issues.

ExpanderGroup now has aria-expanded prop for open/close all button. In addition, ExpanderGroup props now follow the naming conventions.

ExpanderTitleButton no longer supports custom aria attributes explicitly due to those being redundant when used with aria-expanded property. Standard aria props can still be used via toggleButtonProps. 

ExpanderTitle now requires providing a title id for the toggle button to make this variant more accessible for screen readers. With this title variant the toggle button does not contain any title information and could be difficult to understand e.g. when using button navigation mode with a screen reader. By adding the title id as aria-describedby for the toggle button solves this issue.

ExpanderContent height and overflow styles are now fixed and should work better in some contexts.

## Related Issue
Some improvements are based on results from accessibility testing by Avaava while others are based on reports from Suomi.fi services.

## Motivation and Context
Expander and related components had some accessibility and style issues. These changes were necessary to fix the issues.

## How Has This Been Tested?
Tested with MacOS using VoiceOver with Safari, Chrome, Firefox and Edge, with Android using Talkback with Chrome and with iOS using Safari.

## Release notes
- ExpanderGroup
  - **Breaking change:** Rename props OpenAllText, AriaOpenAllText, CloseAllText, AriaCloseAllText => openAllText, ariaOpenAllText, closeAllText, ariaCloseAllText,
  - Add aria-expanded prop for Open/Close all button
- ExpanderTitleButton
  - **Breaking change:** remove ariaOpenText and ariaCloseText props
- ExpanderTitle:
  - **Breaking change:** Add required toggleButtonAriaDescribedBy prop
- ExpanderContent:
  - Fix expander content height and overflow styles