### PR TITLE
Fix/modal initial focus and width

### DIFF
--- a/src/core/Modal/Modal/Modal.baseStyles.tsx
+++ b/src/core/Modal/Modal/Modal.baseStyles.tsx
@@ -5,7 +5,7 @@ import { alphaHex } from '../../../utils/css';
 import { element, font } from '../../theme/reset';
 
 export const baseStyles = css`
-  &.fi-modal {
+  &.fi-modal_base {
     ${element(theme)}
     ${font(theme)('actionElementInnerTextBold')}
     width: 100%;
@@ -27,35 +27,30 @@ export const baseStyles = css`
       justify-content: center;
       align-items: center;
     }
-
-    & .fi-modal_content-container {
-      border-radius: ${radius.modal};
-      background-color: ${theme.colors.whiteBase};
-      border-top: ${theme.spacing.insetXs} solid ${theme.colors.highlightBase};
-      overflow: hidden;
-      max-height: calc(100% - 50px);
-      min-height: 230px;
-      width: 800px;
-      flex: 0 1 auto;
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
-    }
+  }
+  & .fi-modal {
+    border-radius: ${radius.modal};
+    background-color: ${theme.colors.whiteBase};
+    border-top: ${theme.spacing.insetXs} solid ${theme.colors.highlightBase};
+    overflow: hidden;
+    max-height: calc(100% - 50px);
+    min-height: 230px;
+    width: 800px;
+    flex: 0 1 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
 
     &--no-scroll {
-      & .fi-modal_content-container {
-        width: 540px;
-        min-height: 190px;
-      }
+      width: 540px;
+      min-height: 190px;
     }
 
     &--small-screen {
-      & .fi-modal_content-container {
-        border-radius: 0;
-        width: 100%;
-        height: 100%;
-        max-height: 100%;
-      }
+      border-radius: 0;
+      width: 100%;
+      height: 100%;
+      max-height: 100%;
     }
   }
 `;

--- a/src/core/Modal/Modal/Modal.md
+++ b/src/core/Modal/Modal/Modal.md
@@ -118,9 +118,11 @@ const [smallScreen, setSmallScreen] = useState(false);
 
 ### Modal with onClose and onOpen focus set
 
-By default, Modal will focus the first focusable element inside the modal when opened and return the focus to where it was before opening the modal.
+By default, initial focus will be in the modal title. When closed, focus will return to where it was before opening.
 
 _focusOnOpenRef_ and _focusOnCloseRef_ props can be used to change this behaviour.
+
+NOTE: **use with caution** as screen reader users may get confused if initial focus is not in the beginning of modal or if focus does not return to where it was before opening the modal.
 
 ```js
 import { useState, useRef } from 'react';

--- a/src/core/Modal/Modal/Modal.test.tsx
+++ b/src/core/Modal/Modal/Modal.test.tsx
@@ -27,8 +27,8 @@ describe('Basic modal', () => {
   });
 
   it('should have given className', () => {
-    const { container } = render(BasicModal({ className: 'test-class-name' }));
-    expect(container.firstChild).toHaveClass('test-class-name');
+    const { getByRole } = render(BasicModal({ className: 'test-class-name' }));
+    expect(getByRole('dialog')).toHaveClass('test-class-name');
   });
 
   it('should match snapshot', () => {
@@ -198,8 +198,8 @@ describe('Modal variant', () => {
   );
 
   it('smallScreen should have correct classname', () => {
-    const { container } = render(ModalWithProps({ variant: 'smallScreen' }));
-    expect(container.firstChild).toHaveClass('fi-modal--small-screen');
+    const { getByRole } = render(ModalWithProps({ variant: 'smallScreen' }));
+    expect(getByRole('dialog')).toHaveClass('fi-modal--small-screen');
   });
 });
 
@@ -217,17 +217,12 @@ describe('Modal focus', () => {
     </Modal>
   );
 
-  it('should be on primary button if there is no other focusable content', async () => {
+  it('should be on heading by default', async () => {
     const { getAllByRole } = render(ModalWithProps(<p>Modal Content</p>));
-    await waitFor(() => expect(getAllByRole('button')[0]).toHaveFocus());
+    await waitFor(() => expect(getAllByRole('heading')[0]).toHaveFocus());
   });
 
-  it('should be on the first element by default', async () => {
-    const { getByRole } = render(ModalWithProps(<input type="text" />));
-    await waitFor(() => expect(getByRole('textbox')).toHaveFocus());
-  });
-
-  it('should be on given element by default', async () => {
+  it('should be on element provided in props', async () => {
     const RefTest1 = () => {
       const ref = useRef(null);
       return (

--- a/src/core/Modal/Modal/Modal.tsx
+++ b/src/core/Modal/Modal/Modal.tsx
@@ -17,7 +17,7 @@ export interface ModalProps
   extends Omit<HtmlDivProps, 'children' | 'className' | 'title' | 'ref'> {
   /** Show or hide the modal */
   visible: boolean;
-  /** Modal container div class name for custom styling. */
+  /** Modal container div classname for custom styling. */
   className?: string;
   /** Children */
   children: ModalContent | ModalFooter | ReactNode;
@@ -74,8 +74,9 @@ const {
 
 export const baseClassName = 'fi-modal';
 const modalClassNames = {
-  noPortal: `${baseClassName}--no-portal`,
   smallScreen: `${baseClassName}--small-screen`,
+  base: `${baseClassName}_base`,
+  noPortal: `${baseClassName}_base--no-portal`,
   overlay: `${baseClassName}_overlay`,
   contentContainer: `${baseClassName}_content-container`,
   content: `${baseClassName}_content`,
@@ -86,7 +87,7 @@ const modalClassNames = {
   disableBodyContent: `${baseClassName}--disable-body-content`,
 };
 
-class BaseModal extends Component<ModalProps> {
+class BaseModal extends Component<ModalProps & { propClassName?: string }> {
   private previouslyFocusedElement: any;
 
   private focusTrapWrapperRef: React.RefObject<HTMLDivElement>;
@@ -255,6 +256,7 @@ class BaseModal extends Component<ModalProps> {
     const {
       visible,
       id,
+      propClassName,
       className,
       children,
       variant = 'default',
@@ -269,19 +271,19 @@ class BaseModal extends Component<ModalProps> {
     const titleId = `${id}_title`;
     const content = (
       <HtmlDiv
-        className={classnames(className, baseClassName, {
-          [modalClassNames.smallScreen]: variant === 'smallScreen',
-          [modalClassNames.noScroll]: scrollable === false,
+        className={classnames(className, modalClassNames.base, {
           [modalClassNames.noPortal]: usePortal === false,
         })}
       >
         <HtmlDiv className={modalClassNames.overlay}>
           <HtmlDivWithRef
             forwardedRef={this.focusTrapWrapperRef}
-            aria-describedby={titleId}
             role="dialog"
             aria-modal="true"
-            className={modalClassNames.contentContainer}
+            className={classnames(propClassName, baseClassName, {
+              [modalClassNames.smallScreen]: variant === 'smallScreen',
+              [modalClassNames.noScroll]: scrollable === false,
+            })}
             {...passProps}
           >
             <ModalProvider value={{ titleId, variant, scrollable }}>
@@ -313,11 +315,23 @@ const StyledModal = styled(BaseModal)`
  */
 export class Modal extends Component<ModalProps> {
   render() {
-    const { id: propId, visible, ...passProps } = this.props;
+    const {
+      id: propId,
+      visible,
+      className: propClassName,
+      ...passProps
+    } = this.props;
     if (!visible) return null;
     return (
       <AutoId id={propId}>
-        {(id) => <StyledModal id={id} visible={visible} {...passProps} />}
+        {(id) => (
+          <StyledModal
+            id={id}
+            visible={visible}
+            propClassName={propClassName}
+            {...passProps}
+          />
+        )}
       </AutoId>
     );
   }

--- a/src/core/Modal/Modal/Modal.tsx
+++ b/src/core/Modal/Modal/Modal.tsx
@@ -45,6 +45,15 @@ export interface ModalProps
   onEscKeyDown?: () => void;
 }
 
+interface InternalModalProps extends ModalProps {
+  /**
+   * Used to capture user provided classname for use with BaseModal.
+   * Passed on to the BaseModal inner element with fi-modal classname to allow custom styles.
+   * className is internally reserved for BaseModal root element to allow styled component style injection.
+   */
+  propClassName?: string;
+}
+
 export interface ModalProviderState {
   variant: ModalVariant;
   titleId: string | undefined;
@@ -87,7 +96,7 @@ const modalClassNames = {
   disableBodyContent: `${baseClassName}--disable-body-content`,
 };
 
-class BaseModal extends Component<ModalProps & { propClassName?: string }> {
+class BaseModal extends Component<InternalModalProps> {
   private previouslyFocusedElement: any;
 
   private focusTrapWrapperRef: React.RefObject<HTMLDivElement>;

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`Basic modal should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c1.fi-modal {
+.c1.fi-modal_base {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -163,11 +163,11 @@ exports[`Basic modal should match snapshot 1`] = `
   left: 0;
 }
 
-.c1.fi-modal--no-portal {
+.c1.fi-modal_base--no-portal {
   z-index: 100;
 }
 
-.c1.fi-modal .fi-modal_overlay {
+.c1.fi-modal_base .fi-modal_overlay {
   background-color: rgba(41,41,41,0.5);
   width: 100%;
   height: 100%;
@@ -188,7 +188,7 @@ exports[`Basic modal should match snapshot 1`] = `
   align-items: center;
 }
 
-.c1.fi-modal .fi-modal_content-container {
+.c1 .fi-modal {
   border-radius: 4px;
   background-color: hsl(0,0%,100%);
   border-top: 4px solid hsl(212,63%,45%);
@@ -212,12 +212,12 @@ exports[`Basic modal should match snapshot 1`] = `
   align-items: stretch;
 }
 
-.c1.fi-modal--no-scroll .fi-modal_content-container {
+.c1 .fi-modal--no-scroll {
   width: 540px;
   min-height: 190px;
 }
 
-.c1.fi-modal--small-screen .fi-modal_content-container {
+.c1 .fi-modal--small-screen {
   border-radius: 0;
   width: 100%;
   height: 100%;
@@ -504,15 +504,38 @@ exports[`Basic modal should match snapshot 1`] = `
 }
 
 .c6.fi-modal_title {
-  padding-bottom: 20px;
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 20px;
+}
+
+.c6.fi-modal_title:focus {
+  outline: 0;
+}
+
+.c6.fi-modal_title:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c6.fi-modal_title--no-scroll {
-  padding-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 .c6.fi-modal_title--small-screen {
-  padding-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .c7.fi-modal_footer {
@@ -784,7 +807,7 @@ exports[`Basic modal should match snapshot 1`] = `
 }
 
 <div
-  class="c0 c1 fi-modal fi-modal--no-portal"
+  class="c0 c1 fi-modal_base fi-modal_base--no-portal"
   role="presentation"
 >
   <div
@@ -792,9 +815,8 @@ exports[`Basic modal should match snapshot 1`] = `
     role="presentation"
   >
     <div
-      aria-describedby="3_title"
       aria-modal="true"
-      class="c2 fi-modal_content-container"
+      class="c2 fi-modal"
       role="dialog"
     >
       <div
@@ -803,6 +825,7 @@ exports[`Basic modal should match snapshot 1`] = `
         <h2
           class="c4 fi-heading c5 c6 fi-modal_title fi-heading--h3"
           id="3_title"
+          tabindex="0"
         >
           Test modal
         </h2>

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c1.fi-modal {
+.c1.fi-modal_base {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -110,11 +110,11 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   left: 0;
 }
 
-.c1.fi-modal--no-portal {
+.c1.fi-modal_base--no-portal {
   z-index: 100;
 }
 
-.c1.fi-modal .fi-modal_overlay {
+.c1.fi-modal_base .fi-modal_overlay {
   background-color: rgba(41,41,41,0.5);
   width: 100%;
   height: 100%;
@@ -135,7 +135,7 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   align-items: center;
 }
 
-.c1.fi-modal .fi-modal_content-container {
+.c1 .fi-modal {
   border-radius: 4px;
   background-color: hsl(0,0%,100%);
   border-top: 4px solid hsl(212,63%,45%);
@@ -159,12 +159,12 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   align-items: stretch;
 }
 
-.c1.fi-modal--no-scroll .fi-modal_content-container {
+.c1 .fi-modal--no-scroll {
   width: 540px;
   min-height: 190px;
 }
 
-.c1.fi-modal--small-screen .fi-modal_content-container {
+.c1 .fi-modal--small-screen {
   border-radius: 0;
   width: 100%;
   height: 100%;
@@ -451,19 +451,42 @@ exports[`Basic ModalContent should match snapshot 1`] = `
 }
 
 .c6.fi-modal_title {
-  padding-bottom: 20px;
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 20px;
+}
+
+.c6.fi-modal_title:focus {
+  outline: 0;
+}
+
+.c6.fi-modal_title:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c6.fi-modal_title--no-scroll {
-  padding-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 .c6.fi-modal_title--small-screen {
-  padding-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 <div
-  class="c0 c1 fi-modal fi-modal--no-portal"
+  class="c0 c1 fi-modal_base fi-modal_base--no-portal"
   role="presentation"
 >
   <div
@@ -471,9 +494,8 @@ exports[`Basic ModalContent should match snapshot 1`] = `
     role="presentation"
   >
     <div
-      aria-describedby="5_title"
       aria-modal="true"
-      class="c2 fi-modal_content-container"
+      class="c2 fi-modal"
       role="dialog"
     >
       <div
@@ -483,6 +505,7 @@ exports[`Basic ModalContent should match snapshot 1`] = `
         <h2
           class="c4 fi-heading c5 c6 fi-modal_title fi-heading--h3"
           id="5_title"
+          tabindex="0"
         >
           Test modal
         </h2>

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c1.fi-modal {
+.c1.fi-modal_base {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -134,11 +134,11 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   left: 0;
 }
 
-.c1.fi-modal--no-portal {
+.c1.fi-modal_base--no-portal {
   z-index: 100;
 }
 
-.c1.fi-modal .fi-modal_overlay {
+.c1.fi-modal_base .fi-modal_overlay {
   background-color: rgba(41,41,41,0.5);
   width: 100%;
   height: 100%;
@@ -159,7 +159,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   align-items: center;
 }
 
-.c1.fi-modal .fi-modal_content-container {
+.c1 .fi-modal {
   border-radius: 4px;
   background-color: hsl(0,0%,100%);
   border-top: 4px solid hsl(212,63%,45%);
@@ -183,12 +183,12 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   align-items: stretch;
 }
 
-.c1.fi-modal--no-scroll .fi-modal_content-container {
+.c1 .fi-modal--no-scroll {
   width: 540px;
   min-height: 190px;
 }
 
-.c1.fi-modal--small-screen .fi-modal_content-container {
+.c1 .fi-modal--small-screen {
   border-radius: 0;
   width: 100%;
   height: 100%;
@@ -464,7 +464,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 }
 
 <div
-  class="c0 c1 fi-modal fi-modal--no-portal"
+  class="c0 c1 fi-modal_base fi-modal_base--no-portal"
   role="presentation"
 >
   <div
@@ -472,9 +472,8 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
     role="presentation"
   >
     <div
-      aria-describedby="3_title"
       aria-modal="true"
-      class="c2 fi-modal_content-container"
+      class="c2 fi-modal"
       role="dialog"
     >
       <div

--- a/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
+++ b/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
@@ -1,16 +1,28 @@
 import { css } from 'styled-components';
 import { defaultThemeTokens as theme } from '../../theme';
+import { absoluteFocus } from '../../theme/utils';
 
 export const baseStyles = css`
   &.fi-modal_title {
-    padding-bottom: ${theme.spacing.m};
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+
+    &:focus {
+      outline: 0;
+      &:after {
+        ${absoluteFocus}
+      }
+    }
+
+    margin-bottom: ${theme.spacing.m};
 
     &--no-scroll {
-      padding-bottom: ${theme.spacing.xs};
+      margin-bottom: ${theme.spacing.xs};
     }
 
     &--small-screen {
-      padding-bottom: ${theme.spacing.m};
+      margin-bottom: ${theme.spacing.m};
     }
   }
 `;

--- a/src/core/Modal/ModalTitle/ModalTitle.tsx
+++ b/src/core/Modal/ModalTitle/ModalTitle.tsx
@@ -30,7 +30,7 @@ const headingClassNames = {
 
 class BaseModalTitle extends Component<InternalModalTitleProps> {
   state = {
-    tabIndex: 0,
+    titleFocusable: true,
   };
 
   render() {
@@ -51,8 +51,8 @@ class BaseModalTitle extends Component<InternalModalTitleProps> {
           [headingClassNames.smallScreen]: modalVariant === 'smallScreen',
           [headingClassNames.noScroll]: scrollable === false,
         })}
-        tabIndex={this.state.tabIndex}
-        onBlur={() => this.setState({ tabIndex: -1 })}
+        {...(this.state.titleFocusable ? { tabIndex: 0 } : {})}
+        onBlur={() => this.setState({ titleFocusable: false })}
         id={id}
         variant={variant}
         as={as}

--- a/src/core/Modal/ModalTitle/ModalTitle.tsx
+++ b/src/core/Modal/ModalTitle/ModalTitle.tsx
@@ -29,6 +29,10 @@ const headingClassNames = {
 };
 
 class BaseModalTitle extends Component<InternalModalTitleProps> {
+  state = {
+    tabIndex: 0,
+  };
+
   render() {
     const {
       className,
@@ -47,6 +51,8 @@ class BaseModalTitle extends Component<InternalModalTitleProps> {
           [headingClassNames.smallScreen]: modalVariant === 'smallScreen',
           [headingClassNames.noScroll]: scrollable === false,
         })}
+        tabIndex={this.state.tabIndex}
+        onBlur={() => this.setState({ tabIndex: -1 })}
         id={id}
         variant={variant}
         as={as}


### PR DESCRIPTION
## Description
This PR fixes Modal component initial focus to be in the heading instead of the first tabbable element unless a specific element ref is provided for focusing after opening the Modal. In addition, this PR introduces changes to styles so, that it's easier to modify the size of the Modal without relying on implementation details.

Now it's possible to use `<Modal className="custom-modal"` with `.fi-modal.custom-modal.custom-modal { width: '1000px'` and `.fi-modal--smallScreen.custom-modal.custom-modal { width: '100%'`.

## Related Issue
Changes are based on feedback from stakeholders and accessibility testing.

## Motivation and Context
Modal contents other than confirm buttons were not communicated for screen reader users in a proper manner. Having initial focus on the title should resolve the issue.

It was also difficult to customize the modal size due to style structure and css specificity issues. With restructured styles things should now be more simple. 

## How Has This Been Tested?
Tested with Styleguidist build, CRA TS project, SSR test app
- MacOS and VoiceOver using Safari, Chrome, Firefox and Edge
- Android and TalkBack using Chrome

## Release notes
- Modal
 - **Breaking change:** custom className is now passed onto outermost content container instead of component root
 - Initial focus is now in title