### PR TITLE
[Fix] Form element status accessibility

### DIFF
--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -1,8 +1,8 @@
 import React, { Component, forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { InputStatus } from '../types';
-import { getConditionalAriaProp, AriaLiveMode } from '../../../utils/aria';
+import { InputStatus, StatusTextCommonProps } from '../types';
+import { getConditionalAriaProp } from '../../../utils/aria';
 import { logger } from '../../../utils/logger';
 import { AutoId } from '../../../utils/AutoId';
 import { HtmlLabel, HtmlDiv, HtmlInput } from '../../../reset';
@@ -35,7 +35,7 @@ const iconClassnames = {
 
 type CheckboxStatus = Exclude<InputStatus, 'success'>;
 
-interface InternalCheckboxProps {
+interface InternalCheckboxProps extends StatusTextCommonProps {
   /** Controlled checked-state - user actions use onClick to change  */
   checked?: boolean;
   /** Default status of Checkbox when not using controlled 'checked' state
@@ -62,14 +62,6 @@ interface InternalCheckboxProps {
    * @default default
    */
   status?: CheckboxStatus;
-  /**
-   * Status text to be displayed in the status text element. Will not be displayed when element is disabled.
-   */
-  statusText?: string;
-  /** Aria-live mode for the status text element
-   * @default assertive
-   */
-  statusTextAriaLiveMode?: AriaLiveMode;
   /**
    * Hint text to be displayed under the label.
    */

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ import React, { Component, forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { InputStatus } from '../types';
-import { getConditionalAriaProp } from '../../../utils/aria';
+import { getConditionalAriaProp, ariaLiveModes } from '../../../utils/aria';
 import { logger } from '../../../utils/logger';
 import { AutoId } from '../../../utils/AutoId';
 import { HtmlLabel, HtmlDiv, HtmlInput } from '../../../reset';
@@ -66,6 +66,10 @@ interface InternalCheckboxProps {
    * Status text to be displayed in the status text element. Will not be displayed when element is disabled.
    */
   statusText?: string;
+  /** Aria-live mode for the status text element
+   * @default assertive
+   */
+  statusTextAriaLiveMode?: ariaLiveModes;
   /**
    * Hint text to be displayed under the label.
    */
@@ -139,6 +143,7 @@ class BaseCheckbox extends Component<CheckboxProps & InnerRef> {
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
       'aria-describedby': ariaDescribedBy,
+      statusTextAriaLiveMode = 'assertive',
       children,
       checked: dismissChecked,
       defaultChecked: dismissDefaultChecked,
@@ -227,7 +232,11 @@ class BaseCheckbox extends Component<CheckboxProps & InnerRef> {
           {children}
         </HtmlLabel>
         <HintText id={hintTextId}>{hintText}</HintText>
-        <StatusText id={statusTextId} status={status}>
+        <StatusText
+          id={statusTextId}
+          status={status}
+          aria-live={statusTextAriaLiveMode}
+        >
           {statusText}
         </StatusText>
       </HtmlDiv>

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ import React, { Component, forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { InputStatus } from '../types';
-import { getConditionalAriaProp, ariaLiveModes } from '../../../utils/aria';
+import { getConditionalAriaProp, AriaLiveModes } from '../../../utils/aria';
 import { logger } from '../../../utils/logger';
 import { AutoId } from '../../../utils/AutoId';
 import { HtmlLabel, HtmlDiv, HtmlInput } from '../../../reset';
@@ -69,7 +69,7 @@ interface InternalCheckboxProps {
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: ariaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveModes;
   /**
    * Hint text to be displayed under the label.
    */
@@ -235,7 +235,8 @@ class BaseCheckbox extends Component<CheckboxProps & InnerRef> {
         <StatusText
           id={statusTextId}
           status={status}
-          aria-live={statusTextAriaLiveMode}
+          disabled={disabled}
+          ariaLiveMode={statusTextAriaLiveMode}
         >
           {statusText}
         </StatusText>

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ import React, { Component, forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { InputStatus } from '../types';
-import { getConditionalAriaProp, AriaLiveModes } from '../../../utils/aria';
+import { getConditionalAriaProp, AriaLiveMode } from '../../../utils/aria';
 import { logger } from '../../../utils/logger';
 import { AutoId } from '../../../utils/AutoId';
 import { HtmlLabel, HtmlDiv, HtmlInput } from '../../../reset';
@@ -69,7 +69,7 @@ interface InternalCheckboxProps {
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: AriaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveMode;
   /**
    * Hint text to be displayed under the label.
    */

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -88,6 +88,59 @@ exports[`props children has matching snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c5.fi-status-text {
+  margin-top: 5px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c5.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -239,5 +292,8 @@ exports[`props children has matching snapshot 1`] = `
   >
     Regular
   </label>
+  <span
+    class="c4 c5"
+  />
 </div>
 `;

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -293,6 +293,7 @@ exports[`props children has matching snapshot 1`] = `
     Regular
   </label>
   <span
+    aria-live="assertive"
     class="c4 c5"
   />
 </div>

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -118,7 +118,6 @@ exports[`props children has matching snapshot 1`] = `
 }
 
 .c5.fi-status-text {
-  margin-top: 5px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -139,6 +138,10 @@ exports[`props children has matching snapshot 1`] = `
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
+}
+
+.c5.fi-status-text.fi-status-text--hasContent {
+  margin-top: 5px;
 }
 
 .c1 {
@@ -294,7 +297,7 @@ exports[`props children has matching snapshot 1`] = `
   </label>
   <span
     aria-live="assertive"
-    class="c4 c5"
+    class="c4 c5 fi-status-text"
   />
 </div>
 `;

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -9,7 +9,7 @@ import {
   HtmlInput,
 } from '../../../reset';
 import { AutoId } from '../../../utils/AutoId';
-import { getConditionalAriaProp } from '../../../utils/aria';
+import { getConditionalAriaProp, ariaLiveModes } from '../../../utils/aria';
 import { LabelText, LabelMode } from '../LabelText/LabelText';
 import { StatusText } from '../StatusText/StatusText';
 import { baseStyles } from './FilterInput.baseStyles';
@@ -51,6 +51,10 @@ interface InternalFilterInputProps<T> extends Omit<HtmlInputProps, 'type'> {
   status?: FilterInputStatus;
   /** Status text to be shown below the component and hint text. Use e.g. for validation error */
   statusText?: string;
+  /** Aria-live mode for the status text element
+   * @default assertive
+   */
+  statusTextAriaLiveMode?: ariaLiveModes;
   /** FilterInput name */
   name?: string;
   /** Align label on top or on the left side of the input field
@@ -89,6 +93,7 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
       id,
       labelAlign,
       'aria-describedby': ariaDescribedBy,
+      statusTextAriaLiveMode = 'assertive',
       items: propItems,
       onFilter: propOnFiltering,
       filterFunc: propFilterRule,
@@ -153,7 +158,11 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
                 onChange={onChangeHandler}
               />
             </HtmlDiv>
-            <StatusText id={statusTextId} status={status}>
+            <StatusText
+              id={statusTextId}
+              status={status}
+              aria-live={statusTextAriaLiveMode}
+            >
               {statusText}
             </StatusText>
           </HtmlDiv>

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -9,7 +9,7 @@ import {
   HtmlInput,
 } from '../../../reset';
 import { AutoId } from '../../../utils/AutoId';
-import { getConditionalAriaProp, ariaLiveModes } from '../../../utils/aria';
+import { getConditionalAriaProp, AriaLiveModes } from '../../../utils/aria';
 import { LabelText, LabelMode } from '../LabelText/LabelText';
 import { StatusText } from '../StatusText/StatusText';
 import { baseStyles } from './FilterInput.baseStyles';
@@ -54,7 +54,7 @@ interface InternalFilterInputProps<T> extends Omit<HtmlInputProps, 'type'> {
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: ariaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveModes;
   /** FilterInput name */
   name?: string;
   /** Align label on top or on the left side of the input field
@@ -161,7 +161,8 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
             <StatusText
               id={statusTextId}
               status={status}
-              aria-live={statusTextAriaLiveMode}
+              disabled={passProps.disabled}
+              ariaLiveMode={statusTextAriaLiveMode}
             >
               {statusText}
             </StatusText>

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ChangeEvent, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { InputStatus } from '../types';
+import { InputStatus, StatusTextCommonProps } from '../types';
 import {
   HtmlInputProps,
   HtmlDiv,
@@ -9,7 +9,7 @@ import {
   HtmlInput,
 } from '../../../reset';
 import { AutoId } from '../../../utils/AutoId';
-import { getConditionalAriaProp, AriaLiveMode } from '../../../utils/aria';
+import { getConditionalAriaProp } from '../../../utils/aria';
 import { LabelText, LabelMode } from '../LabelText/LabelText';
 import { StatusText } from '../StatusText/StatusText';
 import { baseStyles } from './FilterInput.baseStyles';
@@ -27,7 +27,9 @@ const filterInputClassNames = {
 
 type FilterInputStatus = Exclude<InputStatus, 'success'>;
 
-interface InternalFilterInputProps<T> extends Omit<HtmlInputProps, 'type'> {
+interface InternalFilterInputProps<T>
+  extends Omit<HtmlInputProps, 'type'>,
+    StatusTextCommonProps {
   /** FilterInput container div class name for custom styling. */
   className?: string;
   /** FilterInput container div props */
@@ -49,12 +51,6 @@ interface InternalFilterInputProps<T> extends Omit<HtmlInputProps, 'type'> {
    * @default default
    */
   status?: FilterInputStatus;
-  /** Status text to be shown below the component and hint text. Use e.g. for validation error */
-  statusText?: string;
-  /** Aria-live mode for the status text element
-   * @default assertive
-   */
-  statusTextAriaLiveMode?: AriaLiveMode;
   /** FilterInput name */
   name?: string;
   /** Align label on top or on the left side of the input field

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -9,7 +9,7 @@ import {
   HtmlInput,
 } from '../../../reset';
 import { AutoId } from '../../../utils/AutoId';
-import { getConditionalAriaProp, AriaLiveModes } from '../../../utils/aria';
+import { getConditionalAriaProp, AriaLiveMode } from '../../../utils/aria';
 import { LabelText, LabelMode } from '../LabelText/LabelText';
 import { StatusText } from '../StatusText/StatusText';
 import { baseStyles } from './FilterInput.baseStyles';
@@ -54,7 +54,7 @@ interface InternalFilterInputProps<T> extends Omit<HtmlInputProps, 'type'> {
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: AriaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveMode;
   /** FilterInput name */
   name?: string;
   /** Align label on top or on the left side of the input field

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -119,7 +119,6 @@ exports[`snapshot matches 1`] = `
 }
 
 .c5.fi-status-text {
-  margin-top: 5px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -140,6 +139,10 @@ exports[`snapshot matches 1`] = `
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
+}
+
+.c5.fi-status-text.fi-status-text--hasContent {
+  margin-top: 5px;
 }
 
 .c1 .fi-filter-input {
@@ -322,7 +325,7 @@ exports[`snapshot matches 1`] = `
       </div>
       <span
         aria-live="assertive"
-        class="c3 c5"
+        class="c3 c5 fi-status-text"
       />
     </div>
   </div>

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -118,6 +118,30 @@ exports[`snapshot matches 1`] = `
   font-weight: 400;
 }
 
+.c5.fi-status-text {
+  margin-top: 5px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c5.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
 .c1 .fi-filter-input {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -296,6 +320,9 @@ exports[`snapshot matches 1`] = `
           type="text"
         />
       </div>
+      <span
+        class="c3 c5"
+      />
     </div>
   </div>
 </div>

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -321,6 +321,7 @@ exports[`snapshot matches 1`] = `
         />
       </div>
       <span
+        aria-live="assertive"
         class="c3 c5"
       />
     </div>

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, Component, createRef, FocusEvent } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../../utils/AutoId';
-import { getConditionalAriaProp, ariaLiveModes } from '../../../utils/aria';
+import { getConditionalAriaProp, AriaLiveModes } from '../../../utils/aria';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import {
   HtmlInput,
@@ -63,7 +63,7 @@ export interface SearchInputProps
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: ariaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveModes;
   /** Input name */
   name?: string;
   /** Set components width to 100% */
@@ -276,7 +276,7 @@ class BaseSearchInput extends Component<SearchInputProps> {
           <StatusText
             id={statusTextId}
             status={status}
-            aria-live={statusTextAriaLiveMode}
+            ariaLiveMode={statusTextAriaLiveMode}
           >
             {statusText}
           </StatusText>

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, Component, createRef, FocusEvent } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../../utils/AutoId';
-import { getConditionalAriaProp, AriaLiveModes } from '../../../utils/aria';
+import { getConditionalAriaProp, AriaLiveMode } from '../../../utils/aria';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import {
   HtmlInput,
@@ -63,7 +63,7 @@ export interface SearchInputProps
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: AriaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveMode;
   /** Input name */
   name?: string;
   /** Set components width to 100% */

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, Component, createRef, FocusEvent } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../../utils/AutoId';
-import { getConditionalAriaProp, AriaLiveMode } from '../../../utils/aria';
+import { getConditionalAriaProp } from '../../../utils/aria';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import {
   HtmlInput,
@@ -17,7 +17,7 @@ import { VisuallyHidden } from '../../../components/Visually-hidden/Visually-hid
 import { StatusText } from '../StatusText/StatusText';
 import { LabelText, LabelMode } from '../LabelText/LabelText';
 import { Icon } from '../../Icon/Icon';
-import { InputStatus } from '../types';
+import { InputStatus, StatusTextCommonProps } from '../types';
 import { baseStyles } from './SearchInput.baseStyles';
 
 type SearchInputValue = string | number | undefined;
@@ -25,16 +25,17 @@ type SearchInputValue = string | number | undefined;
 type SearchInputStatus = Exclude<InputStatus, 'success'>;
 
 export interface SearchInputProps
-  extends Omit<
-    HtmlInputProps,
-    | 'type'
-    | 'disabled'
-    | 'onChange'
-    | 'children'
-    | 'onClick'
-    | 'value'
-    | 'defaultValue'
-  > {
+  extends StatusTextCommonProps,
+    Omit<
+      HtmlInputProps,
+      | 'type'
+      | 'disabled'
+      | 'onChange'
+      | 'children'
+      | 'onClick'
+      | 'value'
+      | 'defaultValue'
+    > {
   /** SearchInput container div class name for custom styling. */
   className?: string;
   /** SearchInput wrapping div element props */
@@ -58,12 +59,6 @@ export interface SearchInputProps
    * @default default
    */
   status?: SearchInputStatus;
-  /** Status text to be shown below the component and hint text. Use e.g. for validation error */
-  statusText?: string;
-  /** Aria-live mode for the status text element
-   * @default assertive
-   */
-  statusTextAriaLiveMode?: AriaLiveMode;
   /** Input name */
   name?: string;
   /** Set components width to 100% */

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -60,6 +60,10 @@ export interface SearchInputProps
   status?: SearchInputStatus;
   /** Status text to be shown below the component and hint text. Use e.g. for validation error */
   statusText?: string;
+  /** Aria-live mode for the status text element
+   * @default assertive
+   */
+  statusTextAriaLiveMode?: ariaLiveModes;
   /** Input name */
   name?: string;
   /** Set components width to 100% */
@@ -76,10 +80,6 @@ export interface SearchInputProps
   onSearch?: (value: SearchInputValue) => void;
   /** Debounce time in milliseconds for onChange function. No debounce is applied if no value is given. */
   debounce?: number;
-  /** Aria-live mode for the status text element
-   * @default assertive
-   */
-  statusTextAriaLiveMode?: ariaLiveModes;
 }
 
 const baseClassName = 'fi-search-input';

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, Component, createRef, FocusEvent } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../../utils/AutoId';
-import { getConditionalAriaProp } from '../../../utils/aria';
+import { getConditionalAriaProp, ariaLiveModes } from '../../../utils/aria';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import {
   HtmlInput,
@@ -76,6 +76,10 @@ export interface SearchInputProps
   onSearch?: (value: SearchInputValue) => void;
   /** Debounce time in milliseconds for onChange function. No debounce is applied if no value is given. */
   debounce?: number;
+  /** Aria-live mode for the status text element
+   * @default assertive
+   */
+  statusTextAriaLiveMode?: ariaLiveModes;
 }
 
 const baseClassName = 'fi-search-input';
@@ -137,6 +141,7 @@ class BaseSearchInput extends Component<SearchInputProps> {
       fullWidth,
       debounce,
       'aria-describedby': ariaDescribedBy,
+      statusTextAriaLiveMode = 'assertive',
       ...passProps
     } = this.props;
 
@@ -268,7 +273,11 @@ class BaseSearchInput extends Component<SearchInputProps> {
               </HtmlDiv>
             )}
           </Debounce>
-          <StatusText id={statusTextId} status={status}>
+          <StatusText
+            id={statusTextId}
+            status={status}
+            aria-live={statusTextAriaLiveMode}
+          >
             {statusText}
           </StatusText>
         </HtmlSpan>

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -158,7 +158,6 @@ exports[`snapshot should have matching default structure 1`] = `
 }
 
 .c8.fi-status-text {
-  margin-top: 5px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -179,6 +178,10 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c8.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
+}
+
+.c8.fi-status-text.fi-status-text--hasContent {
+  margin-top: 5px;
 }
 
 .c3.fi-label-text .fi-label-text_label-span {
@@ -579,7 +582,7 @@ exports[`snapshot should have matching default structure 1`] = `
     </div>
     <span
       aria-live="assertive"
-      class="c2 c8"
+      class="c2 c8 fi-status-text"
       id="1-statusText"
     />
   </span>

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -578,6 +578,7 @@ exports[`snapshot should have matching default structure 1`] = `
       </button>
     </div>
     <span
+      aria-live="assertive"
       class="c2 c8"
       id="1-statusText"
     />

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -157,6 +157,30 @@ exports[`snapshot should have matching default structure 1`] = `
   overflow: hidden;
 }
 
+.c8.fi-status-text {
+  margin-top: 5px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c8.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
 .c3.fi-label-text .fi-label-text_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -553,6 +577,10 @@ exports[`snapshot should have matching default structure 1`] = `
         </svg>
       </button>
     </div>
+    <span
+      class="c2 c8"
+      id="1-statusText"
+    />
   </span>
 </div>
 `;

--- a/src/core/Form/StatusText/StatusText.baseStyles.tsx
+++ b/src/core/Form/StatusText/StatusText.baseStyles.tsx
@@ -4,7 +4,6 @@ import { font } from '../../theme/reset';
 
 export const baseStyles = css`
   &.fi-status-text {
-    margin-top: ${theme.spacing.xxs};
     ${font(theme)('bodySemiBoldSmall')};
     color: ${theme.colors.blackBase};
     font-size: 14px;
@@ -12,6 +11,10 @@ export const baseStyles = css`
 
     &.fi-status-text--error {
       color: ${theme.colors.alertBase};
+    }
+
+    &.fi-status-text--hasContent {
+      margin-top: ${theme.spacing.xxs};
     }
   }
 `;

--- a/src/core/Form/StatusText/StatusText.test.tsx
+++ b/src/core/Form/StatusText/StatusText.test.tsx
@@ -10,6 +10,10 @@ describe('props', () => {
       const { container } = render(<StatusText>Test text</StatusText>);
       expect(container.firstChild).toHaveTextContent('Test text');
     });
+    it('renders element even without content', () => {
+      const { container } = render(<StatusText />);
+      expect(container.children.length).toEqual(1);
+    });
   });
 
   describe('id', () => {

--- a/src/core/Form/StatusText/StatusText.test.tsx
+++ b/src/core/Form/StatusText/StatusText.test.tsx
@@ -38,6 +38,24 @@ describe('props', () => {
       expect(container.firstChild).toHaveClass('fi-status-text--error');
     });
   });
+
+  describe('aria-live', () => {
+    it('should have the specified aria-live attribute', () => {
+      const { container } = render(
+        <StatusText ariaLiveMode="assertive">Test text</StatusText>,
+      );
+      expect(container.firstChild).toHaveAttribute('aria-live', 'assertive');
+    });
+
+    it('should not have aria-live attribute when disabled', () => {
+      const { container } = render(
+        <StatusText disabled ariaLiveMode="assertive">
+          Test text
+        </StatusText>,
+      );
+      expect(container.firstChild).not.toHaveAttribute('aria-live');
+    });
+  });
 });
 
 test(

--- a/src/core/Form/StatusText/StatusText.test.tsx
+++ b/src/core/Form/StatusText/StatusText.test.tsx
@@ -44,7 +44,7 @@ describe('props', () => {
   });
 
   describe('aria-live', () => {
-    it('should have aria-live=assertive as default even when empty', () => {
+    it('should have given aria-live attribute even when empty', () => {
       const { container } = render(<StatusText ariaLiveMode="assertive" />);
       expect(container.firstChild).toHaveAttribute('aria-live', 'assertive');
     });

--- a/src/core/Form/StatusText/StatusText.test.tsx
+++ b/src/core/Form/StatusText/StatusText.test.tsx
@@ -10,11 +10,6 @@ describe('props', () => {
       const { container } = render(<StatusText>Test text</StatusText>);
       expect(container.firstChild).toHaveTextContent('Test text');
     });
-
-    it('is null when no children given', () => {
-      const { container } = render(<StatusText />);
-      expect(container.firstChild).toEqual(null);
-    });
   });
 
   describe('id', () => {
@@ -41,13 +36,6 @@ describe('props', () => {
         <StatusText status="error">Test text</StatusText>,
       );
       expect(container.firstChild).toHaveClass('fi-status-text--error');
-    });
-  });
-
-  describe('disabled', () => {
-    it('is null when disabled', () => {
-      const { container } = render(<StatusText disabled>Test text</StatusText>);
-      expect(container.firstChild).toEqual(null);
     });
   });
 });

--- a/src/core/Form/StatusText/StatusText.test.tsx
+++ b/src/core/Form/StatusText/StatusText.test.tsx
@@ -44,20 +44,24 @@ describe('props', () => {
   });
 
   describe('aria-live', () => {
-    it('should have the specified aria-live attribute', () => {
-      const { container } = render(
-        <StatusText ariaLiveMode="assertive">Test text</StatusText>,
-      );
+    it('should have aria-live=assertive as default even when empty', () => {
+      const { container } = render(<StatusText ariaLiveMode="assertive" />);
       expect(container.firstChild).toHaveAttribute('aria-live', 'assertive');
     });
+    it('should have the specified aria-live attribute', () => {
+      const { container } = render(
+        <StatusText ariaLiveMode="polite">Test text</StatusText>,
+      );
+      expect(container.firstChild).toHaveAttribute('aria-live', 'polite');
+    });
 
-    it('should not have aria-live attribute when disabled', () => {
+    it('aria-live should be off when disabled', () => {
       const { container } = render(
         <StatusText disabled ariaLiveMode="assertive">
           Test text
         </StatusText>,
       );
-      expect(container.firstChild).not.toHaveAttribute('aria-live');
+      expect(container.firstChild).toHaveAttribute('aria-live', 'off');
     });
   });
 });

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -35,7 +35,9 @@ const StyledStatusText = styled(
     ariaLiveMode,
     ...passProps
   }: StatusTextProps) => {
-    const ariaLiveProp = !disabled ? { 'aria-live': ariaLiveMode } : {};
+    const ariaLiveProp = !disabled
+      ? { 'aria-live': ariaLiveMode }
+      : { 'aria-live': 'off' };
 
     return (
       <HtmlSpan

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -4,10 +4,12 @@ import { default as styled } from 'styled-components';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
 import { InputStatus } from '../types';
 import { baseStyles } from './StatusText.baseStyles';
+import { AriaLiveModes } from 'utils/aria';
 
 const baseClassName = 'fi-status-text';
 const statusTextClassNames = {
   error: `${baseClassName}--error`,
+  hasContent: `${baseClassName}--hasContent`,
 };
 
 export interface StatusTextProps extends HtmlSpanProps {
@@ -21,6 +23,8 @@ export interface StatusTextProps extends HtmlSpanProps {
   disabled?: boolean;
   /** Status */
   status?: InputStatus;
+  /** aria-live mode for the element */
+  ariaLiveMode?: AriaLiveModes;
 }
 
 const StyledStatusText = styled(
@@ -29,18 +33,24 @@ const StyledStatusText = styled(
     children,
     disabled,
     status,
+    ariaLiveMode,
     ...passProps
-  }: StatusTextProps) => (
-    <HtmlSpan
-      {...passProps}
-      className={classnames(className, {
-        [baseClassName]: children && !disabled,
-        [statusTextClassNames.error]: status === 'error',
-      })}
-    >
-      {children}
-    </HtmlSpan>
-  ),
+  }: StatusTextProps) => {
+    const ariaLiveProp = !disabled ? { 'aria-live': ariaLiveMode } : {};
+
+    return (
+      <HtmlSpan
+        {...passProps}
+        {...ariaLiveProp}
+        className={classnames(className, baseClassName, {
+          [statusTextClassNames.hasContent]: children,
+          [statusTextClassNames.error]: status === 'error',
+        })}
+      >
+        {children}
+      </HtmlSpan>
+    );
+  },
 )`
   ${baseStyles}
 `;

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -24,10 +24,17 @@ export interface StatusTextProps extends HtmlSpanProps {
 }
 
 const StyledStatusText = styled(
-  ({ className, children, status, ...passProps }: StatusTextProps) => (
+  ({
+    className,
+    children,
+    disabled,
+    status,
+    ...passProps
+  }: StatusTextProps) => (
     <HtmlSpan
       {...passProps}
-      className={classnames(className, baseClassName, {
+      className={classnames(className, {
+        [baseClassName]: children && !disabled,
         [statusTextClassNames.error]: status === 'error',
       })}
     >
@@ -40,10 +47,7 @@ const StyledStatusText = styled(
 
 export class StatusText extends Component<StatusTextProps> {
   render() {
-    const { disabled, children, ...passProps } = this.props;
-    if (disabled || !children) {
-      return null;
-    }
+    const { children, ...passProps } = this.props;
     return <StyledStatusText {...passProps}>{children}</StyledStatusText>;
   }
 }

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -2,9 +2,8 @@ import React, { Component, ReactNode } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
-import { InputStatus } from '../types';
+import { InputStatus, AriaLiveMode } from '../types';
 import { baseStyles } from './StatusText.baseStyles';
-import { AriaLiveMode } from 'utils/aria';
 
 const baseClassName = 'fi-status-text';
 const statusTextClassNames = {

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -4,7 +4,7 @@ import { default as styled } from 'styled-components';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
 import { InputStatus } from '../types';
 import { baseStyles } from './StatusText.baseStyles';
-import { AriaLiveModes } from 'utils/aria';
+import { AriaLiveMode } from 'utils/aria';
 
 const baseClassName = 'fi-status-text';
 const statusTextClassNames = {
@@ -24,7 +24,7 @@ export interface StatusTextProps extends HtmlSpanProps {
   /** Status */
   status?: InputStatus;
   /** aria-live mode for the element */
-  ariaLiveMode?: AriaLiveModes;
+  ariaLiveMode?: AriaLiveMode;
 }
 
 const StyledStatusText = styled(

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -65,17 +65,15 @@ const statusText = errorState
   : undefined;
 const status = errorState ? 'error' : 'default';
 
-<>
-  <TextInput
-    labelText="Test TextInput"
-    statusText={statusText}
-    status={status}
-  />
-
-  <Button onClick={() => setErrorState(!errorState)}>
-    Toggle error state
-  </Button>
-</>;
+<TextInput
+  labelText="TextInput with changing error status"
+  statusText={statusText}
+  status={status}
+  debounce={300}
+  onChange={() => {
+    setErrorState(!errorState);
+  }}
+/>;
 ```
 
 ```js

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -82,6 +82,10 @@ interface InternalTextInputProps
   icon?: BaseIconKeys;
   /** Properties for the icon */
   iconProps?: Omit<IconProps, 'icon'>;
+  /** Aria-live mode for the status text element
+   * @default assertive
+   */
+  statusTextAriaLiveMode?: 'assertive' | 'polite' | 'off';
 }
 
 interface InnerRef {
@@ -113,6 +117,7 @@ class BaseTextInput extends Component<TextInputProps & InnerRef> {
       iconProps,
       forwardedRef,
       debounce,
+      statusTextAriaLiveMode = 'assertive',
       'aria-describedby': ariaDescribedBy,
       ...passProps
     } = this.props;
@@ -168,7 +173,11 @@ class BaseTextInput extends Component<TextInputProps & InnerRef> {
             </Debounce>
             {resolvedIcon && <Icon {...{ ...iconProps, icon: resolvedIcon }} />}
           </HtmlDiv>
-          <StatusText id={statusTextId} status={status}>
+          <StatusText
+            id={statusTextId}
+            status={status}
+            aria-live={statusTextAriaLiveMode}
+          >
             {statusText}
           </StatusText>
         </HtmlSpan>

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -64,6 +64,10 @@ interface InternalTextInputProps
   status?: InputStatus;
   /** Status text to be shown below the component and hint text. Use e.g. for validation error */
   statusText?: string;
+  /** Aria-live mode for the status text element
+   * @default assertive
+   */
+  statusTextAriaLiveMode?: ariaLiveModes;
   /** 'text' | 'email' | 'number' | 'password' | 'tel' | 'url'
    * @default text
    */
@@ -82,10 +86,6 @@ interface InternalTextInputProps
   icon?: BaseIconKeys;
   /** Properties for the icon */
   iconProps?: Omit<IconProps, 'icon'>;
-  /** Aria-live mode for the status text element
-   * @default assertive
-   */
-  statusTextAriaLiveMode?: ariaLiveModes;
 }
 
 interface InnerRef {

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -3,7 +3,7 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../../utils/AutoId';
 import { Debounce } from '../../utils/Debounce/Debounce';
-import { AriaLiveMode, getConditionalAriaProp } from '../../../utils/aria';
+import { getConditionalAriaProp } from '../../../utils/aria';
 import {
   HtmlInputProps,
   HtmlDiv,
@@ -15,7 +15,7 @@ import { Icon, IconProps, BaseIconKeys } from '../../Icon/Icon';
 import { LabelText, LabelMode } from '../LabelText/LabelText';
 import { StatusText } from '../StatusText/StatusText';
 import { HintText } from '../HintText/HintText';
-import { InputStatus } from '../types';
+import { InputStatus, StatusTextCommonProps } from '../types';
 import { baseStyles } from './TextInput.baseStyles';
 
 const baseClassName = 'fi-text-input';
@@ -34,7 +34,8 @@ export const textInputClassNames = {
 type TextInputValue = string | number | undefined;
 
 interface InternalTextInputProps
-  extends Omit<HtmlInputProps, 'type' | 'onChange'> {
+  extends StatusTextCommonProps,
+    Omit<HtmlInputProps, 'type' | 'onChange'> {
   /** TextInput container div class name for custom styling. */
   className?: string;
   /** TextInput wrapping div element props */
@@ -62,12 +63,6 @@ interface InternalTextInputProps
    * @default default
    */
   status?: InputStatus;
-  /** Status text to be shown below the component and hint text. Use e.g. for validation error */
-  statusText?: string;
-  /** Aria-live mode for the status text element
-   * @default assertive
-   */
-  statusTextAriaLiveMode?: AriaLiveMode;
   /** 'text' | 'email' | 'number' | 'password' | 'tel' | 'url'
    * @default text
    */

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -3,7 +3,7 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../../utils/AutoId';
 import { Debounce } from '../../utils/Debounce/Debounce';
-import { getConditionalAriaProp } from '../../../utils/aria';
+import { ariaLiveModes, getConditionalAriaProp } from '../../../utils/aria';
 import {
   HtmlInputProps,
   HtmlDiv,
@@ -85,7 +85,7 @@ interface InternalTextInputProps
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: 'assertive' | 'polite' | 'off';
+  statusTextAriaLiveMode?: ariaLiveModes;
 }
 
 interface InnerRef {

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -3,7 +3,7 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../../utils/AutoId';
 import { Debounce } from '../../utils/Debounce/Debounce';
-import { AriaLiveModes, getConditionalAriaProp } from '../../../utils/aria';
+import { AriaLiveMode, getConditionalAriaProp } from '../../../utils/aria';
 import {
   HtmlInputProps,
   HtmlDiv,
@@ -67,7 +67,7 @@ interface InternalTextInputProps
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: AriaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveMode;
   /** 'text' | 'email' | 'number' | 'password' | 'tel' | 'url'
    * @default text
    */

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -3,7 +3,7 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../../utils/AutoId';
 import { Debounce } from '../../utils/Debounce/Debounce';
-import { ariaLiveModes, getConditionalAriaProp } from '../../../utils/aria';
+import { AriaLiveModes, getConditionalAriaProp } from '../../../utils/aria';
 import {
   HtmlInputProps,
   HtmlDiv,
@@ -67,7 +67,7 @@ interface InternalTextInputProps
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: ariaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveModes;
   /** 'text' | 'email' | 'number' | 'password' | 'tel' | 'url'
    * @default text
    */
@@ -176,7 +176,8 @@ class BaseTextInput extends Component<TextInputProps & InnerRef> {
           <StatusText
             id={statusTextId}
             status={status}
-            aria-live={statusTextAriaLiveMode}
+            ariaLiveMode={statusTextAriaLiveMode}
+            disabled={passProps.disabled}
           >
             {statusText}
           </StatusText>

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -333,6 +333,7 @@ exports[`snapshots match error status with statustext 1`] = `
       />
     </div>
     <span
+      aria-live="assertive"
       class="c2 c5 fi-status-text fi-status-text--error"
       id="test-id2-statusText"
     >
@@ -470,6 +471,30 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c6.fi-status-text {
+  margin-top: 5px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c6.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
 }
 
 .c1.fi-text-input {
@@ -661,6 +686,11 @@ exports[`snapshots match hidden label with placeholder 1`] = `
         type="text"
       />
     </div>
+    <span
+      aria-live="assertive"
+      class="c2 c6"
+      id="test-id1-statusText"
+    />
   </span>
 </div>
 `;
@@ -781,6 +811,30 @@ exports[`snapshots match minimal implementation 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c5.fi-status-text {
+  margin-top: 5px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c5.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
 }
 
 .c1.fi-text-input {
@@ -971,6 +1025,11 @@ exports[`snapshots match minimal implementation 1`] = `
         type="text"
       />
     </div>
+    <span
+      aria-live="assertive"
+      class="c2 c5"
+      id="test-id-statusText"
+    />
   </span>
 </div>
 `;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -119,7 +119,6 @@ exports[`snapshots match error status with statustext 1`] = `
 }
 
 .c5.fi-status-text {
-  margin-top: 5px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -140,6 +139,10 @@ exports[`snapshots match error status with statustext 1`] = `
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
+}
+
+.c5.fi-status-text.fi-status-text--hasContent {
+  margin-top: 5px;
 }
 
 .c1.fi-text-input {
@@ -334,7 +337,7 @@ exports[`snapshots match error status with statustext 1`] = `
     </div>
     <span
       aria-live="assertive"
-      class="c2 c5 fi-status-text fi-status-text--error"
+      class="c2 c5 fi-status-text fi-status-text--hasContent fi-status-text--error"
       id="test-id2-statusText"
     >
       This is a status text
@@ -474,7 +477,6 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 }
 
 .c6.fi-status-text {
-  margin-top: 5px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -495,6 +497,10 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 
 .c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
+}
+
+.c6.fi-status-text.fi-status-text--hasContent {
+  margin-top: 5px;
 }
 
 .c1.fi-text-input {
@@ -688,7 +694,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
     </div>
     <span
       aria-live="assertive"
-      class="c2 c6"
+      class="c2 c6 fi-status-text"
       id="test-id1-statusText"
     />
   </span>
@@ -814,7 +820,6 @@ exports[`snapshots match minimal implementation 1`] = `
 }
 
 .c5.fi-status-text {
-  margin-top: 5px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -835,6 +840,10 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
+}
+
+.c5.fi-status-text.fi-status-text--hasContent {
+  margin-top: 5px;
 }
 
 .c1.fi-text-input {
@@ -1027,7 +1036,7 @@ exports[`snapshots match minimal implementation 1`] = `
     </div>
     <span
       aria-live="assertive"
-      class="c2 c5"
+      class="c2 c5 fi-status-text"
       id="test-id-statusText"
     />
   </span>

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ChangeEvent, FocusEvent, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { getConditionalAriaProp, AriaLiveModes } from '../../../utils/aria';
+import { getConditionalAriaProp, AriaLiveMode } from '../../../utils/aria';
 import { AutoId } from '../../../utils/AutoId';
 import {
   HtmlTextarea,
@@ -62,7 +62,7 @@ interface InternalTextareaProps extends Omit<HtmlTextareaProps, 'placeholder'> {
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: AriaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveMode;
   /** Resize mode of the textarea
       'both' | 'vertical' | 'horizontal' | 'none'
       @default 'vertical' 

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -59,6 +59,10 @@ interface InternalTextareaProps extends Omit<HtmlTextareaProps, 'placeholder'> {
   status?: TextareaStatus;
   /** Status text to be shown below the component and hint text. Use e.g. for validation error */
   statusText?: string;
+  /** Aria-live mode for the status text element
+   * @default assertive
+   */
+  statusTextAriaLiveMode?: ariaLiveModes;
   /** Resize mode of the textarea
       'both' | 'vertical' | 'horizontal' | 'none'
       @default 'vertical' 
@@ -77,10 +81,6 @@ interface InternalTextareaProps extends Omit<HtmlTextareaProps, 'placeholder'> {
   fullWidth?: boolean;
   /** Textarea container div props */
   containerProps?: Omit<HtmlDivProps, 'className'>;
-  /** Aria-live mode for the status text element
-   * @default assertive
-   */
-  statusTextAriaLiveMode?: ariaLiveModes;
 }
 
 interface InnerRef {

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ChangeEvent, FocusEvent, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { getConditionalAriaProp, AriaLiveMode } from '../../../utils/aria';
+import { getConditionalAriaProp } from '../../../utils/aria';
 import { AutoId } from '../../../utils/AutoId';
 import {
   HtmlTextarea,
@@ -12,7 +12,7 @@ import {
 import { LabelText } from '../LabelText/LabelText';
 import { HintText } from '../HintText/HintText';
 import { StatusText } from '../StatusText/StatusText';
-import { InputStatus } from '../types';
+import { InputStatus, StatusTextCommonProps } from '../types';
 import { baseStyles } from './Textarea.baseStyles';
 
 const baseClassName = 'fi-textarea';
@@ -29,7 +29,9 @@ const textareaClassNames = {
 
 type TextareaStatus = Exclude<InputStatus, 'success'>;
 
-interface InternalTextareaProps extends Omit<HtmlTextareaProps, 'placeholder'> {
+interface InternalTextareaProps
+  extends StatusTextCommonProps,
+    Omit<HtmlTextareaProps, 'placeholder'> {
   /** Custom classname to extend or customize */
   className?: string;
   /** Disable usage */
@@ -57,12 +59,6 @@ interface InternalTextareaProps extends Omit<HtmlTextareaProps, 'placeholder'> {
    * @default default
    */
   status?: TextareaStatus;
-  /** Status text to be shown below the component and hint text. Use e.g. for validation error */
-  statusText?: string;
-  /** Aria-live mode for the status text element
-   * @default assertive
-   */
-  statusTextAriaLiveMode?: AriaLiveMode;
   /** Resize mode of the textarea
       'both' | 'vertical' | 'horizontal' | 'none'
       @default 'vertical' 

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ChangeEvent, FocusEvent, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { getConditionalAriaProp } from '../../../utils/aria';
+import { getConditionalAriaProp, ariaLiveModes } from '../../../utils/aria';
 import { AutoId } from '../../../utils/AutoId';
 import {
   HtmlTextarea,
@@ -77,6 +77,10 @@ interface InternalTextareaProps extends Omit<HtmlTextareaProps, 'placeholder'> {
   fullWidth?: boolean;
   /** Textarea container div props */
   containerProps?: Omit<HtmlDivProps, 'className'>;
+  /** Aria-live mode for the status text element
+   * @default assertive
+   */
+  statusTextAriaLiveMode?: ariaLiveModes;
 }
 
 interface InnerRef {
@@ -108,6 +112,7 @@ class BaseTextarea extends Component<TextareaProps & InnerRef> {
       fullWidth,
       containerProps,
       forwardedRef,
+      statusTextAriaLiveMode = 'assertive',
       ...passProps
     } = this.props;
 
@@ -155,7 +160,11 @@ class BaseTextarea extends Component<TextareaProps & InnerRef> {
             {...onClickProps}
           />
         </HtmlDiv>
-        <StatusText id={statusTextId} status={status}>
+        <StatusText
+          id={statusTextId}
+          status={status}
+          aria-live={statusTextAriaLiveMode}
+        >
           {statusText}
         </StatusText>
       </HtmlDiv>

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ChangeEvent, FocusEvent, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { getConditionalAriaProp, ariaLiveModes } from '../../../utils/aria';
+import { getConditionalAriaProp, AriaLiveModes } from '../../../utils/aria';
 import { AutoId } from '../../../utils/AutoId';
 import {
   HtmlTextarea,
@@ -62,7 +62,7 @@ interface InternalTextareaProps extends Omit<HtmlTextareaProps, 'placeholder'> {
   /** Aria-live mode for the status text element
    * @default assertive
    */
-  statusTextAriaLiveMode?: ariaLiveModes;
+  statusTextAriaLiveMode?: AriaLiveModes;
   /** Resize mode of the textarea
       'both' | 'vertical' | 'horizontal' | 'none'
       @default 'vertical' 
@@ -163,7 +163,8 @@ class BaseTextarea extends Component<TextareaProps & InnerRef> {
         <StatusText
           id={statusTextId}
           status={status}
-          aria-live={statusTextAriaLiveMode}
+          disabled={disabled}
+          ariaLiveMode={statusTextAriaLiveMode}
         >
           {statusText}
         </StatusText>

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -303,6 +303,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
     />
   </div>
   <span
+    aria-live="assertive"
     class="c3 c5"
   />
 </div>

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -119,7 +119,6 @@ exports[`snapshot default structure should match snapshot 1`] = `
 }
 
 .c5.fi-status-text {
-  margin-top: 5px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -140,6 +139,10 @@ exports[`snapshot default structure should match snapshot 1`] = `
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
+}
+
+.c5.fi-status-text.fi-status-text--hasContent {
+  margin-top: 5px;
 }
 
 .c1 {
@@ -304,7 +307,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
   </div>
   <span
     aria-live="assertive"
-    class="c3 c5"
+    class="c3 c5 fi-status-text"
   />
 </div>
 `;

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -118,6 +118,30 @@ exports[`snapshot default structure should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c5.fi-status-text {
+  margin-top: 5px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,16%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c5.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
 .c1 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -278,5 +302,8 @@ exports[`snapshot default structure should match snapshot 1`] = `
       id="just-for-snapshot-to-be-same"
     />
   </div>
+  <span
+    class="c3 c5"
+  />
 </div>
 `;

--- a/src/core/Form/types.ts
+++ b/src/core/Form/types.ts
@@ -1,1 +1,12 @@
+import { AriaLiveMode } from '../../utils/aria';
+
 export type InputStatus = 'default' | 'error' | 'success';
+
+export interface StatusTextCommonProps {
+  /** Status text to be shown below the component and hint text. Use e.g. for validation error */
+  statusText?: string;
+  /** Aria-live mode for the status text element
+   * @default assertive
+   */
+  statusTextAriaLiveMode?: AriaLiveMode;
+}

--- a/src/core/Form/types.ts
+++ b/src/core/Form/types.ts
@@ -1,6 +1,6 @@
-import { AriaLiveMode } from '../../utils/aria';
-
 export type InputStatus = 'default' | 'error' | 'success';
+
+export type AriaLiveMode = 'assertive' | 'polite' | 'off';
 
 export interface StatusTextCommonProps {
   /** Status text to be shown below the component and hint text. Use e.g. for validation error */

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -5,7 +5,7 @@ export const ariaLabelOrHidden = (ariaLabel?: string) =>
     ? { 'aria-label': ariaLabel, role: 'img' }
     : { 'aria-hidden': true };
 
-export type AriaLiveModes = 'assertive' | 'polite' | 'off';
+export type AriaLiveMode = 'assertive' | 'polite' | 'off';
 
 /**
  * Set element ability to be focusable based on aria-label

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -5,7 +5,7 @@ export const ariaLabelOrHidden = (ariaLabel?: string) =>
     ? { 'aria-label': ariaLabel, role: 'img' }
     : { 'aria-hidden': true };
 
-export type ariaLiveModes = 'assertive' | 'polite' | 'off';
+export type AriaLiveModes = 'assertive' | 'polite' | 'off';
 
 /**
  * Set element ability to be focusable based on aria-label

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -5,6 +5,8 @@ export const ariaLabelOrHidden = (ariaLabel?: string) =>
     ? { 'aria-label': ariaLabel, role: 'img' }
     : { 'aria-hidden': true };
 
+export type ariaLiveModes = 'assertive' | 'polite' | 'off';
+
 /**
  * Set element ability to be focusable based on aria-label
  * @param {String} ariaLabel optional aria-label
@@ -14,6 +16,7 @@ export const ariaFocusableNoLabel = (ariaLabel?: string) =>
 
 type ariaPropName = 'aria-describedby' | 'aria-labelledby' | 'aria-label';
 type ariaProp = { [key in ariaPropName]: string } | {};
+
 /**
  * Returns object with 'aria-' property which can be spread to props.
  * E.g:

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -5,8 +5,6 @@ export const ariaLabelOrHidden = (ariaLabel?: string) =>
     ? { 'aria-label': ariaLabel, role: 'img' }
     : { 'aria-hidden': true };
 
-export type AriaLiveMode = 'assertive' | 'polite' | 'off';
-
 /**
  * Set element ability to be focusable based on aria-label
  * @param {String} ariaLabel optional aria-label


### PR DESCRIPTION
## Description
This PR makes status text an aria-live region, so screen reader users get information of status changes immediately. It also implements this change into form components using StatusText.

## Motivation and Context
The lack of information about component status changes was something that has come up in the recent accessibility clinics and needed to be addressed.

## How Has This Been Tested?
Tested with NVDA + chrome + FF and Talkback + Chrome.

## Release notes
### TextInput, TextArea, Checkbox, SearchInput
* Status text now has `aria-live="assertive"` by default. This can be changed via `statusTextAriaLiveMode` prop.
