### PR TITLE
[Feature] Add aria-atomic to StatusText component

### DIFF
--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -296,6 +296,7 @@ exports[`props children has matching snapshot 1`] = `
     Regular
   </label>
   <span
+    aria-atomic="true"
     aria-live="assertive"
     class="c4 c5 fi-status-text"
   />

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -324,6 +324,7 @@ exports[`snapshot matches 1`] = `
         />
       </div>
       <span
+        aria-atomic="true"
         aria-live="assertive"
         class="c3 c5 fi-status-text"
       />

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -581,6 +581,7 @@ exports[`snapshot should have matching default structure 1`] = `
       </button>
     </div>
     <span
+      aria-atomic="true"
       aria-live="assertive"
       class="c2 c8 fi-status-text"
       id="1-statusText"

--- a/src/core/Form/StatusText/StatusText.test.tsx
+++ b/src/core/Form/StatusText/StatusText.test.tsx
@@ -43,7 +43,7 @@ describe('props', () => {
     });
   });
 
-  describe('aria-live', () => {
+  describe('aria attributes', () => {
     it('should have given aria-live attribute even when empty', () => {
       const { container } = render(<StatusText ariaLiveMode="assertive" />);
       expect(container.firstChild).toHaveAttribute('aria-live', 'assertive');
@@ -53,6 +53,10 @@ describe('props', () => {
         <StatusText ariaLiveMode="polite">Test text</StatusText>,
       );
       expect(container.firstChild).toHaveAttribute('aria-live', 'polite');
+    });
+    it('should have aria-atomic set to true by default', () => {
+      const { container } = render(<StatusText>Test text</StatusText>);
+      expect(container.firstChild).toHaveAttribute('aria-atomic', 'true');
     });
 
     it('aria-live should be off when disabled', () => {

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -47,6 +47,7 @@ const StyledStatusText = styled(
           [statusTextClassNames.hasContent]: children,
           [statusTextClassNames.error]: status === 'error',
         })}
+        aria-atomic="true"
       >
         {children}
       </HtmlSpan>

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -336,6 +336,7 @@ exports[`snapshots match error status with statustext 1`] = `
       />
     </div>
     <span
+      aria-atomic="true"
       aria-live="assertive"
       class="c2 c5 fi-status-text fi-status-text--hasContent fi-status-text--error"
       id="test-id2-statusText"
@@ -693,6 +694,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
       />
     </div>
     <span
+      aria-atomic="true"
       aria-live="assertive"
       class="c2 c6 fi-status-text"
       id="test-id1-statusText"
@@ -1035,6 +1037,7 @@ exports[`snapshots match minimal implementation 1`] = `
       />
     </div>
     <span
+      aria-atomic="true"
       aria-live="assertive"
       class="c2 c5 fi-status-text"
       id="test-id-statusText"

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -306,6 +306,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
     />
   </div>
   <span
+    aria-atomic="true"
     aria-live="assertive"
     class="c3 c5 fi-status-text"
   />


### PR DESCRIPTION
## Description
This PR adds aria-atomic to the StatusText component in order to have screen readers read the status messages in their entirety even when only a part of them changes. It also adds a test for the new prop.

## Motivation and Context
It was decided that it would be better to ensure that the error and other status messages are read in their entirety even when only a part of them changes.

## How Has This Been Tested?
Tested by running locally in styleguidist in Chrome and FF. Changing content triggers reading the whole content of the StatusText element.

## Release notes
### TextInput, SearchInput, TextArea, Checkbox
* Status texts now have `aria-atomic` set to true
