### PR TITLE
[Fix] Component focusability in modal

### DIFF
--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -95,8 +95,8 @@ class BaseButton extends Component<ButtonProps & InnerRef> {
         <HtmlButton
           {...passProps}
           {...onClickProp}
+          {...(!!disabled ? {} : { tabIndex: 0 })}
           aria-disabled={!!ariaDisabled || !!disabled}
-          tabIndex={0}
           forwardedRef={forwardedRef}
           disabled={!!disabled}
           className={classnames(baseClassName, className, {

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -4,6 +4,10 @@ import { element, inputButton } from '../../theme/reset';
 import { absoluteFocus } from '../../theme/utils';
 
 export const baseStyles = css`
+  &.fi-dropdown {
+    display: inline-block;
+  }
+
   & [data-reach-listbox-button].fi-dropdown_button {
     ${inputButton(theme)}
     position: relative;

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -85,6 +85,10 @@ exports[`Basic dropdown should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-dropdown {
+  display: inline-block;
+}
+
 .c1 [data-reach-listbox-button].fi-dropdown_button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -349,6 +353,10 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c1.fi-dropdown {
+  display: inline-block;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button {
@@ -618,6 +626,10 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-dropdown {
+  display: inline-block;
+}
+
 .c1 [data-reach-listbox-button].fi-dropdown_button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -882,6 +894,10 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c1.fi-dropdown {
+  display: inline-block;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button {
@@ -1160,6 +1176,10 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c1.fi-dropdown {
+  display: inline-block;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button {

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
@@ -24,6 +24,10 @@ export const expanderTitleBaseStyles = css`
     border-bottom-right-radius: 0;
   }
 
+  & .fi-expander_title-content {
+    display: inline-block;
+  }
+
   & .fi-expander_title-button {
     ${button(theme)}
     ${font(theme)('bodySemiBold')}

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -15,6 +15,7 @@ import { expanderTitleBaseStyles } from './ExpanderTitle.baseStyles';
 
 const baseClassName = 'fi-expander_title';
 const titleOpenClassName = `${baseClassName}--open`;
+const titleContentClassName = `${baseClassName}-content`;
 const titleButtonClassName = `${baseClassName}-button`;
 const iconClassName = `${baseClassName}-icon`;
 const iconOpenClassName = `${iconClassName}--open`;
@@ -66,7 +67,9 @@ class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
           [titleOpenClassName]: !!consumer.open,
         })}
       >
-        <HtmlSpan id={consumer.titleId}>{children}</HtmlSpan>
+        <HtmlSpan className={titleContentClassName} id={consumer.titleId}>
+          {children}
+        </HtmlSpan>
         <HtmlButton
           {...toggleButtonProps}
           onClick={consumer.onToggleExpander}

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -170,6 +170,10 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   border-bottom-right-radius: 0;
 }
 
+.c1 .fi-expander_title-content {
+  display: inline-block;
+}
+
 .c1 .fi-expander_title-button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -272,7 +276,7 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   data-testid="expander-title"
 >
   <span
-    class="c2"
+    class="c2 fi-expander_title-content"
     id="test-id_title"
   >
     <span

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -10,7 +10,7 @@ export const baseStyles = css`
     width: 290px;
   }
 
-  &_wrapper {
+  & .fi-text-input_wrapper {
     width: 100%;
     display: inline-block;
   }

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`snapshots match error status with statustext 1`] = `
   width: 290px;
 }
 
-.c1_wrapper {
+.c1 .fi-text-input_wrapper {
   width: 100%;
   display: inline-block;
 }
@@ -521,7 +521,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   width: 290px;
 }
 
-.c1_wrapper {
+.c1 .fi-text-input_wrapper {
   width: 100%;
   display: inline-block;
 }
@@ -865,7 +865,7 @@ exports[`snapshots match minimal implementation 1`] = `
   width: 290px;
 }
 
-.c1_wrapper {
+.c1 .fi-text-input_wrapper {
   width: 100%;
   display: inline-block;
 }

--- a/src/core/Modal/Modal/Modal.md
+++ b/src/core/Modal/Modal/Modal.md
@@ -6,7 +6,7 @@ Small screen variant takes all available screen space.
 
 Aria props override the primary and secondary button labels for screenreaders and allow more detailed description.
 
-**NOTE:** React-modal does not consider some inline elements to be focusable. To ensure focusability inside Modal, components must have non-zero size, be visible, have tabindex of 1 or 0, must be of node type input, select, textarea, button, object or a with either tabIndex or href attribute and cannot be disabled! ([source](https://github.com/reactjs/react-modal/blob/827796d48e7d4c74b4362cf90955e162082ee46d/src/helpers/tabbable.js))
+**NOTE:** React-modal does not consider some inline elements to be focusable. To ensure focusability inside Modal, components must have non-zero size, be visible, have tabindex of 0 or greater, must be of node type input, select, textarea, button, object or a with either tabIndex or href attribute and cannot be disabled! ([source](https://github.com/reactjs/react-modal/blob/827796d48e7d4c74b4362cf90955e162082ee46d/src/helpers/tabbable.js))
 
 ```js
 import { useState } from 'react';

--- a/src/core/Modal/Modal/Modal.md
+++ b/src/core/Modal/Modal/Modal.md
@@ -211,6 +211,8 @@ Modal content wrapper default styles, e.g. width, can be overriden using the `st
 
 It is possible to override the default styles using css as well. Using the className prop e.g. with `custom` and defining `.fi-modal.custom` and `.fi-modal--small-screen.custom` styles overrides the defaults.
 
+ModalContent `scroll-padding-bottom` style defaults to 75px and determines how the browser scrolls the content when focus shifts outside or close to the borders of the current view. This style can be overridden with method described above using `.fi-modal_content` classname.
+
 ```js
 import { useState } from 'react';
 import {
@@ -261,7 +263,7 @@ const [smallScreen, setSmallScreen] = useState(false);
     style={{ width: smallScreen ? '100%' : '1000px' }}
     onEscKeyDown={() => setVisible(false)}
   >
-    <ModalContent>
+    <ModalContent style={{ scrollPaddingBottom: '150px' }}>
       <ModalTitle>Test modal</ModalTitle>
       <ExpanderGroup
         openAllText="Open all"

--- a/src/core/Modal/Modal/Modal.md
+++ b/src/core/Modal/Modal/Modal.md
@@ -6,6 +6,8 @@ Small screen variant takes all available screen space.
 
 Aria props override the primary and secondary button labels for screenreaders and allow more detailed description.
 
+**NOTE:** React-modal does not consider some inline elements to be focusable. To ensure focusability inside Modal, components must have non-zero size, be visible, have tabindex of 1 or 0, must be of node type input, select, textarea, button, object or a with either tabIndex or href attribute and cannot be disabled! ([source](https://github.com/reactjs/react-modal/blob/827796d48e7d4c74b4362cf90955e162082ee46d/src/helpers/tabbable.js))
+
 ```js
 import { useState } from 'react';
 import {

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -235,6 +235,10 @@ exports[`Basic modal should match snapshot 1`] = `
   max-height: 100%;
   padding: 24px 30px 50px 30px;
   overflow-y: auto;
+  -webkit-scroll-padding-bottom: 75px;
+  -moz-scroll-padding-bottom: 75px;
+  -ms-scroll-padding-bottom: 75px;
+  scroll-padding-bottom: 75px;
 }
 
 .c2.fi-modal_content--no-scroll {

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -239,6 +239,10 @@ exports[`Basic modal should match snapshot 1`] = `
   -moz-scroll-padding-bottom: 75px;
   -ms-scroll-padding-bottom: 75px;
   scroll-padding-bottom: 75px;
+  -webkit-scroll-padding-top: 75px;
+  -moz-scroll-padding-top: 75px;
+  -ms-scroll-padding-top: 75px;
+  scroll-padding-top: 75px;
 }
 
 .c2.fi-modal_content--no-scroll {

--- a/src/core/Modal/ModalContent/ModalContent.baseStyles.tsx
+++ b/src/core/Modal/ModalContent/ModalContent.baseStyles.tsx
@@ -8,6 +8,7 @@ export const baseStyles = css`
     padding: 24px ${theme.spacing.xl} 50px ${theme.spacing.xl};
     overflow-y: auto;
     scroll-padding-bottom: 75px;
+    scroll-padding-top: 75px;
 
     &--no-scroll {
       overflow: hidden;

--- a/src/core/Modal/ModalContent/ModalContent.baseStyles.tsx
+++ b/src/core/Modal/ModalContent/ModalContent.baseStyles.tsx
@@ -7,6 +7,7 @@ export const baseStyles = css`
     max-height: 100%;
     padding: 24px ${theme.spacing.xl} 50px ${theme.spacing.xl};
     overflow-y: auto;
+    scroll-padding-bottom: 75px;
 
     &--no-scroll {
       overflow: hidden;

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -186,6 +186,10 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   -moz-scroll-padding-bottom: 75px;
   -ms-scroll-padding-bottom: 75px;
   scroll-padding-bottom: 75px;
+  -webkit-scroll-padding-top: 75px;
+  -moz-scroll-padding-top: 75px;
+  -ms-scroll-padding-top: 75px;
+  scroll-padding-top: 75px;
 }
 
 .c2.fi-modal_content--no-scroll {

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -182,6 +182,10 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   max-height: 100%;
   padding: 24px 30px 50px 30px;
   overflow-y: auto;
+  -webkit-scroll-padding-bottom: 75px;
+  -moz-scroll-padding-bottom: 75px;
+  -ms-scroll-padding-bottom: 75px;
+  scroll-padding-bottom: 75px;
 }
 
 .c2.fi-modal_content--no-scroll {


### PR DESCRIPTION
## Description
This PR fixes some component styles to enable focusing inside modal using tab-key. In addition, this PR introduces scroll padding for the ModalContent to ensure focused content fits into view. 

**NOTE: React-modal does not consider some inline elements to be focusable. To ensure focusability inside Modal, components must have non zero size, be visible, have tabindex of 1 or 0, must be of node type /input|select|textarea|button|object or a with either tabIndex or href attribute and cannot be disabled!**
(https://github.com/reactjs/react-modal/blob/master/src/helpers/tabbable.js)

## Motivation and Context
After refactoring the Modal to use react-modal under the hood, some components became impossible to focus using tab-key when placed inside modal. This was caused by react-modals white-listing strategy for focus lock. Changing the styles to comply with the white list rules (element type/role, tab index, styles visible and size possible to calculate), makes these components focusable when necessary.

Automatic scrolling when a component focused is focused is handled by browser and the default behaviour varies between different browsers. In some cases parts of the focused components remained outside the current view due to these scrolling strategies. Adding scroll-padding-bottom resolves this issue without manual focus or scroll position management.

## How Has This Been Tested?
Tested using Create React App TypeScript project, Styleguidist build and SSR-test application. Test setup with MacOS and Windows using Chrome, Safari and Firefox.

## Release notes
- ModalContent: Add scroll-padding-bottom and -top default styles
- Button: Remove tabIndex for disabled button
- Dropdown: Change default display css value to inline-block.
- ExpanderTitle: Change title content display css value to inline-block.
- TextInput: Change input element display to inline-block and width to 100% by fixing internal class name issue 
