### PR TITLE
[Fix] Dropdown tab-key focus issue

### DIFF
--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -98,6 +98,13 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
         : undefined,
   };
 
+  buttonRef: React.RefObject<HTMLButtonElement>;
+
+  constructor(props: DropdownProps & InnerRef) {
+    super(props);
+    this.buttonRef = React.createRef();
+  }
+
   static getDerivedStateFromProps(
     nextProps: DropdownProps,
     prevState: DropdownState,
@@ -190,6 +197,7 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
             value={selectedValue || ''}
           >
             <ListboxButton
+              ref={this.buttonRef}
               {...dropdownButtonProps}
               id={buttonId}
               className={classnames(dropdownClassNames.button, {
@@ -205,6 +213,12 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
             <ListboxPopover
               position={positionMatchWidth}
               {...passDropdownPopoverProps}
+              onKeyDownCapture={(event: KeyboardEvent) => {
+                if (event.code === 'Tab' && !!this.buttonRef.current) {
+                  event.preventDefault();
+                  this.buttonRef.current.focus();
+                }
+              }}
             >
               <ListboxList>{children}</ListboxList>
             </ListboxPopover>


### PR DESCRIPTION
## Description
This PR adds additional logic for Dropdown tab-key event handling. Current version of Reach-UI has a focus issue with the used Listbox component that allows focus to default if tab key is pressed when the listbox menu is open. This PR introduces logic to prevent the focus from escaping.

## Related Issue
https://github.com/reach/reach-ui/issues/691

## Motivation and Context
Current behaviour of Dropdown allowed focus to escape when using tab while the dropdown is open. Usually focus defaults to document body, which is really bad for keyboard, let alone screen reader, users. To temporarily address the issue:
- default tab-keypress event behviour is prevented if the Dropdown is open 
- Dropdown is closed
- Focus is returned to the Dropdown.

## How Has This Been Tested?
Tested with styleguidist build using MacOS Safari, Chrome and Edge.

## Release notes
- Fix Dropdown focus issue when focus escapes if tab is pressed while Dropdown is open. Now focus returns to Dropdown instead of browser default.