### PR TITLE
[Feature] Soft disable support for Chip

### DIFF
--- a/src/core/Chip/Chip/Chip.md
+++ b/src/core/Chip/Chip/Chip.md
@@ -47,5 +47,7 @@ const chipStyle = {
   </Chip>
 
   <Chip disabled>Disabled chip</Chip>
+
+  <Chip aria-disabled>Aria-disabled chip</Chip>
 </>;
 ```

--- a/src/core/Chip/Chip/Chip.test.tsx
+++ b/src/core/Chip/Chip/Chip.test.tsx
@@ -19,6 +19,15 @@ describe('disabled', () => {
     expect(getByRole('button')).toHaveAttribute('disabled');
   });
 
+  it('is aria-disabled and changes to enabled', () => {
+    const { getByRole, rerender } = render(
+      <Chip aria-disabled={true}>Aria-disabled Chip</Chip>,
+    );
+    expect(getByRole('button')).toHaveAttribute('aria-disabled', 'true');
+    rerender(<Chip aria-disabled={false}>Aria-disabled Chip</Chip>);
+    expect(getByRole('button')).toHaveAttribute('aria-disabled', 'false');
+  });
+
   it('should match snapshot', () => {
     const { container } = render(DisabledChip);
     expect(container).toMatchSnapshot();

--- a/src/core/Chip/Chip/Chip.tsx
+++ b/src/core/Chip/Chip/Chip.tsx
@@ -35,6 +35,8 @@ interface InternalChipProps
   removable?: boolean;
   /** Aria-label attribute to let screen reader users know pressing the button will remove the chip/selection  */
   actionLabel?: string;
+  /** Soft disable the button to allow tab-focus, but disable onClick functionality */
+  'aria-disabled'?: boolean;
 }
 
 interface InnerRef {
@@ -56,6 +58,7 @@ class DefaultChip extends Component<ChipProps & InnerRef> {
       actionLabel,
       forwardedRef,
       disabled = false,
+      'aria-disabled': ariaDisabled = false,
       ...passProps
     } = this.props;
 
@@ -71,11 +74,12 @@ class DefaultChip extends Component<ChipProps & InnerRef> {
           chipButtonClassNames.button,
           className,
           {
-            [chipClassNames.disabled]: !!disabled,
+            [chipClassNames.disabled]: !!disabled || !!ariaDisabled,
             [chipButtonClassNames.removable]: !!removable,
           },
         )}
         disabled={disabled}
+        aria-disabled={!!ariaDisabled || !!disabled}
         onClick={onClick}
         forwardedRef={forwardedRef}
         {...passProps}

--- a/src/core/Chip/Chip/Chip.tsx
+++ b/src/core/Chip/Chip/Chip.tsx
@@ -35,7 +35,7 @@ interface InternalChipProps
   removable?: boolean;
   /** Aria-label attribute to let screen reader users know pressing the button will remove the chip/selection  */
   actionLabel?: string;
-  /** Soft disable the button to allow tab-focus, but disable onClick functionality */
+  /** Soft disable the chip to allow tab-focus, but disable onClick functionality */
   'aria-disabled'?: boolean;
 }
 

--- a/src/core/Chip/Chip/Chip.tsx
+++ b/src/core/Chip/Chip/Chip.tsx
@@ -62,6 +62,8 @@ class DefaultChip extends Component<ChipProps & InnerRef> {
       ...passProps
     } = this.props;
 
+    const onClickProp = !!disabled || !!ariaDisabled ? {} : { onClick };
+
     if (removable && !actionLabel) {
       logger.error(
         'Provide actionLabel to communicate removability to screen readers',
@@ -80,7 +82,7 @@ class DefaultChip extends Component<ChipProps & InnerRef> {
         )}
         disabled={disabled}
         aria-disabled={!!ariaDisabled || !!disabled}
-        onClick={onClick}
+        {...onClickProp}
         forwardedRef={forwardedRef}
         {...passProps}
       >

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -189,6 +189,7 @@ exports[`children should match snapshot 1`] = `
 
 <div>
   <button
+    aria-disabled="false"
     class="c0 fi-chip fi-chip--button c1"
     type="button"
   >
@@ -394,6 +395,7 @@ exports[`classnames should match snapshot 1`] = `
 
 <div>
   <button
+    aria-disabled="false"
     class="c0 fi-chip fi-chip--button c1 custom-class"
     type="button"
   >
@@ -595,6 +597,7 @@ exports[`disabled should match snapshot 1`] = `
 
 <div>
   <button
+    aria-disabled="true"
     class="c0 fi-chip fi-chip--button c1 fi-chip--disabled"
     disabled=""
     type="button"


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Adds soft disable support for a Chip. Implementation is mimicked from the Button, where the same functionality exists.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
Soft disabled Chip was needed for currently in progress component, Combobox (MultiSelect). It enables screenreader users also to "see" selected but disabled Chips in the listing under the input.

## How Has This Been Tested?
Locally in styleguidist.


## Release notes

* Soft disable support for Chip (#476)
