### PR TITLE
[Fix] MultiSelect not showing up in styleguidist

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -13,7 +13,7 @@ const primitiveComponents = [
   ['Form', 'Checkbox'],
   ['Form', 'Textarea'],
   ['Form', 'RadioButton'],
-  ['Form', 'Combobox'],
+  ['Form', 'MultiSelect'],
 ];
 
 const getComponent = ({ name, underName }) =>
@@ -105,9 +105,9 @@ module.exports = {
               components: getComponents(['Icon', 'StaticIcon']),
             },
             {
-              name: 'Combobox',
-              components: getComponentWithVariants('Form/Combobox')([
-                'Combobox/Combobox',
+              name: 'MultiSelect',
+              components: getComponentWithVariants('Form/MultiSelect')([
+                'MultiSelect/MultiSelect',
               ]),
             },
           ],


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

MultiSelect was not showing up in styleguidist because styleguidist config still had the previous name, Combobox.

## How Has This Been Tested?
Ran styleguidist locally AFTER changes to styleguidist config as it seems to be culprit and initially introduced this mistake.


## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
* Fix: MultiSelect was not showing up in styleguidist