### PR TITLE
[Release] 4.0.0

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -104,12 +104,12 @@ module.exports = {
               name: 'Icon',
               components: getComponents(['Icon', 'StaticIcon']),
             },
-            {
-              name: 'MultiSelect',
-              components: getComponentWithVariants('Form/MultiSelect')([
-                'MultiSelect/MultiSelect',
-              ]),
-            },
+            // {
+            //   name: 'MultiSelect',
+            //   components: getComponentWithVariants('Form/MultiSelect')([
+            //     'MultiSelect/MultiSelect',
+            //   ]),
+            // },
           ],
           expand: true,
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "4.0.0-beta.9",
+  "version": "4.0.0",
   "description": "Suomi.fi UI component library",
   "main": "dist/index.js",
   "module": "dist/suomifi-ui-components.esm.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,9 @@ export { Dropdown, DropdownProps } from './core/Dropdown/';
 export { DropdownItem, DropdownItemProps } from './core/Dropdown/';
 export { Chip, ChipProps } from './core/Chip/';
 export { StaticChip, StaticChipProps } from './core/Chip/';
+// MultiSelect,
+// MultiSelectProps,
+// MultiSelectData,
 export {
   Checkbox,
   CheckboxProps,
@@ -25,9 +28,6 @@ export {
   RadioButtonProps,
   RadioButtonGroup,
   RadioButtonGroupProps,
-  MultiSelect,
-  MultiSelectProps,
-  MultiSelectData,
 } from './core/Form/Form';
 export { Heading, HeadingProps } from './core/Heading/Heading';
 export { Icon, IconProps, BaseIconKeys } from './core/Icon/Icon';


### PR DESCRIPTION
## Description
This PR increases version number to 4.0.0 and hides MultiSelect component from Styleguide and exports. MultiSelect will be released with 4.1 once accessibility improvements have been finalised.

## Release notes

## General changes

### Dependency updates and upgrades (#443, #449, #453, #458,#464, #468,  #470, #475)
* Breaking change: Reach-ui peer dependency versions upgraded.
* Update for vulnerable dependencies
* Suomifi-design-tokens updated to 3.1.1
* Remove uuid dependency

### AutoId (#445)
* Fix AutoId SSR issue and return children always, also on server but with empty string as id.

### Tokens (#439)
* Breaking Change: Tokens prop is now removed from all components

### Documentation updates (#455)

## Component changes and additions

### Button (#446, #441, #448)
* Breaking change: Replace Button tertiary variant with link button variant
* Breaking change: Rename Button secondary-noborder variant to secondaryNoBorder
* Breaking change:  Change depthSecondaryDark1 color token value
* Update suomifi-design-tokens
* Change Button secondaryNoBorder variant hover styles
* Remove static variants. Use variant prop instead.
* Fix link button background gradient direction

### Checkbox (#441, #461, #465)
* Breaking change: Remove static variants. Use variant prop instead.
* Add ref prop
* Add aria-live="assertive" as default for Status text. This can be changed via statusTextAriaLiveMode prop.
* Add  aria-atomic true for Status texts

### Chip (#441, #447, #476)
* Breaking change: Remove as prop
* Breaking change: Split component into Chip and StaticChip. Remove static variants.
* Fix Remove icon alignment in Safari
* Add Soft disable support for Chip

### Dropdown (#473, #441)
* Fix Dropdown focus issue when focus escapes if tab is pressed while Dropdown is open. Now focus returns to Dropdown instead of browser default.
* Add ref prop

### Expander (#452, #459)
* ExpanderGroup
    * Improve performance
* Expander
    * Breaking change: Remove undocumented consumer prop from public API
    * Fix font styles
* ExpanderGroup
    * Breaking change: Rename props OpenAllText, AriaOpenAllText, CloseAllText, AriaCloseAllText => openAllText, ariaOpenAllText, closeAllText, ariaCloseAllText,
    * Add aria-expanded prop for Open/Close all button
* ExpanderTitleButton
    * Breaking change: Remove ariaOpenText and ariaCloseText props
* ExpanderTitle:
    * Breaking change: Add required toggleButtonAriaDescribedBy prop
* ExpanderContent:
    * Fix expander content height and overflow styles


### Heading (#454)
* Breaking change: Remove Static variants removed. Use variant prop instead.
* Breaking change: Remove ‘asProp' prop. Use 'as' instead.
* Fix API descriptions order

### Icon (#473)
* Add new icons
* Fix colors.

### Modal (#444, #450, #457, #460, #467, #477)
* Add Modal dialog component

### RadioButton (#441, #437)
* Breaking change: Change ComponentIcon class names
* Add ref prop
* Fix RadioButton icons

### SearchInput (#432, #451, #461, #465)
* Breaking change: Rename inputContainerProps to wrapperProps
* Add better support for SSR by replacing uuid with AutoId
* Add support for styling SearchInput directly without breaking the component's internal layout
* Fix debounce prop destructuring and prevent passing to the input element
* Add aria-live="assertive" as default for Status text. This can be changed via statusTextAriaLiveMode prop.
* Add  aria-atomic true for Status texts

## StaticIcon (#473, #480)
* Breaking change: Change StaticIcon class names
* Add highlightColor prop
* Add baseColor prop

### Text (#456)
* Fix broken color prop

### Textarea (#441, #461, #465)
* Add ref prop
* Add aria-live="assertive" as default for Status text. This can be changed via statusTextAriaLiveMode prop.
* Add  aria-atomic true for Status texts

### TextInput (#435, #436, #441, #451, #461, #465)
* Breaking change: rename inputContainerProps to wrapperProps
* Add ref prop
* Add aria-live="assertive" as default for Status text. This can be changed via statusTextAriaLiveMode prop.
* Add  aria-atomic true for Status texts
* Fix debounce prop and prevent passing to the input element
* Fix Error and success status border width to 2px
* Fix icon props

### Toggle (#434, #437, #441)
* Breaking Change: Change ToggleButton onClick parameter type is now boolean instead of { toggleState: boolean }
* Breaking Change: Remove variant support. <Toggle.withInput> will no longer work. Use ToggleButton and ToggleInput components instead.
* Breaking Change: Remove toggleInputProps
* Breaking Change: Remove toggleInputComponent
* Breaking Change: Remove onClick from ToggleInput, use onChange instead
* Breaking Change: Change additional props to be passed for button and input elements.
* Breaking change: ComponentIcon class name changes
* Add better styling support for wrapperProps
* Add ref prop
* Fix AutoId to Server Side Rendering support
* Fix Toggle icon


### VisuallyHidden (#478)
* Add export for VisuallyHiddenProps

