### PR TITLE
[Fix] MultiSelect accessibility improvements 

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -105,12 +105,12 @@ module.exports = {
               name: 'Icon',
               components: getComponents(['Icon', 'StaticIcon']),
             },
-            // {
-            //   name: 'MultiSelect',
-            //   components: getComponentWithVariants('Form/MultiSelect')([
-            //     'MultiSelect/MultiSelect',
-            //   ]),
-            // },
+            {
+              name: 'MultiSelect',
+              components: getComponentWithVariants('Form/MultiSelect')([
+                'MultiSelect/MultiSelect',
+              ]),
+            },
           ],
           expand: true,
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "4.0.0",
+  "version": "4.1.0-beta.0",
   "description": "Suomi.fi UI component library",
   "main": "dist/index.js",
   "module": "dist/suomifi-ui-components.esm.js",

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -11,6 +11,7 @@ import {
 import { AutoId } from '../../../utils/AutoId';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { LabelText, LabelMode } from '../LabelText/LabelText';
+import { HintText } from '../HintText/HintText';
 import { StatusText } from '../StatusText/StatusText';
 import { baseStyles } from './FilterInput.baseStyles';
 
@@ -46,6 +47,8 @@ interface InternalFilterInputProps<T>
   labelMode?: LabelMode;
   /** Text to mark a field optional. Will be wrapped in parentheses and shown after labelText. */
   optionalText?: string;
+  /** Hint text to be shown below the label */
+  hintText?: string;
   /**
    * 'default' | 'error'
    * @default default
@@ -84,6 +87,7 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
       visualPlaceholder,
       labelText,
       labelMode,
+      hintText,
       optionalText,
       status,
       statusText,
@@ -120,6 +124,7 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
       }
     };
 
+    const hintTextId = hintText ? `${id}-hintText` : undefined;
     const statusTextId = statusText ? `${id}-statusText` : undefined;
 
     return (
@@ -140,6 +145,7 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
           >
             {labelText}
           </LabelText>
+          <HintText id={hintTextId}>{hintText}</HintText>
           <HtmlDiv className={filterInputClassNames.functionalityContainer}>
             <HtmlDiv className={filterInputClassNames.inputElementContainer}>
               <HtmlInput

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -157,6 +157,7 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
                 placeholder={visualPlaceholder}
                 {...getConditionalAriaProp('aria-describedby', [
                   statusTextId,
+                  hintTextId,
                   ariaDescribedBy,
                 ])}
                 autoComplete="off"

--- a/src/core/Form/MultiSelect/MultiSelect/AriaAnnounceText.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/AriaAnnounceText.tsx
@@ -21,9 +21,13 @@ const debounce = (func: Function, waitFor: number) => {
 };
 
 export interface AriaAnnounceTextProps {
+  /** Unique id */
   id: string;
+  /** Text that is announced by screen reader. Change in this will also trigger the debounce. */
   announceText: string;
+  /** aria-live mode for the element. */
   ariaLiveMode?: AriaLiveMode;
+  /** Debounce time in milliseconds. */
   waitFor?: number;
 }
 

--- a/src/core/Form/MultiSelect/MultiSelect/AriaAnnounceText.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/AriaAnnounceText.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { VisuallyHidden } from '../../../VisuallyHidden/VisuallyHidden';
+
+const debounce = (func: Function, waitFor: number) => {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  return function anonymous(...args: any[]): void {
+    const later = function anononymous(): void {
+      timeoutId = null;
+      func.apply(this, args);
+    };
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    timeoutId = setTimeout(later, waitFor);
+    if (!timeoutId) {
+      func.apply(this, args);
+    }
+  };
+};
+
+export interface AriaAnnounceTextProps {
+  id: string;
+  announceText: string;
+}
+
+interface AriaAnnounceTextState {
+  debounced: boolean;
+  toggle: boolean;
+  announceText: string;
+}
+
+export class AriaAnnounceText extends React.Component<AriaAnnounceTextProps> {
+  private debounceStatusUpdate: () => void;
+
+  state: AriaAnnounceTextState = {
+    debounced: false,
+    toggle: false,
+    announceText: '',
+  };
+
+  componentDidMount() {
+    this.debounceStatusUpdate = debounce(() => {
+      if (!this.state.debounced) {
+        this.setState((prevState: AriaAnnounceTextState) => ({
+          debounced: true,
+          toggle: !prevState.toggle,
+        }));
+      }
+    }, 1000);
+  }
+
+  static getDerivedStateFromProps(
+    nextProps: AriaAnnounceTextProps,
+    prevState: AriaAnnounceTextState,
+  ) {
+    if (nextProps.announceText !== prevState.announceText) {
+      return { debounced: false, announceText: nextProps.announceText };
+    }
+    return null;
+  }
+
+  render() {
+    const { id, announceText } = this.props;
+    const { debounced, toggle } = this.state;
+    if (this.debounceStatusUpdate) {
+      this.debounceStatusUpdate();
+    }
+    return (
+      <VisuallyHidden
+        aria-live="polite"
+        aria-atomic="true"
+        id={id}
+        key={`${toggle}`}
+      >
+        {debounced ? announceText : ''}
+      </VisuallyHidden>
+    );
+  }
+}

--- a/src/core/Form/MultiSelect/MultiSelect/AriaAnnounceText.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/AriaAnnounceText.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AriaLiveMode } from '../../types';
 import { VisuallyHidden } from '../../../VisuallyHidden/VisuallyHidden';
 
 const debounce = (func: Function, waitFor: number) => {
@@ -22,6 +23,8 @@ const debounce = (func: Function, waitFor: number) => {
 export interface AriaAnnounceTextProps {
   id: string;
   announceText: string;
+  ariaLiveMode?: AriaLiveMode;
+  waitFor?: number;
 }
 
 interface AriaAnnounceTextState {
@@ -40,14 +43,17 @@ export class AriaAnnounceText extends React.Component<AriaAnnounceTextProps> {
   };
 
   componentDidMount() {
-    this.debounceStatusUpdate = debounce(() => {
-      if (!this.state.debounced) {
-        this.setState((prevState: AriaAnnounceTextState) => ({
-          debounced: true,
-          toggle: !prevState.toggle,
-        }));
-      }
-    }, 1000);
+    this.debounceStatusUpdate = debounce(
+      () => {
+        if (!this.state.debounced) {
+          this.setState((prevState: AriaAnnounceTextState) => ({
+            debounced: true,
+            toggle: !prevState.toggle,
+          }));
+        }
+      },
+      this.props.waitFor ? this.props.waitFor : 1000,
+    );
   }
 
   static getDerivedStateFromProps(
@@ -61,14 +67,14 @@ export class AriaAnnounceText extends React.Component<AriaAnnounceTextProps> {
   }
 
   render() {
-    const { id, announceText } = this.props;
+    const { id, announceText, ariaLiveMode = 'polite' } = this.props;
     const { debounced, toggle } = this.state;
     if (this.debounceStatusUpdate) {
       this.debounceStatusUpdate();
     }
     return (
       <VisuallyHidden
-        aria-live="polite"
+        aria-live={ariaLiveMode}
         aria-atomic="true"
         id={id}
         key={`${toggle}`}

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.md
@@ -100,6 +100,7 @@ const defaultSelectedTools = [
     defaultSelectedItems={defaultSelectedTools}
     ariaSelectedAmountText="tools selected"
     ariaOptionsAvailableText="options left"
+    ariaOptionChipRemovedText="removed"
   />
 </>;
 ```
@@ -138,6 +139,7 @@ const animals = [
       ariaChipActionLabel="Remove"
       ariaSelectedAmountText="animals selected"
       ariaOptionsAvailableText="options left"
+      ariaOptionChipRemovedText="removed"
     />
 
     <span>There can be only one!</span>

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.md
@@ -89,12 +89,13 @@ const defaultSelectedTools = [
 
 <>
   <MultiSelect
-    labelText="MultiSelect"
+    labelText="Tools"
+    hintText="You can filter results by typing in the field"
     items={tools}
     chipListVisible={true}
     ariaChipActionLabel="Remove"
     removeAllButtonLabel="Remove all selections"
-    visualPlaceholder="Choose your tool(s)"
+    visualPlaceholder="Choose your tools"
     noItemsText="No items"
     defaultSelectedItems={defaultSelectedTools}
     ariaSelectedAmountText="tools selected"
@@ -129,9 +130,10 @@ const animals = [
       items={animals}
       selectedItems={selectedAnimals}
       labelText="Animals"
+      hintText="You can filter results by typing in the field"
       noItemsText="No animals"
       chipListVisible={true}
-      visualPlaceholder="Try to choose animal(s)"
+      visualPlaceholder="Try to choose animals"
       ariaChipActionLabel="Remove"
       ariaSelectedAmountText="animals selected"
     />

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.md
@@ -99,6 +99,7 @@ const defaultSelectedTools = [
     noItemsText="No items"
     defaultSelectedItems={defaultSelectedTools}
     ariaSelectedAmountText="tools selected"
+    ariaOptionsAvailableText="options left"
   />
 </>;
 ```
@@ -136,6 +137,7 @@ const animals = [
       visualPlaceholder="Try to choose animals"
       ariaChipActionLabel="Remove"
       ariaSelectedAmountText="animals selected"
+      ariaOptionsAvailableText="options left"
     />
 
     <span>There can be only one!</span>

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -107,6 +107,7 @@ const BasicCombobox = (
     noItemsText="No items"
     defaultSelectedItems={defaultSelectedTools}
     ariaSelectedAmountText="tools selected"
+    ariaOptionsAvailableText="tools left"
   />
 );
 
@@ -133,6 +134,7 @@ describe('Chips', () => {
     await act(async () => {
       const { getByText, queryByText } = render(BasicCombobox);
       const hammerChip = getByText('Hammer');
+      expect(queryByText('Hammer')).not.toBeNull();
 
       expect(hammerChip.classList).toContain('fi-chip--content');
       await act(async () => {
@@ -160,6 +162,7 @@ describe('Chips', () => {
           defaultSelectedItems={defaultSelectedTools}
           onItemSelect={onItemSelect}
           ariaSelectedAmountText="tools selected"
+          ariaOptionsAvailableText="tools left"
         />,
       );
       const hammerChip = container.querySelectorAll('.fi-chip')[1];
@@ -208,6 +211,7 @@ describe('Chips', () => {
           defaultSelectedItems={defaultSelectedTools}
           onRemoveAll={mockOnRemoveAll}
           ariaSelectedAmountText="tools selected"
+          ariaOptionsAvailableText="tools left"
         />,
       );
       const removeAllButton = container.querySelectorAll(
@@ -252,6 +256,7 @@ describe('Controlled', () => {
         noItemsText="No items"
         defaultSelectedItems={defaultSelectedTools}
         ariaSelectedAmountText="tools selected"
+        ariaOptionsAvailableText="tools left"
       />
     );
 
@@ -302,6 +307,7 @@ describe('Controlled', () => {
         visualPlaceholder="Try to choose animal(s)"
         ariaChipActionLabel="Remove"
         ariaSelectedAmountText="tools selected"
+        ariaOptionsAvailableText="tools left"
       />
     );
 
@@ -331,6 +337,7 @@ test('className: has given custom classname', async () => {
         noItemsText="No items"
         className="custom-class"
         ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
       />,
     );
     expect(container.firstChild).toHaveClass('custom-class');
@@ -345,6 +352,7 @@ test('labelText: has the given text as label', async () => {
         items={[]}
         noItemsText="No items"
         ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
       />,
     );
     expect(queryByText('MultiSelect')).not.toBeNull();
@@ -359,6 +367,7 @@ test('visualPlaceholder: has the given text as placeholder attribute', () => {
       noItemsText="No items"
       visualPlaceholder="Select item(s)"
       ariaSelectedAmountText=""
+      ariaOptionsAvailableText=""
     />,
   );
   const inputfield = getByRole('textbox') as HTMLInputElement;
@@ -373,6 +382,7 @@ test('id: has the given id', () => {
       items={[]}
       noItemsText="No items"
       ariaSelectedAmountText=""
+      ariaOptionsAvailableText=""
     />,
   );
   expect(getByRole('textbox')).toHaveAttribute('id', 'cb-123');
@@ -389,6 +399,7 @@ describe('statusText', () => {
         visualPlaceholder="Select item(s)"
         statusText="EROR EROR"
         ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
       />,
     );
     const statusText = getByText('EROR EROR');
@@ -405,6 +416,7 @@ describe('statusText', () => {
         visualPlaceholder="Select item(s)"
         statusText="EROR EROR"
         ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
       />,
     );
     expect(getByRole('textbox')).toHaveAttribute(
@@ -425,6 +437,7 @@ describe('status', () => {
         visualPlaceholder="Select item(s)"
         status="error"
         ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
       />,
     );
     expect(container.firstChild).toHaveClass('fi-multiselect--error');

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -108,6 +108,7 @@ const BasicCombobox = (
     defaultSelectedItems={defaultSelectedTools}
     ariaSelectedAmountText="tools selected"
     ariaOptionsAvailableText="tools left"
+    ariaOptionChipRemovedText="removed"
   />
 );
 
@@ -163,6 +164,7 @@ describe('Chips', () => {
           onItemSelect={onItemSelect}
           ariaSelectedAmountText="tools selected"
           ariaOptionsAvailableText="tools left"
+          ariaOptionChipRemovedText="removed"
         />,
       );
       const hammerChip = container.querySelectorAll('.fi-chip')[1];
@@ -212,6 +214,7 @@ describe('Chips', () => {
           onRemoveAll={mockOnRemoveAll}
           ariaSelectedAmountText="tools selected"
           ariaOptionsAvailableText="tools left"
+          ariaOptionChipRemovedText="removed"
         />,
       );
       const removeAllButton = container.querySelectorAll(
@@ -257,6 +260,7 @@ describe('Controlled', () => {
         defaultSelectedItems={defaultSelectedTools}
         ariaSelectedAmountText="tools selected"
         ariaOptionsAvailableText="tools left"
+        ariaOptionChipRemovedText="removed"
       />
     );
 
@@ -308,6 +312,7 @@ describe('Controlled', () => {
         ariaChipActionLabel="Remove"
         ariaSelectedAmountText="tools selected"
         ariaOptionsAvailableText="tools left"
+        ariaOptionChipRemovedText="removed"
       />
     );
 
@@ -338,6 +343,7 @@ test('className: has given custom classname', async () => {
         className="custom-class"
         ariaSelectedAmountText=""
         ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
       />,
     );
     expect(container.firstChild).toHaveClass('custom-class');
@@ -353,6 +359,7 @@ test('labelText: has the given text as label', async () => {
         noItemsText="No items"
         ariaSelectedAmountText=""
         ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
       />,
     );
     expect(queryByText('MultiSelect')).not.toBeNull();
@@ -368,6 +375,7 @@ test('visualPlaceholder: has the given text as placeholder attribute', () => {
       visualPlaceholder="Select item(s)"
       ariaSelectedAmountText=""
       ariaOptionsAvailableText=""
+      ariaOptionChipRemovedText=""
     />,
   );
   const inputfield = getByRole('textbox') as HTMLInputElement;
@@ -383,6 +391,7 @@ test('id: has the given id', () => {
       noItemsText="No items"
       ariaSelectedAmountText=""
       ariaOptionsAvailableText=""
+      ariaOptionChipRemovedText=""
     />,
   );
   expect(getByRole('textbox')).toHaveAttribute('id', 'cb-123');
@@ -400,6 +409,7 @@ describe('statusText', () => {
         statusText="EROR EROR"
         ariaSelectedAmountText=""
         ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
       />,
     );
     const statusText = getByText('EROR EROR');
@@ -417,6 +427,7 @@ describe('statusText', () => {
         statusText="EROR EROR"
         ariaSelectedAmountText=""
         ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
       />,
     );
     expect(getByRole('textbox')).toHaveAttribute(
@@ -438,6 +449,7 @@ describe('status', () => {
         status="error"
         ariaSelectedAmountText=""
         ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
       />,
     );
     expect(container.firstChild).toHaveClass('fi-multiselect--error');

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -8,7 +8,6 @@ import { Debounce } from '../../../utils/Debounce/Debounce';
 import { Button } from '../../../Button/Button';
 import { Chip } from '../../../Chip';
 import { Popover } from '../../../Popover/Popover';
-import { VisuallyHidden } from '../../../VisuallyHidden/VisuallyHidden';
 import { FilterInput, FilterInputStatus } from '../../FilterInput/FilterInput';
 import { MultiSelectItemList } from '../MultiSelectItemList/MultiSelectItemList';
 import { MultiSelectItem } from '../MultiSelectItem/MultiSelectItem';
@@ -482,6 +481,7 @@ class BaseMultiSelect<T> extends Component<
       selectedItems,
       disabledKeys,
       filterInputValue,
+      chipRemovalAnnounceText,
     } = this.state;
 
     const {
@@ -712,25 +712,20 @@ class BaseMultiSelect<T> extends Component<
             )}
           </HtmlDiv>
         </HtmlDiv>
-        <VisuallyHidden
-          aria-live="polite"
-          aria-atomic="true"
+        <AriaAnnounceText
           id={`${id}-selectedItems-length`}
-        >
-          {selectedItems.length}
-          {ariaSelectedAmountText}
-        </VisuallyHidden>
+          announceText={`${selectedItems.length} ${ariaSelectedAmountText}`}
+        />
         <AriaAnnounceText
           id={`${id}-filteredItems-length`}
           announceText={`${filteredItems.length} ${ariaOptionsAvailableText}`}
         />
-        <VisuallyHidden
-          aria-live="assertive"
-          aria-atomic="true"
+        <AriaAnnounceText
           id={`${id}-chip-removal-announce`}
-        >
-          {this.state.chipRemovalAnnounceText}
-        </VisuallyHidden>
+          ariaLiveMode="assertive"
+          waitFor={100}
+          announceText={chipRemovalAnnounceText}
+        />
       </>
     );
   }

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -84,11 +84,11 @@ export interface MultiSelectProps<T extends MultiSelectData> {
   /** Text for screen reader to indicate how many items are selected */
   ariaSelectedAmountText: string;
   /** Text for screen reader indicating the amount of available options after filtering by typing. Will be read after the amount.
-   * E.g 'options available' as prop value would result in '{amount} options available' being read to screen reader upon removal.
+   * E.g 'options available' as prop value would result in '{amount} options available' being read by screen reader upon removal.
    */
   ariaOptionsAvailableText: string;
   /** Text for screen reader to read, after labelText/chipText, when selected option is removed from chip list.
-   * E.g 'removed' as prop value would result in '{option} removed' being read to screen reader upon removal.
+   * E.g 'removed' as prop value would result in '{option} removed' being read by screen reader upon removal.
    */
   ariaOptionChipRemovedText: string;
 }

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -14,6 +14,7 @@ import { MultiSelectItemList } from '../MultiSelectItemList/MultiSelectItemList'
 import { MultiSelectItem } from '../MultiSelectItem/MultiSelectItem';
 import { MultiSelectEmptyItem } from '../MultiSelectEmptyItem/MultiSelectEmptyItem';
 import { ChipList } from '../ChipList/ChipList';
+import { AriaAnnounceText } from './AriaAnnounceText';
 import { baseStyles } from './MultiSelect.baseStyles';
 
 const baseClassName = 'fi-multiselect';
@@ -719,18 +720,10 @@ class BaseMultiSelect<T> extends Component<
           {selectedItems.length}
           {ariaSelectedAmountText}
         </VisuallyHidden>
-        <VisuallyHidden
-          aria-live="polite"
-          aria-atomic="true"
+        <AriaAnnounceText
           id={`${id}-filteredItems-length`}
-        >
-          {this.focusInInput(this.getOwnerDocument()) ? (
-            <>
-              {filteredItems.length}
-              {ariaOptionsAvailableText}
-            </>
-          ) : null}
-        </VisuallyHidden>
+          announceText={`${filteredItems.length} ${ariaOptionsAvailableText}`}
+        />
         <VisuallyHidden
           aria-live="assertive"
           aria-atomic="true"

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -85,6 +85,7 @@ export interface MultiSelectProps<T extends MultiSelectData> {
   ariaSelectedAmountText: string;
   /** Text for screen reader indicating the amount of available options after filtering by typing. Will be read after the amount.
    * E.g '4 options available'
+   * E.g 'options available' as prop value would result in '<amount> options available' being read to screen reader upon removal.
    */
   ariaOptionsAvailableText: string;
 }

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -309,7 +309,7 @@ class BaseMultiSelect<T> extends Component<
     this.setState({ showPopover: visible });
   };
 
-  private focusInInput = () => {
+  private getOwnerDocument = () => {
     if (this.popoverListRef !== null && this.popoverListRef.current !== null) {
       const elem = this.popoverListRef.current;
       const ownerDocument = windowAvailable()
@@ -317,23 +317,20 @@ class BaseMultiSelect<T> extends Component<
           ? elem.ownerDocument
           : document
         : null;
-      if (ownerDocument) {
-        return ownerDocument.activeElement === this.filterInputRef.current;
-      }
+      return ownerDocument;
     }
-    return false;
+    return null;
   };
+
+  private focusInInput = (ownerDocument: Document | null) =>
+    ownerDocument
+      ? ownerDocument.activeElement === this.filterInputRef.current
+      : false;
 
   private handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     event.preventDefault();
     if (this.popoverListRef !== null && this.popoverListRef.current !== null) {
-      const elem = this.popoverListRef.current;
-      const ownerDocument = windowAvailable()
-        ? elem
-          ? elem.ownerDocument
-          : document
-        : null;
-
+      const ownerDocument = this.getOwnerDocument();
       if (!ownerDocument) {
         return;
       }
@@ -341,8 +338,7 @@ class BaseMultiSelect<T> extends Component<
         const focusInPopover = this.popoverListRef.current?.contains(
           ownerDocument.activeElement,
         );
-        const focusInInput =
-          ownerDocument.activeElement === this.filterInputRef.current;
+        const focusInInput = this.focusInInput(ownerDocument);
         const focusInCombobox = focusInPopover || focusInInput;
         this.setPopoverVisibility(focusInCombobox);
 
@@ -714,7 +710,7 @@ class BaseMultiSelect<T> extends Component<
           aria-atomic="true"
           id={`${id}-filteredItems-length`}
         >
-          {this.focusInInput() ? (
+          {this.focusInInput(this.getOwnerDocument()) ? (
             <>
               {filteredItems.length}
               {ariaFilteredAmountText}

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -81,8 +81,12 @@ export interface MultiSelectProps<T extends MultiSelectData> {
   onItemSelect?: (uniqueItemId: string) => void;
   /** Event to be sent when pressing remove all button */
   onRemoveAll?: () => void;
-  /** Text to be read by screenreader to indicate how many items are selected */
+  /** Text for screen reader to indicate how many items are selected */
   ariaSelectedAmountText: string;
+  /** Text for screen reader indicating the amount of available options after filtering by typing. Will be read after the amount.
+   * E.g '4 options available'
+   */
+  ariaOptionsAvailableText: string;
 }
 
 // actual boolean value does not matter, only if it exists on the list
@@ -305,6 +309,21 @@ class BaseMultiSelect<T> extends Component<
     this.setState({ showPopover: visible });
   };
 
+  private focusInInput = () => {
+    if (this.popoverListRef !== null && this.popoverListRef.current !== null) {
+      const elem = this.popoverListRef.current;
+      const ownerDocument = windowAvailable()
+        ? elem
+          ? elem.ownerDocument
+          : document
+        : null;
+      if (ownerDocument) {
+        return ownerDocument.activeElement === this.filterInputRef.current;
+      }
+    }
+    return false;
+  };
+
   private handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     event.preventDefault();
     if (this.popoverListRef !== null && this.popoverListRef.current !== null) {
@@ -483,6 +502,7 @@ class BaseMultiSelect<T> extends Component<
       onItemSelect,
       onRemoveAll,
       ariaSelectedAmountText,
+      ariaOptionsAvailableText: ariaFilteredAmountText,
       ...passProps
     } = this.props;
 
@@ -688,6 +708,18 @@ class BaseMultiSelect<T> extends Component<
         >
           {selectedItems.length}
           {ariaSelectedAmountText}
+        </VisuallyHidden>
+        <VisuallyHidden
+          aria-live="polite"
+          aria-atomic="true"
+          id={`${id}-filteredItems-length`}
+        >
+          {this.focusInInput() ? (
+            <>
+              {filteredItems.length}
+              {ariaFilteredAmountText}
+            </>
+          ) : null}
         </VisuallyHidden>
       </>
     );

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -48,6 +48,8 @@ export interface MultiSelectProps<T extends MultiSelectData> {
   id?: string;
   /** Label */
   labelText: string;
+  /** Hint text to be shown below the label */
+  hintText?: string;
   /** Event that is fired when item selections change */
   onItemSelectionsChange?: (selectedItems: Array<T>) => void;
   /** Show chip list */
@@ -465,6 +467,7 @@ class BaseMultiSelect<T> extends Component<
       className,
       items: propItems,
       labelText,
+      hintText,
       onItemSelectionsChange,
       chipListVisible,
       ariaChipActionLabel,
@@ -544,6 +547,7 @@ class BaseMultiSelect<T> extends Component<
                 <FilterInput
                   id={id}
                   labelText={labelText}
+                  hintText={hintText}
                   items={propItems}
                   onFilter={(filtered) =>
                     this.setState({ filteredItems: filtered })

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -617,7 +617,12 @@ class BaseMultiSelect<T> extends Component<
                 {selectedItems
                   .filter((item) => item.disabled)
                   .map((disabledItem) => (
-                    <Chip aria-disabled={true} key={disabledItem.uniqueItemId}>
+                    <Chip
+                      aria-disabled={true}
+                      key={disabledItem.uniqueItemId}
+                      actionLabel={ariaChipActionLabel}
+                      removable={true}
+                    >
                       {disabledItem.chipText
                         ? disabledItem.chipText
                         : disabledItem.labelText}

--- a/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -84,11 +84,11 @@ export interface MultiSelectProps<T extends MultiSelectData> {
   /** Text for screen reader to indicate how many items are selected */
   ariaSelectedAmountText: string;
   /** Text for screen reader indicating the amount of available options after filtering by typing. Will be read after the amount.
-   * E.g 'options available' as prop value would result in '<amount> options available' being read to screen reader upon removal.
+   * E.g 'options available' as prop value would result in '{amount} options available' being read to screen reader upon removal.
    */
   ariaOptionsAvailableText: string;
   /** Text for screen reader to read, after labelText/chipText, when selected option is removed from chip list.
-   * E.g 'removed' as prop value would result in '<option> removed' being read to screen reader upon removal.
+   * E.g 'removed' as prop value would result in '{option} removed' being read to screen reader upon removal.
    */
   ariaOptionChipRemovedText: string;
 }

--- a/src/core/Form/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -847,13 +847,32 @@ exports[`has matching snapshot 1`] = `
       >
         <button
           aria-disabled="true"
-          class="c8 fi-chip fi-chip--button c9 fi-chip--disabled"
+          class="c8 fi-chip fi-chip--button c9 fi-chip--disabled fi-chip--removable"
           type="button"
         >
           <span
             class="c4 fi-chip--content"
           >
             Powersaw
+          </span>
+          <svg
+            aria-hidden="true"
+            class="fi-icon c10 fi-chip--icon fi-icon--cursor-pointer"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 13.45L4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45z"
+            />
+          </svg>
+          <span
+            class="c4 c11 fi-visually-hidden"
+          >
+            Remove
           </span>
         </button>
         <button

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,10 +10,10 @@ export { Dropdown, DropdownProps } from './core/Dropdown/';
 export { DropdownItem, DropdownItemProps } from './core/Dropdown/';
 export { Chip, ChipProps } from './core/Chip/';
 export { StaticChip, StaticChipProps } from './core/Chip/';
-// MultiSelect,
-// MultiSelectProps,
-// MultiSelectData,
 export {
+  MultiSelect,
+  MultiSelectProps,
+  MultiSelectData,
   Checkbox,
   CheckboxProps,
   TextInput,


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Following changes improves the accessibility of the MultiSelect component. These issues were noticed in the accessibility clinic.

- `hintText` prop for MultiSelect as optional prop. Useful for user to tell that the input field can be used to filter available options.
-  `ariaOptionsAvailableText` prop as required prop for MultiSelect. It will be used to tell for screen reader user how many options are available after filtering.
-  `ariaOptionChipRemovedText` prop as required prop for MultiSelect. It will be read when selection chip is removed.
- MultiSelect is now made visible again in the styleguidist and exported from the library

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

This improves accessibility of the MultiSelect, especially for screen reader users.

## How Has This Been Tested?

Locally in styleguidist on macOS Safari and Brave browsers.

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

- Add `hintText` prop for MultiSelect
- Add `ariaOptionsAvailableText` prop for MultiSelect
- Add `ariaOptionChipRemovedText` prop for MultiSelect