### PR TITLE
[Fix] Destructure baseColor from props in the StaticIcon

### DIFF
--- a/src/core/StaticIcon/StaticIcon.tsx
+++ b/src/core/StaticIcon/StaticIcon.tsx
@@ -40,6 +40,7 @@ const StyledSuomifiStaticIcon = styled(
     ariaLabel,
     mousePointer,
     highlightColor,
+    baseColor,
     ...passProps
   }: StaticIconProps) => (
     <SuomifiStaticIcon


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

Destructure the `baseColor` prop from the props of StaticIcon, so it will not end up in the DOM anymore.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Motivation and Context
`baseColor` prop was not destructured from props, so it ended up in the DOM.

The error was like following:
```
React does not recognize the `baseColor` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `basecolor` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```


<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally in styleguidist

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

- Fix: Destructure baseColor from props in the StaticIcon