### PR TITLE
[Fix] ToggleInput example

### DIFF
--- a/src/core/Form/Toggle/ToggleButton/ToggleButton.md
+++ b/src/core/Form/Toggle/ToggleButton/ToggleButton.md
@@ -14,9 +14,8 @@ const exampleRef = React.createRef();
     Unchecked enabled using button
   </ToggleButton>
   <ToggleButton
-    onClick={(checked) => console.log(checked)}
+    onClick={(checked) => console.log(checked, exampleRef.current)}
     ref={exampleRef}
-    onClick={() => console.log(exampleRef.current)}
   >
     Unchecked enabled using button
   </ToggleButton>


### PR DESCRIPTION
## Description
Fix for ToggleInput example. This PR combines two separate onClick handlers for a single ToggleInput component example.

## Motivation and Context
Having more than one of the same event handlers in a React component is considered an error. This error had gone unnoticed due to md file formats not being checked by linters or build.

## Release notes
ToggleInput
- Fix example onClick handler.