### PR TITLE
Remove normalize.cssinjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "@reach/popover": "0.15.0",
     "@types/react-modal": "3.12.0",
     "classnames": "2.3.1",
-    "normalize.cssinjs": "1.1.1",
     "polished": "4.1.2",
     "react-modal": "3.13.1",
     "react-popper": "2.2.5",

--- a/src/reset/utils/index.ts
+++ b/src/reset/utils/index.ts
@@ -1,7 +1,68 @@
 import { css } from 'styled-components';
-import { normalizeCssInJs } from 'normalize.cssinjs';
 
-const normalize = normalizeCssInJs({ cssToString: true });
+const normalize = {
+  html:
+    'line-height: 1.15; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;',
+  h1: 'font-size: 2em; margin: 0.67em 0;',
+  'dl dl': 'margin: 0;',
+  'dl ol': 'margin: 0;',
+  'dl ul': 'margin: 0;',
+  'ol dl': 'margin: 0;',
+  'ul dl': 'margin: 0;',
+  'ol ol': 'margin: 0;',
+  'ol ul': 'margin: 0;',
+  'ul ol': 'margin: 0;',
+  'ul ul': 'margin: 0;',
+  hr: 'box-sizing: content-box; height: 0; overflow: visible;',
+  main: 'display: block;',
+  pre: 'font-family: monospace, monospace; font-size: 1em;',
+  a: 'background-color: transparent;',
+  'abbr[title]':
+    'text-decoration: underline; text-decoration: underline dotted;',
+  b: 'font-weight: bolder;',
+  strong: 'font-weight: bolder;',
+  code: 'font-family: monospace, monospace; font-size: 1em;',
+  kbd: 'font-family: monospace, monospace; font-size: 1em;',
+  samp: 'font-family: monospace, monospace; font-size: 1em;',
+  small: 'font-size: 80%;',
+  audio: 'display: inline-block;',
+  video: 'display: inline-block;',
+  'audio:not([controls])': 'display: none; height: 0;',
+  img: 'border-style: none;',
+  'svg:not(:root)': 'overflow: hidden;',
+  button:
+    'margin: 0;overflow: visible; text-transform: none;-webkit-appearance: button;',
+  input: 'margin: 0;overflow: visible;',
+  select: 'margin: 0;text-transform: none;',
+  '[type="button"]': '-webkit-appearance: button;',
+  '[type="reset"]': '-webkit-appearance: button;',
+  '[type="submit"]': '-webkit-appearance: button;',
+  fieldset: 'padding: 0.35em 0.75em 0.625em;',
+  legend:
+    'box-sizing: border-box; color: inherit; display: table; max-width: 100%; white-space: normal;',
+  progress: 'display: inline-block; vertical-align: baseline;',
+  textarea: 'margin: 0; overflow: auto;',
+  '[type="checkbox"]': 'box-sizing: border-box; padding: 0;',
+  '[type="radio"]': 'box-sizing: border-box; padding: 0;',
+  '[type="search"]': '-webkit-appearance: textfield; outline-offset: -2px;',
+  '::-webkit-inner-spin-button': 'height: auto;',
+  '::-webkit-outer-spin-button': 'height: auto;',
+  '::-webkit-input-placeholder': 'color: inherit; opacity: 0.54;',
+  '::-webkit-search-decoration': '-webkit-appearance: none;',
+  '::-webkit-file-upload-button': '-webkit-appearance: button; font: inherit;',
+  '::-moz-focus-inner': 'border-style: none; padding: 0;',
+  ':-moz-focusring': 'outline: 1px dotted ButtonText;',
+  ':-moz-ui-invalid': 'box-shadow: none;',
+  details: 'display: block;',
+  dialog:
+    // eslint-disable-next-line max-len
+    'background-color: white; border: solid; color: black; display: block; height: -moz-fit-content; height: -webkit-fit-content; height: fit-content; left: 0; margin: auto; padding: 1em; position: absolute; right: 0; width: -moz-fit-content; width: -webkit-fit-content; width: fit-content;',
+  'dialog:not([open])': 'display: none;',
+  summary: 'display: list-item;',
+  canvas: 'display: inline-block;',
+  template: 'display: none;',
+  '[hidden]': 'display: none;',
+} as Record<string, string>;
 
 const common = css`
   margin: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,11 +1265,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@csstools/normalize.css@10.1.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
-  integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
-
 "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
@@ -1338,14 +1333,6 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
-
-"@j-kallunki/css-in-to-js@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@j-kallunki/css-in-to-js/-/css-in-to-js-1.0.6.tgz#01de224f7f3b003286b07b335a0c525f9955f964"
-  integrity sha512-3pjXzUM/rFcpjbDGgYFU2+jmDPomzwd/twmxrrF8xy9MbbdxybWrFpVl6w4yBNaeQduySET4IaM4Hpv/NNGUag==
-  dependencies:
-    lodash "4.17.15"
-    postcss "7.0.5"
 
 "@jest/console@^25.5.0":
   version "25.5.0"
@@ -8995,7 +8982,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@4.17.21, lodash@4.x, lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0, lodash@~4.17.10:
+lodash@4.17.21, lodash@4.x, lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9821,14 +9808,6 @@ normalize-url@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
-
-normalize.cssinjs@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/normalize.cssinjs/-/normalize.cssinjs-1.1.1.tgz#f7f6ff17e2ac56ab1cb3b6b6ff350573b1cd8733"
-  integrity sha512-0BalwcNxZ8FAdkqcr2wLXMZgVFua3aTSSXKUdBy3hb1R3/un8OFo8XGkh9hp46dYKPUNCfx5392eePIhhzbmWQ==
-  dependencies:
-    "@csstools/normalize.css" "10.1.0"
-    "@j-kallunki/css-in-to-js" "1.0.6"
 
 npm-run-all@4.1.5:
   version "4.1.5"
@@ -11193,15 +11172,6 @@ postcss-value-parser@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz#651ff4593aa9eda8d5d0d66593a2417aeaeb325d"
   integrity sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==
-
-postcss@7.0.5:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.5.tgz#70e6443e36a6d520b0fd4e7593fcca3635ee9f55"
-  integrity sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==
-  dependencies:
-    chalk "^2.4.1"
-    source-map "^0.6.1"
-    supports-color "^5.5.0"
 
 postcss@8.2.13, postcss@^8.2.10:
   version "8.2.13"


### PR DESCRIPTION
## Description

This PR removes the `normalize.cssinjs` dependency and replaces it with an explicit object with all of the reset styles. This does not change how the utility reset functions work (just the way the data is stored); however, updates (if any) from the normalize.css stylesheet will no longer be applied automatically.

## Motivation and Context

- `normalize.cssinjs`'s dependencies haven't been updated updated in a while, and as such there are some vulnerable packages like lodash and postcss included (this causes `npm audit` to fail unless the packages are overridden manually via `resolutions`)
- `normalize.cssinjs`'s dependency `@j-kallunki/css-in-to-js` requires postcss to be included even in runtime bundles, which increases bundle sizes
  - this is unnecessary as the underlying normalize.css will not change between build-time and runtime, so it's just unnecessary work for the client bundle to parse CSS via postcss and download postcss itself when the outcome is basically the same always
- explicitly stating the used reset styles allows editing/versioning them down the line and also acts as a reference for what is being reset and how
- by removing `normalize.cssinjs` runtime bundle sizes can be decreased by as much as ~(53 + 8 = 61) kB (tree shaken, non-tree shaken ~(500 + 10 = 510) kB) because `normalize.cssinjs` is not tree-shakeable