### PR TITLE
[Feature] Update suomifi-icons to 5.0.0

### DIFF
--- a/.styleguidist/styleguidist.require.js
+++ b/.styleguidist/styleguidist.require.js
@@ -1,3 +1,4 @@
 import '../src/core/theme/fontFaces.css';
+import '../src/docs/iconExampleStyles.css';
 import '@reach/menu-button/styles.css';
 import '@reach/listbox/styles.css';

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "react-popper": "2.2.5",
     "react-svg": "13.0.3",
     "suomifi-design-tokens": "3.1.1",
-    "suomifi-icons": "^4.0.0"
+    "suomifi-icons": "^5.0.0"
   },
   "peerDependencies": {
     "@types/styled-components": ">=5.1.9",

--- a/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -32,7 +32,9 @@ export const baseStyles = css`
     &_icon {
       transform: translateY(0.2em);
       margin: 0 ${theme.spacing.insetXs};
-      fill: ${theme.colors.depthDark1};
+      & .fi-icon-base-fill {
+        fill: ${theme.colors.depthDark1};
+      }
     }
   }
 `;

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -291,6 +291,9 @@ exports[`calling render with the same component on the same container does not r
   -ms-transform: translateY(0.2em);
   transform: translateY(0.2em);
   margin: 0 4px;
+}
+
+.c1 .fi-breadcrumb_icon .fi-icon-base-fill {
   fill: hsl(202,7%,40%);
 }
 

--- a/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -155,6 +155,14 @@ exports[`calling render with the same component on the same container does not r
   vertical-align: baseline;
 }
 
+.c6 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c6 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c6.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -306,7 +314,6 @@ exports[`calling render with the same component on the same container does not r
       <svg
         aria-hidden="true"
         class="fi-icon c6 fi-breadcrumb_icon"
-        fill="currentColor"
         focusable="false"
         height="1em"
         viewBox="0 0 24 24"
@@ -314,7 +321,10 @@ exports[`calling render with the same component on the same container does not r
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
+          class="fi-icon-base-fill"
           d="M6 18v-2.12l5.902-2.328 3.748-1.492v-.12l-3.748-1.492L6 8.119V6l12 5.015v1.97z"
+          fill="#292929"
+          fill-rule="evenodd"
         />
       </svg>
     </li>
@@ -330,7 +340,6 @@ exports[`calling render with the same component on the same container does not r
       <svg
         aria-hidden="true"
         class="fi-icon c6 fi-breadcrumb_icon"
-        fill="currentColor"
         focusable="false"
         height="1em"
         viewBox="0 0 24 24"
@@ -338,7 +347,10 @@ exports[`calling render with the same component on the same container does not r
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
+          class="fi-icon-base-fill"
           d="M6 18v-2.12l5.902-2.328 3.748-1.492v-.12l-3.748-1.492L6 8.119V6l12 5.015v1.97z"
+          fill="#292929"
+          fill-rule="evenodd"
         />
       </svg>
     </li>

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -201,6 +201,14 @@ exports[`Basic expander shoud match snapshot 1`] = `
   vertical-align: baseline;
 }
 
+.c5 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c5 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c5.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -349,7 +357,6 @@ exports[`Basic expander shoud match snapshot 1`] = `
         <svg
           aria-hidden="true"
           class="fi-icon c5 fi-expander_title-button-icon"
-          fill="currentColor"
           focusable="false"
           height="1em"
           viewBox="0 0 24 24"
@@ -357,7 +364,10 @@ exports[`Basic expander shoud match snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+            class="fi-icon-base-fill"
+            d="M12.99 15.61c-.273.26-.632.39-.99.39s-.717-.13-.99-.39l-5.6-5.334a1.287 1.287 0 010-1.885 1.448 1.448 0 011.98 0l4.61 4.39 4.61-4.39a1.448 1.448 0 011.98 0c.547.52.547 1.365 0 1.885l-5.6 5.333z"
+            fill="#292929"
+            fill-rule="evenodd"
           />
         </svg>
       </button>

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -333,6 +333,14 @@ exports[`Basic expander group should match snapshot 1`] = `
   vertical-align: baseline;
 }
 
+.c7 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c7 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c7.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -504,7 +512,6 @@ exports[`Basic expander group should match snapshot 1`] = `
             <svg
               aria-hidden="true"
               class="fi-icon c7 fi-expander_title-button-icon"
-              fill="currentColor"
               focusable="false"
               height="1em"
               viewBox="0 0 24 24"
@@ -512,7 +519,10 @@ exports[`Basic expander group should match snapshot 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+                class="fi-icon-base-fill"
+                d="M12.99 15.61c-.273.26-.632.39-.99.39s-.717-.13-.99-.39l-5.6-5.334a1.287 1.287 0 010-1.885 1.448 1.448 0 011.98 0l4.61 4.39 4.61-4.39a1.448 1.448 0 011.98 0c.547.52.547 1.365 0 1.885l-5.6 5.333z"
+                fill="#292929"
+                fill-rule="evenodd"
               />
             </svg>
           </button>
@@ -554,7 +564,6 @@ exports[`Basic expander group should match snapshot 1`] = `
             <svg
               aria-hidden="true"
               class="fi-icon c7 fi-expander_title-button-icon"
-              fill="currentColor"
               focusable="false"
               height="1em"
               viewBox="0 0 24 24"
@@ -562,7 +571,10 @@ exports[`Basic expander group should match snapshot 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+                class="fi-icon-base-fill"
+                d="M12.99 15.61c-.273.26-.632.39-.99.39s-.717-.13-.99-.39l-5.6-5.334a1.287 1.287 0 010-1.885 1.448 1.448 0 011.98 0l4.61 4.39 4.61-4.39a1.448 1.448 0 011.98 0c.547.52.547 1.365 0 1.885l-5.6 5.333z"
+                fill="#292929"
+                fill-rule="evenodd"
               />
             </svg>
           </button>

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -129,6 +129,14 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   vertical-align: baseline;
 }
 
+.c5 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c5 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c5.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -300,7 +308,6 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
     <svg
       aria-hidden="true"
       class="fi-icon c5 fi-expander_title-icon"
-      fill="currentColor"
       focusable="false"
       height="1em"
       viewBox="0 0 24 24"
@@ -308,7 +315,10 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+        class="fi-icon-base-fill"
+        d="M12.99 15.61c-.273.26-.632.39-.99.39s-.717-.13-.99-.39l-5.6-5.334a1.287 1.287 0 010-1.885 1.448 1.448 0 011.98 0l4.61 4.39 4.61-4.39a1.448 1.448 0 011.98 0c.547.52.547 1.365 0 1.885l-5.6 5.333z"
+        fill="#292929"
+        fill-rule="evenodd"
       />
     </svg>
   </button>

--- a/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
@@ -117,6 +117,14 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   vertical-align: baseline;
 }
 
+.c4 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c4 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c4.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -261,7 +269,6 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
       <svg
         aria-hidden="true"
         class="fi-icon c4 fi-expander_title-button-icon"
-        fill="currentColor"
         focusable="false"
         height="1em"
         viewBox="0 0 24 24"
@@ -269,7 +276,10 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+          class="fi-icon-base-fill"
+          d="M12.99 15.61c-.273.26-.632.39-.99.39s-.717-.13-.99-.39l-5.6-5.334a1.287 1.287 0 010-1.885 1.448 1.448 0 011.98 0l4.61 4.39 4.61-4.39a1.448 1.448 0 011.98 0c.547.52.547 1.365 0 1.885l-5.6 5.333z"
+          fill="#292929"
+          fill-rule="evenodd"
         />
       </svg>
     </button>

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -10,7 +10,7 @@ const checkedStyles = css`
       &::before {
         border-color: ${theme.colors.highlightBase};
       }
-      & > .fi-checkbox_icon {
+      & > .fi-checkbox_icon .fi-icon-base-fill {
         fill: ${theme.colors.highlightBase};
       }
     }
@@ -27,7 +27,7 @@ const disabledStyles = css`
         border-color: ${theme.colors.depthLight1};
         border-width: 1px;
       }
-      & > .fi-checkbox_icon {
+      & > .fi-checkbox_icon .fi-icon-base-fill {
         fill: ${theme.colors.depthLight1};
       }
     }
@@ -46,7 +46,7 @@ const errorStyles = css`
         border-color: ${theme.colors.alertBase};
         border-width: 2px;
       }
-      & > .fi-checkbox_icon {
+      & > .fi-checkbox_icon .fi-icon-base-fill {
         fill: ${theme.colors.alertBase};
       }
     }

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -247,7 +247,7 @@ exports[`props children has matching snapshot 1`] = `
   border-color: hsl(212,63%,45%);
 }
 
-.c1.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon {
+.c1.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
   fill: hsl(212,63%,45%);
 }
 
@@ -256,7 +256,7 @@ exports[`props children has matching snapshot 1`] = `
   border-width: 2px;
 }
 
-.c1.fi-checkbox--error .fi-checkbox_label > .fi-checkbox_icon {
+.c1.fi-checkbox--error .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
   fill: hsl(3,59%,48%);
 }
 
@@ -271,7 +271,7 @@ exports[`props children has matching snapshot 1`] = `
   border-width: 1px;
 }
 
-.c1.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon {
+.c1.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
   fill: hsl(202,7%,80%);
 }
 

--- a/src/core/Form/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -150,6 +150,14 @@ exports[`has matching snapshot 1`] = `
   vertical-align: baseline;
 }
 
+.c10 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c10 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c10.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -869,7 +877,6 @@ exports[`has matching snapshot 1`] = `
           <svg
             aria-hidden="true"
             class="fi-icon c10 fi-chip--icon fi-icon--cursor-pointer"
-            fill="currentColor"
             focusable="false"
             height="1em"
             viewBox="0 0 24 24"
@@ -877,7 +884,10 @@ exports[`has matching snapshot 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M12 13.45L4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45z"
+              class="fi-icon-base-fill"
+              d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+              fill="#292929"
+              fill-rule="evenodd"
             />
           </svg>
           <span
@@ -899,7 +909,6 @@ exports[`has matching snapshot 1`] = `
           <svg
             aria-hidden="true"
             class="fi-icon c10 fi-chip--icon fi-icon--cursor-pointer"
-            fill="currentColor"
             focusable="false"
             height="1em"
             viewBox="0 0 24 24"
@@ -907,7 +916,10 @@ exports[`has matching snapshot 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M12 13.45L4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45z"
+              class="fi-icon-base-fill"
+              d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+              fill="#292929"
+              fill-rule="evenodd"
             />
           </svg>
           <span
@@ -927,7 +939,6 @@ exports[`has matching snapshot 1`] = `
       <svg
         aria-hidden="true"
         class="fi-icon c10 fi-button_icon fi-icon--cursor-pointer"
-        fill="currentColor"
         focusable="false"
         height="1em"
         viewBox="0 0 24 24"
@@ -935,7 +946,10 @@ exports[`has matching snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M16 4h5a1 1 0 010 2h-1.09l-1.805 16.117A2.143 2.143 0 0116 24H8a2.141 2.141 0 01-2.104-1.885L4.119 6H3a1 1 0 010-2h1.987a.99.99 0 01.066 0H8V3c0-1.654 1.346-3 3-3h2c1.654 0 3 1.346 3 3v1zm-2 0V3c0-.552-.449-1-1-1h-2c-.551 0-1 .448-1 1v1h4zM6.132 6l1.753 15.896c.004.04.075.104.115.104h8c.041 0 .113-.065.118-.105L17.898 6H6.132z"
+          class="fi-icon-base-fill"
+          d="M13 0c1.654 0 3 1.346 3 3v1h5a1 1 0 010 2h-1.091l-1.804 16.117A2.143 2.143 0 0116 24H8a2.141 2.141 0 01-2.104-1.885L4.119 6H3a1 1 0 010-2h5V3c0-1.654 1.346-3 3-3h2zm4.898 6H6.132l1.753 15.896c.004.04.075.104.115.104h8c.041 0 .113-.065.118-.105L17.898 6zM13 2h-2c-.551 0-1 .448-1 1v1h4V3c0-.552-.449-1-1-1z"
+          fill="#292929"
+          fill-rule="evenodd"
         />
       </svg>
       Remove all selections

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -162,7 +162,7 @@ export const baseStyles = css`
       &:active {
         background-color: ${theme.colors.highlightDark1};
       }
-      & .fi-search-input_button-search-icon {
+      & .fi-search-input_button-search-icon .fi-icon-base-fill {
         fill: ${theme.colors.whiteBase};
       }
     }

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -103,7 +103,9 @@ export const baseStyles = css`
         &-icon {
           width: 12px;
           height: 12px;
-          fill: ${theme.colors.highlightDark1};
+          & .fi-icon-base-fill {
+            fill: ${theme.colors.highlightDark1};
+          }
         }
       }
 
@@ -116,7 +118,9 @@ export const baseStyles = css`
         &-icon {
           width: 18px;
           height: 18px;
-          fill: ${theme.colors.depthDark1};
+          & .fi-icon-base-fill {
+            fill: ${theme.colors.depthDark1};
+          }
         }
       }
     }

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -422,6 +422,9 @@ exports[`snapshot should have matching default structure 1`] = `
 .c1 .fi-search-input_button-clear-icon {
   width: 12px;
   height: 12px;
+}
+
+.c1 .fi-search-input_button-clear-icon .fi-icon-base-fill {
   fill: hsl(212,63%,37%);
 }
 
@@ -436,6 +439,9 @@ exports[`snapshot should have matching default structure 1`] = `
 .c1 .fi-search-input_button-search-icon {
   width: 18px;
   height: 18px;
+}
+
+.c1 .fi-search-input_button-search-icon .fi-icon-base-fill {
   fill: hsl(202,7%,40%);
 }
 

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -215,6 +215,14 @@ exports[`snapshot should have matching default structure 1`] = `
   vertical-align: baseline;
 }
 
+.c7 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c7 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c7.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -484,7 +492,7 @@ exports[`snapshot should have matching default structure 1`] = `
   background-color: hsl(212,63%,37%);
 }
 
-.c1.fi-search-input--not-empty .fi-search-input_button-search .fi-search-input_button-search-icon {
+.c1.fi-search-input--not-empty .fi-search-input_button-search .fi-search-input_button-search-icon .fi-icon-base-fill {
   fill: hsl(0,0%,100%);
 }
 
@@ -543,7 +551,6 @@ exports[`snapshot should have matching default structure 1`] = `
         <svg
           aria-hidden="true"
           class="fi-icon c7 fi-search-input_button-clear-icon"
-          fill="currentColor"
           focusable="false"
           height="1em"
           viewBox="0 0 24 24"
@@ -551,7 +558,10 @@ exports[`snapshot should have matching default structure 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M12 13.45L4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45z"
+            class="fi-icon-base-fill"
+            d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+            fill="#292929"
+            fill-rule="evenodd"
           />
         </svg>
       </button>
@@ -569,7 +579,6 @@ exports[`snapshot should have matching default structure 1`] = `
         <svg
           aria-hidden="true"
           class="fi-icon c7 fi-search-input_button-search-icon"
-          fill="currentColor"
           focusable="false"
           height="1em"
           viewBox="0 0 24 24"
@@ -577,7 +586,10 @@ exports[`snapshot should have matching default structure 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M9 2C5.14 2 2 5.141 2 9.001 2 12.86 5.14 16 9 16s7-3.14 7-6.999C16 5.141 12.86 2 9 2m7.029 12.615l7.678 7.678a.999.999 0 11-1.414 1.414l-7.678-7.678A8.957 8.957 0 019 18c-4.962 0-9-4.037-9-8.999C0 4.038 4.038 0 9 0s9 4.038 9 9.001a8.955 8.955 0 01-1.971 5.614z"
+            class="fi-icon-base-fill"
+            d="M9 0c4.962 0 9 4.038 9 9.001a8.955 8.955 0 01-1.971 5.614l7.678 7.678a.999.999 0 11-1.414 1.414l-7.678-7.678A8.957 8.957 0 019 18c-4.962 0-9-4.037-9-8.999C0 4.038 4.038 0 9 0zm0 2C5.14 2 2 5.141 2 9.001 2 12.86 5.14 16 9 16s7-3.14 7-6.999C16 5.141 12.86 2 9 2z"
+            fill="#292929"
+            fill-rule="evenodd"
           />
         </svg>
       </button>

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -98,7 +98,7 @@ export const baseStyles = css`
       color: ${theme.colors.depthBase};
       background-color: ${theme.colors.depthLight3};
     }
-    & .fi-icon {
+    & .fi-icon-base-fill {
       fill: ${theme.colors.depthBase};
     }
   }

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`snapshots match error status with statustext 1`] = `
   background-color: hsl(202,7%,97%);
 }
 
-.c1.fi-text-input--disabled .fi-icon {
+.c1.fi-text-input--disabled .fi-icon-base-fill {
   fill: hsl(202,7%,67%);
 }
 
@@ -661,7 +661,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   background-color: hsl(202,7%,97%);
 }
 
-.c1.fi-text-input--disabled .fi-icon {
+.c1.fi-text-input--disabled .fi-icon-base-fill {
   fill: hsl(202,7%,67%);
 }
 
@@ -1005,7 +1005,7 @@ exports[`snapshots match minimal implementation 1`] = `
   background-color: hsl(202,7%,97%);
 }
 
-.c1.fi-text-input--disabled .fi-icon {
+.c1.fi-text-input--disabled .fi-icon-base-fill {
   fill: hsl(202,7%,67%);
 }
 

--- a/src/core/Icon/Icon.baseStyles.tsx
+++ b/src/core/Icon/Icon.baseStyles.tsx
@@ -1,8 +1,16 @@
 import { css } from 'styled-components';
 
-export const iconBaseStyles = css`
+export const iconBaseStyles = ({ color }: { color?: string }) => css`
   display: inline-block;
   vertical-align: baseline;
+
+  ${!!color &&
+  `.fi-icon-base-fill {
+    fill: ${color};
+  }
+  .fi-icon-base-stroke {
+    stroke: ${color}
+  }`}
 
   &.fi-icon--cursor-pointer {
     cursor: pointer;

--- a/src/core/Icon/Icon.baseStyles.tsx
+++ b/src/core/Icon/Icon.baseStyles.tsx
@@ -1,21 +1,31 @@
 import { css } from 'styled-components';
 
-export const iconBaseStyles = ({ color }: { color?: string }) => css`
-  display: inline-block;
-  vertical-align: baseline;
+export const iconBaseStyles = ({
+  color,
+  fill,
+}: {
+  color?: string;
+  fill: string;
+}) => {
+  const resolvedColor = fill ?? color ?? 'currentColor';
 
-  ${!!color &&
-  `.fi-icon-base-fill {
-    fill: ${color};
-  }
-  .fi-icon-base-stroke {
-    stroke: ${color}
-  }`}
+  return css`
+    display: inline-block;
+    vertical-align: baseline;
 
-  &.fi-icon--cursor-pointer {
-    cursor: pointer;
-    & * {
-      cursor: inherit;
+    .fi-icon-base-fill {
+      fill: ${resolvedColor};
     }
-  }
-`;
+
+    .fi-icon-base-stroke {
+      stroke: ${resolvedColor};
+    }
+
+    &.fi-icon--cursor-pointer {
+      cursor: pointer;
+      & * {
+        cursor: inherit;
+      }
+    }
+  `;
+};

--- a/src/core/Icon/Icon.md
+++ b/src/core/Icon/Icon.md
@@ -1,4 +1,4 @@
-- Uses currentColor by default if `fill` prop is not given.
+- Uses currentColor by default if no `fill` or `color` prop is given.
 
 ```jsx
 import { Icon } from 'suomifi-ui-components';

--- a/src/core/Icon/Icon.md
+++ b/src/core/Icon/Icon.md
@@ -1,14 +1,33 @@
-- Uses currentColor by default if no `fill` or `color` prop is given.
+- Uses currentColor by default if no `fill` or `color` prop is given
+- Icons can be styled via props or internal classes.
 
 ```jsx
 import { Icon } from 'suomifi-ui-components';
 
 <>
-  <Icon
-    icon="login"
-    ariaLabel="Login here"
-    className="my-icon--test"
-  />
+  <Icon icon="login" ariaLabel="Login here" className="custom-icon" />
+  <div style={{ color: 'orange' }}>
+    <Icon
+      icon="search"
+      ariaLabel="Search"
+      className="my-icon--test"
+    />
+  </div>
+  <Icon icon="checkSelected" ariaLabel="Selected" color="green" />
+</>;
+```
+
+```jsx
+import { Icon } from 'suomifi-ui-components';
+
+/**
+ .fi-icon.custom-icon .fi-icon-base-fill {
+   fill: red;
+ }
+*/
+
+<>
+  <Icon icon="login" ariaLabel="Login here" className="custom-icon" />
   <div style={{ color: 'orange' }}>
     <Icon
       icon="login"

--- a/src/core/Icon/Icon.md
+++ b/src/core/Icon/Icon.md
@@ -5,17 +5,21 @@
 import { Icon } from 'suomifi-ui-components';
 
 <>
-  <Icon icon="login" ariaLabel="Login here" className="custom-icon" />
+  <Icon
+    icon="login"
+    ariaLabel="Login here"
+    className="my-icon-class"
+  />
+
   <div style={{ color: 'orange' }}>
-    <Icon
-      icon="search"
-      ariaLabel="Search"
-      className="my-icon--test"
-    />
+    <Icon icon="search" ariaLabel="Search" />
   </div>
+
   <Icon icon="checkSelected" ariaLabel="Selected" color="green" />
 </>;
 ```
+
+### Styling using classNames
 
 ```jsx
 import { Icon } from 'suomifi-ui-components';
@@ -28,6 +32,7 @@ import { Icon } from 'suomifi-ui-components';
 
 <>
   <Icon icon="login" ariaLabel="Login here" className="custom-icon" />
+
   <div style={{ color: 'orange' }}>
     <Icon
       icon="login"

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -18,6 +18,10 @@ export interface IconBaseProps {
   ariaLabel?: string;
   /** Show mouse cursor as hand-pointer */
   mousePointer?: boolean;
+  /** Custom fill color */
+  color?: string;
+  /** Custom fill color, takes precedence over color if both are provided */
+  fill?: string;
   testId?: string;
 }
 
@@ -61,13 +65,11 @@ const StyledSuomifiIcon = styled(
  */
 export class Icon extends Component<IconProps> {
   render() {
-    const { color, icon, fill, ...passProps } = this.props;
+    const { icon, ...passProps } = this.props;
     const { className, ariaLabel } = this.props;
 
-    const iconColor = fill ?? color ?? 'currentColor';
-
     if (icon !== undefined) {
-      return <StyledSuomifiIcon {...passProps} icon={icon} color={iconColor} />;
+      return <StyledSuomifiIcon {...passProps} icon={icon} />;
     }
 
     iconLogger(ariaLabel, className);

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -61,10 +61,10 @@ const StyledSuomifiIcon = styled(
  */
 export class Icon extends Component<IconProps> {
   render() {
-    const { color, icon, ...passProps } = this.props;
+    const { color, icon, fill, ...passProps } = this.props;
     const { className, ariaLabel } = this.props;
 
-    const iconColor = color !== undefined ? color : 'currentColor';
+    const iconColor = fill ?? color ?? 'currentColor';
 
     if (icon !== undefined) {
       return <StyledSuomifiIcon {...passProps} icon={icon} color={iconColor} />;

--- a/src/core/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/core/Icon/__snapshots__/Icon.test.tsx.snap
@@ -6,6 +6,14 @@ exports[`calling render with the same component on the same container does not r
   vertical-align: baseline;
 }
 
+.c0 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c0 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c0.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -19,7 +27,6 @@ exports[`calling render with the same component on the same container does not r
     aria-label="Test label"
     class="fi-icon c0 my-icon--test"
     data-testid="icon"
-    fill="currentColor"
     height="1em"
     role="img"
     viewBox="0 0 24 24"
@@ -27,13 +34,15 @@ exports[`calling render with the same component on the same container does not r
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M22.01 0c1.103 0 2 .897 2 2v20c0 1.103-.897 2-2 2H10c-1.103 0-2-.897-2-2v-5a1 1 0 012 0v5h12.01V2H10v5a1 1 0 01-2 0V2c0-1.103.897-2 2-2h12.01zm-9.717 15.293L14.586 13H1a1 1 0 010-2h13.586l-2.293-2.293a.999.999 0 111.414-1.414l4 4a.999.999 0 01.216 1.089.999.999 0 01-.216.325l-4 4a.997.997 0 01-1.414 0 .999.999 0 010-1.414z"
+      class="fi-icon-base-fill"
+      d="M22.01 0c1.103 0 2 .897 2 2v20c0 1.103-.897 2-2 2H10c-1.103 0-2-.897-2-2v-5a1 1 0 012 0v5h12.01V2H10v5a1 1 0 01-2 0V2c0-1.103.897-2 2-2h12.01zm-9.717 7.293a.999.999 0 011.414 0l4 4a.999.999 0 01.216 1.089.999.999 0 01-.216.325l-4 4a.997.997 0 01-1.414 0 .999.999 0 010-1.414L14.586 13H1a1 1 0 010-2h13.586l-2.293-2.293a.999.999 0 010-1.414z"
+      fill="#292929"
+      fill-rule="evenodd"
     />
   </svg>
   <svg
     aria-hidden="true"
     class="fi-icon c0"
-    fill="currentColor"
     focusable="false"
     height="1em"
     viewBox="0 0 24 24"
@@ -41,7 +50,10 @@ exports[`calling render with the same component on the same container does not r
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M17.3 2a6.59 6.59 0 00-4.734 2.001l-.575.588-.574-.588a6.589 6.589 0 00-4.732-2 6.593 6.593 0 00-4.734 2C-.65 6.67-.65 11.034 1.952 13.702l8.608 8.822a1.99 1.99 0 001.431.604c.52 0 1.04-.2 1.432-.604l8.608-8.822c2.603-2.668 2.603-7.033 0-9.7A6.587 6.587 0 0017.3 2M6.685 4a4.58 4.58 0 013.301 1.397l.575.59 1.43 1.466 1.432-1.467.574-.589A4.586 4.586 0 0117.3 4 4.58 4.58 0 0120.6 5.398c1.858 1.904 1.858 5.003 0 6.907l-8.609 8.823-8.607-8.823c-1.858-1.904-1.858-5.003 0-6.907A4.583 4.583 0 016.684 4"
+      class="fi-icon-base-fill"
+      d="M17.3 2c1.715 0 3.43.667 4.731 2.001 2.603 2.668 2.603 7.033 0 9.701l-8.608 8.822a1.992 1.992 0 01-1.432.604 1.99 1.99 0 01-1.43-.604l-8.609-8.822c-2.603-2.668-2.603-7.033 0-9.7A6.593 6.593 0 016.684 2c1.716 0 3.43.667 4.732 2.001l.574.588.575-.588a6.59 6.59 0 014.733-2zm0 2c-1.25 0-2.423.497-3.303 1.397l-.574.59-1.432 1.466-1.43-1.467-.575-.589A4.58 4.58 0 006.686 4c-1.25 0-2.423.497-3.303 1.398-1.857 1.904-1.857 5.003.001 6.907l8.607 8.823 8.61-8.823c1.857-1.904 1.857-5.003 0-6.907A4.58 4.58 0 0017.298 4z"
+      fill="#292929"
+      fill-rule="evenodd"
     />
   </svg>
 </div>

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -23,7 +23,10 @@ export const baseStyles = css`
         width: 1em;
         transform: translateY(0.2em);
         margin-left: ${theme.spacing.xs};
-        fill: ${theme.colors.highlightBase};
+
+        & .fi-icon-base-fill {
+          fill: ${theme.colors.highlightBase};
+        }
       }
 
       &:focus {

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -35,6 +35,14 @@ exports[`calling render with the same component on the same container does not r
   vertical-align: baseline;
 }
 
+.c2 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c2 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c2.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -73,6 +81,9 @@ exports[`calling render with the same component on the same container does not r
   -ms-transform: translateY(0.2em);
   transform: translateY(0.2em);
   margin-left: 10px;
+}
+
+.c1 > [data-reach-menu-button].fi-language-menu_button.fi-language-menu-language_button > .fi-language-menu-language_icon .fi-icon-base-fill {
   fill: hsl(212,63%,45%);
 }
 
@@ -127,7 +138,6 @@ exports[`calling render with the same component on the same container does not r
       <svg
         aria-hidden="true"
         class="fi-icon c2 fi-language-menu-language_icon"
-        fill="currentColor"
         focusable="false"
         height="1em"
         viewBox="0 0 24 24"
@@ -135,7 +145,10 @@ exports[`calling render with the same component on the same container does not r
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M13 15.6c-.3.3-.6.4-1 .4s-.7-.1-1-.4l-5.6-5.3c-.5-.5-.5-1.4 0-1.9s1.4-.5 2 0l4.6 4.4 4.6-4.4c.5-.5 1.4-.5 2 0 .5.5.5 1.4 0 1.9L13 15.6z"
+          class="fi-icon-base-fill"
+          d="M12.99 15.61c-.273.26-.632.39-.99.39s-.717-.13-.99-.39l-5.6-5.334a1.287 1.287 0 010-1.885 1.448 1.448 0 011.98 0l4.61 4.39 4.61-4.39a1.448 1.448 0 011.98 0c.547.52.547 1.365 0 1.885l-5.6 5.333z"
+          fill="#292929"
+          fill-rule="evenodd"
         />
       </svg>
     </button>

--- a/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
+++ b/src/core/Link/__snapshots__/LinkExternal.test.tsx.snap
@@ -73,6 +73,14 @@ exports[`calling render with the same component on the same container does not r
   vertical-align: baseline;
 }
 
+.c5 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c5 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
 .c5.fi-icon--cursor-pointer {
   cursor: pointer;
 }
@@ -164,7 +172,6 @@ exports[`calling render with the same component on the same container does not r
   <svg
     aria-hidden="true"
     class="fi-icon c5 fi-link_icon"
-    fill="currentColor"
     focusable="false"
     height="1em"
     viewBox="0 0 24 24"
@@ -172,7 +179,9 @@ exports[`calling render with the same component on the same container does not r
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
+      class="fi-icon-base-fill"
       d="M12 4a1 1 0 010 2H2v16h16V12a1 1 0 012 0v10c0 1.103-.897 2-2 2H2c-1.103 0-2-.897-2-2V6c0-1.103.897-2 2-2h10zm11-4a1 1 0 011 1v6.657a1 1 0 01-2 0l-.001-4.242-9.792 9.792a.997.997 0 01-1.414 0 .999.999 0 010-1.414L20.586 2h-4.243a1 1 0 010-2H23z"
+      fill="#292929"
       fill-rule="evenodd"
     />
   </svg>

--- a/src/docs/iconExampleStyles.css
+++ b/src/docs/iconExampleStyles.css
@@ -1,0 +1,3 @@
+.fi-icon.custom-icon .fi-icon-base-fill {
+  fill: red;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13249,10 +13249,10 @@ suomifi-design-tokens@3.1.1:
   resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-3.1.1.tgz#5df2372d484152b4d361f656cfeefa1bdca4af55"
   integrity sha512-74RX9W99Hruk464ga11Fi+MaUYaQm5bLg8YI+kneGP9YktOXHtjgeQx75iDAqpNsXNBVnkQ/JjCfNsEX9hDz9g==
 
-suomifi-icons@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-4.0.0.tgz#66b247ec5c963cb69dcf9c87a4ceed38b009db85"
-  integrity sha512-Xap3UT2T/AeELWcjZ/6V/9xokXBiA0r7vfE62en/eOw7WZ6VkdEureYIbJdm4o67jkoGlpLJ/dQ4FLs2MIrXbw==
+suomifi-icons@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-5.0.0.tgz#8e4c3e9535065c32de757d3e6a75393a70414e73"
+  integrity sha512-tqLU2lfh9EyEgXCYeSYhJEhBUgc0nOlvs4e7TBLWMvTTnPPa14VCWSK1DL7HPHuwy95VODjjiHg1Y9B+vzoccA==
 
 supports-color@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13249,7 +13249,7 @@ suomifi-design-tokens@3.1.1:
   resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-3.1.1.tgz#5df2372d484152b4d361f656cfeefa1bdca4af55"
   integrity sha512-74RX9W99Hruk464ga11Fi+MaUYaQm5bLg8YI+kneGP9YktOXHtjgeQx75iDAqpNsXNBVnkQ/JjCfNsEX9hDz9g==
 
-suomifi-icons@5.0.0:
+suomifi-icons@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-5.0.0.tgz#8e4c3e9535065c32de757d3e6a75393a70414e73"
   integrity sha512-tqLU2lfh9EyEgXCYeSYhJEhBUgc0nOlvs4e7TBLWMvTTnPPa14VCWSK1DL7HPHuwy95VODjjiHg1Y9B+vzoccA==


### PR DESCRIPTION
## Description
This PR updates the suomifi-icons dependency to the latest version of 5.0.0. It adjusts examples and component styles to accommodate for the changes in suomifi-icons.

## Motivation and Context
New icons were needed in projects using suomifi-ui-components and icons. The styling logic now also offers more control over the internal styles of the svgs themselves.

## How Has This Been Tested?
Tested in styleguidist in Chrome as well as a CRA project in Chrome.

## Release notes
* **Breaking change**: Update suomifi-icons to 5.0.0
  * Includes changes to styling logic which might cause css-based styling to require adjustment
