### PR TITLE
Fix Input clear button focus position and update snapshots.

### DIFF
--- a/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
+++ b/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
@@ -3,6 +3,7 @@ import { SuomifiTheme } from '../../theme';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-input-clear-button {
+    position: relative;
     cursor: pointer;
     pointer-events: all;
     height: 20px;
@@ -11,7 +12,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     justify-content: center;
     align-items: center;
     &:focus {
-      position: relative;
       outline: none;
       &:after {
         ${theme.focus.absoluteFocus}

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -232,6 +232,7 @@ exports[`snapshot should have matching default structure 1`] = `
 }
 
 .c6.fi-input-clear-button {
+  position: relative;
   cursor: pointer;
   pointer-events: all;
   height: 20px;
@@ -251,7 +252,6 @@ exports[`snapshot should have matching default structure 1`] = `
 }
 
 .c6.fi-input-clear-button:focus {
-  position: relative;
   outline: none;
 }
 

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -434,6 +434,7 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c8.fi-input-clear-button {
+  position: relative;
   cursor: pointer;
   pointer-events: all;
   height: 20px;
@@ -453,7 +454,6 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c8.fi-input-clear-button:focus {
-  position: relative;
   outline: none;
 }
 


### PR DESCRIPTION
## Description
Fix SearchInput clear button positioning when focused. Internally affects also SingleSelect styles, but the actual visual bug did not concern SingleSelect.

## Motivation and Context
InputClearButton is used in SingleSelect and SearchInput and it had a position relative style accidentally applied to focus state while it should have been applied all the time. This resulted the clear button to bounce outside SearchInput while focues. 

## How Has This Been Tested?
Tested with Styleguidist build using MacOS Chrome and Safari.

## Release notes
SearchInput
- Fix clear button positioning