### PR TITLE
[Release] v6.0.0.

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -125,12 +125,12 @@ module.exports = {
                 'MultiSelect/MultiSelect/MultiSelect',
               ]),
             },
-            {
-              name: 'SingleSelect',
-              components: getComponentWithVariants('Form/Select')([
-                'SingleSelect/SingleSelect',
-              ]),
-            },
+            // {
+            //   name: 'SingleSelect',
+            //   components: getComponentWithVariants('Form/Select')([
+            //     'SingleSelect/SingleSelect',
+            //   ]),
+            // },
           ],
           expand: true,
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Suomi.fi UI component library",
   "main": "dist/index.js",
   "module": "dist/suomifi-ui-components.esm.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,10 @@ export { Dropdown, DropdownProps } from './core/Dropdown/';
 export { DropdownItem, DropdownItemProps } from './core/Dropdown/';
 export { Chip, ChipProps } from './core/Chip/';
 export { StaticChip, StaticChipProps } from './core/Chip/';
+// SingleSelect,
+// SingleSelectProps,
+// SingleSelectData,
+// SingleSelectStatus,
 export {
   Checkbox,
   CheckboxProps,
@@ -30,10 +34,6 @@ export {
   MultiSelectProps,
   MultiSelectData,
   MultiSelectStatus,
-  SingleSelect,
-  SingleSelectProps,
-  SingleSelectData,
-  SingleSelectStatus,
 } from './core/Form/Form';
 export { Heading, HeadingProps } from './core/Heading/Heading';
 export { Icon, IconProps, BaseIconKeys } from './core/Icon/Icon';


### PR DESCRIPTION
## Description
This PR increases version number to 6.0.0 and hides SingleSelect component from Styleguide and exports. SingleSelect will be released with 6.1 once accessibility has been validated.

## Release notes

### Dependencies (#497, #504, #508)
- Update vulnerable dependencies.

### Fonts (#494)
- **Breaking change:** Remove font imports from library provided css. Font's have to be imported separately from now on.

### Theme and styles (#491):
- Add export for suomifiTheme and related interfaces
- Add and export SuomifiThemeProvider and related documentation
- Remove css.in-to-js dependency and replace it with static object
- Refactor theme generation and remove redundant focus utils. Include derived tokens to theme.
- Directory structure:
  - Remove unused login icon and directory
  - Move styleguidist components to docs directory
  - Cleanup utils directory structure
- Types:
  - Remove all custom Reach-UI types and replace with the ones exported by Reach-UI

### MultiSelect (#438, #479, #483, #496, #503)
- Add MultiSelect component

### SearchInput (#503, #509)
- Add abstractions and share functionality with upcoming SingleSelect

### StaticIcon (#486)
- Fix: Destructure baseColor from props in the StaticIcon

### ToggleInput (#487)
- Fix example onClick handler.

### Link (#488)
- **Breaking change:** Remove static variants. Use SkipLink and ExternalLink components instead.

### Text #488
- **Breaking change:** Remove static variants. Use the variant prop instead.

### Block (#488)
- **Breaking change:** Remove static variants. Use the variant prop instead.

### Breadcrumb (#488, #495)
- **Breaking change:** static variants no longer in use. Use the BreadcrumbLink component instead.
- **Breaking changes:** Remove variant prop. Use BreadcrumbLink instead of variant="link". Internal classnames have changed which may affect custom styles.
- Remove background color

### LanguageMenu (#490, #491)
- **Breaking changes:** Remove LanguageMenuItemLanguage, LanguageMenuItemLanguageProps, LanguageMenuLinkLanguage, LanguageMenuLinkLanguageProps. Use LanguageMenuItem, LanguageMenuItemProps, LanguageMenuLink, LanguageMenuLinkProps instead.
- **Breaking changes:** Remove statics languageItem and LinkLanguage. Use LanguageMenuItem and LanguageMenuLink instead.
- **Breaking changes:** Remove languageMenuPopoverProps and languageMenuPopoverComponent from LanguageMenuProps, remove related interfaces, remove popover and popoverLang classNames from internal styles.
