### PR TITLE
[Fix] documentation related to statics and component level.

### DIFF
--- a/.styleguidist/colors.md
+++ b/.styleguidist/colors.md
@@ -1,4 +1,6 @@
-Suomifi-styleguide colors
+Suomifi-styleguide colors.
+
+Click the figures to copy the color token name to clipboard.
 
 ## Base
 

--- a/.styleguidist/introduction.md
+++ b/.styleguidist/introduction.md
@@ -13,18 +13,18 @@ import { Button } from 'suomifi-ui-components';
 ReactDOM.render(<Button />, mountNode);
 ```
 
-### 🌊 `Component.variant`
+### 🌊 `Component variants`
 
-Components have variant-property for different versions of the current component. Easiest way to use variant-prop is with (static method) `Component.variant`.
+Components have variant-property for different versions of the current component.
 
 ```jsx static
 import { Button } from 'suomifi-ui-components';
-<Button.secondary>This is seconday button</Button.secondary>;
+<Button variant="secondary">This is seconday button</Button>;
 ```
 
 ### ⛱ Extending styles
 
-Components' styles can be customized with [Styled Components](https://github.com/styled-components/styled-components) / [Emotion](https://github.com/emotion-js/emotion):
+Components' styles can be customized with [Styled Components](https://github.com/styled-components/styled-components):
 
 ```javascript static
 styled(Button)...

--- a/.styleguidist/spacing.md
+++ b/.styleguidist/spacing.md
@@ -1,3 +1,5 @@
+Click the figures to copy the spacing token name to clipboard.
+
 ```js noeditor
 import { default as styled } from 'styled-components';
 import { defaultSuomifiTheme } from '../src/core/theme';

--- a/.styleguidist/typography.md
+++ b/.styleguidist/typography.md
@@ -1,4 +1,6 @@
-Suomifi-styleguide typography
+Suomifi-styleguide typography.
+
+Click the examples to copy the typography token name to clipboard.
 
 ```js noeditor
 import { default as styled } from 'styled-components';

--- a/.styleguidist/typography.md
+++ b/.styleguidist/typography.md
@@ -1,6 +1,6 @@
 Suomifi-styleguide typography.
 
-Click the examples to copy the typography token name to clipboard.
+Click the examples to copy related JSX tags to clipboard.
 
 ```js noeditor
 import { default as styled } from 'styled-components';

--- a/.styleguidist/typography.md
+++ b/.styleguidist/typography.md
@@ -75,14 +75,14 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
     variant="body"
     name="Body text"
     size={typographyTokens.bodyTextSmall.fontSize}
-    code="<Text smallScreen></Text>"
+    code="<Text smallScreen='true'></Text>"
   />
 
   <TextSet
     variant="lead"
     name="Lead text"
     size={typographyTokens.leadText.fontSize}
-    code="<Text.lead></Text.lead>"
+    code="<Text variant='lead'></Text>"
   />
   <TextSet
     mb
@@ -90,14 +90,14 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
     variant="lead"
     name="Lead text"
     size={typographyTokens.leadTextSmallScreen.fontSize}
-    code="<Text.lead smallScreen></Text.lead>"
+    code="<Text variant='lead' smallScreen='true'></Text>"
   />
 
   <HeadingSet
     variant="h1hero"
     name="Heading 1 hero"
     size={typographyTokens.heading1.fontSize}
-    code="<Heading.h1hero></Heading.h1hero>"
+    code="<Heading variant='h1hero'></Heading>"
   />
   <HeadingSet
     mb
@@ -105,7 +105,7 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
     variant="h1hero"
     name="Heading 1 hero"
     size={typographyTokens.heading1SmallScreen.fontSize}
-    code="<Heading.h1hero smallScreen></Heading.h1hero>"
+    code="<Heading variant='h1hero' smallScreen='true'></Heading>"
   />
 
   {[1, 2, 3, 4, 5].map((n) => (
@@ -114,7 +114,7 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
         variant={`h${n}`}
         name={`Heading ${n}`}
         size={typographyTokens[`heading${n}`].fontSize}
-        code={`<Heading.h${n}></Heading.h${n}>`}
+        code={`<Heading variant='h${n}'></Heading>`}
       />
       <HeadingSet
         mb
@@ -122,7 +122,7 @@ const HeadingSet = ({ name, size, mb, code, ...passProps }) => (
         variant={`h${n}`}
         name={`Heading ${n}`}
         size={typographyTokens[`heading${n}SmallScreen`].fontSize}
-        code={`<Heading.h${n} smallScreen></Heading.h${n}>`}
+        code={`<Heading variant='h${n}' smallScreen='true'></Heading>`}
       />
     </React.Fragment>
   ))}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ See [DEVELOPMENT.md](/DEVELOPMENT.md).
 
 On release `develop` is merged to `master` and tagged with version. Release notes can be added to version via GitHub. We are mostly following [git flow](https://nvie.com/posts/a-successful-git-branching-model/).
 
-If API changes are approved to `develop`, rebase `master` to `develop`. Use semantic versioning to communicate the changes.
+Use semantic versioning to communicate the changes.
 
 Minor versions and patches are only applied to the latest major version.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,20 +30,18 @@ After cloning suomifi-ui-components, run `yarn` to fetch its dependencies. Then,
 
 ## Source
 
-Source contains 3 stages of components:
+Source contains 2 stages of components:
 
-1. `reset` is for resetting html tags (don't do too opinionated stuff here).
-2. `components` are bare bones accessibility implementations without Suomi.fi styles. This abstraction is being removed and will not be used in the future.
-3. `core` contains Suomi.fi-styleguide as theme, components and CSS exports.
+1. `reset` is for resetting html tag styles to avoid external styles affecting the components (don't do too opinionated stuff here).
+2. `core` contains the actual components, theme and CSS exports.
 
 - _Export `src/core`-components at `src/core/index` and `src/index`._
-- Export `src/components`-components at `src/components/index`.
 
-**Don't do relative imports from `src/index`, use those 3-levels export locations.**
+**Don't do relative imports from `src/index`, use those 2-levels export locations.**
 
 **Do not create duplication of source or styles for component.**
 
-Export interfaces for exported functions/components. Typescript will generate declaration files from exported interfaces (.d.ts). Write comments/documentatiion to all properties that need to be shown at styleguide.
+Export interfaces for exported functions/components. Typescript will generate declaration files from exported interfaces (.d.ts). Write comments/documentation to all properties that need to be shown at styleguide.
 
 ### Props that are passed on to another component
 
@@ -101,12 +99,11 @@ and/or atom-classes:
 .fi-block.fi-rounded .fi-block_element.fi-highlight;
 ```
 
-- All colors, typography and spacing must come from tokens (suomifi-design-tokens) and all tokens not defined in suomifi-design-tokens must be defined at internal tokens
+- All colors, typography and spacing must come from tokens (suomifi-design-tokens) and all reusable tokens not defined in suomifi-design-tokens must be defined internally
 - Don't use relative units without an important reason
 - Comment CSS when doing project specific solutions
-- All opinionated resets to **theme**
 
-Components' styles can be customized with [Styled Components](https://github.com/styled-components/styled-components) / [Emotion](https://github.com/emotion-js/emotion):
+Components' styles can be customized with [Styled Components](https://github.com/styled-components/styled-components):
 
 ```javascript
 styled(Button)...

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ReactDOM.render(<Button />, mountNode);
 
 ### 🌊 Component variants
 
-Components have variant-property for different versions of the current component. Some components might also have static variants e.g. `Component.variant`, but using these is discouraged as they are being removed in future releases.
+Components have variant-property for different versions of the current component.
 
 ```jsx
 import { Button } from 'suomifi-ui-components';

--- a/README.md
+++ b/README.md
@@ -73,18 +73,16 @@ Components have variant-property for different versions of the current component
 
 ```jsx
 import { Button } from 'suomifi-ui-components';
-<Button variant=”secondary”>This is a seconday button</Button>;
+<Button variant="secondary">This is a seconday button</Button>;
 ```
 
 ### ⛱ Extending styles
 
-Components' styles can be customized with [Styled Components](https://github.com/styled-components/styled-components) / [Emotion](https://github.com/emotion-js/emotion):
+Components' styles can be customized with [Styled Components](https://github.com/styled-components/styled-components):
 
 ```javascript
 styled(Button)...
 ```
-
-_HOX!!! If you use Styled Components you cannot use Component.variant (static methods) and you need to use variant-property to get variants from the styled(Component)._ Partly for this reason we are getting rid of the static variants in the future releases.
 
 **or** using CSS-ClassName:
 


### PR DESCRIPTION
## Description
This PR aligns documentation with previous static and components level removals.

## Motivation and Context
Some of the documentation was still referring to statics and components level and needed to be updated to reflect the latest changes.

## How Has This Been Tested?
Tested using Styleguidst on MacOS using Chrome.

## Release notes
General changes
- Fix documentation related to use of statics and components level.