### PR TITLE
[Feature] Restore SingleSelect exports and Styleguide page.

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -125,12 +125,12 @@ module.exports = {
                 'MultiSelect/MultiSelect/MultiSelect',
               ]),
             },
-            // {
-            //   name: 'SingleSelect',
-            //   components: getComponentWithVariants('Form/Select')([
-            //     'SingleSelect/SingleSelect',
-            //   ]),
-            // },
+            {
+              name: 'SingleSelect',
+              components: getComponentWithVariants('Form/Select')([
+                'SingleSelect/SingleSelect',
+              ]),
+            },
           ],
           expand: true,
         },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,10 +11,6 @@ export { Dropdown, DropdownProps } from './core/Dropdown/';
 export { DropdownItem, DropdownItemProps } from './core/Dropdown/';
 export { Chip, ChipProps } from './core/Chip/';
 export { StaticChip, StaticChipProps } from './core/Chip/';
-// SingleSelect,
-// SingleSelectProps,
-// SingleSelectData,
-// SingleSelectStatus,
 export {
   Checkbox,
   CheckboxProps,
@@ -34,6 +30,10 @@ export {
   MultiSelectProps,
   MultiSelectData,
   MultiSelectStatus,
+  SingleSelect,
+  SingleSelectProps,
+  SingleSelectData,
+  SingleSelectStatus,
 } from './core/Form/Form';
 export { Heading, HeadingProps } from './core/Heading/Heading';
 export { Icon, IconProps, BaseIconKeys } from './core/Icon/Icon';


### PR DESCRIPTION
## Description
This PR restores the previously out commented exports and Styleguide page for SingleSelect component.

## Motivation and Context
SingleSelect needs to be available for beta release for testing outside the team and for accessibility clinic.

## Release notes
SingleSelect
- Add SingleSelect component