### PR TITLE
[Fix] SingleSelect controlled state select item and onBlur issue.

### DIFF
--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -227,6 +227,10 @@ class BaseSingleSelect<T> extends Component<
         selectedItem: item || null,
         filterInputValue: item?.labelText || '',
       });
+    } else {
+      this.setState((prevState: SingleSelectState<T & SingleSelectData>) => ({
+        filterInputValue: prevState.selectedItem?.labelText || '',
+      }));
     }
     if (!!onItemSelect) {
       onItemSelect(item?.uniqueItemId || null);


### PR DESCRIPTION
## Description
This PR fixes SingleSelect controlled state issue where input was left blank after selection or onBlur. 

## Motivation and Context
SingleSelect controlled state was not working as expected.

## How Has This Been Tested?
Tested using MacOS + Chrome with Styleguidist build.

## Release notes
SingleSelect
- Fix controlled state input value issue