### PR TITLE
[feature] Add icon names to icon style guide documentation from branch

### DIFF
--- a/src/core/Icon/Icon.md
+++ b/src/core/Icon/Icon.md
@@ -73,11 +73,10 @@ const IconWrapper = styled.figure`
 
 <div>
   {baseIcons.map((icon) => (
-    <IconWrapper>
+    <IconWrapper key={icon}>
       <StyledIcon
         mousePointer
         icon={icon}
-        key={icon}
         onClick={() => clipboardCopy(icon)}
       />
       <figcaption>{icon}</figcaption>

--- a/src/core/StaticIcon/StaticIcon.md
+++ b/src/core/StaticIcon/StaticIcon.md
@@ -49,11 +49,10 @@ const IconWrapper = styled.figure`
 <div>
   <div>
     {illustrativeIcons.map((icon) => (
-      <IconWrapper>
+      <IconWrapper key={icon}>
         <StyledStaticIcon
           mousePointer
           icon={icon}
-          key={icon}
           onClick={() => clipboardCopy(icon)}
         />
         <figcaption>{icon}</figcaption>
@@ -62,11 +61,10 @@ const IconWrapper = styled.figure`
   </div>
   <div>
     {doctypeIcons.map((icon) => (
-      <IconWrapper>
+      <IconWrapper key={icon}>
         <StyledStaticIcon
           mousePointer
           icon={icon}
-          key={icon}
           onClick={() => clipboardCopy(icon)}
         />
         <figcaption>{icon}</figcaption>


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

This PR adds better usability to examples. Shows icon name on list in documentation.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

## Motivation and Context

Before you needed to click icon to get name. Bad usability.

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Now icons names are in Suomifi-ui-component icon list component.
<img width="1013" alt="Screenshot 2021-10-06 at 13 42 34" src="https://user-images.githubusercontent.com/91665617/136188831-00981998-c7c5-4c3e-b568-2a80f67c4702.png">

## Release notes
Icon list
Add visible icon names to list view in documentation.

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
