### PR TITLE
[Bugfix] Alert spacing, role, colors and examples

### DIFF
--- a/src/core/Alert/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert/Alert.baseStyles.ts
@@ -5,6 +5,13 @@ import { baseAlertBaseStyles } from '../BaseAlert/BaseAlert.baseStyles';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${baseAlertBaseStyles(theme)}
+
+  & .fi-alert_icon-wrapper {
+    display: flex;
+    flex: 1 0 auto;
+    justify-content: flex-end;
+  }
+
   & .fi-alert_close-button-wrapper {
     flex: 1 0 auto;
     display: flex;
@@ -42,14 +49,13 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       width: 14px;
       height: 14px;
       margin-left: ${theme.spacing.xxs};
-      margin-top: ${theme.spacing.xxs};
-      transform: translateY(1px);
+      transform: translateY(0.1em);
     }
   }
 
   /** Small screen variant styles */
-  &--small-screen {
-    & .fi-alert-close-button-wrapper {
+  &.fi-alert--small-screen {
+    & .fi-alert_close-button-wrapper {
       justify-content: flex-end;
       margin: 0;
       & .fi-icon {

--- a/src/core/Alert/Alert/Alert.md
+++ b/src/core/Alert/Alert/Alert.md
@@ -1,5 +1,5 @@
 ```js
-import { Alert, InlineAlert } from 'suomifi-ui-components';
+import { Alert } from 'suomifi-ui-components';
 
 <>
   <Alert closeText="Close" smallScreen>
@@ -20,10 +20,6 @@ import { Alert, InlineAlert } from 'suomifi-ui-components';
     ultrices efficitur pellentesque. Sed luctus ac metus sed rhoncus.
   </Alert>
 
-  <InlineAlert status="error">
-    Something went wrong. Please try again in a moment.
-  </InlineAlert>
-
   <Alert status="error" closeText="Long close text">
     Something went wrong. Please try again in a moment.
   </Alert>
@@ -32,15 +28,5 @@ import { Alert, InlineAlert } from 'suomifi-ui-components';
     The service will be temporarily unavailable on 5.6.2021 at 21.00 –
     23.59 due to maintenance.
   </Alert>
-
-  <InlineAlert status="warning" labelText="Warning">
-    The service will be temporarily unavailable on 5.6.2021 at 21.00 –
-    23.59 due to maintenance.
-  </InlineAlert>
-
-  <InlineAlert labelText="Long label Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi est nulla, rhoncus ac odio at">
-    The service will be temporarily unavailable on 5.6.2021 at 21.00 –
-    23.59 due to maintenance.
-  </InlineAlert>
 </>;
 ```

--- a/src/core/Alert/Alert/Alert.test.tsx
+++ b/src/core/Alert/Alert/Alert.test.tsx
@@ -82,32 +82,21 @@ describe('props', () => {
     expect(closeButton).toHaveAttribute('disabled');
     expect(closeButton).toHaveClass('testClass');
   });
-  describe('Aria-live mode and className check', () => {
-    const AlertWithDefaultAriaLiveMode = (
+  describe('Alert role and className check', () => {
+    const DefaultAlert = (
       <Alert id="testIdDefault" closeText="Close">
         Testcontent
       </Alert>
     );
-    const AlertWithAriaLiveModeOff = (
-      <Alert id="testIdOff" closeText="Close" ariaLiveMode="off">
-        Testcontent
-      </Alert>
-    );
-    it('should have default aria-live mode', () => {
-      const { container } = render(AlertWithDefaultAriaLiveMode);
+
+    it('should have alert role by default', () => {
+      const { container } = render(DefaultAlert);
       expect(container.querySelector('#testIdDefault')).toHaveClass(
         'fi-alert_text-content-wrapper',
       );
       expect(container.querySelector('#testIdDefault')).toHaveAttribute(
-        'aria-live',
-        'assertive',
-      );
-    });
-    it('should have specified aria-live mode', () => {
-      const { container } = render(AlertWithAriaLiveModeOff);
-      expect(container.querySelector('#testIdOff')).toHaveAttribute(
-        'aria-live',
-        'off',
+        'role',
+        'alert',
       );
     });
   });

--- a/src/core/Alert/Alert/Alert.tsx
+++ b/src/core/Alert/Alert/Alert.tsx
@@ -38,7 +38,6 @@ class BaseAlert extends Component<AlertProps & InnerRef> {
     const {
       className,
       status = 'neutral',
-      ariaLiveMode = 'assertive',
       children,
       id,
       closeText,
@@ -72,7 +71,7 @@ class BaseAlert extends Component<AlertProps & InnerRef> {
           <HtmlDiv
             className={alertClassNames.textContentWrapper}
             id={id}
-            aria-live={ariaLiveMode}
+            role="alert"
           >
             <HtmlDiv className={alertClassNames.content}>{children}</HtmlDiv>
           </HtmlDiv>
@@ -90,7 +89,7 @@ class BaseAlert extends Component<AlertProps & InnerRef> {
               {...getConditionalAriaProp('aria-label', [closeText])}
               {...closeButtonPassProps}
             >
-              {!smallScreen ? closeText?.toUpperCase() : ''}
+              {!smallScreen ? closeText.toUpperCase() : ''}
               <Icon icon="close" />
             </HtmlButton>
           </HtmlDiv>

--- a/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
@@ -359,9 +359,9 @@ exports[`props children should match snapshot 1`] = `
         </svg>
       </div>
       <div
-        aria-live="assertive"
         class="c2 fi-alert_text-content-wrapper"
         id="7"
+        role="alert"
       >
         <div
           class="c2 fi-alert_content"

--- a/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
@@ -210,7 +210,7 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-alert--neutral .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
-  fill: #4698c3;
+  fill: hsl(196,77%,44%);
 }
 
 .c1.fi-alert--error {
@@ -226,7 +226,21 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-alert--warning .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
-  fill: #b54439;
+  fill: hsl(23,82%,53%);
+}
+
+.c1 .fi-alert_icon-wrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
 }
 
 .c1 .fi-alert_close-button-wrapper {
@@ -300,13 +314,12 @@ exports[`props children should match snapshot 1`] = `
   width: 14px;
   height: 14px;
   margin-left: 5px;
-  margin-top: 5px;
-  -webkit-transform: translateY(1px);
-  -ms-transform: translateY(1px);
-  transform: translateY(1px);
+  -webkit-transform: translateY(0.1em);
+  -ms-transform: translateY(0.1em);
+  transform: translateY(0.1em);
 }
 
-.c1--small-screen .fi-alert-close-button-wrapper {
+.c1.fi-alert--small-screen .fi-alert_close-button-wrapper {
   -webkit-box-pack: end;
   -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
@@ -314,7 +327,7 @@ exports[`props children should match snapshot 1`] = `
   margin: 0;
 }
 
-.c1--small-screen .fi-alert-close-button-wrapper .fi-icon {
+.c1.fi-alert--small-screen .fi-alert_close-button-wrapper .fi-icon {
   margin-right: 5px;
 }
 

--- a/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
+++ b/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
@@ -41,7 +41,7 @@ export const baseAlertBaseStyles = (theme: SuomifiTheme) => css`
     &--neutral {
       background-color: ${theme.colors.accentSecondaryLight1};
       & .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
-        fill: #4698c3; /* Later add to theme styling these colors */
+        fill: ${theme.colors.accentSecondary};
       }
     }
 
@@ -55,7 +55,7 @@ export const baseAlertBaseStyles = (theme: SuomifiTheme) => css`
     &--warning {
       background-color: #fff6e0; /** needs to be warningLight1 but the token is yet to be added */
       & .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
-        fill: #b54439; /* Later add to theme styling these colors */
+        fill: ${theme.colors.accentBase};
       }
     }
   }

--- a/src/core/Alert/BaseAlert/BaseAlert.tsx
+++ b/src/core/Alert/BaseAlert/BaseAlert.tsx
@@ -21,10 +21,6 @@ export interface BaseAlertProps extends HtmlDivWithRefProps {
    * @default 'neutral'
    */
   status?: 'neutral' | 'warning' | 'error';
-  /** Set aria-live mode for the alert text content and label.
-   * @default 'assertive'
-   */
-  ariaLiveMode?: 'polite' | 'assertive' | 'off';
   /** Main content of the alert */
   children?: ReactNode;
 }

--- a/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
@@ -17,11 +17,11 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       flex: 0;
     }
     &.fi-alert--neutral {
-      border-left: 4px solid ${theme.colors.accentSecondary}; /* Later add to theme styling these colors */
+      border-left: 4px solid ${theme.colors.accentSecondary};
     }
 
     &.fi-alert--error {
-      border-left: 4px solid ${theme.colors.alertBase}; /* Later add to theme styling these colors */
+      border-left: 4px solid ${theme.colors.alertBase};
     }
 
     &.fi-alert--warning {

--- a/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
@@ -17,15 +17,15 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       flex: 0;
     }
     &.fi-alert--neutral {
-      border-left: 4px solid #4698c3; /* Later add to theme styling these colors */
+      border-left: 4px solid ${theme.colors.accentSecondary}; /* Later add to theme styling these colors */
     }
 
     &.fi-alert--error {
-      border-left: 4px solid #b54439; /* Later add to theme styling these colors */
+      border-left: 4px solid ${theme.colors.alertBase}; /* Later add to theme styling these colors */
     }
 
     &.fi-alert--warning {
-      border-left: 4px solid #c33932;
+      border-left: 4px solid ${theme.colors.accentBase};
     }
   }
 `;

--- a/src/core/Alert/InlineAlert/InlineAlert.md
+++ b/src/core/Alert/InlineAlert/InlineAlert.md
@@ -1,0 +1,18 @@
+```js
+import { InlineAlert } from 'suomifi-ui-components';
+
+<>
+  <InlineAlert labelText="Notification">
+    The service will be temporarily unavailable on 5.6.2021 at 21.00 –
+    23.59 due to maintenance.
+  </InlineAlert>
+
+  <InlineAlert status="error" labelText="Error">
+    Something went wrong. Please try again in a moment.
+  </InlineAlert>
+
+  <InlineAlert status="warning">
+    Something is not right. Please try again in a moment.
+  </InlineAlert>
+</>;
+```

--- a/src/core/Alert/InlineAlert/InlineAlert.md
+++ b/src/core/Alert/InlineAlert/InlineAlert.md
@@ -2,9 +2,9 @@
 import { InlineAlert } from 'suomifi-ui-components';
 
 <>
-  <InlineAlert labelText="Notification">
-    The service will be temporarily unavailable on 5.6.2021 at 21.00 –
-    23.59 due to maintenance.
+  <InlineAlert labelText="Info">
+    Make sure that your name is typed exactly as it appears in your
+    identification.
   </InlineAlert>
 
   <InlineAlert status="error" labelText="Error">

--- a/src/core/Alert/InlineAlert/InlineAlert.tsx
+++ b/src/core/Alert/InlineAlert/InlineAlert.tsx
@@ -15,6 +15,10 @@ import { baseStyles } from './InlineAlert.baseStyles';
 export interface InlineAlertProps extends BaseAlertProps {
   /** Label for the alert */
   labelText?: string;
+  /** Set aria-live mode for the alert text content and label.
+   * @default 'assertive'
+   */
+  ariaLiveMode?: 'polite' | 'assertive' | 'off';
 }
 
 interface InnerRef {

--- a/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-alert--neutral .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
-  fill: #4698c3;
+  fill: hsl(196,77%,44%);
 }
 
 .c1.fi-alert--error {
@@ -173,7 +173,7 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-alert--warning .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
-  fill: #b54439;
+  fill: hsl(23,82%,53%);
 }
 
 .c1 .fi-alert_label {
@@ -204,15 +204,15 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-alert--inline.fi-alert--neutral {
-  border-left: 4px solid #4698c3;
+  border-left: 4px solid hsl(196,77%,44%);
 }
 
 .c1.fi-alert--inline.fi-alert--error {
-  border-left: 4px solid #b54439;
+  border-left: 4px solid hsl(3,59%,48%);
 }
 
 .c1.fi-alert--inline.fi-alert--warning {
-  border-left: 4px solid #c33932;
+  border-left: 4px solid hsl(23,82%,53%);
 }
 
 <div>


### PR DESCRIPTION
## Description
The alert resize, coloring and icon alignment were broken after the latest updates to the component. This PR fixes these issues. In addition, it separates the Alert and InlineAlert styleguidist examples to separate files and removes the `ariaLiveMode` prop from Alert and replaces it with hardcoded `role="alert"`.

## Motivation and Context
The component should look as in the designs and behave correctly when the window is resized.
Since the default Alert is meant to be used in the beginning of main content, even before the H1, it is easily accidentally passed by the user. It should thus have `role="alert"` to ensure it is not missed by screen reader users.

## How Has This Been Tested?
Tested by running locally in styleguidist in Chrome. Final accessibility testing needed especially for the `role="alert"` change.

## Release notes
### Alert
* Remove `ariaLiveMode` prop and add `role="alert"` for main content
* Fix color and spacing/resize issues
### InlineAlert
* Move InlineAlert examples under the right heading in Styleguidist
