### PR TITLE
[Fix] Update internal aria util

### DIFF
--- a/src/utils/aria/aria.ts
+++ b/src/utils/aria/aria.ts
@@ -17,7 +17,8 @@ type ariaProp = { [key in ariaPropName]: string } | {};
 
 /**
  * Returns object with 'aria-' property which can be spread to props.
- * Using with different 'aria-' properties require different kind of use, see examples below.
+ * Using the util prevents generation of empty 'aria-' properties when no valid values are given.
+ * Using with different 'aria-' properties requires different kinds of use - see examples below.
  * E.g:
  * @example
  * <Component

--- a/src/utils/aria/aria.ts
+++ b/src/utils/aria/aria.ts
@@ -17,6 +17,7 @@ type ariaProp = { [key in ariaPropName]: string } | {};
 
 /**
  * Returns object with 'aria-' property which can be spread to props.
+ * Using with different 'aria-' properties require different kind of use, see examples below.
  * E.g:
  * @example
  * <Component
@@ -25,18 +26,23 @@ type ariaProp = { [key in ariaPropName]: string } | {};
  *      otherDescribingElement ? "id-of-other-describing-element" : undefined,
  *   ])}
  * />
+ * <Component
+ *   {...getConditionalAriaProp('aria-label', [
+ *      "Very describing label text value",
+ *   ])}
+ * />
  * @param propName String of Aria property name
- * @param describedByIds Array of id-strings
+ * @param idsOrValues Array of id-strings or an array with the actual value.
  * @returns Object with 'aria-' property if there is atleast one string value that is not undefined. Otherwise returns empty Object.
  */
 export const getConditionalAriaProp = (
   propName: ariaPropName,
-  describedByIds: (string | undefined)[],
+  idsOrValues: (string | undefined)[],
 ): ariaProp => {
-  const existing = describedByIds.filter((id) => !!id);
+  const existing = idsOrValues.filter((id) => !!id);
   if (existing.length > 0) {
-    const ariaIds = existing.join(' ').trim();
-    return { [propName]: ariaIds };
+    const ariaIdsOrValues = existing.join(' ').trim();
+    return { [propName]: ariaIdsOrValues };
   }
   return {};
 };


### PR DESCRIPTION


<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Update internal aria util. getConditionalAriaProp documentation and parameter naming changed.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Util documentation says that it should receive one or multiple id's. But there are multiple use cases where we are giving just text value that needs to be read by screenreader and not the id of that element. See difference of using it with e.g `aria-describedby` vs `aria-label`.

Understanding how to use the util was confusing/harder than it should be.

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
No release notes as this is internal change.