### PR TITLE
Update Notification. Hide from 6.1.0 release

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -168,10 +168,10 @@ module.exports = {
                 'LanguageMenuLink/LanguageMenuLink',
               ]),
             },
-            {
-              name: 'Notification',
-              components: getComponents(['Notification']),
-            },
+            // {
+            //   name: 'Notification',
+            //   components: getComponents(['Notification']),
+            // },
             {
               name: 'Expander',
               components: getComponentWithVariants('Expander')([

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,10 +6,10 @@ export {
   BreadcrumbLinkProps,
 } from './core/Breadcrumb';
 export { Alert, AlertProps, InlineAlert, InlineAlertProps } from './core/Alert';
-export {
-  Notification,
-  NotificationProps,
-} from './core/Notification/Notification';
+// export {
+//   Notification,
+//   NotificationProps,
+// } from './core/Notification/Notification';
 export { Block, BlockProps } from './core/Block/Block';
 export { Button, ButtonProps } from './core/Button/Button';
 export { Dropdown, DropdownProps } from './core/Dropdown/';


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Commenting the Notification out from the 6.1.0 release.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Notification was not yet gone through the accessibility clinic and therefore not ready for stable release, yet.
