### PR TITLE
[Fix] Align inner form component styles

### DIFF
--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -5,6 +5,10 @@ import { element, inputButton } from '../../theme/reset';
 export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-dropdown {
     display: inline-block;
+
+    & .fi-label-text {
+      margin-bottom: ${theme.spacing.xs};
+    }
   }
 
   & [data-reach-listbox-button].fi-dropdown_button {

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -6,7 +6,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-dropdown {
     display: inline-block;
 
-    & .fi-label-text {
+    & .fi-dropdown_label--visible {
       margin-bottom: ${theme.spacing.xs};
     }
   }

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -32,7 +32,7 @@ const baseClassName = 'fi-dropdown';
 
 export const dropdownClassNames = {
   baseClassName,
-  label: `${baseClassName}_label`,
+  labelIsVisible: `${baseClassName}_label--visible`,
   button: `${baseClassName}_button`,
   popover: `${baseClassName}_popover`,
   item: `${baseClassName}_item`,
@@ -252,7 +252,14 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
         {...passProps}
       >
         <HtmlDiv>
-          <Label id={labelId} labelMode={labelMode} optionalText={optionalText}>
+          <Label
+            id={labelId}
+            labelMode={labelMode}
+            optionalText={optionalText}
+            className={classnames({
+              [dropdownClassNames.labelIsVisible]: labelMode !== 'hidden',
+            })}
+          >
             {labelText}
           </Label>
           <ListboxInput

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   display: inline-block;
 }
 
-.c1.fi-dropdown .fi-label-text {
+.c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
 
@@ -235,7 +235,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
       class="c2"
     >
       <label
-        class="c2 c3 fi-label-text"
+        class="c2 c3 fi-dropdown_label--visible fi-label-text"
         id="test-id-label"
       >
         <span
@@ -363,7 +363,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   display: inline-block;
 }
 
-.c1.fi-dropdown .fi-label-text {
+.c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
 
@@ -511,7 +511,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
       class="c2"
     >
       <label
-        class="c2 c3 fi-label-text"
+        class="c2 c3 fi-dropdown_label--visible fi-label-text"
         id="test-id-label"
       >
         <span
@@ -639,7 +639,7 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   display: inline-block;
 }
 
-.c1.fi-dropdown .fi-label-text {
+.c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
 
@@ -786,7 +786,7 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
       class="c2"
     >
       <label
-        class="c2 c3 fi-label-text"
+        class="c2 c3 fi-dropdown_label--visible fi-label-text"
         id="test-id-label"
       >
         <span
@@ -914,7 +914,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   display: inline-block;
 }
 
-.c1.fi-dropdown .fi-label-text {
+.c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
 
@@ -1061,7 +1061,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
       class="c2"
     >
       <label
-        class="c2 c3 fi-label-text"
+        class="c2 c3 fi-dropdown_label--visible fi-label-text"
         id="test-id-label"
       >
         <span
@@ -1201,7 +1201,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   display: inline-block;
 }
 
-.c1.fi-dropdown .fi-label-text {
+.c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
 

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -74,7 +74,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -87,6 +86,10 @@ exports[`Basic dropdown should match snapshot 1`] = `
 
 .c1.fi-dropdown {
   display: inline-block;
+}
+
+.c1.fi-dropdown .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button {
@@ -346,7 +349,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -359,6 +361,10 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 
 .c1.fi-dropdown {
   display: inline-block;
+}
+
+.c1.fi-dropdown .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button {
@@ -619,7 +625,6 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -632,6 +637,10 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
 
 .c1.fi-dropdown {
   display: inline-block;
+}
+
+.c1.fi-dropdown .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button {
@@ -891,7 +900,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -904,6 +912,10 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 
 .c1.fi-dropdown {
   display: inline-block;
+}
+
+.c1.fi-dropdown .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button {
@@ -1175,7 +1187,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -1188,6 +1199,10 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 
 .c1.fi-dropdown {
   display: inline-block;
+}
+
+.c1.fi-dropdown .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 [data-reach-listbox-button].fi-dropdown_button {

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -107,6 +107,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       background-color: ${theme.colors.whiteBase};
     }
   }
+
   & .fi-checkbox_icon {
     position: absolute;
     height: 10px;
@@ -132,7 +133,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   & .fi-hint-text {
     padding-left: ${theme.spacing.l};
     color: ${theme.colors.depthDark1};
-    margin-bottom: 0;
   }
 
   & .fi-status-text {

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -136,8 +136,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   & .fi-status-text {
-    display: block;
     line-height: 18px;
+    &.fi-checkbox_statusText--has-content {
+      margin-top: ${theme.spacing.xxs};
+    }
   }
 
   ${largeVariantStyles(theme)};

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@ const checkboxClassNames = {
   container: `${baseClassName}_container`,
   input: `${baseClassName}_input`,
   label: `${baseClassName}_label`,
-  statusText: `${baseClassName}_status`,
+  statusTextHasContent: `${baseClassName}_statusText--has-content`,
   hintText: `${baseClassName}_hintText`,
   disabled: `${baseClassName}--disabled`,
   error: `${baseClassName}--error`,
@@ -224,6 +224,9 @@ class BaseCheckbox extends Component<CheckboxProps & InnerRef> {
         </HtmlLabel>
         <HintText id={hintTextId}>{hintText}</HintText>
         <StatusText
+          className={classnames({
+            [checkboxClassNames.statusTextHasContent]: !!statusText,
+          })}
           id={statusTextId}
           status={status}
           disabled={disabled}

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -207,7 +207,6 @@ exports[`props children has matching snapshot 1`] = `
 .c1 .fi-hint-text {
   padding-left: 25px;
   color: hsl(202,7%,40%);
-  margin-bottom: 0;
 }
 
 .c1 .fi-status-text {

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -134,14 +134,11 @@ exports[`props children has matching snapshot 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+  display: block;
 }
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c5.fi-status-text.fi-status-text--hasContent {
-  margin-top: 5px;
 }
 
 .c1 {
@@ -210,8 +207,11 @@ exports[`props children has matching snapshot 1`] = `
 }
 
 .c1 .fi-status-text {
-  display: block;
   line-height: 18px;
+}
+
+.c1 .fi-status-text.fi-checkbox_statusText--has-content {
+  margin-top: 5px;
 }
 
 .c1.fi-checkbox--large .fi-checkbox_label {

--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -11,7 +11,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     display: inline-block;
     width: 100%;
 
-    & .fi-label-text {
+    & .fi-filter-input_label--visible {
       margin-bottom: ${theme.spacing.xs};
     }
 

--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -11,6 +11,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     display: inline-block;
     width: 100%;
 
+    & .fi-label-text {
+      margin-bottom: ${theme.spacing.xs};
+    }
+
     & .fi-hint-text {
       margin-bottom: ${theme.spacing.xs};
     }

--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -44,6 +44,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         height: 20px;
       }
     }
+
+    & .fi-filter-input_statusText--has-content {
+      margin-top: ${theme.spacing.xxs};
+    }
   }
 
   & .fi-filter-input_input-element-container {

--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -10,6 +10,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   & .fi-filter-input_wrapper {
     display: inline-block;
     width: 100%;
+
+    & .fi-hint-text {
+      margin-bottom: ${theme.spacing.xs};
+    }
   }
 
   & .fi-filter-input_functionalityContainer {

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -21,6 +21,7 @@ const filterInputClassNames = {
   error: `${baseClassName}--error`,
   disabled: `${baseClassName}--disabled`,
   labelAlignLeft: `${baseClassName}--label-align-left`,
+  labelIsVisible: `${baseClassName}_label--visible`,
   wrapper: `${baseClassName}_wrapper`,
   functionalityContainer: `${baseClassName}_functionalityContainer`,
   inputElementContainer: `${baseClassName}_input-element-container`,
@@ -163,7 +164,14 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
         })}
       >
         <HtmlDiv className={classnames(filterInputClassNames.wrapper, {})}>
-          <Label id={labelId} labelMode={labelMode} optionalText={optionalText}>
+          <Label
+            id={labelId}
+            labelMode={labelMode}
+            optionalText={optionalText}
+            className={classnames({
+              [filterInputClassNames.labelIsVisible]: labelMode !== 'hidden',
+            })}
+          >
             {labelText}
           </Label>
           <HintText id={hintTextId}>{hintText}</HintText>

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -26,6 +26,7 @@ const filterInputClassNames = {
   inputElementContainer: `${baseClassName}_input-element-container`,
   inputElement: `${baseClassName}_input`,
   actionElementsContainer: `${baseClassName}_action-elements-container`,
+  statusTextHasContent: `${baseClassName}_statusText--has-content`,
 };
 
 export type FilterInputStatus = Exclude<InputStatus, 'success'>;
@@ -206,6 +207,9 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
             )}
             <StatusText
               id={statusTextId}
+              className={classnames({
+                [filterInputClassNames.statusTextHasContent]: !!statusText,
+              })}
               status={status}
               disabled={passProps.disabled}
               ariaLiveMode={statusTextAriaLiveMode}

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`snapshot matches 1`] = `
   width: 100%;
 }
 
-.c1 .fi-filter-input_wrapper .fi-label-text {
+.c1 .fi-filter-input_wrapper .fi-filter-input_label--visible {
   margin-bottom: 10px;
 }
 
@@ -343,7 +343,7 @@ exports[`snapshot matches 1`] = `
     class="c0 fi-filter-input_wrapper"
   >
     <label
-      class="c0 c2 fi-label-text"
+      class="c0 c2 fi-filter-input_label--visible fi-label-text"
       id="1-label"
     >
       <span

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -107,7 +107,6 @@ exports[`snapshot matches 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -164,6 +163,10 @@ exports[`snapshot matches 1`] = `
 .c1 .fi-filter-input_wrapper {
   display: inline-block;
   width: 100%;
+}
+
+.c1 .fi-filter-input_wrapper .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 .fi-filter-input_wrapper .fi-hint-text {

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -134,14 +134,11 @@ exports[`snapshot matches 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+  display: block;
 }
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c5.fi-status-text.fi-status-text--hasContent {
-  margin-top: 5px;
 }
 
 .c1 .fi-filter-input {
@@ -212,6 +209,10 @@ exports[`snapshot matches 1`] = `
   border-right: 1px solid hsl(202,7%,67%);
   padding-right: 8px;
   height: 20px;
+}
+
+.c1 .fi-filter-input_functionalityContainer .fi-filter-input_statusText--has-content {
+  margin-top: 5px;
 }
 
 .c1 .fi-filter-input_input-element-container > input:focus {

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -166,6 +166,10 @@ exports[`snapshot matches 1`] = `
   width: 100%;
 }
 
+.c1 .fi-filter-input_wrapper .fi-hint-text {
+  margin-bottom: 10px;
+}
+
 .c1 .fi-filter-input_functionalityContainer {
   line-height: 1.5;
   position: relative;

--- a/src/core/Form/HintText/HintText.baseStyles.tsx
+++ b/src/core/Form/HintText/HintText.baseStyles.tsx
@@ -6,7 +6,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-hint-text {
     display: block;
     color: ${theme.colors.blackBase};
-    margin-bottom: ${theme.spacing.xs};
     ${font(theme)('bodyTextSmall')};
   }
 `;

--- a/src/core/Form/HintText/HintText.md
+++ b/src/core/Form/HintText/HintText.md
@@ -1,8 +1,32 @@
 HintText is a component that generates an accessible hint text for an adjacent element. Give the ID of the HintText as an `aria-describedby` value to the related component. Applicable form components in the library already have HintText as an integral part.
 
 ```js
-import { HintText } from 'suomifi-ui-components';
 import React from 'react';
+import { HintText } from 'suomifi-ui-components';
 
 <HintText>This is a hint regarding an adjacent input</HintText>;
+```
+
+```js
+import React from 'react';
+import { HintText } from 'suomifi-ui-components';
+
+<>
+  <div>
+    <label
+      htmlFor="custom-input"
+      style={{ display: 'block', marginBottom: '10px' }}
+    >
+      Custom input
+    </label>
+    <HintText id="hint-text" style={{ marginBottom: '10px' }}>
+      This is a hint regarding an adjacent input
+    </HintText>
+    <input
+      id="custom-input"
+      type="text"
+      aria-describedby="hint-text"
+    />
+  </div>
+</>;
 ```

--- a/src/core/Form/Label/Label.baseStyles.tsx
+++ b/src/core/Form/Label/Label.baseStyles.tsx
@@ -7,7 +7,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-label-text_label-span {
       ${font(theme)('actionElementInnerTextBold')};
       display: block;
-      margin-bottom: ${theme.spacing.xs};
       color: ${theme.colors.blackBase};
 
       & .fi-label-text_optionalText {

--- a/src/core/Form/Label/Label.md
+++ b/src/core/Form/Label/Label.md
@@ -1,11 +1,29 @@
 Label is an accessible label component to use with custom input elements. Applicable form components in the library already have Label as an integral part.
 
 ```js
-import { Label } from 'suomifi-ui-components';
 import React from 'react';
+import { Label } from 'suomifi-ui-components';
 <>
   <Label>This is a label for an adjacent input</Label>
   <Label optionalText="optional">Label for an optional field</Label>
   <Label labelMode="hidden">A visually hidden label</Label>
+</>;
+```
+
+```js
+import React from 'react';
+import { Label } from 'suomifi-ui-components';
+
+<>
+  <div>
+    <Label
+      htmlFor="custom-input"
+      optionalText="optional"
+      style={{ marginBottom: '10px' }}
+    >
+      Label for an optional field
+    </Label>
+    <input id="custom-input" type="text" />
+  </div>
 </>;
 ```

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -14,7 +14,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       min-width: 105px;
       display: inline-block;
 
-      & .fi-label-text {
+      & .fi-search-input_label--visible {
         margin-bottom: ${theme.spacing.xs};
       }
 

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -17,6 +17,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       & .fi-label-text {
         margin-bottom: ${theme.spacing.xs};
       }
+
+      & .fi-search-input_statusText--has-content {
+        margin-top: ${theme.spacing.xxs};
+      }
     }
 
     &_functionality-container {

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -13,6 +13,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       width: 100%;
       min-width: 105px;
       display: inline-block;
+
+      & .fi-label-text {
+        margin-bottom: ${theme.spacing.xs};
+      }
     }
 
     &_functionality-container {

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -84,6 +84,7 @@ const searchInputClassNames = {
   fullWidth: `${baseClassName}--full-width`,
   error: `${baseClassName}--error`,
   notEmpty: `${baseClassName}--not-empty`,
+  labelIsVisible: `${baseClassName}_label--visible`,
   styleWrapper: `${baseClassName}_wrapper`,
   inputElement: `${baseClassName}_input`,
   inputElementContainer: `${baseClassName}_input-element-container`,
@@ -213,7 +214,13 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
         })}
       >
         <HtmlSpan className={searchInputClassNames.styleWrapper}>
-          <Label htmlFor={id} labelMode={labelMode}>
+          <Label
+            htmlFor={id}
+            labelMode={labelMode}
+            className={classnames({
+              [searchInputClassNames.labelIsVisible]: labelMode !== 'hidden',
+            })}
+          >
             {labelText}
           </Label>
           <Debounce waitFor={debounce}>

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -88,6 +88,7 @@ const searchInputClassNames = {
   inputElement: `${baseClassName}_input`,
   inputElementContainer: `${baseClassName}_input-element-container`,
   functionalityContainer: `${baseClassName}_functionality-container`,
+  statusTextHasContent: `${baseClassName}_statusText--has-content`,
   button: `${baseClassName}_button`,
   searchButton: `${baseClassName}_button-search`,
   searchIcon: `${baseClassName}_button-search-icon`,
@@ -267,6 +268,9 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
           </Debounce>
           <StatusText
             id={statusTextId}
+            className={classnames({
+              [searchInputClassNames.statusTextHasContent]: !!statusText,
+            })}
             status={status}
             ariaLiveMode={statusTextAriaLiveMode}
           >

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -299,7 +299,7 @@ exports[`snapshot should have matching default structure 1`] = `
   display: inline-block;
 }
 
-.c1 .fi-search-input_wrapper .fi-label-text {
+.c1 .fi-search-input_wrapper .fi-search-input_label--visible {
   margin-bottom: 10px;
 }
 
@@ -571,7 +571,7 @@ exports[`snapshot should have matching default structure 1`] = `
     class="c2 fi-search-input_wrapper"
   >
     <label
-      class="c0 c3 fi-label-text"
+      class="c0 c3 fi-search-input_label--visible fi-label-text"
       for="1"
     >
       <span

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -199,7 +199,6 @@ exports[`snapshot should have matching default structure 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -301,6 +300,10 @@ exports[`snapshot should have matching default structure 1`] = `
   width: 100%;
   min-width: 105px;
   display: inline-block;
+}
+
+.c1 .fi-search-input_wrapper .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 .fi-search-input_functionality-container {

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -174,14 +174,11 @@ exports[`snapshot should have matching default structure 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+  display: block;
 }
 
 .c9.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c9.fi-status-text.fi-status-text--hasContent {
-  margin-top: 5px;
 }
 
 .c3.fi-label-text .fi-label-text_label-span {
@@ -304,6 +301,10 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c1 .fi-search-input_wrapper .fi-label-text {
   margin-bottom: 10px;
+}
+
+.c1 .fi-search-input_wrapper .fi-search-input_statusText--has-content {
+  margin-top: 5px;
 }
 
 .c1 .fi-search-input_functionality-container {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -199,14 +199,11 @@ exports[`has matching snapshot 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+  display: block;
 }
 
 .c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c6.fi-status-text.fi-status-text--hasContent {
-  margin-top: 5px;
 }
 
 .c2 .fi-filter-input {
@@ -277,6 +274,10 @@ exports[`has matching snapshot 1`] = `
   border-right: 1px solid hsl(202,7%,67%);
   padding-right: 8px;
   height: 20px;
+}
+
+.c2 .fi-filter-input_functionalityContainer .fi-filter-input_statusText--has-content {
+  margin-top: 5px;
 }
 
 .c2 .fi-filter-input_input-element-container > input:focus {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -227,7 +227,7 @@ exports[`has matching snapshot 1`] = `
   width: 100%;
 }
 
-.c2 .fi-filter-input_wrapper .fi-label-text {
+.c2 .fi-filter-input_wrapper .fi-filter-input_label--visible {
   margin-bottom: 10px;
 }
 
@@ -853,7 +853,7 @@ exports[`has matching snapshot 1`] = `
         class="c0 fi-filter-input_wrapper"
       >
         <label
-          class="c0 c3 fi-label-text"
+          class="c0 c3 fi-filter-input_label--visible fi-label-text"
           id="1-label"
         >
           <span

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -231,6 +231,10 @@ exports[`has matching snapshot 1`] = `
   width: 100%;
 }
 
+.c2 .fi-filter-input_wrapper .fi-hint-text {
+  margin-bottom: 10px;
+}
+
 .c2 .fi-filter-input_functionalityContainer {
   line-height: 1.5;
   position: relative;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -172,7 +172,6 @@ exports[`has matching snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -229,6 +228,10 @@ exports[`has matching snapshot 1`] = `
 .c2 .fi-filter-input_wrapper {
   display: inline-block;
   width: 100%;
+}
+
+.c2 .fi-filter-input_wrapper .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c2 .fi-filter-input_wrapper .fi-hint-text {

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -217,14 +217,11 @@ exports[`has matching snapshot 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+  display: block;
 }
 
 .c12.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c12.fi-status-text.fi-status-text--hasContent {
-  margin-top: 5px;
 }
 
 .c2 .fi-filter-input {
@@ -295,6 +292,10 @@ exports[`has matching snapshot 1`] = `
   border-right: 1px solid hsl(202,7%,67%);
   padding-right: 8px;
   height: 20px;
+}
+
+.c2 .fi-filter-input_functionalityContainer .fi-filter-input_statusText--has-content {
+  margin-top: 5px;
 }
 
 .c2 .fi-filter-input_input-element-container > input:focus {

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -172,7 +172,6 @@ exports[`has matching snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -247,6 +246,10 @@ exports[`has matching snapshot 1`] = `
 .c2 .fi-filter-input_wrapper {
   display: inline-block;
   width: 100%;
+}
+
+.c2 .fi-filter-input_wrapper .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c2 .fi-filter-input_wrapper .fi-hint-text {

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -245,7 +245,7 @@ exports[`has matching snapshot 1`] = `
   width: 100%;
 }
 
-.c2 .fi-filter-input_wrapper .fi-label-text {
+.c2 .fi-filter-input_wrapper .fi-filter-input_label--visible {
   margin-bottom: 10px;
 }
 
@@ -559,7 +559,7 @@ exports[`has matching snapshot 1`] = `
       class="c0 fi-filter-input_wrapper"
     >
       <label
-        class="c0 c3 fi-label-text"
+        class="c0 c3 fi-filter-input_label--visible fi-label-text"
         id="1-label"
       >
         <span

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -186,7 +186,6 @@ exports[`has matching snapshot 1`] = `
 .c5.fi-hint-text {
   display: block;
   color: hsl(0,0%,16%);
-  margin-bottom: 10px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -248,6 +247,10 @@ exports[`has matching snapshot 1`] = `
 .c2 .fi-filter-input_wrapper {
   display: inline-block;
   width: 100%;
+}
+
+.c2 .fi-filter-input_wrapper .fi-hint-text {
+  margin-bottom: 10px;
 }
 
 .c2 .fi-filter-input_functionalityContainer {

--- a/src/core/Form/StatusText/StatusText.baseStyles.tsx
+++ b/src/core/Form/StatusText/StatusText.baseStyles.tsx
@@ -8,13 +8,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     color: ${theme.colors.blackBase};
     font-size: 14px;
     line-height: 20px;
+    display: block;
 
     &.fi-status-text--error {
       color: ${theme.colors.alertBase};
-    }
-
-    &.fi-status-text--hasContent {
-      margin-top: ${theme.spacing.xxs};
     }
   }
 `;

--- a/src/core/Form/StatusText/StatusText.md
+++ b/src/core/Form/StatusText/StatusText.md
@@ -1,24 +1,37 @@
 StatusText is a component that is used under input elements to show error messages and other status messages. Give the ID of the HintText as an `aria-describedby` value to the related component. Applicable form components in the library already have StatusText as an integral part. StatusText should not be rendered conditionally if `aria-live` is enabled.
 
 ```js
+import React from 'react';
+import { StatusText } from 'suomifi-ui-components';
+
+<>
+  <StatusText>A regular StatusText</StatusText>
+  <StatusText status="error">An error message</StatusText>
+</>;
+```
+
+```js
 import React, { useState } from 'react';
 import { StatusText } from 'suomifi-ui-components';
 
 const [error, setError] = useState(true);
 
 <>
-  <StatusText>A regular StatusText</StatusText>
-  <StatusText status="error">An error message</StatusText>
   <div>
-    <label for="custom_input" style={{ display: 'block' }}>
+    <label
+      htmlFor="custom-input"
+      style={{ display: 'block', marginBottom: '10px' }}
+    >
       Custom input
     </label>
     <input
-      id="custom_input"
+      id="custom-input"
       type="text"
-      onChange={() => setError(!error)}
+      aria-describedby="status-text"
+      onChange={(event) => setError(!(event.target.value.length > 4))}
     />
     <StatusText
+      id="status-text"
       status="error"
       aria-live="polite"
       style={{ marginTop: error ? '5px' : '0' }}

--- a/src/core/Form/StatusText/StatusText.md
+++ b/src/core/Form/StatusText/StatusText.md
@@ -1,10 +1,30 @@
-StatusText is a component that is used under input elements to show error messages and other status messages. Give the ID of the HintText as an `aria-describedby` value to the related component. Applicable form components in the library already have StatusText as an integral part.
+StatusText is a component that is used under input elements to show error messages and other status messages. Give the ID of the HintText as an `aria-describedby` value to the related component. Applicable form components in the library already have StatusText as an integral part. StatusText should not be rendered conditionally if `aria-live` is enabled.
 
 ```js
+import React, { useState } from 'react';
 import { StatusText } from 'suomifi-ui-components';
-import React from 'react';
+
+const [error, setError] = useState(true);
+
 <>
   <StatusText>A regular StatusText</StatusText>
   <StatusText status="error">An error message</StatusText>
+  <div>
+    <label for="custom_input" style={{ display: 'block' }}>
+      Custom input
+    </label>
+    <input
+      id="custom_input"
+      type="text"
+      onChange={() => setError(!error)}
+    />
+    <StatusText
+      status="error"
+      aria-live="polite"
+      style={{ marginTop: error ? '5px' : '0' }}
+    >
+      {error ? 'A conditional error message' : ''}
+    </StatusText>
+  </div>
 </>;
 ```

--- a/src/core/Form/StatusText/StatusText.md
+++ b/src/core/Form/StatusText/StatusText.md
@@ -1,4 +1,6 @@
-StatusText is a component that is used under input elements to show error messages and other status messages. Give the ID of the HintText as an `aria-describedby` value to the related component. Applicable form components in the library already have StatusText as an integral part. StatusText should not be rendered conditionally if `aria-live` is enabled.
+StatusText is a component that is used under input elements to show error messages and other status messages. Give the ID of the HintText as an `aria-describedby` value to the related component. Applicable form components in the library already have StatusText as an integral part.
+
+StatusText should not be rendered conditionally unless `aria-live` is explicitly turned off.
 
 ```js
 import React from 'react';
@@ -33,7 +35,6 @@ const [error, setError] = useState(true);
     <StatusText
       id="status-text"
       status="error"
-      aria-live="polite"
       style={{ marginTop: error ? '5px' : '0' }}
     >
       {error ? 'A conditional error message' : ''}

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -9,7 +9,6 @@ import { baseStyles } from './StatusText.baseStyles';
 const baseClassName = 'fi-status-text';
 const statusTextClassNames = {
   error: `${baseClassName}--error`,
-  hasContent: `${baseClassName}--hasContent`,
 };
 
 export interface StatusTextProps extends HtmlSpanProps {
@@ -46,7 +45,6 @@ const StyledStatusText = styled(
         {...passProps}
         {...ariaLiveProp}
         className={classnames(className, baseClassName, {
-          [statusTextClassNames.hasContent]: children,
           [statusTextClassNames.error]: status === 'error',
         })}
         aria-atomic="true"

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -18,11 +18,14 @@ export interface StatusTextProps extends HtmlSpanProps {
   children?: ReactNode;
   /** Custom class name for styling and customizing  */
   className?: string;
-  /** Disable StatusText */
+  /** Disable StatusText aria live. */
   disabled?: boolean;
   /** Status */
   status?: InputStatus;
-  /** aria-live mode for the element */
+  /**
+   * aria-live mode for the element
+   * @default polite
+   */
   ariaLiveMode?: AriaLiveMode;
 }
 
@@ -33,7 +36,7 @@ const StyledStatusText = styled(
     disabled,
     status,
     theme,
-    ariaLiveMode,
+    ariaLiveMode = 'polite',
     ...passProps
   }: StatusTextProps & SuomifiThemeProp) => {
     const ariaLiveProp = !disabled

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -12,6 +12,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   & .fi-text-input_wrapper {
     width: 100%;
     display: inline-block;
+
+    & .fi-hint-text {
+      margin-bottom: ${theme.spacing.xs};
+    }
   }
 
   & .fi-text-input_input-element-container {

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -13,7 +13,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     width: 100%;
     display: inline-block;
 
-    & .fi-label-text {
+    & .fi-text-input_label--visible {
       margin-bottom: ${theme.spacing.xs};
     }
 

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -20,6 +20,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-hint-text {
       margin-bottom: ${theme.spacing.xs};
     }
+
+    & .fi-text-input_statusText--has-content {
+      margin-top: ${theme.spacing.xxs};
+    }
   }
 
   & .fi-text-input_input-element-container {

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -13,6 +13,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     width: 100%;
     display: inline-block;
 
+    & .fi-label-text {
+      margin-bottom: ${theme.spacing.xs};
+    }
+
     & .fi-hint-text {
       margin-bottom: ${theme.spacing.xs};
     }

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -30,6 +30,7 @@ export const textInputClassNames = {
   inputElementContainer: `${baseClassName}_input-element-container`,
   inputElement: `${baseClassName}_input`,
   styleWrapper: `${baseClassName}_wrapper`,
+  statusTextHasContent: `${baseClassName}_statusText--has-content`,
 };
 
 type TextInputValue = string | number | undefined;
@@ -166,6 +167,9 @@ class BaseTextInput extends Component<TextInputProps & InnerRef> {
           </HtmlDiv>
           <StatusText
             id={statusTextId}
+            className={classnames({
+              [textInputClassNames.statusTextHasContent]: !!statusText,
+            })}
             status={status}
             ariaLiveMode={statusTextAriaLiveMode}
             disabled={passProps.disabled}

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -26,6 +26,7 @@ export const textInputClassNames = {
   disabled: `${baseClassName}--disabled`,
   error: `${baseClassName}--error`,
   success: `${baseClassName}--success`,
+  labelIsVisible: `${baseClassName}_label--visible`,
   icon: `${baseClassName}_with-icon`,
   inputElementContainer: `${baseClassName}_input-element-container`,
   inputElement: `${baseClassName}_input`,
@@ -135,7 +136,14 @@ class BaseTextInput extends Component<TextInputProps & InnerRef> {
         })}
       >
         <HtmlSpan className={textInputClassNames.styleWrapper}>
-          <Label htmlFor={id} labelMode={labelMode} optionalText={optionalText}>
+          <Label
+            htmlFor={id}
+            labelMode={labelMode}
+            optionalText={optionalText}
+            className={classnames({
+              [textInputClassNames.labelIsVisible]: labelMode !== 'hidden',
+            })}
+          >
             {labelText}
           </Label>
           <HintText id={hintTextId}>{hintText}</HintText>

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`snapshots match error status with statustext 1`] = `
   display: inline-block;
 }
 
-.c1 .fi-text-input_wrapper .fi-label-text {
+.c1 .fi-text-input_wrapper .fi-text-input_label--visible {
   margin-bottom: 10px;
 }
 
@@ -321,7 +321,7 @@ exports[`snapshots match error status with statustext 1`] = `
     class="c2 fi-text-input_wrapper"
   >
     <label
-      class="c0 c3 fi-label-text"
+      class="c0 c3 fi-text-input_label--visible fi-label-text"
       for="test-id2"
     >
       <span
@@ -530,7 +530,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   display: inline-block;
 }
 
-.c1 .fi-text-input_wrapper .fi-label-text {
+.c1 .fi-text-input_wrapper .fi-text-input_label--visible {
   margin-bottom: 10px;
 }
 
@@ -882,7 +882,7 @@ exports[`snapshots match minimal implementation 1`] = `
   display: inline-block;
 }
 
-.c1 .fi-text-input_wrapper .fi-label-text {
+.c1 .fi-text-input_wrapper .fi-text-input_label--visible {
   margin-bottom: 10px;
 }
 
@@ -1040,7 +1040,7 @@ exports[`snapshots match minimal implementation 1`] = `
     class="c2 fi-text-input_wrapper"
   >
     <label
-      class="c0 c3 fi-label-text"
+      class="c0 c3 fi-text-input_label--visible fi-label-text"
       for="test-id"
     >
       <span

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -134,14 +134,11 @@ exports[`snapshots match error status with statustext 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+  display: block;
 }
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c5.fi-status-text.fi-status-text--hasContent {
-  margin-top: 5px;
 }
 
 .c1.fi-text-input {
@@ -172,6 +169,10 @@ exports[`snapshots match error status with statustext 1`] = `
 
 .c1 .fi-text-input_wrapper .fi-hint-text {
   margin-bottom: 10px;
+}
+
+.c1 .fi-text-input_wrapper .fi-text-input_statusText--has-content {
+  margin-top: 5px;
 }
 
 .c1 .fi-text-input_input-element-container > input:focus {
@@ -345,7 +346,7 @@ exports[`snapshots match error status with statustext 1`] = `
     <span
       aria-atomic="true"
       aria-live="assertive"
-      class="c2 c5 fi-status-text fi-status-text--hasContent fi-status-text--error"
+      class="c2 c5 fi-text-input_statusText--has-content fi-status-text fi-status-text--error"
       id="test-id2-statusText"
     >
       This is a status text
@@ -500,14 +501,11 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+  display: block;
 }
 
 .c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c6.fi-status-text.fi-status-text--hasContent {
-  margin-top: 5px;
 }
 
 .c1.fi-text-input {
@@ -538,6 +536,10 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 
 .c1 .fi-text-input_wrapper .fi-hint-text {
   margin-bottom: 10px;
+}
+
+.c1 .fi-text-input_wrapper .fi-text-input_statusText--has-content {
+  margin-top: 5px;
 }
 
 .c1 .fi-text-input_input-element-container > input:focus {
@@ -851,14 +853,11 @@ exports[`snapshots match minimal implementation 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+  display: block;
 }
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c5.fi-status-text.fi-status-text--hasContent {
-  margin-top: 5px;
 }
 
 .c1.fi-text-input {
@@ -889,6 +888,10 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c1 .fi-text-input_wrapper .fi-hint-text {
   margin-bottom: 10px;
+}
+
+.c1 .fi-text-input_wrapper .fi-text-input_statusText--has-content {
+  margin-top: 5px;
 }
 
 .c1 .fi-text-input_input-element-container > input:focus {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -167,6 +167,10 @@ exports[`snapshots match error status with statustext 1`] = `
   display: inline-block;
 }
 
+.c1 .fi-text-input_wrapper .fi-hint-text {
+  margin-bottom: 10px;
+}
+
 .c1 .fi-text-input_input-element-container > input:focus {
   outline-color: hsl(196,77%,44%);
   outline-width: 2px;
@@ -526,6 +530,10 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   display: inline-block;
 }
 
+.c1 .fi-text-input_wrapper .fi-hint-text {
+  margin-bottom: 10px;
+}
+
 .c1 .fi-text-input_input-element-container > input:focus {
   outline-color: hsl(196,77%,44%);
   outline-width: 2px;
@@ -868,6 +876,10 @@ exports[`snapshots match minimal implementation 1`] = `
 .c1 .fi-text-input_wrapper {
   width: 100%;
   display: inline-block;
+}
+
+.c1 .fi-text-input_wrapper .fi-hint-text {
+  margin-bottom: 10px;
 }
 
 .c1 .fi-text-input_input-element-container > input:focus {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -107,7 +107,6 @@ exports[`snapshots match error status with statustext 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -165,6 +164,10 @@ exports[`snapshots match error status with statustext 1`] = `
 .c1 .fi-text-input_wrapper {
   width: 100%;
   display: inline-block;
+}
+
+.c1 .fi-text-input_wrapper .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 .fi-text-input_wrapper .fi-hint-text {
@@ -470,7 +473,6 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -528,6 +530,10 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 .c1 .fi-text-input_wrapper {
   width: 100%;
   display: inline-block;
+}
+
+.c1 .fi-text-input_wrapper .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 .fi-text-input_wrapper .fi-hint-text {
@@ -818,7 +824,6 @@ exports[`snapshots match minimal implementation 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -876,6 +881,10 @@ exports[`snapshots match minimal implementation 1`] = `
 .c1 .fi-text-input_wrapper {
   width: 100%;
   display: inline-block;
+}
+
+.c1 .fi-text-input_wrapper .fi-label-text {
+  margin-bottom: 10px;
 }
 
 .c1 .fi-text-input_wrapper .fi-hint-text {

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -12,6 +12,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     color: ${theme.colors.blackBase};
     width: 290px;
 
+    & .fi-textarea_statusText--has-content {
+      margin-top: ${theme.spacing.xxs};
+    }
+
     & .fi-textarea_textarea-element-container {
       margin-top: ${theme.spacing.insetL};
       &:focus-within {

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -16,10 +16,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       margin-bottom: 0;
     }
 
-    & .fi-hint-text {
-      margin-bottom: 0;
-    }
-
     & .fi-textarea_textarea-element-container {
       margin-top: ${theme.spacing.insetL};
       &:focus-within {

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -12,10 +12,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     color: ${theme.colors.blackBase};
     width: 290px;
 
-    & .fi-label-text_label-span {
-      margin-bottom: 0;
-    }
-
     & .fi-textarea_textarea-element-container {
       margin-top: ${theme.spacing.insetL};
       &:focus-within {

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -26,6 +26,7 @@ const textareaClassNames = {
   resizeNone: `${baseClassName}_textarea-resize--none`,
   disabled: `${baseClassName}--disabled`,
   error: `${baseClassName}--error`,
+  statusTextHasContent: `${baseClassName}_statusText--has-content`,
 };
 
 type TextareaStatus = Exclude<InputStatus, 'success'>;
@@ -154,6 +155,9 @@ class BaseTextarea extends Component<TextareaProps & InnerRef> {
         </HtmlDiv>
         <StatusText
           id={statusTextId}
+          className={classnames({
+            [textareaClassNames.statusTextHasContent]: !!statusText,
+          })}
           status={status}
           disabled={disabled}
           ariaLiveMode={statusTextAriaLiveMode}

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -107,7 +107,6 @@ exports[`snapshot default structure should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   display: block;
-  margin-bottom: 10px;
   color: hsl(0,0%,16%);
 }
 
@@ -172,10 +171,6 @@ exports[`snapshot default structure should match snapshot 1`] = `
   flex-direction: column;
   color: hsl(0,0%,16%);
   width: 290px;
-}
-
-.c1.fi-textarea .fi-label-text_label-span {
-  margin-bottom: 0;
 }
 
 .c1.fi-textarea .fi-textarea_textarea-element-container {

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -134,14 +134,11 @@ exports[`snapshot default structure should match snapshot 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+  display: block;
 }
 
 .c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c5.fi-status-text.fi-status-text--hasContent {
-  margin-top: 5px;
 }
 
 .c1 {
@@ -171,6 +168,10 @@ exports[`snapshot default structure should match snapshot 1`] = `
   flex-direction: column;
   color: hsl(0,0%,16%);
   width: 290px;
+}
+
+.c1.fi-textarea .fi-textarea_statusText--has-content {
+  margin-top: 5px;
 }
 
 .c1.fi-textarea .fi-textarea_textarea-element-container {

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -178,10 +178,6 @@ exports[`snapshot default structure should match snapshot 1`] = `
   margin-bottom: 0;
 }
 
-.c1.fi-textarea .fi-hint-text {
-  margin-bottom: 0;
-}
-
 .c1.fi-textarea .fi-textarea_textarea-element-container {
   margin-top: 10px;
 }


### PR DESCRIPTION
## Description
This PR removes outer margins from StatusText, HintText and Label components. Components affected by this change have been adjusted accordingly. In addition, default aria-live mode for StatusText is changed to polite.

## Motivation and Context
All exported components should follow the same principles and strategy for styling and API. This PR adjusts previously internal StatusText, HintText and Label components to be aligned with all other exported components.

## How Has This Been Tested?
Tested using Styleguidist using MacOS, Chrome and VoiceOver.

## Release notes
### Label
- Remove margins
- Add examples

### HintText
- Remove margins
- Add examples

### StatusText
- Remove margins
- Change aria-live default to polite
- Add examples

### TextInput
- Fix missing status text margin