### PR TITLE
[Fix] MultiSelect's controlled state should now filter also after selection

### DIFF
--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -112,7 +112,6 @@ interface MultiSelectState<T extends MultiSelectData> {
   showOptionsAvailableText: boolean;
   focusedDescendantId: string | null;
   selectedItems: T[];
-  initialItems: T[];
   chipRemovalAnnounceText: string;
 }
 
@@ -141,7 +140,6 @@ class BaseMultiSelect<T> extends Component<
     selectedItems: this.props.selectedItems
       ? this.props.selectedItems || []
       : this.props.defaultSelectedItems || [],
-    initialItems: this.props.items,
     chipRemovalAnnounceText: '',
   };
 
@@ -149,16 +147,13 @@ class BaseMultiSelect<T> extends Component<
     nextProps: MultiSelectProps<U & MultiSelectData>,
     prevState: MultiSelectState<U & MultiSelectData>,
   ) {
-    const { items: propItems, selectedItems } = nextProps;
+    const { selectedItems } = nextProps;
     if (
-      ('selectedItems' in nextProps &&
-        selectedItems !== prevState.selectedItems) ||
-      propItems !== prevState.initialItems
+      'selectedItems' in nextProps &&
+      selectedItems !== prevState.selectedItems
     ) {
       return {
         selectedItems: selectedItems || prevState.selectedItems || [],
-        filteredItems: propItems,
-        initialItems: propItems,
       };
     }
     return null;
@@ -206,9 +201,6 @@ class BaseMultiSelect<T> extends Component<
             if (onItemSelectionsChange) {
               onItemSelectionsChange(newSelectedItems);
             }
-            return {
-              selectedItems: newSelectedItems,
-            };
           }
         }
       },


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
- Fix the issue when using MultiSelect in controlled state and when selecting item. Before fix the filtering value in input was not affecting and it showed all the items after selection.
- Also removes the unnecessary logic that was remaining.
- Add tests for controlled and "normal" cases so that the item amount matches after filtering.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Error report

Here is the error report we got from service which found this:

> If in controlled state for MultiSelect, an user has filtered with text then changing the selectedItems-list will keep the filter text the same but it will show all options without filtering.
> 
> E.g like this, when writing "sn" and then choosing "Snail"
> 
> ```
> const [selectedAnimals, setSelectedAnimals] = React.useState([]);
> 
> const animals = React.useMemo(() => ([
>   {   
>     age: 2,
>     labelText: 'Rabbit',
>     uniqueItemId: 'rabbit-123'
>   },
>   {
>     age: 1,
>     labelText: 'Snail',
>     uniqueItemId: 'snail-321'
>   },
>   {
>     price: 5,
>     labelText: 'Turtle',
>     uniqueItemId: 'turtle-987'
>   }
> ]), []);
> 
> const onItemSelect = React.useCallback((animalId) => {
>   setSelectedAnimals((prevSelectedAnimals) => {
>     const selectedAnimalIds = prevSelectedAnimals.map((animal) => animal.uniqueItemId);
>     if (selectedAnimalIds.includes(animalId)) {
>       return prevSelectedAnimals.filter((animal) => animal.uniqueItemId !== animalId);
>     } else {
>       return prevSelectedAnimals.concat([animals.find((animal) => animal.uniqueItemId === animalId)]);
>     }
>   })
> }, []);
> 
> <MultiSelect
>   items={animals}
>   selectedItems={selectedAnimals}
>   onItemSelect={onItemSelect}
>   labelText="Animals"
>   hintText="You can filter options by typing in the field"
>   noItemsText="No animals"
>   chipListVisible={true}
>   visualPlaceholder="Try to choose animals"
>   ariaChipActionLabel="Remove"
>   ariaSelectedAmountText="animals selected"
>   ariaOptionsAvailableText="options available"
>   ariaOptionChipRemovedText="removed"
> />
> 
> ```

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Controlled state should work as intended

## How Has This Been Tested?
Locally in styleguidist and CRA-TS test project

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

- Fix MultiSelect's controlled state. Filter should now work after selection.