### PR TITLE
[Dependency] Upgrade suomifi-design-tokens to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "react-modal": "3.14.4",
     "react-popper": "2.2.5",
     "react-svg": "14.1.8",
-    "suomifi-design-tokens": "3.1.1",
+    "suomifi-design-tokens": "3.2.0",
     "suomifi-icons": "^6.0.0"
   },
   "peerDependencies": {

--- a/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-alert--warning {
-  background-color: #fff6e0;
+  background-color: hsl(42,100%,94%);
 }
 
 .c1.fi-alert--warning .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {

--- a/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
+++ b/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
@@ -53,7 +53,7 @@ export const baseAlertBaseStyles = (theme: SuomifiTheme) => css`
     }
 
     &--warning {
-      background-color: #fff6e0; /** needs to be warningLight1 but the token is yet to be added */
+      background-color: ${theme.colors.warningLight1};
       & .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
         fill: ${theme.colors.accentBase};
       }

--- a/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-alert--warning {
-  background-color: #fff6e0;
+  background-color: hsl(42,100%,94%);
 }
 
 .c1.fi-alert--warning .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {

--- a/src/docs/Colors/Colors.tsx
+++ b/src/docs/Colors/Colors.tsx
@@ -39,6 +39,8 @@ const {
   warningBase,
   alertBase,
   alertLight1,
+  successDark1,
+  warningLight1,
 } = defaultSuomifiTheme.colors;
 
 export const colorTokens = {
@@ -84,6 +86,8 @@ export const colorTokens = {
     warningBase,
     alertBase,
     alertLight1,
+    successDark1,
+    warningLight1,
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12677,10 +12677,10 @@ stylelint@14.2.0:
     v8-compile-cache "^2.3.0"
     write-file-atomic "^3.0.3"
 
-suomifi-design-tokens@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-3.1.1.tgz#5df2372d484152b4d361f656cfeefa1bdca4af55"
-  integrity sha512-74RX9W99Hruk464ga11Fi+MaUYaQm5bLg8YI+kneGP9YktOXHtjgeQx75iDAqpNsXNBVnkQ/JjCfNsEX9hDz9g==
+suomifi-design-tokens@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-3.2.0.tgz#62e8dcef327a1dca080cef0ceadd39196bdf5d66"
+  integrity sha512-M/bFDY1DpogqwDQ80SL6RnCp+k2gd8wcti06eoW4ql3G1zVPxCX2YFBcDvG8p84agXNzxJWASkM0Qy1pi+/SWQ==
 
 suomifi-icons@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
Suomifi-design-tokens has been updated to new version and now it has two new color tokens. With this PR we import those to UI components and start using one of those. colors are "successDark1" and "warningLight1".
Component layouts should look same after this PR. Only color section should change.
<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Motivation and Context
Better to use "theme" variables, than color codes in CSS.
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
On Mac and Chrome and Safari in Styleguidist. 

## Release notes

- Introducing new two new color tokens from Suomifi-design-tokens. "successDark1" and "warningLight1"