### PR TITLE
[Fix] Modal text styles

### DIFF
--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -229,6 +229,23 @@ exports[`Basic modal should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c2 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .c2.fi-modal_content {
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;

--- a/src/core/Modal/ModalContent/ModalContent.baseStyles.tsx
+++ b/src/core/Modal/ModalContent/ModalContent.baseStyles.tsx
@@ -1,7 +1,10 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
+import { element, font } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  ${element(theme)}
+  ${font(theme)('bodyText')}
   &.fi-modal_content {
     flex: 1 1 auto;
     max-height: 100%;

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -176,6 +176,23 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   max-height: 100%;
 }
 
+.c2 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
 .c2.fi-modal_content {
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
Suomi.fi services needed text styles to be correct without html-tags. This PR fixes &.fi-modal_content divs styles for plain text.

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue
Fixes the issue that look and feel does not look correct for plain text. Jira ticket is: SFIDS-574

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

## Motivation and Context
Look and feel does not look correct for plain text.
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
On Mac and Chrome and Safari with Styleguidist.
