### PR TITLE
[Fix] Fixed width layout for Alert

### DIFF
--- a/src/core/Alert/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert/Alert.baseStyles.ts
@@ -8,27 +8,24 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   & .fi-alert_icon-wrapper {
     display: flex;
-    flex: 1 0 auto;
-    justify-content: flex-end;
   }
 
-  & .fi-alert_close-button-wrapper {
-    flex: 1 0 auto;
-    display: flex;
-    flex-wrap: nowrap;
-    box-sizing: border-box;
-    margin-top: 7px;
-    margin-right: ${theme.spacing.xs};
-    margin-bottom: ${theme.spacing.insetM};
+  & .fi-alert_style-wrapper {
+    max-width: 1110px;
+    margin: auto;
   }
 
   & .fi-alert_close-button {
     ${font(theme)('bodyTextSmall')}
     height: 40px;
-    min-width: 40px;
-    padding: 7px 8px;
+    display: inline-block;
+    padding: 7px;
+    margin-top: 7px;
+    margin-right: ${theme.spacing.xs};
+    margin-bottom: ${theme.spacing.insetM};
     border: 1px solid transparent;
     border-radius: ${theme.radius.basic};
+    white-space: nowrap;
 
     &:focus-visible {
       outline: 0;
@@ -50,13 +47,24 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       height: 14px;
       margin-left: ${theme.spacing.xxs};
       transform: translateY(0.1em);
+
+      .fi-icon-base-fill {
+        fill: currentColor;
+      }
     }
   }
 
   /** Small screen variant styles */
   &.fi-alert--small-screen {
-    & .fi-alert_close-button-wrapper {
-      justify-content: flex-end;
+    & .fi-alert_style-wrapper {
+      max-width: 100%;
+    }
+
+    & .fi-alert_text-content-wrapper {
+      padding: 0 0 0 10px;
+    }
+
+    & .fi-alert_close-button {
       margin: 0;
       & .fi-icon {
         margin-right: ${theme.spacing.xxs};

--- a/src/core/Alert/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert/Alert.baseStyles.ts
@@ -11,7 +11,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   & .fi-alert_style-wrapper {
-    max-width: 1110px;
+    display: block;
+    max-width: 1110px; /** Based on Suomi.fi front page header content width on large screens */
     margin: auto;
   }
 
@@ -57,7 +58,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   /** Small screen variant styles */
   &.fi-alert--small-screen {
     & .fi-alert_style-wrapper {
-      max-width: 100%;
+      width: 100%;
     }
 
     & .fi-alert_text-content-wrapper {

--- a/src/core/Alert/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert/Alert.baseStyles.ts
@@ -6,14 +6,17 @@ import { baseAlertBaseStyles } from '../BaseAlert/BaseAlert.baseStyles';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${baseAlertBaseStyles(theme)}
 
-  & .fi-alert_icon-wrapper {
-    display: flex;
-  }
-
   & .fi-alert_style-wrapper {
     display: block;
     max-width: 1110px; /** Based on Suomi.fi front page header content width on large screens */
     margin: auto;
+  }
+
+  & .fi-alert_text-content-wrapper {
+    display: flex;
+    flex-direction: column;
+    padding: 0 ${theme.spacing.m};
+    margin: ${theme.spacing.s} auto ${theme.spacing.s} 0;
   }
 
   & .fi-alert_close-button {
@@ -62,7 +65,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     & .fi-alert_text-content-wrapper {
-      padding: 0 0 0 10px;
+      padding: 0 0 0 ${theme.spacing.xs};
     }
 
     & .fi-alert_close-button {

--- a/src/core/Alert/Alert/Alert.tsx
+++ b/src/core/Alert/Alert/Alert.tsx
@@ -25,8 +25,6 @@ export interface AlertProps extends BaseAlertProps {
   onCloseButtonClick?: () => void;
   /** Custom props passed to the close button */
   closeButtonProps?: Omit<HtmlButtonProps, 'onClick' | 'aria-label'>;
-  /** Use small screen styling */
-  smallScreen?: boolean;
 }
 
 interface InnerRef {
@@ -64,9 +62,7 @@ class BaseAlert extends Component<AlertProps & InnerRef> {
         })}
       >
         <HtmlDiv className={alertClassNames.styleWrapper}>
-          <HtmlDiv className={alertClassNames.iconWrapper}>
-            <Icon icon={variantIcon} className={alertClassNames.icon} />
-          </HtmlDiv>
+          <Icon icon={variantIcon} className={alertClassNames.icon} />
 
           <HtmlDiv
             className={alertClassNames.textContentWrapper}
@@ -75,24 +71,22 @@ class BaseAlert extends Component<AlertProps & InnerRef> {
           >
             <HtmlDiv className={alertClassNames.content}>{children}</HtmlDiv>
           </HtmlDiv>
-          <HtmlDiv className={alertClassNames.closeButtonWrapper}>
-            <HtmlButton
-              className={classnames(
-                alertClassNames.closeButton,
-                customCloseButtonClassName,
-              )}
-              {...getConditionalAriaProp('aria-describedby', [
-                id,
-                closeButtonPropsAriaDescribedBy,
-              ])}
-              onClick={onCloseButtonClick}
-              {...getConditionalAriaProp('aria-label', [closeText])}
-              {...closeButtonPassProps}
-            >
-              {!smallScreen ? closeText.toUpperCase() : ''}
-              <Icon icon="close" />
-            </HtmlButton>
-          </HtmlDiv>
+          <HtmlButton
+            className={classnames(
+              alertClassNames.closeButton,
+              customCloseButtonClassName,
+            )}
+            {...getConditionalAriaProp('aria-describedby', [
+              id,
+              closeButtonPropsAriaDescribedBy,
+            ])}
+            onClick={onCloseButtonClick}
+            {...getConditionalAriaProp('aria-label', [closeText])}
+            {...closeButtonPassProps}
+          >
+            {!smallScreen ? closeText.toUpperCase() : ''}
+            <Icon icon="close" />
+          </HtmlButton>
         </HtmlDiv>
       </HtmlDivWithRef>
     );

--- a/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
@@ -179,8 +179,8 @@ exports[`props children should match snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  padding: 0 20px 0 15px;
-  margin: 15px auto 15px 0;
+  padding: 0 20px;
+  margin: 15px 0;
 }
 
 .c1.fi-alert .fi-alert_text-content-wrapper .fi-alert_content {
@@ -224,17 +224,22 @@ exports[`props children should match snapshot 1`] = `
   fill: hsl(23,82%,53%);
 }
 
-.c1 .fi-alert_icon-wrapper {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .c1 .fi-alert_style-wrapper {
   display: block;
   max-width: 1110px;
   margin: auto;
+}
+
+.c1 .fi-alert_text-content-wrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding: 0 20px;
+  margin: 15px auto 15px 0;
 }
 
 .c1 .fi-alert_close-button {

--- a/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
@@ -180,7 +180,6 @@ exports[`props children should match snapshot 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0 20px;
-  margin: 15px 0;
 }
 
 .c1.fi-alert .fi-alert_text-content-wrapper .fi-alert_content {

--- a/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
@@ -162,12 +162,11 @@ exports[`props children should match snapshot 1`] = `
   align-items: flex-start;
 }
 
-.c1.fi-alert .fi-alert_icon-wrapper {
+.c1.fi-alert .fi-alert_icon {
   margin-left: 20px;
   margin-top: 16px;
-}
-
-.c1.fi-alert .fi-alert_icon-wrapper .fi-alert_icon {
+  min-height: 24px;
+  min-width: 24px;
   height: 24px;
   width: 24px;
 }
@@ -177,15 +176,11 @@ exports[`props children should match snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 3 1 auto;
-  -ms-flex: 3 1 auto;
-  flex: 3 1 auto;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  padding: 0 20px;
-  margin-top: 15px;
-  margin-bottom: 15px;
+  padding: 0 20px 0 15px;
+  margin: 15px auto 15px 0;
 }
 
 .c1.fi-alert .fi-alert_text-content-wrapper .fi-alert_content {
@@ -209,7 +204,7 @@ exports[`props children should match snapshot 1`] = `
   background-color: hsl(196,77%,97%);
 }
 
-.c1.fi-alert--neutral .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
+.c1.fi-alert--neutral .fi-icon .fi-icon-base-fill {
   fill: hsl(196,77%,44%);
 }
 
@@ -217,7 +212,7 @@ exports[`props children should match snapshot 1`] = `
   background-color: hsl(0,59%,96%);
 }
 
-.c1.fi-alert--error .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
+.c1.fi-alert--error .fi-icon .fi-icon-base-fill {
   fill: hsl(3,59%,48%);
 }
 
@@ -225,7 +220,7 @@ exports[`props children should match snapshot 1`] = `
   background-color: hsl(42,100%,94%);
 }
 
-.c1.fi-alert--warning .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
+.c1.fi-alert--warning .fi-icon .fi-icon-base-fill {
   fill: hsl(23,82%,53%);
 }
 
@@ -234,30 +229,12 @@ exports[`props children should match snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
 }
 
-.c1 .fi-alert_close-button-wrapper {
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  box-sizing: border-box;
-  margin-top: 7px;
-  margin-right: 10px;
-  margin-bottom: 8px;
+.c1 .fi-alert_style-wrapper {
+  display: block;
+  max-width: 1110px;
+  margin: auto;
 }
 
 .c1 .fi-alert_close-button {
@@ -275,10 +252,14 @@ exports[`props children should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   height: 40px;
-  min-width: 40px;
-  padding: 7px 8px;
+  display: inline-block;
+  padding: 7px;
+  margin-top: 7px;
+  margin-right: 10px;
+  margin-bottom: 8px;
   border: 1px solid transparent;
   border-radius: 2px;
+  white-space: nowrap;
 }
 
 .c1 .fi-alert_close-button:focus-visible {
@@ -319,15 +300,23 @@ exports[`props children should match snapshot 1`] = `
   transform: translateY(0.1em);
 }
 
-.c1.fi-alert--small-screen .fi-alert_close-button-wrapper {
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
+.c1 .fi-alert_close-button .fi-icon .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c1.fi-alert--small-screen .fi-alert_style-wrapper {
+  width: 100%;
+}
+
+.c1.fi-alert--small-screen .fi-alert_text-content-wrapper {
+  padding: 0 0 0 10px;
+}
+
+.c1.fi-alert--small-screen .fi-alert_close-button {
   margin: 0;
 }
 
-.c1.fi-alert--small-screen .fi-alert_close-button-wrapper .fi-icon {
+.c1.fi-alert--small-screen .fi-alert_close-button .fi-icon {
   margin-right: 5px;
 }
 
@@ -338,26 +327,22 @@ exports[`props children should match snapshot 1`] = `
     <div
       class="c2 fi-alert_style-wrapper"
     >
-      <div
-        class="c2 fi-alert_icon-wrapper"
+      <svg
+        aria-hidden="true"
+        class="fi-icon c3 fi-alert_icon"
+        focusable="false"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          aria-hidden="true"
-          class="fi-icon c3 fi-alert_icon"
-          focusable="false"
-          height="1em"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            class="fi-icon-base-fill"
-            d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0zm0 2C6.486 2 2 6.486 2 12s4.486 10 10 10 10-4.486 10-10S17.514 2 12 2zm.003 8a1 1 0 011 1v6h1a1 1 0 010 2H10a1 1 0 010-2h1v-5h-1a1 1 0 010-2h2.003zm-.501-5a1.5 1.5 0 01.145 2.994L11.502 8H11.5a1.5 1.5 0 110-3h.002z"
-            fill="#222"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </div>
+        <path
+          class="fi-icon-base-fill"
+          d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0zm0 2C6.486 2 2 6.486 2 12s4.486 10 10 10 10-4.486 10-10S17.514 2 12 2zm.003 8a1 1 0 011 1v6h1a1 1 0 010 2H10a1 1 0 010-2h1v-5h-1a1 1 0 010-2h2.003zm-.501-5a1.5 1.5 0 01.145 2.994L11.502 8H11.5a1.5 1.5 0 110-3h.002z"
+          fill="#222"
+          fill-rule="evenodd"
+        />
+      </svg>
       <div
         class="c2 fi-alert_text-content-wrapper"
         id="7"
@@ -371,34 +356,30 @@ exports[`props children should match snapshot 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="c2 fi-alert_close-button-wrapper"
+      <button
+        aria-describedby="7"
+        aria-label="Close"
+        class="c4 fi-alert_close-button"
+        type="button"
       >
-        <button
-          aria-describedby="7"
-          aria-label="Close"
-          class="c4 fi-alert_close-button"
-          type="button"
+        CLOSE
+        <svg
+          aria-hidden="true"
+          class="fi-icon c3"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          CLOSE
-          <svg
-            aria-hidden="true"
-            class="fi-icon c3"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fi-icon-base-fill"
-              d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </button>
-      </div>
+          <path
+            class="fi-icon-base-fill"
+            d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+            fill="#222"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </button>
     </div>
   </section>
 </div>

--- a/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
+++ b/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
@@ -13,23 +13,20 @@ export const baseAlertBaseStyles = (theme: SuomifiTheme) => css`
       align-items: flex-start;
     }
 
-    & .fi-alert_icon-wrapper {
+    & .fi-alert_icon {
       margin-left: ${theme.spacing.m};
       margin-top: ${theme.spacing.insetXl};
-
-      & .fi-alert_icon {
-        height: 24px;
-        width: 24px;
-      }
+      min-height: 24px;
+      min-width: 24px;
+      height: 24px;
+      width: 24px;
     }
 
     & .fi-alert_text-content-wrapper {
       display: flex;
-      flex: 3 1 auto;
       flex-direction: column;
-      padding: 0 20px;
-      margin-top: ${theme.spacing.s};
-      margin-bottom: ${theme.spacing.s};
+      padding: 0 20px 0 15px;
+      margin: ${theme.spacing.s} auto ${theme.spacing.s} 0;
 
       & .fi-alert_content {
         vertical-align: middle;
@@ -40,21 +37,21 @@ export const baseAlertBaseStyles = (theme: SuomifiTheme) => css`
     /** Status variant styles */
     &--neutral {
       background-color: ${theme.colors.accentSecondaryLight1};
-      & .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
+      & .fi-icon .fi-icon-base-fill {
         fill: ${theme.colors.accentSecondary};
       }
     }
 
     &--error {
       background-color: ${theme.colors.alertLight1};
-      & .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
+      & .fi-icon .fi-icon-base-fill {
         fill: ${theme.colors.alertBase};
       }
     }
 
     &--warning {
       background-color: ${theme.colors.warningLight1};
-      & .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
+      & .fi-icon .fi-icon-base-fill {
         fill: ${theme.colors.accentBase};
       }
     }

--- a/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
+++ b/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
@@ -26,7 +26,6 @@ export const baseAlertBaseStyles = (theme: SuomifiTheme) => css`
       display: flex;
       flex-direction: column;
       padding: 0 ${theme.spacing.m};
-      margin: ${theme.spacing.s} 0;
 
       & .fi-alert_content {
         vertical-align: middle;

--- a/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
+++ b/src/core/Alert/BaseAlert/BaseAlert.baseStyles.ts
@@ -25,8 +25,8 @@ export const baseAlertBaseStyles = (theme: SuomifiTheme) => css`
     & .fi-alert_text-content-wrapper {
       display: flex;
       flex-direction: column;
-      padding: 0 20px 0 15px;
-      margin: ${theme.spacing.s} auto ${theme.spacing.s} 0;
+      padding: 0 ${theme.spacing.m};
+      margin: ${theme.spacing.s} 0;
 
       & .fi-alert_content {
         vertical-align: middle;

--- a/src/core/Alert/BaseAlert/BaseAlert.tsx
+++ b/src/core/Alert/BaseAlert/BaseAlert.tsx
@@ -23,4 +23,6 @@ export interface BaseAlertProps extends HtmlDivWithRefProps {
   status?: 'neutral' | 'warning' | 'error';
   /** Main content of the alert */
   children?: ReactNode;
+  /** Use small screen styling */
+  smallScreen?: boolean;
 }

--- a/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
@@ -13,6 +13,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     & .fi-alert_text-content-wrapper {
       padding: 0 ${theme.spacing.s};
+      margin: ${theme.spacing.s} 0;
     }
 
     &.fi-alert--inline {

--- a/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
@@ -10,12 +10,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     margin-bottom: ${theme.spacing.xxs};
   }
 
-  /** Inline variant styles  */
   &.fi-alert--inline {
     padding: 5px 0px 4px 0px;
-    & .fi-alert_icon-wrapper {
-      flex: 0;
-    }
+
     &.fi-alert--neutral {
       border-left: 4px solid ${theme.colors.accentSecondary};
     }
@@ -26,6 +23,13 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &.fi-alert--warning {
       border-left: 4px solid ${theme.colors.accentBase};
+    }
+
+    /** Small screen variant styles */
+    &.fi-alert--small-screen {
+      & .fi-alert_text-content-wrapper {
+        padding: 0 15px 0 10px;
+      }
     }
   }
 `;

--- a/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
@@ -5,30 +5,42 @@ import { baseAlertBaseStyles } from '../BaseAlert/BaseAlert.baseStyles';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${baseAlertBaseStyles(theme)}
-  & .fi-alert_label {
-    ${font(theme)('bodySemiBold')}
-    margin-bottom: ${theme.spacing.xxs};
-  }
-
-  &.fi-alert--inline {
-    padding: 5px 0px 4px 0px;
-
-    &.fi-alert--neutral {
-      border-left: 4px solid ${theme.colors.accentSecondary};
+  &.fi-alert {
+    & .fi-alert_label {
+      ${font(theme)('bodySemiBold')}
+      margin-bottom: ${theme.spacing.xxs};
     }
 
-    &.fi-alert--error {
-      border-left: 4px solid ${theme.colors.alertBase};
+    & .fi-alert_text-content-wrapper {
+      padding: 0 ${theme.spacing.s};
     }
 
-    &.fi-alert--warning {
-      border-left: 4px solid ${theme.colors.accentBase};
-    }
+    &.fi-alert--inline {
+      padding: 5px 0px 4px 0px;
 
-    /** Small screen variant styles */
-    &.fi-alert--small-screen {
-      & .fi-alert_text-content-wrapper {
-        padding: 0 15px 0 10px;
+      &.fi-alert--neutral {
+        border-left: 4px solid ${theme.colors.accentSecondary};
+        & .fi-alert_text-content-wrapper {
+          padding-left: ${theme.spacing.m};
+        }
+      }
+
+      &.fi-alert--error {
+        border-left: 4px solid ${theme.colors.alertBase};
+      }
+
+      &.fi-alert--warning {
+        border-left: 4px solid ${theme.colors.accentBase};
+      }
+
+      /** Small screen variant styles */
+      &.fi-alert--small-screen {
+        & .fi-alert_icon {
+          margin-left: ${theme.spacing.s};
+        }
+        & .fi-alert_text-content-wrapper {
+          padding: 0 ${theme.spacing.xs} 0 ${theme.spacing.xs};
+        }
       }
     }
   }

--- a/src/core/Alert/InlineAlert/InlineAlert.tsx
+++ b/src/core/Alert/InlineAlert/InlineAlert.tsx
@@ -33,11 +33,11 @@ class BaseInlineAlert extends Component<InlineAlertProps & InnerRef> {
       ariaLiveMode = 'assertive',
       labelText,
       children,
+      smallScreen,
       id,
       ...passProps
     } = this.props;
 
-    const variantIcon = status === 'neutral' ? 'info' : status;
     return (
       <HtmlDivWithRef
         as="section"
@@ -48,13 +48,14 @@ class BaseInlineAlert extends Component<InlineAlertProps & InnerRef> {
           className,
           {
             [`${baseClassName}--${status}`]: !!status,
+            [alertClassNames.smallScreen]: !!smallScreen,
           },
         )}
       >
         <HtmlDiv className={alertClassNames.styleWrapper}>
-          <HtmlDiv className={alertClassNames.iconWrapper}>
-            <Icon icon={variantIcon} className={alertClassNames.icon} />
-          </HtmlDiv>
+          {status !== 'neutral' && (
+            <Icon icon={status} className={alertClassNames.icon} />
+          )}
 
           <HtmlDiv
             className={alertClassNames.textContentWrapper}

--- a/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -59,27 +59,6 @@ exports[`children should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
-  display: inline-block;
-  vertical-align: baseline;
-}
-
-.c3 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c3 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c3.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c3.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
 .c1.fi-alert {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -109,12 +88,11 @@ exports[`children should match snapshot 1`] = `
   align-items: flex-start;
 }
 
-.c1.fi-alert .fi-alert_icon-wrapper {
+.c1.fi-alert .fi-alert_icon {
   margin-left: 20px;
   margin-top: 16px;
-}
-
-.c1.fi-alert .fi-alert_icon-wrapper .fi-alert_icon {
+  min-height: 24px;
+  min-width: 24px;
   height: 24px;
   width: 24px;
 }
@@ -124,15 +102,11 @@ exports[`children should match snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 3 1 auto;
-  -ms-flex: 3 1 auto;
-  flex: 3 1 auto;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  padding: 0 20px;
-  margin-top: 15px;
-  margin-bottom: 15px;
+  padding: 0 20px 0 15px;
+  margin: 15px auto 15px 0;
 }
 
 .c1.fi-alert .fi-alert_text-content-wrapper .fi-alert_content {
@@ -156,7 +130,7 @@ exports[`children should match snapshot 1`] = `
   background-color: hsl(196,77%,97%);
 }
 
-.c1.fi-alert--neutral .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
+.c1.fi-alert--neutral .fi-icon .fi-icon-base-fill {
   fill: hsl(196,77%,44%);
 }
 
@@ -164,7 +138,7 @@ exports[`children should match snapshot 1`] = `
   background-color: hsl(0,59%,96%);
 }
 
-.c1.fi-alert--error .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
+.c1.fi-alert--error .fi-icon .fi-icon-base-fill {
   fill: hsl(3,59%,48%);
 }
 
@@ -172,7 +146,7 @@ exports[`children should match snapshot 1`] = `
   background-color: hsl(42,100%,94%);
 }
 
-.c1.fi-alert--warning .fi-alert_icon-wrapper .fi-icon .fi-icon-base-fill {
+.c1.fi-alert--warning .fi-icon .fi-icon-base-fill {
   fill: hsl(23,82%,53%);
 }
 
@@ -197,12 +171,6 @@ exports[`children should match snapshot 1`] = `
   padding: 5px 0px 4px 0px;
 }
 
-.c1.fi-alert--inline .fi-alert_icon-wrapper {
-  -webkit-flex: 0;
-  -ms-flex: 0;
-  flex: 0;
-}
-
 .c1.fi-alert--inline.fi-alert--neutral {
   border-left: 4px solid hsl(196,77%,44%);
 }
@@ -215,6 +183,10 @@ exports[`children should match snapshot 1`] = `
   border-left: 4px solid hsl(23,82%,53%);
 }
 
+.c1.fi-alert--inline.fi-alert--small-screen .fi-alert_text-content-wrapper {
+  padding: 0 15px 0 10px;
+}
+
 <div>
   <section
     class="c0 fi-alert fi-alert--inline c1 fi-alert--neutral"
@@ -222,26 +194,6 @@ exports[`children should match snapshot 1`] = `
     <div
       class="c2 fi-alert_style-wrapper"
     >
-      <div
-        class="c2 fi-alert_icon-wrapper"
-      >
-        <svg
-          aria-hidden="true"
-          class="fi-icon c3 fi-alert_icon"
-          focusable="false"
-          height="1em"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            class="fi-icon-base-fill"
-            d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0zm0 2C6.486 2 2 6.486 2 12s4.486 10 10 10 10-4.486 10-10S17.514 2 12 2zm.003 8a1 1 0 011 1v6h1a1 1 0 010 2H10a1 1 0 010-2h1v-5h-1a1 1 0 010-2h2.003zm-.501-5a1.5 1.5 0 01.145 2.994L11.502 8H11.5a1.5 1.5 0 110-3h.002z"
-            fill="#222"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </div>
       <div
         aria-live="assertive"
         class="c2 fi-alert_text-content-wrapper"

--- a/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -106,7 +106,6 @@ exports[`children should match snapshot 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 0 20px;
-  margin: 15px 0;
 }
 
 .c1.fi-alert .fi-alert_text-content-wrapper .fi-alert_content {
@@ -169,6 +168,7 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-alert .fi-alert_text-content-wrapper {
   padding: 0 15px;
+  margin: 15px 0;
 }
 
 .c1.fi-alert.fi-alert--inline {

--- a/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -105,8 +105,8 @@ exports[`children should match snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  padding: 0 20px 0 15px;
-  margin: 15px auto 15px 0;
+  padding: 0 20px;
+  margin: 15px 0;
 }
 
 .c1.fi-alert .fi-alert_text-content-wrapper .fi-alert_content {
@@ -150,7 +150,7 @@ exports[`children should match snapshot 1`] = `
   fill: hsl(23,82%,53%);
 }
 
-.c1 .fi-alert_label {
+.c1.fi-alert .fi-alert_label {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -167,24 +167,36 @@ exports[`children should match snapshot 1`] = `
   margin-bottom: 5px;
 }
 
-.c1.fi-alert--inline {
+.c1.fi-alert .fi-alert_text-content-wrapper {
+  padding: 0 15px;
+}
+
+.c1.fi-alert.fi-alert--inline {
   padding: 5px 0px 4px 0px;
 }
 
-.c1.fi-alert--inline.fi-alert--neutral {
+.c1.fi-alert.fi-alert--inline.fi-alert--neutral {
   border-left: 4px solid hsl(196,77%,44%);
 }
 
-.c1.fi-alert--inline.fi-alert--error {
+.c1.fi-alert.fi-alert--inline.fi-alert--neutral .fi-alert_text-content-wrapper {
+  padding-left: 20px;
+}
+
+.c1.fi-alert.fi-alert--inline.fi-alert--error {
   border-left: 4px solid hsl(3,59%,48%);
 }
 
-.c1.fi-alert--inline.fi-alert--warning {
+.c1.fi-alert.fi-alert--inline.fi-alert--warning {
   border-left: 4px solid hsl(23,82%,53%);
 }
 
-.c1.fi-alert--inline.fi-alert--small-screen .fi-alert_text-content-wrapper {
-  padding: 0 15px 0 10px;
+.c1.fi-alert.fi-alert--inline.fi-alert--small-screen .fi-alert_icon {
+  margin-left: 15px;
+}
+
+.c1.fi-alert.fi-alert--inline.fi-alert--small-screen .fi-alert_text-content-wrapper {
+  padding: 0 10px 0 10px;
 }
 
 <div>


### PR DESCRIPTION
## Description
This PR changes regular Alert structure and styling in order to have a fixed width content area containing the icon, the main content and the close button. It also contains some previously overlooked changes in spacing for the small screen variant. Because of this, the `smallScreen` prop now appears in both Alert and InlineAlert.

In addition, the icon is removed from neutral variant InlineAlert as per the designs. 

## Motivation and Context
This was discussed with developers and the designers, and the intended usage was further clarified resulting in the need to change the way the Alert looks and behaves when resized.

## How Has This Been Tested?
So far tested in styleguidist + chrome on windows. Needs to be tested in a project to make sure no styles leak inside the component etc. Preferably with breakpoint-dependent styling as well.

## Release notes
### Alert
* Change internal structure and styling
### InlineAlert
* Add `smallScreen` prop
* Remove icon from neutral variant 
