### PR TITLE
[Fix] Duplicate div was removed from LanguageMenu

### DIFF
--- a/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
@@ -82,7 +82,7 @@ class BaseLanguageMenu extends Component<LanguageMenuProps & SuomifiThemeProp> {
                 {name}
               </MenuButton>
               <StyledMenuPopover theme={theme} position={positionDefault}>
-                <MenuItems>{children}</MenuItems>
+                {children}
               </StyledMenuPopover>
             </Fragment>
           )}


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Duplicate use of MenuItems removed from the LanguageMenu. Causing problems at least because having duplicate ids and other possible issues.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

We got report from a service about the accessibility issue with the LanguageMenu, v6.1.1, that the duplicate ids were causing.
Issue existed in the latest develop branch also.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
We would want to have the component to be as accessible as possible.

## How Has This Been Tested?
Locally in styleguidist.
_Issue can be verified from the DOM before fix and how it is corrected after the fix, was no need to test in CRA-TS or similar test projects._

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

- Fix LanguageMenu issue with duplicate id.