### PR TITLE
[Fix] MultiSelect's item selection in non-controlled state

### DIFF
--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -227,38 +227,91 @@ describe('Chips', () => {
   });
 });
 
-test('correct amount of items are shown on filtering and after selection', async () => {
-  await act(async () => {
-    const { getByRole, findAllByRole, getByText } = render(
-      <MultiSelect
-        labelText="MultiSelect"
-        items={tools}
-        chipListVisible={false}
-        ariaChipActionLabel="Remove"
-        removeAllButtonLabel="Remove all selections"
-        visualPlaceholder="Choose your tool(s)"
-        noItemsText="No items"
-        ariaSelectedAmountText="tools selected"
-        ariaOptionsAvailableText="tools left"
-        ariaOptionChipRemovedText="removed"
-      />,
-    );
-    const textfield = getByRole('textbox') as HTMLInputElement;
+describe('Non-controlled', () => {
+  it('has correct amount of items are shown on filtering and after selection', async () => {
     await act(async () => {
-      fireEvent.change(textfield, { target: { value: 'hammer' } });
+      const { getByRole, findAllByRole, getByText } = render(
+        <MultiSelect
+          labelText="MultiSelect"
+          items={tools}
+          chipListVisible={false}
+          ariaChipActionLabel="Remove"
+          removeAllButtonLabel="Remove all selections"
+          visualPlaceholder="Choose your tool(s)"
+          noItemsText="No items"
+          ariaSelectedAmountText="tools selected"
+          ariaOptionsAvailableText="tools left"
+          ariaOptionChipRemovedText="removed"
+        />,
+      );
+      const textfield = getByRole('textbox') as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(textfield, { target: { value: 'hammer' } });
+      });
+
+      const hammerItem = getByText('Hammer');
+      expect(hammerItem).toHaveTextContent('Hammer');
+
+      const opts = await findAllByRole('option');
+      expect(opts).toHaveLength(3);
+
+      await act(async () => {
+        fireEvent.click(hammerItem);
+      });
+
+      const allOptions = await findAllByRole('option');
+      expect(allOptions).toHaveLength(3);
     });
-    const hammerItem = getByText('Hammer');
-    expect(hammerItem).toHaveTextContent('Hammer');
+  });
 
-    const opts = await findAllByRole('option');
-    expect(opts).toHaveLength(3);
-
+  it('has possibility to select item', async () => {
     await act(async () => {
-      fireEvent.click(hammerItem);
-    });
+      const { getByRole, container, getByText, rerender } = render(
+        <MultiSelect
+          labelText="MultiSelect"
+          items={tools}
+          chipListVisible={true}
+          ariaChipActionLabel="Remove"
+          removeAllButtonLabel="Remove all selections"
+          visualPlaceholder="Choose your tool(s)"
+          noItemsText="No items"
+          ariaSelectedAmountText="tools selected"
+          ariaOptionsAvailableText="tools left"
+          ariaOptionChipRemovedText="removed"
+        />,
+      );
+      let chips = container.querySelectorAll('.fi-chip');
+      expect(chips).toHaveLength(0);
 
-    const allOptions = await findAllByRole('option');
-    expect(allOptions).toHaveLength(3);
+      const textfield = getByRole('textbox') as HTMLInputElement;
+      await act(async () => {
+        fireEvent.focus(textfield);
+      });
+      await act(async () => {
+        rerender(
+          <MultiSelect
+            labelText="MultiSelect"
+            items={tools}
+            chipListVisible={true}
+            ariaChipActionLabel="Remove"
+            removeAllButtonLabel="Remove all selections"
+            visualPlaceholder="Choose your tool(s)"
+            noItemsText="No items"
+            ariaSelectedAmountText="tools selected"
+            ariaOptionsAvailableText="tools left"
+            ariaOptionChipRemovedText="removed"
+          />,
+        );
+      });
+      const hammerItem = getByText('Hammer');
+
+      await act(async () => {
+        fireEvent.click(hammerItem);
+      });
+
+      chips = container.querySelectorAll('.fi-chip');
+      expect(chips).toHaveLength(1);
+    });
   });
 });
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -201,6 +201,9 @@ class BaseMultiSelect<T> extends Component<
             if (onItemSelectionsChange) {
               onItemSelectionsChange(newSelectedItems);
             }
+            return {
+              selectedItems: newSelectedItems,
+            };
           }
         }
       },


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Fix the MultiSelect issue for not able to select items in non-controlled state.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
We would like the component to work as intended.

## How Has This Been Tested?
Locally in styleguidist and cra-ts. 
Added new test that should ensure it is behaving as wanted in this case.

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
- Fix MultiSelect's item selection in non-controlled state 