### PR TITLE
[fix]: Remove css from top wrappers

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,7 +4,8 @@
     "stylelint-config-styled-components"
   ],
   "rules": {
-    "no-extra-semicolons": null
+    "no-extra-semicolons": null,
+    "no-descending-specificity": null
   },
   "overrides": [
     {

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,8 +4,7 @@
     "stylelint-config-styled-components"
   ],
   "rules": {
-    "no-extra-semicolons": null,
-    "no-descending-specificity": null
+    "no-extra-semicolons": null
   },
   "overrides": [
     {

--- a/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
@@ -113,8 +113,11 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c3 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c3.fi-icon {
+  display: inline-block;
 }
 
 .c3 .fi-icon-base-fill {

--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -232,8 +232,11 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c8 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c8.fi-icon {
+  display: inline-block;
 }
 
 .c8 .fi-icon-base-fill {
@@ -254,6 +257,9 @@ exports[`calling render with the same component on the same container does not r
 
 .c5 {
   font-size: 16px;
+}
+
+.c5.fi-breadcrumb-link {
   display: inline-block;
 }
 

--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -252,7 +252,7 @@ exports[`calling render with the same component on the same container does not r
   cursor: inherit;
 }
 
-.c5.fi-breadcrumb-link {
+.c5 {
   font-size: 16px;
   display: inline-block;
 }

--- a/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.baseStyles.ts
+++ b/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.baseStyles.ts
@@ -7,8 +7,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   font-size: ${cssValueToString(
     theme.values.typography.bodyTextSmall.fontSize,
   )};
-  display: inline-block;
   &.fi-breadcrumb-link {
+    display: inline-block;
     & .fi-breadcrumb-link_link {
       ${font(theme)('bodyTextSmall')}
       &--current {

--- a/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.baseStyles.ts
+++ b/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.baseStyles.ts
@@ -4,11 +4,11 @@ import { font } from '../../theme/reset';
 import { cssValueToString } from '../../../utils/css';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  font-size: ${cssValueToString(
+    theme.values.typography.bodyTextSmall.fontSize,
+  )};
+  display: inline-block;
   &.fi-breadcrumb-link {
-    font-size: ${cssValueToString(
-      theme.values.typography.bodyTextSmall.fontSize,
-    )};
-    display: inline-block;
     & .fi-breadcrumb-link_link {
       ${font(theme)('bodyTextSmall')}
       &--current {

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -9,16 +9,13 @@ const invertedStyles = (theme: SuomifiTheme) => css`
     background-color: ${theme.colors.highlightBase};
     border: 1px solid ${theme.colors.whiteBase};
     text-shadow: none;
-
     &:hover {
       background: ${theme.gradients.whiteBaseNegative};
     }
-
     &:active {
       background: none;
       background-color: ${theme.colors.highlightBase};
     }
-
     &.fi-button--disabled,
     &[disabled],
     &:disabled {
@@ -35,16 +32,13 @@ const secondary = (theme: SuomifiTheme) => css`
   background-color: ${theme.colors.whiteBase};
   border: 1px solid ${theme.colors.highlightBase};
   text-shadow: none;
-
   &:hover {
     background: ${theme.gradients.whiteBaseToDepthLight2};
   }
-
   &:active {
     background: none;
     background-color: ${theme.colors.depthLight2};
   }
-
   &.fi-button--disabled,
   &[disabled],
   &:disabled {
@@ -71,19 +65,17 @@ const secondaryNoBorderStyles = (theme: SuomifiTheme) => css`
 `;
 
 const linkStyles = (theme: SuomifiTheme) => css`
-  color: ${theme.colors.highlightBase};
-  ${secondary(theme)}
-  background: ${theme.gradients.depthSecondaryToDepthSecondaryDark1};
-  border: none;
   &.fi-button--link {
+    color: ${theme.colors.highlightBase};
+    ${secondary(theme)}
+    background: ${theme.gradients.depthSecondaryToDepthSecondaryDark1};
+    border: none;
     &:hover {
       background: ${theme.gradients.highlightLight4ToDepthSecondary};
     }
-
     &:active {
       background: ${theme.gradients.depthLight3ToDepthLight2};
     }
-
     &.fi-button--disabled,
     &[disabled],
     &:disabled {
@@ -104,24 +96,19 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   text-align: center;
   text-shadow: ${theme.shadows.invertTextShadow};
   cursor: pointer;
-
   &:focus {
     outline: none;
     position: relative;
-
     &::after {
       ${theme.focus.absoluteFocus}
     }
   }
-
   &:hover {
     background: ${theme.gradients.highlightLight1ToHighlightBase};
   }
-
   &:active {
     background: ${theme.colors.highlightDark1};
   }
-
   &.fi-button--disabled,
   &[disabled],
   &:disabled {
@@ -130,22 +117,18 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     user-select: none;
     cursor: not-allowed;
   }
-
   &.fi-button--disabled::after {
     border: none;
     box-shadow: none;
   }
-
   &.fi-button--fullwidth {
     display: block;
     width: 100%;
   }
-
   ${invertedStyles(theme)}
   ${secondaryStyles(theme)}
   ${secondaryNoBorderStyles(theme)}
   ${linkStyles(theme)}
-
   & > .fi-button_icon {
     width: 16px;
     height: 16px;

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -71,12 +71,11 @@ const secondaryNoBorderStyles = (theme: SuomifiTheme) => css`
 `;
 
 const linkStyles = (theme: SuomifiTheme) => css`
+  color: ${theme.colors.highlightBase};
+  ${secondary(theme)}
+  background: ${theme.gradients.depthSecondaryToDepthSecondaryDark1};
+  border: none;
   &.fi-button--link {
-    color: ${theme.colors.highlightBase};
-    ${secondary(theme)}
-    background: ${theme.gradients.depthSecondaryToDepthSecondaryDark1};
-    border: none;
-
     &:hover {
       background: ${theme.gradients.highlightLight4ToDepthSecondary};
     }

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -104,15 +104,17 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   border-radius: ${theme.radius.basic};
   text-align: center;
   text-shadow: ${theme.shadows.invertTextShadow};
-
   cursor: pointer;
+
   &:focus {
     outline: none;
     position: relative;
+
     &::after {
       ${theme.focus.absoluteFocus}
     }
   }
+
   &:hover {
     background: ${theme.gradients.highlightLight1ToHighlightBase};
   }
@@ -144,6 +146,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${secondaryStyles(theme)}
   ${secondaryNoBorderStyles(theme)}
   ${linkStyles(theme)}
+  
   & > .fi-button_icon {
     width: 16px;
     height: 16px;

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -9,13 +9,16 @@ const invertedStyles = (theme: SuomifiTheme) => css`
     background-color: ${theme.colors.highlightBase};
     border: 1px solid ${theme.colors.whiteBase};
     text-shadow: none;
+
     &:hover {
       background: ${theme.gradients.whiteBaseNegative};
     }
+
     &:active {
       background: none;
       background-color: ${theme.colors.highlightBase};
     }
+
     &.fi-button--disabled,
     &[disabled],
     &:disabled {
@@ -32,13 +35,16 @@ const secondary = (theme: SuomifiTheme) => css`
   background-color: ${theme.colors.whiteBase};
   border: 1px solid ${theme.colors.highlightBase};
   text-shadow: none;
+
   &:hover {
     background: ${theme.gradients.whiteBaseToDepthLight2};
   }
+
   &:active {
     background: none;
     background-color: ${theme.colors.depthLight2};
   }
+
   &.fi-button--disabled,
   &[disabled],
   &:disabled {
@@ -70,12 +76,15 @@ const linkStyles = (theme: SuomifiTheme) => css`
     ${secondary(theme)}
     background: ${theme.gradients.depthSecondaryToDepthSecondaryDark1};
     border: none;
+
     &:hover {
       background: ${theme.gradients.highlightLight4ToDepthSecondary};
     }
+
     &:active {
       background: ${theme.gradients.depthLight3ToDepthLight2};
     }
+
     &.fi-button--disabled,
     &[disabled],
     &:disabled {
@@ -95,6 +104,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   border-radius: ${theme.radius.basic};
   text-align: center;
   text-shadow: ${theme.shadows.invertTextShadow};
+
   cursor: pointer;
   &:focus {
     outline: none;
@@ -106,9 +116,11 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &:hover {
     background: ${theme.gradients.highlightLight1ToHighlightBase};
   }
+
   &:active {
     background: ${theme.colors.highlightDark1};
   }
+
   &.fi-button--disabled,
   &[disabled],
   &:disabled {
@@ -117,14 +129,17 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     user-select: none;
     cursor: not-allowed;
   }
+
   &.fi-button--disabled::after {
     border: none;
     box-shadow: none;
   }
+
   &.fi-button--fullwidth {
     display: block;
     width: 100%;
   }
+
   ${invertedStyles(theme)}
   ${secondaryStyles(theme)}
   ${secondaryNoBorderStyles(theme)}
@@ -140,6 +155,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       margin-left: ${theme.spacing.insetM};
     }
   }
+
   &.fi-button--disabled > .fi-button_icon {
     cursor: not-allowed;
   }

--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -10,6 +10,7 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
   color: ${theme.colors.whiteBase};
   background: ${theme.colors.highlightBase};
   max-height: 28px;
+
   &:focus {
     outline: 0;
     position: relative;
@@ -22,6 +23,7 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
 
   &.fi-chip {
     display: inline-block;
+
     & .fi-chip--content {
       display: inline-block;
       max-width: 270px;

--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -10,7 +10,6 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
   color: ${theme.colors.whiteBase};
   background: ${theme.colors.highlightBase};
   max-height: 28px;
-  display: inline-block;
   &:focus {
     outline: 0;
     position: relative;
@@ -22,6 +21,7 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
   }
 
   &.fi-chip {
+    display: inline-block;
     & .fi-chip--content {
       display: inline-block;
       max-width: 270px;

--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -5,8 +5,13 @@ import { element, font } from '../../theme/reset';
 export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('actionElementInnerTextBold')}
-
-    &:focus {
+  border-radius: 14px;
+  padding: ${theme.spacing.insetXxs} ${theme.spacing.insetL};
+  color: ${theme.colors.whiteBase};
+  background: ${theme.colors.highlightBase};
+  max-height: 28px;
+  display: inline-block;
+  &:focus {
     outline: 0;
     position: relative;
 
@@ -17,13 +22,6 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
   }
 
   &.fi-chip {
-    border-radius: 14px;
-    padding: ${theme.spacing.insetXxs} ${theme.spacing.insetL};
-    color: ${theme.colors.whiteBase};
-    background: ${theme.colors.highlightBase};
-    max-height: 28px;
-    display: inline-block;
-
     & .fi-chip--content {
       display: inline-block;
       max-width: 270px;

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -98,6 +98,12 @@ exports[`children should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 28px;
+  display: inline-block;
 }
 
 .c1:focus {
@@ -120,15 +126,6 @@ exports[`children should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 28px;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -304,6 +301,12 @@ exports[`classnames should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 28px;
+  display: inline-block;
 }
 
 .c1:focus {
@@ -326,15 +329,6 @@ exports[`classnames should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 28px;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -506,6 +500,12 @@ exports[`disabled should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 28px;
+  display: inline-block;
 }
 
 .c1:focus {
@@ -528,15 +528,6 @@ exports[`disabled should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 28px;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -103,7 +103,6 @@ exports[`children should match snapshot 1`] = `
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
-  display: inline-block;
 }
 
 .c1:focus {
@@ -126,6 +125,10 @@ exports[`children should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
+}
+
+.c1.fi-chip {
+  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -306,7 +309,6 @@ exports[`classnames should match snapshot 1`] = `
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
-  display: inline-block;
 }
 
 .c1:focus {
@@ -329,6 +331,10 @@ exports[`classnames should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
+}
+
+.c1.fi-chip {
+  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -505,7 +511,6 @@ exports[`disabled should match snapshot 1`] = `
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
-  display: inline-block;
 }
 
 .c1:focus {
@@ -528,6 +533,10 @@ exports[`disabled should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
+}
+
+.c1.fi-chip {
+  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {

--- a/src/core/Chip/ChipList/ChipList.baseStyles.tsx
+++ b/src/core/Chip/ChipList/ChipList.baseStyles.tsx
@@ -3,10 +3,8 @@ import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &.fi-chip-list {
-    ${font(theme)('bodyText')}
-    padding-top: 5px;
-  }
+  ${font(theme)('bodyText')}
+  padding-top: 5px;
 
   & .fi-chip-list_content_wrapper > * {
     margin-right: 10px;

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -50,7 +50,6 @@ exports[`children should match snapshot 1`] = `
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
-  display: inline-block;
 }
 
 .c1:focus {
@@ -73,6 +72,10 @@ exports[`children should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
+}
+
+.c1.fi-chip {
+  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -161,7 +164,6 @@ exports[`classnames should match snapshot 1`] = `
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
-  display: inline-block;
 }
 
 .c1:focus {
@@ -184,6 +186,10 @@ exports[`classnames should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
+}
+
+.c1.fi-chip {
+  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -268,7 +274,6 @@ exports[`disabled should match snapshot 1`] = `
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
-  display: inline-block;
 }
 
 .c1:focus {
@@ -291,6 +296,10 @@ exports[`disabled should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
+}
+
+.c1.fi-chip {
+  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -45,6 +45,12 @@ exports[`children should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 28px;
+  display: inline-block;
 }
 
 .c1:focus {
@@ -67,15 +73,6 @@ exports[`children should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 28px;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -159,6 +156,12 @@ exports[`classnames should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 28px;
+  display: inline-block;
 }
 
 .c1:focus {
@@ -181,15 +184,6 @@ exports[`classnames should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 28px;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -269,6 +263,12 @@ exports[`disabled should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 28px;
+  display: inline-block;
 }
 
 .c1:focus {
@@ -291,15 +291,6 @@ exports[`disabled should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 28px;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -3,8 +3,8 @@ import { SuomifiTheme } from '../../theme';
 import { element, inputButton } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  display: inline-block;
   &.fi-dropdown {
+    display: inline-block;
     & .fi-dropdown_label--visible {
       margin-bottom: ${theme.spacing.xs};
     }

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -3,9 +3,8 @@ import { SuomifiTheme } from '../../theme';
 import { element, inputButton } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  display: inline-block;
   &.fi-dropdown {
-    display: inline-block;
-
     & .fi-dropdown_label--visible {
       margin-bottom: ${theme.spacing.xs};
     }

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -5,6 +5,7 @@ import { element, inputButton } from '../../theme/reset';
 export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-dropdown {
     display: inline-block;
+
     & .fi-dropdown_label--visible {
       margin-bottom: ${theme.spacing.xs};
     }

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -77,6 +77,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     max-height: 265px;
     overflow-y: auto;
     overflow-x: hidden;
+
     &:focus-within {
       outline: 0;
       box-shadow: none;
@@ -88,6 +89,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       background-color: ${theme.colors.whiteBase};
       ${theme.typography.actionElementInnerText};
     }
+
     & [data-reach-listbox-option][data-current-nav].fi-dropdown_item {
       color: ${theme.colors.blackBase};
       background-image: none;

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1 {
+.c1.fi-dropdown {
   display: inline-block;
 }
 
@@ -359,7 +359,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1 {
+.c1.fi-dropdown {
   display: inline-block;
 }
 
@@ -635,7 +635,7 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1 {
+.c1.fi-dropdown {
   display: inline-block;
 }
 
@@ -910,7 +910,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1 {
+.c1.fi-dropdown {
   display: inline-block;
 }
 
@@ -1197,7 +1197,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1 {
+.c1.fi-dropdown {
   display: inline-block;
 }
 

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1.fi-dropdown {
+.c1 {
   display: inline-block;
 }
 
@@ -359,7 +359,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1.fi-dropdown {
+.c1 {
   display: inline-block;
 }
 
@@ -635,7 +635,7 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1.fi-dropdown {
+.c1 {
   display: inline-block;
 }
 
@@ -910,7 +910,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1.fi-dropdown {
+.c1 {
   display: inline-block;
 }
 
@@ -1197,7 +1197,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1.fi-dropdown {
+.c1 {
   display: inline-block;
 }
 

--- a/src/core/Expander/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander/Expander.baseStyles.tsx
@@ -10,10 +10,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   padding: 0;
   border-radius: ${theme.radius.basic};
   box-shadow: ${theme.shadows.panelShadow};
-  display: block;
+
   width: 100%;
   max-width: 100%;
-
+  &.fi-expander {
+    display: block;
+  }
   &:before {
     background-color: ${theme.colors.highlightLight4};
     opacity: 0;

--- a/src/core/Expander/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander/Expander.baseStyles.tsx
@@ -10,9 +10,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   padding: 0;
   border-radius: ${theme.radius.basic};
   box-shadow: ${theme.shadows.panelShadow};
-
   width: 100%;
   max-width: 100%;
+
   &.fi-expander {
     display: block;
   }

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -132,9 +132,12 @@ exports[`Basic expander shoud match snapshot 1`] = `
   padding: 0;
   border-radius: 2px;
   box-shadow: 0 1px 2px 0 rgba(41,41,41,0.14),0 1px 5px 0 rgba(41,41,41,0.12);
-  display: block;
   width: 100%;
   max-width: 100%;
+}
+
+.c1.fi-expander {
+  display: block;
 }
 
 .c1:before {
@@ -161,7 +164,6 @@ exports[`Basic expander shoud match snapshot 1`] = `
   border-radius: inherit;
   position: relative;
   visibility: hidden;
-  display: block;
   height: 0;
   overflow: hidden;
   word-break: break-word;
@@ -174,6 +176,10 @@ exports[`Basic expander shoud match snapshot 1`] = `
   -webkit-transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
   transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
   will-change: transition,height;
+}
+
+.c6.fi-expander {
+  display: block;
 }
 
 .c6:not(.fi-expander_content--no-padding) {
@@ -197,8 +203,11 @@ exports[`Basic expander shoud match snapshot 1`] = `
 }
 
 .c5 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c5.fi-icon {
+  display: inline-block;
 }
 
 .c5 .fi-icon-base-fill {
@@ -220,12 +229,15 @@ exports[`Basic expander shoud match snapshot 1`] = `
 .c2 {
   color: hsl(0,0%,16%);
   position: relative;
-  display: block;
   width: 100%;
   max-width: 100%;
   min-height: 60px;
   background-color: hsl(212,63%,98%);
   border-radius: inherit;
+}
+
+.c2.fi-expander_title-button {
+  display: block;
 }
 
 .c2.fi-expander_title-button--open {

--- a/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
@@ -13,12 +13,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   height: 0;
   overflow: hidden;
   word-break: break-word;
-
   transform: scaleY(0);
   transform-origin: top;
   transition: all ${`${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction}`};
   will-change: transition, height;
+
   &.fi-expander {
     display: block;
   }

--- a/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
@@ -10,7 +10,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   border-radius: inherit;
   position: relative;
   visibility: hidden;
-  display: block;
   height: 0;
   overflow: hidden;
   word-break: break-word;
@@ -20,7 +19,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   transition: all ${`${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction}`};
   will-change: transition, height;
-
+  &.fi-expander {
+    display: block;
+  }
   &:not(.fi-expander_content--no-padding) {
     padding: 0 ${theme.spacing.insetXl};
   }

--- a/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
+++ b/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
@@ -49,7 +49,6 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
   border-radius: inherit;
   position: relative;
   visibility: hidden;
-  display: block;
   height: 0;
   overflow: hidden;
   word-break: break-word;
@@ -62,6 +61,10 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
   -webkit-transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
   transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
   will-change: transition,height;
+}
+
+.c1.fi-expander {
+  display: block;
 }
 
 .c1:not(.fi-expander_content--no-padding) {

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -6,6 +6,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   width: 100%;
   max-width: 100%;
+
   &.fi-expander-group {
     display: flex;
     flex-direction: column;

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -4,11 +4,12 @@ import { element, font } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
-  display: flex;
-  flex-direction: column;
   width: 100%;
   max-width: 100%;
-
+  &.fi-expander-group {
+    display: flex;
+    flex-direction: column;
+  }
   & > .fi-expander-group_expanders {
     flex: none;
 

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -126,6 +126,11 @@ exports[`Basic expander group should match snapshot 1`] = `
 
 .c1 {
   color: hsl(0,0%,16%);
+  width: 100%;
+  max-width: 100%;
+}
+
+.c1.fi-expander-group {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -133,8 +138,6 @@ exports[`Basic expander group should match snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  width: 100%;
-  max-width: 100%;
 }
 
 .c1 > .fi-expander-group_expanders {
@@ -264,9 +267,12 @@ exports[`Basic expander group should match snapshot 1`] = `
   padding: 0;
   border-radius: 2px;
   box-shadow: 0 1px 2px 0 rgba(41,41,41,0.14),0 1px 5px 0 rgba(41,41,41,0.12);
-  display: block;
   width: 100%;
   max-width: 100%;
+}
+
+.c5.fi-expander {
+  display: block;
 }
 
 .c5:before {
@@ -293,7 +299,6 @@ exports[`Basic expander group should match snapshot 1`] = `
   border-radius: inherit;
   position: relative;
   visibility: hidden;
-  display: block;
   height: 0;
   overflow: hidden;
   word-break: break-word;
@@ -306,6 +311,10 @@ exports[`Basic expander group should match snapshot 1`] = `
   -webkit-transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
   transition: all 50ms cubic-bezier(0.28,0.84,0.42,1);
   will-change: transition,height;
+}
+
+.c8.fi-expander {
+  display: block;
 }
 
 .c8:not(.fi-expander_content--no-padding) {
@@ -329,8 +338,11 @@ exports[`Basic expander group should match snapshot 1`] = `
 }
 
 .c7 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c7.fi-icon {
+  display: inline-block;
 }
 
 .c7 .fi-icon-base-fill {
@@ -352,12 +364,15 @@ exports[`Basic expander group should match snapshot 1`] = `
 .c6 {
   color: hsl(0,0%,16%);
   position: relative;
-  display: block;
   width: 100%;
   max-width: 100%;
   min-height: 60px;
   background-color: hsl(212,63%,98%);
   border-radius: inherit;
+}
+
+.c6.fi-expander_title-button {
+  display: block;
 }
 
 .c6.fi-expander_title-button--open {

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
@@ -15,6 +15,7 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
   padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
   white-space: break-word;
   word-wrap: break-word;
+
   &.fi-expander_title {
     display: block;
   }

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
@@ -7,7 +7,6 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodySemiBold')}
   position: relative;
-  display: block;
   width: 100%;
   max-width: 100%;
   min-height: 60px;
@@ -16,7 +15,9 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
   padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
   white-space: break-word;
   word-wrap: break-word;
-
+  &.fi-expander_title {
+    display: block;
+  }
   &.fi-expander_title--open {
     background-color: ${theme.colors.whiteBase};
     border-bottom-left-radius: 0;

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -125,8 +125,11 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
 }
 
 .c5 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c5.fi-icon {
+  display: inline-block;
 }
 
 .c5 .fi-icon-base-fill {
@@ -161,7 +164,6 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   position: relative;
-  display: block;
   width: 100%;
   max-width: 100%;
   min-height: 60px;
@@ -170,6 +172,10 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   padding: 17px 60px 16px 20px;
   white-space: break-word;
   word-wrap: break-word;
+}
+
+.c1.fi-expander_title {
+  display: block;
 }
 
 .c1.fi-expander_title--open {

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
@@ -6,13 +6,14 @@ import { allStates } from '../../../utils/css';
 export const expanderTitleButtonBaseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   position: relative;
-  display: block;
   width: 100%;
   max-width: 100%;
   min-height: 60px;
   background-color: ${theme.colors.highlightLight4};
   border-radius: inherit;
-
+  &.fi-expander_title-button {
+    display: block;
+  }
   &.fi-expander_title-button--open {
     background-color: ${theme.colors.whiteBase};
     border-bottom-left-radius: 0;

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
@@ -11,6 +11,7 @@ export const expanderTitleButtonBaseStyles = (theme: SuomifiTheme) => css`
   min-height: 60px;
   background-color: ${theme.colors.highlightLight4};
   border-radius: inherit;
+
   &.fi-expander_title-button {
     display: block;
   }

--- a/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
@@ -113,8 +113,11 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-icon {
+  display: inline-block;
 }
 
 .c4 .fi-icon-base-fill {
@@ -136,12 +139,15 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
 .c1 {
   color: hsl(0,0%,16%);
   position: relative;
-  display: block;
   width: 100%;
   max-width: 100%;
   min-height: 60px;
   background-color: hsl(212,63%,98%);
   border-radius: inherit;
+}
+
+.c1.fi-expander_title-button {
+  display: block;
 }
 
 .c1.fi-expander_title-button--open {

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -134,6 +134,9 @@ exports[`props children has matching snapshot 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+}
+
+.c5.fi-status-text {
   display: block;
 }
 

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`props children has matching snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5.fi-status-text {
+.c5 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;

--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -3,9 +3,7 @@ import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  & .fi-filter-input {
-    ${font(theme)('bodyText')}
-  }
+  ${font(theme)('bodyText')}
 
   & .fi-filter-input_wrapper {
     display: inline-block;

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`snapshot matches 1`] = `
   font-weight: 400;
 }
 
-.c5.fi-status-text {
+.c5 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -141,7 +141,7 @@ exports[`snapshot matches 1`] = `
   color: hsl(3,59%,48%);
 }
 
-.c1 .fi-filter-input {
+.c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -134,6 +134,9 @@ exports[`snapshot matches 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+}
+
+.c5.fi-status-text {
   display: block;
 }
 

--- a/src/core/Form/HintText/HintText.baseStyles.tsx
+++ b/src/core/Form/HintText/HintText.baseStyles.tsx
@@ -3,9 +3,7 @@ import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &.fi-hint-text {
-    display: block;
-    color: ${theme.colors.blackBase};
-    ${font(theme)('bodyTextSmall')};
-  }
+  display: block;
+  color: ${theme.colors.blackBase};
+  ${font(theme)('bodyTextSmall')};
 `;

--- a/src/core/Form/HintText/HintText.baseStyles.tsx
+++ b/src/core/Form/HintText/HintText.baseStyles.tsx
@@ -3,7 +3,9 @@ import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  display: block;
   color: ${theme.colors.blackBase};
   ${font(theme)('bodyTextSmall')};
+  &.fi-hint-text {
+    display: block;
+  }
 `;

--- a/src/core/Form/HintText/HintText.baseStyles.tsx
+++ b/src/core/Form/HintText/HintText.baseStyles.tsx
@@ -5,6 +5,7 @@ import { font } from '../../theme/reset';
 export const baseStyles = (theme: SuomifiTheme) => css`
   color: ${theme.colors.blackBase};
   ${font(theme)('bodyTextSmall')};
+
   &.fi-hint-text {
     display: block;
   }

--- a/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
+++ b/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
@@ -2,22 +2,21 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &.fi-input-clear-button {
-    position: relative;
-    cursor: pointer;
-    pointer-events: all;
-    height: 20px;
-    width: 20px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    &:focus {
-      outline: none;
-      &:after {
-        ${theme.focus.absoluteFocus}
-      }
+  position: relative;
+  cursor: pointer;
+  pointer-events: all;
+  height: 20px;
+  width: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  &:focus {
+    outline: none;
+    &:after {
+      ${theme.focus.absoluteFocus}
     }
-
+  }
+  &.fi-input-clear-button {
     & .fi-input-clear-button_icon {
       width: 16px;
       height: 16px;

--- a/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
+++ b/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
@@ -7,7 +7,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   pointer-events: all;
   height: 20px;
   width: 20px;
-  display: flex;
   justify-content: center;
   align-items: center;
   &:focus {
@@ -17,6 +16,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
   }
   &.fi-input-clear-button {
+    display: flex;
     & .fi-input-clear-button_icon {
       width: 16px;
       height: 16px;

--- a/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
+++ b/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
@@ -2,15 +2,14 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  pointer-events: all;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   &.fi-input-toggle-button {
-    width: 20px;
-    height: 20px;
-    cursor: pointer;
-    pointer-events: all;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
     & .fi-input-toggle-button_icon {
       pointer-events: none;
       width: 10px;

--- a/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
+++ b/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
@@ -8,6 +8,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   pointer-events: all;
   justify-content: center;
   align-items: center;
+
   &.fi-input-toggle-button {
     display: flex;
     & .fi-input-toggle-button_icon {

--- a/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
+++ b/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
@@ -6,10 +6,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   height: 20px;
   cursor: pointer;
   pointer-events: all;
-  display: flex;
   justify-content: center;
   align-items: center;
   &.fi-input-toggle-button {
+    display: flex;
     & .fi-input-toggle-button_icon {
       pointer-events: none;
       width: 10px;

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -2,7 +2,62 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
 
-/* stylelint-disable no-descending-specificity */
+const disabledStyles = (theme: SuomifiTheme) => css`
+  &.fi-radio-button--disabled {
+    & .fi-radio-button_label {
+      cursor: not-allowed;
+      color: ${theme.colors.depthBase};
+    }
+    & .fi-radio-button_hintText {
+      color: ${theme.colors.depthBase};
+      cursor: not-allowed;
+    }
+    & .fi-radio-button_input {
+      + .fi-radio-button_icon_wrapper {
+        & .fi-icon-radio-base {
+          fill: ${theme.colors.depthLight3};
+          stroke: ${theme.colors.depthLight1};
+        }
+      }
+      &:checked {
+        + .fi-radio-button_icon_wrapper {
+          & .fi-icon-radio-checked {
+            fill: ${theme.colors.depthBase};
+          }
+        }
+      }
+    }
+  }
+`;
+const largeStyles = () => css`
+  &--large {
+    & .fi-radio-button_hintText {
+      padding-left: 40px;
+    }
+    & .fi-radio-button_input {
+      top: 2px;
+      left: 2px;
+      height: 30px;
+      width: 30px;
+      + .fi-radio-button_icon_wrapper {
+        top: 0;
+        left: 0;
+        height: 30px;
+        width: 30px;
+        & .fi-radio-button_icon {
+          height: 30px;
+          width: 30px;
+        }
+      }
+    }
+    & .fi-radio-button_label {
+      padding-left: 40px;
+      padding-top: 2px;
+      min-height: 34px;
+    }
+  }
+`;
+
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
@@ -65,56 +120,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         }
       }
     }
-    &.fi-radio-button--disabled {
-      & .fi-radio-button_label {
-        cursor: not-allowed;
-        color: ${theme.colors.depthBase};
-      }
-      & .fi-radio-button_hintText {
-        color: ${theme.colors.depthBase};
-        cursor: not-allowed;
-      }
-      & .fi-radio-button_input {
-        + .fi-radio-button_icon_wrapper {
-          & .fi-icon-radio-base {
-            fill: ${theme.colors.depthLight3};
-            stroke: ${theme.colors.depthLight1};
-          }
-        }
-        &:checked {
-          + .fi-radio-button_icon_wrapper {
-            & .fi-icon-radio-checked {
-              fill: ${theme.colors.depthBase};
-            }
-          }
-        }
-      }
-    }
-    &--large {
-      & .fi-radio-button_hintText {
-        padding-left: 40px;
-      }
-      & .fi-radio-button_input {
-        top: 2px;
-        left: 2px;
-        height: 30px;
-        width: 30px;
-        + .fi-radio-button_icon_wrapper {
-          top: 0;
-          left: 0;
-          height: 30px;
-          width: 30px;
-          & .fi-radio-button_icon {
-            height: 30px;
-            width: 30px;
-          }
-        }
-      }
-      & .fi-radio-button_label {
-        padding-left: 40px;
-        padding-top: 2px;
-        min-height: 34px;
-      }
-    }
+    ${disabledStyles(theme)};
+    ${largeStyles()};
   }
 `;

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -7,6 +7,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   position: relative;
+
   &.fi-radio-button {
     & .fi-radio-button_hintText {
       display: block;

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -6,8 +6,8 @@ import { element, font } from '../../theme/reset';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-    &.fi-radio-button {
-    position: relative;
+  position: relative;
+  &.fi-radio-button {
     & .fi-radio-button_hintText {
       display: block;
       padding-left: 26px;

--- a/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
-/* stylelint-disable no-descending-specificity */
+
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}

--- a/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
-
+/* stylelint-disable no-descending-specificity */
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -118,8 +118,11 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-static-icon {
+  display: inline-block;
 }
 
 .c4.fi-icon--cursor-pointer {
@@ -430,8 +433,11 @@ exports[`className should match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-static-icon {
+  display: inline-block;
 }
 
 .c4.fi-icon--cursor-pointer {
@@ -742,8 +748,11 @@ exports[`disabled should match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-static-icon {
+  display: inline-block;
 }
 
 .c4.fi-icon--cursor-pointer {
@@ -1055,8 +1064,11 @@ exports[`hintText should match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-static-icon {
+  display: inline-block;
 }
 
 .c4.fi-icon--cursor-pointer {
@@ -1374,8 +1386,11 @@ exports[`id should match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-static-icon {
+  display: inline-block;
 }
 
 .c4.fi-icon--cursor-pointer {
@@ -1686,8 +1701,11 @@ exports[`name should match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-static-icon {
+  display: inline-block;
 }
 
 .c4.fi-icon--cursor-pointer {
@@ -1999,8 +2017,11 @@ exports[`value should match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-static-icon {
+  display: inline-block;
 }
 
 .c4.fi-icon--cursor-pointer {
@@ -2311,8 +2332,11 @@ exports[`variant should match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-static-icon {
+  display: inline-block;
 }
 
 .c4.fi-icon--cursor-pointer {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -145,9 +145,6 @@ exports[`children should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c1.fi-radio-button {
   position: relative;
 }
 
@@ -460,9 +457,6 @@ exports[`className should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c1.fi-radio-button {
   position: relative;
 }
 
@@ -775,9 +769,6 @@ exports[`disabled should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c1.fi-radio-button {
   position: relative;
 }
 
@@ -1091,9 +1082,6 @@ exports[`hintText should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c1.fi-radio-button {
   position: relative;
 }
 
@@ -1413,9 +1401,6 @@ exports[`id should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c1.fi-radio-button {
   position: relative;
 }
 
@@ -1728,9 +1713,6 @@ exports[`name should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c1.fi-radio-button {
   position: relative;
 }
 
@@ -2044,9 +2026,6 @@ exports[`value should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c1.fi-radio-button {
   position: relative;
 }
 
@@ -2359,9 +2338,6 @@ exports[`variant should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c1.fi-radio-button {
   position: relative;
 }
 

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -236,9 +236,6 @@ exports[`default, with only required props should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-radio-button {
   position: relative;
 }
 
@@ -761,9 +758,6 @@ exports[`props className should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-radio-button {
   position: relative;
 }
 
@@ -1286,9 +1280,6 @@ exports[`props defaultValue should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-radio-button {
   position: relative;
 }
 
@@ -1812,9 +1803,6 @@ exports[`props hintText should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-radio-button {
   position: relative;
 }
 
@@ -2342,9 +2330,6 @@ exports[`props id should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-radio-button {
   position: relative;
 }
 
@@ -2867,9 +2852,6 @@ exports[`props label should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-radio-button {
   position: relative;
 }
 
@@ -3404,9 +3386,6 @@ exports[`props labelMode should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c6.fi-radio-button {
   position: relative;
 }
 
@@ -3929,9 +3908,6 @@ exports[`props name should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-radio-button {
   position: relative;
 }
 
@@ -4454,9 +4430,6 @@ exports[`props value should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-radio-button {
   position: relative;
 }
 

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -168,8 +168,11 @@ exports[`default, with only required props should match snapshot 1`] = `
 }
 
 .c7 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c7.fi-static-icon {
+  display: inline-block;
 }
 
 .c7.fi-icon--cursor-pointer {
@@ -690,8 +693,11 @@ exports[`props className should match snapshot 1`] = `
 }
 
 .c7 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c7.fi-static-icon {
+  display: inline-block;
 }
 
 .c7.fi-icon--cursor-pointer {
@@ -1212,8 +1218,11 @@ exports[`props defaultValue should match snapshot 1`] = `
 }
 
 .c7 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c7.fi-static-icon {
+  display: inline-block;
 }
 
 .c7.fi-icon--cursor-pointer {
@@ -1735,8 +1744,11 @@ exports[`props hintText should match snapshot 1`] = `
 }
 
 .c7 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c7.fi-static-icon {
+  display: inline-block;
 }
 
 .c7.fi-icon--cursor-pointer {
@@ -2262,8 +2274,11 @@ exports[`props id should match snapshot 1`] = `
 }
 
 .c7 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c7.fi-static-icon {
+  display: inline-block;
 }
 
 .c7.fi-icon--cursor-pointer {
@@ -2784,8 +2799,11 @@ exports[`props label should match snapshot 1`] = `
 }
 
 .c7 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c7.fi-static-icon {
+  display: inline-block;
 }
 
 .c7.fi-icon--cursor-pointer {
@@ -3306,8 +3324,11 @@ exports[`props labelMode should match snapshot 1`] = `
 }
 
 .c8 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c8.fi-static-icon {
+  display: inline-block;
 }
 
 .c8.fi-icon--cursor-pointer {
@@ -3840,8 +3861,11 @@ exports[`props name should match snapshot 1`] = `
 }
 
 .c7 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c7.fi-static-icon {
+  display: inline-block;
 }
 
 .c7.fi-icon--cursor-pointer {
@@ -4362,8 +4386,11 @@ exports[`props value should match snapshot 1`] = `
 }
 
 .c7 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c7.fi-static-icon {
+  display: inline-block;
 }
 
 .c7.fi-icon--cursor-pointer {

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -3,10 +3,8 @@ import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &.fi-search-input {
-    ${font(theme)('bodyText')}
-    width: 290px;
-  }
+  ${font(theme)('bodyText')}
+  width: 290px;
 
   & .fi-search-input {
     &_wrapper {

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`snapshot should have matching default structure 1`] = `
   overflow: hidden;
 }
 
-.c9.fi-status-text {
+.c9 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -227,7 +227,7 @@ exports[`snapshot should have matching default structure 1`] = `
   cursor: inherit;
 }
 
-.c6.fi-input-clear-button {
+.c6 {
   position: relative;
   cursor: pointer;
   pointer-events: all;
@@ -247,11 +247,11 @@ exports[`snapshot should have matching default structure 1`] = `
   align-items: center;
 }
 
-.c6.fi-input-clear-button:focus {
+.c6:focus {
   outline: none;
 }
 
-.c6.fi-input-clear-button:focus:after {
+.c6:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -276,7 +276,7 @@ exports[`snapshot should have matching default structure 1`] = `
   fill: hsl(212,63%,37%);
 }
 
-.c1.fi-search-input {
+.c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -174,6 +174,9 @@ exports[`snapshot should have matching default structure 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+}
+
+.c9.fi-status-text {
   display: block;
 }
 
@@ -207,8 +210,11 @@ exports[`snapshot should have matching default structure 1`] = `
 }
 
 .c8 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c8.fi-icon {
+  display: inline-block;
 }
 
 .c8 .fi-icon-base-fill {
@@ -233,10 +239,6 @@ exports[`snapshot should have matching default structure 1`] = `
   pointer-events: all;
   height: 20px;
   width: 20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -265,6 +267,13 @@ exports[`snapshot should have matching default structure 1`] = `
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
+}
+
+.c6.fi-input-clear-button {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c6.fi-input-clear-button .fi-input-clear-button_icon {

--- a/src/core/Form/Select/BaseSelect/SelectEmptyItem/SelectEmptyItem.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectEmptyItem/SelectEmptyItem.baseStyles.tsx
@@ -3,13 +3,11 @@ import { SuomifiTheme } from '../../../../theme';
 import { font } from '../../../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &.fi-select-empty-item {
-    ${font(theme)('actionElementInnerText')}
-    padding: ${theme.spacing.insetL};
+  ${font(theme)('actionElementInnerText')}
+  padding: ${theme.spacing.insetL};
 
-    &:focus {
-      outline: none;
-    }
+  &:focus {
+    outline: none;
   }
   & .fi-select-empty-item_content_wrapper {
     display: inline-block;

--- a/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
@@ -3,15 +3,14 @@ import { SuomifiTheme } from '../../../../theme';
 import { font } from '../../../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  position: relative;
+  padding: 8px 32px 8px 10px;
+  ${font(theme)('actionElementInnerText')}
+
+  &:focus {
+    outline: none;
+  }
   &.fi-select-item {
-    position: relative;
-    padding: 8px 32px 8px 10px;
-    ${font(theme)('actionElementInnerText')}
-
-    &:focus {
-      outline: none;
-    }
-
     & .fi-select-item--query_highlight {
       background-color: transparent;
       font-weight: bold;

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
@@ -3,23 +3,21 @@ import { SuomifiTheme } from '../../../../theme';
 import { font } from '../../../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &.fi-select-item-list {
-    ${font(theme)('bodyText')}
-    list-style-type: none;
-    box-sizing: content-box;
-    max-height: 265px;
-    background-color: ${theme.colors.whiteBase};
-    border-width: 0 1px 1px 1px;
-    border-style: solid;
-    border-color: ${theme.colors.depthDark3};
-    border-bottom-left-radius: ${theme.radius.basic};
-    border-bottom-right-radius: ${theme.radius.basic};
-    margin: 0;
-    padding: 4px 0 0 0;
+  ${font(theme)('bodyText')}
+  list-style-type: none;
+  box-sizing: content-box;
+  max-height: 265px;
+  background-color: ${theme.colors.whiteBase};
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+  border-color: ${theme.colors.depthDark3};
+  border-bottom-left-radius: ${theme.radius.basic};
+  border-bottom-right-radius: ${theme.radius.basic};
+  margin: 0;
+  padding: 4px 0 0 0;
 
-    &:focus {
-      outline: none;
-    }
+  &:focus {
+    outline: none;
   }
 
   & .fi-select-item-list_content_wrapper {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
@@ -3,10 +3,10 @@ import { SuomifiTheme } from '../../../../theme';
 import { font } from '../../../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &.fi-multiselect {
-    ${font(theme)('bodyText')}
-    width: 290px;
+  ${font(theme)('bodyText')}
+  width: 290px;
 
+  &.fi-multiselect {
     & .fi-filter-input_input-element-container {
       position: relative;
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`has matching snapshot 1`] = `
   font-weight: 400;
 }
 
-.c6.fi-status-text {
+.c6 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -206,7 +206,7 @@ exports[`has matching snapshot 1`] = `
   color: hsl(3,59%,48%);
 }
 
-.c2 .fi-filter-input {
+.c2 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -437,6 +437,12 @@ exports[`has matching snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 28px;
+  display: inline-block;
 }
 
 .c9:focus {
@@ -459,15 +465,6 @@ exports[`has matching snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c9.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 28px;
-  display: inline-block;
 }
 
 .c9.fi-chip .fi-chip--content {
@@ -526,7 +523,7 @@ exports[`has matching snapshot 1`] = `
   cursor: not-allowed;
 }
 
-.c7.fi-chip-list {
+.c7 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -783,7 +780,7 @@ exports[`has matching snapshot 1`] = `
   cursor: not-allowed;
 }
 
-.c1.fi-multiselect {
+.c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -199,6 +199,9 @@ exports[`has matching snapshot 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+}
+
+.c6.fi-status-text {
   display: block;
 }
 
@@ -402,8 +405,11 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c10 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c10.fi-icon {
+  display: inline-block;
 }
 
 .c10 .fi-icon-base-fill {
@@ -442,7 +448,6 @@ exports[`has matching snapshot 1`] = `
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   max-height: 28px;
-  display: inline-block;
 }
 
 .c9:focus {
@@ -465,6 +470,10 @@ exports[`has matching snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
+}
+
+.c9.fi-chip {
+  display: inline-block;
 }
 
 .c9.fi-chip .fi-chip--content {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -3,10 +3,9 @@ import { SuomifiTheme } from '../../../theme';
 import { font } from '../../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodyText')}
+  width: 290px;
   &.fi-single-select {
-    ${font(theme)('bodyText')}
-    width: 290px;
-
     & .fi-filter-input_input {
       padding-right: 36px;
     }

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -5,6 +5,7 @@ import { font } from '../../../theme/reset';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')}
   width: 290px;
+
   &.fi-single-select {
     & .fi-filter-input_input {
       padding-right: 36px;

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -183,7 +183,6 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c5 {
-  display: block;
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -198,6 +197,10 @@ exports[`has matching snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c5.fi-hint-text {
+  display: block;
 }
 
 .c12 {
@@ -217,6 +220,9 @@ exports[`has matching snapshot 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+}
+
+.c12.fi-status-text {
   display: block;
 }
 
@@ -420,8 +426,11 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c10 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c10.fi-icon {
+  display: inline-block;
 }
 
 .c10 .fi-icon-base-fill {
@@ -446,10 +455,6 @@ exports[`has matching snapshot 1`] = `
   pointer-events: all;
   height: 20px;
   width: 20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -480,6 +485,13 @@ exports[`has matching snapshot 1`] = `
   z-index: 9999;
 }
 
+.c8.fi-input-clear-button {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 .c8.fi-input-clear-button .fi-input-clear-button_icon {
   width: 16px;
   height: 16px;
@@ -494,10 +506,6 @@ exports[`has matching snapshot 1`] = `
   height: 20px;
   cursor: pointer;
   pointer-events: all;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -506,6 +514,13 @@ exports[`has matching snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c11.fi-input-toggle-button {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .c11.fi-input-toggle-button .fi-input-toggle-button_icon {

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`has matching snapshot 1`] = `
   font-weight: 400;
 }
 
-.c5.fi-hint-text {
+.c5 {
   display: block;
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
@@ -200,7 +200,7 @@ exports[`has matching snapshot 1`] = `
   font-weight: 400;
 }
 
-.c12.fi-status-text {
+.c12 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -224,7 +224,7 @@ exports[`has matching snapshot 1`] = `
   color: hsl(3,59%,48%);
 }
 
-.c2 .fi-filter-input {
+.c2 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -440,7 +440,7 @@ exports[`has matching snapshot 1`] = `
   cursor: inherit;
 }
 
-.c8.fi-input-clear-button {
+.c8 {
   position: relative;
   cursor: pointer;
   pointer-events: all;
@@ -460,11 +460,11 @@ exports[`has matching snapshot 1`] = `
   align-items: center;
 }
 
-.c8.fi-input-clear-button:focus {
+.c8:focus {
   outline: none;
 }
 
-.c8.fi-input-clear-button:focus:after {
+.c8:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -489,7 +489,7 @@ exports[`has matching snapshot 1`] = `
   fill: hsl(212,63%,37%);
 }
 
-.c11.fi-input-toggle-button {
+.c11 {
   width: 20px;
   height: 20px;
   cursor: pointer;
@@ -518,7 +518,7 @@ exports[`has matching snapshot 1`] = `
   fill: hsl(0,0%,16%);
 }
 
-.c1.fi-single-select {
+.c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;

--- a/src/core/Form/StatusText/StatusText.baseStyles.tsx
+++ b/src/core/Form/StatusText/StatusText.baseStyles.tsx
@@ -7,8 +7,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   color: ${theme.colors.blackBase};
   font-size: 14px;
   line-height: 20px;
-  display: block;
   &.fi-status-text {
+    display: block;
     &.fi-status-text--error {
       color: ${theme.colors.alertBase};
     }

--- a/src/core/Form/StatusText/StatusText.baseStyles.tsx
+++ b/src/core/Form/StatusText/StatusText.baseStyles.tsx
@@ -7,6 +7,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   color: ${theme.colors.blackBase};
   font-size: 14px;
   line-height: 20px;
+
   &.fi-status-text {
     display: block;
     &.fi-status-text--error {

--- a/src/core/Form/StatusText/StatusText.baseStyles.tsx
+++ b/src/core/Form/StatusText/StatusText.baseStyles.tsx
@@ -3,13 +3,12 @@ import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodySemiBoldSmall')};
+  color: ${theme.colors.blackBase};
+  font-size: 14px;
+  line-height: 20px;
+  display: block;
   &.fi-status-text {
-    ${font(theme)('bodySemiBoldSmall')};
-    color: ${theme.colors.blackBase};
-    font-size: 14px;
-    line-height: 20px;
-    display: block;
-
     &.fi-status-text--error {
       color: ${theme.colors.alertBase};
     }

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -6,6 +6,7 @@ import { math } from 'polished';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')}
   width: 290px;
+
   & .fi-text-input_wrapper {
     width: 100%;
     display: inline-block;

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -4,11 +4,8 @@ import { input, containerIEFocus, font } from '../../theme/reset';
 import { math } from 'polished';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &.fi-text-input {
-    ${font(theme)('bodyText')}
-    width: 290px;
-  }
-
+  ${font(theme)('bodyText')}
+  width: 290px;
   & .fi-text-input_wrapper {
     width: 100%;
     display: inline-block;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`snapshots match error status with statustext 1`] = `
   font-weight: 400;
 }
 
-.c5.fi-status-text {
+.c5 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -141,7 +141,7 @@ exports[`snapshots match error status with statustext 1`] = `
   color: hsl(3,59%,48%);
 }
 
-.c1.fi-text-input {
+.c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -484,7 +484,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   font-weight: 400;
 }
 
-.c6.fi-status-text {
+.c6 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -508,7 +508,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   color: hsl(3,59%,48%);
 }
 
-.c1.fi-text-input {
+.c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -836,7 +836,7 @@ exports[`snapshots match minimal implementation 1`] = `
   font-weight: 400;
 }
 
-.c5.fi-status-text {
+.c5 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -860,7 +860,7 @@ exports[`snapshots match minimal implementation 1`] = `
   color: hsl(3,59%,48%);
 }
 
-.c1.fi-text-input {
+.c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -134,6 +134,9 @@ exports[`snapshots match error status with statustext 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+}
+
+.c5.fi-status-text {
   display: block;
 }
 
@@ -501,6 +504,9 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+}
+
+.c6.fi-status-text {
   display: block;
 }
 
@@ -853,6 +859,9 @@ exports[`snapshots match minimal implementation 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+}
+
+.c5.fi-status-text {
   display: block;
 }
 

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -5,13 +5,11 @@ import { element, font } from '../../theme/reset';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-
-    &.fi-textarea {
-    display: flex;
-    flex-direction: column;
-    color: ${theme.colors.blackBase};
-    width: 290px;
-
+  display: flex;
+  flex-direction: column;
+  color: ${theme.colors.blackBase};
+  width: 290px;
+  &.fi-textarea {
     & .fi-textarea_statusText--has-content {
       margin-top: ${theme.spacing.xxs};
     }

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -7,9 +7,11 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')}
   color: ${theme.colors.blackBase};
   width: 290px;
+
   &.fi-textarea {
     display: flex;
     flex-direction: column;
+
     & .fi-textarea_statusText--has-content {
       margin-top: ${theme.spacing.xxs};
     }

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -5,11 +5,11 @@ import { element, font } from '../../theme/reset';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  display: flex;
-  flex-direction: column;
   color: ${theme.colors.blackBase};
   width: 290px;
   &.fi-textarea {
+    display: flex;
+    flex-direction: column;
     & .fi-textarea_statusText--has-content {
       margin-top: ${theme.spacing.xxs};
     }

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -134,6 +134,9 @@ exports[`snapshot default structure should match snapshot 1`] = `
   color: hsl(0,0%,16%);
   font-size: 14px;
   line-height: 20px;
+}
+
+.c5.fi-status-text {
   display: block;
 }
 
@@ -156,6 +159,11 @@ exports[`snapshot default structure should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
+  color: hsl(0,0%,16%);
+  width: 290px;
+}
+
+.c1.fi-textarea {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -163,8 +171,6 @@ exports[`snapshot default structure should match snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  color: hsl(0,0%,16%);
-  width: 290px;
 }
 
 .c1.fi-textarea .fi-textarea_statusText--has-content {

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c5.fi-status-text {
+.c5 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -156,9 +156,6 @@ exports[`snapshot default structure should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c1.fi-textarea {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/core/Form/Toggle/ToggleBase/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleBase/Toggle.baseStyles.tsx
@@ -17,9 +17,10 @@ export const toggleBaseStyles = (theme: SuomifiTheme) => css`
   background-color: ${theme.colors.whiteBase};
   padding-left: 50px;
   position: relative;
-  display: inline-block;
   cursor: pointer;
-
+  &.fi-toggle {
+    display: inline-block;
+  }
   &.fi-toggle--disabled {
     cursor: not-allowed;
   }

--- a/src/core/Form/Toggle/ToggleBase/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleBase/Toggle.baseStyles.tsx
@@ -18,6 +18,7 @@ export const toggleBaseStyles = (theme: SuomifiTheme) => css`
   padding-left: 50px;
   position: relative;
   cursor: pointer;
+
   &.fi-toggle {
     display: inline-block;
   }

--- a/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -182,8 +182,11 @@ exports[`Basic ToggleButton should match snapshot 1`] = `
 }
 
 .c3 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c3.fi-static-icon {
+  display: inline-block;
 }
 
 .c3.fi-icon--cursor-pointer {
@@ -267,8 +270,11 @@ exports[`Basic ToggleButton should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   padding-left: 50px;
   position: relative;
-  display: inline-block;
   cursor: pointer;
+}
+
+.c1.fi-toggle {
+  display: inline-block;
 }
 
 .c1.fi-toggle--disabled {

--- a/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
@@ -187,8 +187,11 @@ exports[`Basic ToggleInput should match snapshot 1`] = `
 }
 
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-static-icon {
+  display: inline-block;
 }
 
 .c4.fi-icon--cursor-pointer {
@@ -272,8 +275,11 @@ exports[`Basic ToggleInput should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   padding-left: 50px;
   position: relative;
-  display: inline-block;
   cursor: pointer;
+}
+
+.c1.fi-toggle {
+  display: inline-block;
 }
 
 .c1.fi-toggle--disabled {

--- a/src/core/Icon/Icon.baseStyles.tsx
+++ b/src/core/Icon/Icon.baseStyles.tsx
@@ -8,11 +8,11 @@ export const iconBaseStyles = ({
   fill: string;
 }) => {
   const resolvedColor = fill ?? color ?? 'currentColor';
-
   return css`
-    display: inline-block;
     vertical-align: baseline;
-
+    &.fi-icon {
+      display: inline-block;
+    }
     .fi-icon-base-fill {
       fill: ${resolvedColor};
     }

--- a/src/core/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/core/Icon/__snapshots__/Icon.test.tsx.snap
@@ -2,8 +2,11 @@
 
 exports[`calling render with the same component on the same container does not remount 1`] = `
 .c0 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c0.fi-icon {
+  display: inline-block;
 }
 
 .c0 .fi-icon-base-fill {

--- a/src/core/LanguageMenu/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -31,8 +31,11 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c2.fi-icon {
+  display: inline-block;
 }
 
 .c2 .fi-icon-base-fill {

--- a/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
+++ b/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
@@ -2,8 +2,11 @@
 
 exports[`calling render with the same component on the same container does not remount 1`] = `
 .c4 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c4.fi-icon {
+  display: inline-block;
 }
 
 .c4 .fi-icon-base-fill {

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -533,9 +533,12 @@ exports[`Basic modal should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c4.fi-modal_title {
+.c4 {
   max-width: 100%;
   display: block;
+}
+
+.c4.fi-modal_title {
   margin-bottom: 20px;
 }
 

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -535,10 +535,10 @@ exports[`Basic modal should match snapshot 1`] = `
 
 .c4 {
   max-width: 100%;
-  display: block;
 }
 
 .c4.fi-modal_title {
+  display: block;
   margin-bottom: 20px;
 }
 

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -482,10 +482,10 @@ exports[`Basic ModalContent should match snapshot 1`] = `
 
 .c4 {
   max-width: 100%;
-  display: block;
 }
 
 .c4.fi-modal_title {
+  display: block;
   margin-bottom: 20px;
 }
 

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -480,9 +480,12 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c4.fi-modal_title {
+.c4 {
   max-width: 100%;
   display: block;
+}
+
+.c4.fi-modal_title {
   margin-bottom: 20px;
 }
 

--- a/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
+++ b/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
@@ -3,8 +3,10 @@ import { SuomifiTheme } from '../../theme';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   max-width: 100%;
+
   &.fi-modal_title {
     display: block;
+
     & .fi-modal_title_focus-wrapper {
       position: relative;
       display: inline-block;

--- a/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
+++ b/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
@@ -2,10 +2,9 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  max-width: 100%;
+  display: block;
   &.fi-modal_title {
-    max-width: 100%;
-    display: block;
-
     & .fi-modal_title_focus-wrapper {
       position: relative;
       display: inline-block;

--- a/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
+++ b/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
@@ -3,8 +3,8 @@ import { SuomifiTheme } from '../../theme';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   max-width: 100%;
-  display: block;
   &.fi-modal_title {
+    display: block;
     & .fi-modal_title_focus-wrapper {
       position: relative;
       display: inline-block;

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -142,8 +142,11 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c3 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c3.fi-icon {
+  display: inline-block;
 }
 
 .c3 .fi-icon-base-fill {

--- a/src/core/StaticIcon/StaticIcon.baseStyles.tsx
+++ b/src/core/StaticIcon/StaticIcon.baseStyles.tsx
@@ -8,6 +8,7 @@ export const staticIconBaseStyles = ({
   baseColor?: string;
 }) => css`
   vertical-align: baseline;
+
   &.fi-static-icon {
     display: inline-block;
   }

--- a/src/core/StaticIcon/StaticIcon.baseStyles.tsx
+++ b/src/core/StaticIcon/StaticIcon.baseStyles.tsx
@@ -7,9 +7,10 @@ export const staticIconBaseStyles = ({
   highlightColor?: string;
   baseColor?: string;
 }) => css`
-  display: inline-block;
   vertical-align: baseline;
-
+  &.fi-static-icon {
+    display: inline-block;
+  }
   &.fi-icon--cursor-pointer {
     cursor: pointer;
     & * {

--- a/src/core/StaticIcon/__snapshots__/StaticIcon.test.tsx.snap
+++ b/src/core/StaticIcon/__snapshots__/StaticIcon.test.tsx.snap
@@ -2,8 +2,11 @@
 
 exports[`calling render with the same component on the same container does not remount 1`] = `
 .c0 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c0.fi-static-icon {
+  display: inline-block;
 }
 
 .c0.fi-icon--cursor-pointer {

--- a/src/core/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/core/Toast/__snapshots__/Toast.test.tsx.snap
@@ -2,8 +2,11 @@
 
 exports[`props children should match snapshot 1`] = `
 .c3 {
-  display: inline-block;
   vertical-align: baseline;
+}
+
+.c3.fi-icon {
+  display: inline-block;
 }
 
 .c3 .fi-icon-base-fill {


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
This PR moves High level wrappers CSS to Base level(To highest level of CSS). These changes should have no effect to look and feel. If these changes change look and feel then there is mistake.
<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Motivation and Context
These changes make easier to overwrite styles in Suomi.fi sites. 
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
In Styleguidist with Mac and Chrome.

## Release notes
### Changed components in first iteration:
**Breadcrumb**,
**Button**,
**Chip**,
**Dropdown**,
**FIlterInput**,
**Hintext**,
**InputClearButton**,
**InputToggleButton**,
**RadioButton**,
**SearchInput**,
**Select**,
**StatusText**,
**Textarea**,
**TextInput**,
**Modal**

### Changed components in second iteration(moved display and flex css properties inside to top wrappers):
**BreadcrumbLink**,
**BaseChip**,
**Dropdown**,
**Expander**,
**ExpanderContent**,
**ExpanderTitle**,
**ExpanderTitleButton**,
**HintText**,
**InputClearButton**,
**InputToggleButton**,
**StatusText**,
**Textarea**,
**Toggle**,
**Icon**,
**ModalTitle**,
**StaticIcon**,




