### PR TITLE
Clarify onItemSelectionsChange prop documentation

### DIFF
--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -60,7 +60,7 @@ export interface MultiSelectProps<T extends MultiSelectData> {
   optionalText?: string;
   /** Hint text to be shown below the label */
   hintText?: string;
-  /** Event that is fired when item selections change */
+  /** Event that is fired when item selections change. Not fired when in controlled state. */
   onItemSelectionsChange?: (selectedItems: Array<T>) => void;
   /** Show chip list */
   chipListVisible?: boolean;


### PR DESCRIPTION
## Description
This PR makes a simple addition to MultiSelect API documentation after some feedback from users. The `onItemSelectionsChange` event is not fired when the component is in controlled state and this was not documented in the API docs. This mention is now added.

## Motivation and Context
The API should be up to date and clear

## How Has This Been Tested?
Just a quick glance in styleguidist, since only documentation changed.

## Release notes
### MultiSelect
* Improve API documentation concerning `onItemSelectionsChange` event.
