### PR TITLE
[Fix] SingleSelect. Open list by clicking field

### DIFF
--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -209,7 +209,7 @@ class BaseSingleSelect<T> extends Component<
     });
   };
 
-  private focusToInputAndSelectText = (openMenu: any) => {
+  private focusToInputAndSelectText = (openMenu: boolean) => {
     if (!!this.filterInputRef && this.filterInputRef.current) {
       if (openMenu) {
         this.setState({

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -209,18 +209,20 @@ class BaseSingleSelect<T> extends Component<
     });
   };
 
-  private focusToInputAndSelectText = () => {
+  private focusToInputAndSelectText = (openMenu: any) => {
     if (!!this.filterInputRef && this.filterInputRef.current) {
-      this.setState({
-        showPopover: true,
-      });
+      if (openMenu) {
+        this.setState({
+          showPopover: true,
+        });
+      }
       this.filterInputRef.current.focus();
       setTimeout(() => this.filterInputRef.current?.select(), 100);
     }
   };
 
   private focusToInputAndCloseMenu = () => {
-    this.focusToInputAndSelectText();
+    this.focusToInputAndSelectText(false);
     this.setState({
       showPopover: false,
       filterMode: false,
@@ -400,7 +402,7 @@ class BaseSingleSelect<T> extends Component<
                 this.preventShowPopoverOnInputFocus = false;
               }}
               onClick={() => {
-                this.focusToInputAndSelectText();
+                this.focusToInputAndSelectText(true);
               }}
               onKeyDown={this.handleKeyDown}
               onBlur={this.handleBlur}
@@ -436,7 +438,7 @@ class BaseSingleSelect<T> extends Component<
                     }),
                   );
                   this.preventShowPopoverOnInputFocus = true;
-                  this.focusToInputAndSelectText();
+                  this.focusToInputAndSelectText(false);
                 }}
                 aria-hidden={true}
                 tabIndex={-1}

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -211,6 +211,9 @@ class BaseSingleSelect<T> extends Component<
 
   private focusToInputAndSelectText = () => {
     if (!!this.filterInputRef && this.filterInputRef.current) {
+      this.setState({
+        showPopover: true,
+      });
       this.filterInputRef.current.focus();
       setTimeout(() => this.filterInputRef.current?.select(), 100);
     }

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -209,20 +209,15 @@ class BaseSingleSelect<T> extends Component<
     });
   };
 
-  private focusToInputAndSelectText = (openMenu: boolean) => {
+  private focusToInputAndSelectText = () => {
     if (!!this.filterInputRef && this.filterInputRef.current) {
-      if (openMenu) {
-        this.setState({
-          showPopover: true,
-        });
-      }
       this.filterInputRef.current.focus();
       setTimeout(() => this.filterInputRef.current?.select(), 100);
     }
   };
 
   private focusToInputAndCloseMenu = () => {
-    this.focusToInputAndSelectText(false);
+    this.focusToInputAndSelectText();
     this.setState({
       showPopover: false,
       filterMode: false,
@@ -402,7 +397,10 @@ class BaseSingleSelect<T> extends Component<
                 this.preventShowPopoverOnInputFocus = false;
               }}
               onClick={() => {
-                this.focusToInputAndSelectText(true);
+                this.focusToInputAndSelectText();
+                this.setState({
+                  showPopover: true,
+                });
               }}
               onKeyDown={this.handleKeyDown}
               onBlur={this.handleBlur}
@@ -438,7 +436,7 @@ class BaseSingleSelect<T> extends Component<
                     }),
                   );
                   this.preventShowPopoverOnInputFocus = true;
-                  this.focusToInputAndSelectText(false);
+                  this.focusToInputAndSelectText();
                 }}
                 aria-hidden={true}
                 tabIndex={-1}


### PR DESCRIPTION
## Description
In SingleSelect list didn't open from clicking field after user removed selection once.
## Motivation and Context
There was bug before and this fixes it.
## How Has This Been Tested?
Tested in StyleGuidist with mac and chrome.

## Release notes
### SingleSelect
* Fixes bug. In SingleSelect list didn't open from clicking field after user removed selection once.