### PR TITLE
[Fix] External link's screen reader text and asProp

### DIFF
--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -43,7 +43,7 @@ class BaseExternalLink extends Component<ExternalLinkProps> {
         as={asProp}
       >
         {children}
-        <VisuallyHidden>{labelNewWindow}</VisuallyHidden>
+        {toNewWindow && <VisuallyHidden>{labelNewWindow}</VisuallyHidden>}
         {!hideIcon && (
           <Icon
             icon="linkExternal"

--- a/src/core/Link/Link/Link.md
+++ b/src/core/Link/Link/Link.md
@@ -51,14 +51,14 @@ import { ExternalLink } from 'suomifi-ui-components';
     toNewWindow
     labelNewWindow="Opens to a new window"
   >
-    External link
+    External link opens to new window
   </ExternalLink>
   <ExternalLink
     href="https://designsystem.suomi.fi/fi/"
     toNewWindow={false}
     labelNewWindow="Opens to same window"
   >
-    External link
+    External link in same window
   </ExternalLink>
 </>;
 ```

--- a/src/core/Link/Link/Link.md
+++ b/src/core/Link/Link/Link.md
@@ -45,12 +45,22 @@ import { SkipLink } from 'suomifi-ui-components';
 ```js
 import { ExternalLink } from 'suomifi-ui-components';
 
-<ExternalLink
-  href="https://www.sweden.se/"
-  labelNewWindow="Opens to a new window"
->
-  External link
-</ExternalLink>;
+<>
+  <ExternalLink
+    href="https://designsystem.suomi.fi/fi/"
+    toNewWindow
+    labelNewWindow="Opens to a new window"
+  >
+    External link
+  </ExternalLink>
+  <ExternalLink
+    href="https://designsystem.suomi.fi/fi/"
+    toNewWindow={false}
+    labelNewWindow="Opens to same window"
+  >
+    External link
+  </ExternalLink>
+</>;
 ```
 
 ### Change component for the link
@@ -65,7 +75,7 @@ const Component = ({ children, ...passProps }) => (
 <Link
   className="test-classname"
   href="https://www.com/"
-  as={Component}
+  asProp={Component}
 >
   Testing
 </Link>;


### PR DESCRIPTION
## Description
* In External link screen reader read labelNewWindow text even if it was not opening to new window. This is fixed.
* Prop was wrongly used in example. as={Component} is renamed to asProp={Component}
## Motivation and Context
There were bugs before and this fixes them.
## How Has This Been Tested?
Tested in StyleGuidist with mac and chrome.

## Release notes
### SingleSelect
* In External link screen reader read labelNewWindow text even if it was not opening to new window. This is fixed.
* Prop was wrongly used in example. as={Component} is renamed to asProp={Component}