### PR TITLE
[Feature] Multiline chips

### DIFF
--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -9,7 +9,6 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
   padding: ${theme.spacing.insetXxs} ${theme.spacing.insetL};
   color: ${theme.colors.whiteBase};
   background: ${theme.colors.highlightBase};
-  max-height: 28px;
 
   &:focus {
     outline: 0;
@@ -31,8 +30,6 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
 
     & .fi-chip--content {
       display: block;
-      max-width: 100%;
-      white-space: normal;
       word-break: break-word;
       overflow: hidden;
       line-height: 1.5em;

--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -22,14 +22,19 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
   }
 
   &.fi-chip {
+    border-radius: 14px;
+    padding: ${theme.spacing.insetXxs} ${theme.spacing.insetL};
+    color: ${theme.colors.whiteBase};
+    background: ${theme.colors.highlightBase};
+    max-height: 100%;
     display: inline-block;
 
     & .fi-chip--content {
-      display: inline-block;
-      max-width: 270px;
-      white-space: nowrap;
+      display: block;
+      max-width: 100%;
+      white-space: normal;
+      word-break: break-word;
       overflow: hidden;
-      text-overflow: ellipsis;
       line-height: 1.5em;
     }
   }

--- a/src/core/Chip/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip/Chip.baseStyles.tsx
@@ -31,7 +31,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     & .fi-chip--content {
-      max-width: 248px;
       margin-right: ${theme.spacing.xs};
     }
 

--- a/src/core/Chip/Chip/Chip.md
+++ b/src/core/Chip/Chip/Chip.md
@@ -42,8 +42,9 @@ const chipStyle = {
   </div>
 
   <Chip>
-    Chip with a long content that doesn't fit into the component's
-    maximum width of 290px
+    Chip with a
+    reallyReallyLongWeirdWordThatNeedsToBeBrokenToFitInToTheChip and
+    content that doesn't fit in one line and spans multiple lines.
   </Chip>
 
   <Chip disabled>Disabled chip</Chip>

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -128,15 +128,20 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
   display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
-  display: inline-block;
-  max-width: 270px;
-  white-space: nowrap;
+  display: block;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
   overflow: hidden;
-  text-overflow: ellipsis;
   line-height: 1.5em;
 }
 
@@ -179,7 +184,6 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-chip--removable .fi-chip--content {
-  max-width: 248px;
   margin-right: 10px;
 }
 
@@ -334,15 +338,20 @@ exports[`classnames should match snapshot 1`] = `
 }
 
 .c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
   display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
-  display: inline-block;
-  max-width: 270px;
-  white-space: nowrap;
+  display: block;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
   overflow: hidden;
-  text-overflow: ellipsis;
   line-height: 1.5em;
 }
 
@@ -385,7 +394,6 @@ exports[`classnames should match snapshot 1`] = `
 }
 
 .c1.fi-chip--removable .fi-chip--content {
-  max-width: 248px;
   margin-right: 10px;
 }
 
@@ -536,15 +544,20 @@ exports[`disabled should match snapshot 1`] = `
 }
 
 .c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
   display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
-  display: inline-block;
-  max-width: 270px;
-  white-space: nowrap;
+  display: block;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
   overflow: hidden;
-  text-overflow: ellipsis;
   line-height: 1.5em;
 }
 
@@ -587,7 +600,6 @@ exports[`disabled should match snapshot 1`] = `
 }
 
 .c1.fi-chip--removable .fi-chip--content {
-  max-width: 248px;
   margin-right: 10px;
 }
 

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -102,7 +102,6 @@ exports[`children should match snapshot 1`] = `
   padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
-  max-height: 28px;
 }
 
 .c1:focus {
@@ -138,8 +137,6 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-chip .fi-chip--content {
   display: block;
-  max-width: 100%;
-  white-space: normal;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;
@@ -312,7 +309,6 @@ exports[`classnames should match snapshot 1`] = `
   padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
-  max-height: 28px;
 }
 
 .c1:focus {
@@ -348,8 +344,6 @@ exports[`classnames should match snapshot 1`] = `
 
 .c1.fi-chip .fi-chip--content {
   display: block;
-  max-width: 100%;
-  white-space: normal;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;
@@ -518,7 +512,6 @@ exports[`disabled should match snapshot 1`] = `
   padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
-  max-height: 28px;
 }
 
 .c1:focus {
@@ -554,8 +547,6 @@ exports[`disabled should match snapshot 1`] = `
 
 .c1.fi-chip .fi-chip--content {
   display: block;
-  max-width: 100%;
-  white-space: normal;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;

--- a/src/core/Chip/StaticChip/StaticChip.md
+++ b/src/core/Chip/StaticChip/StaticChip.md
@@ -16,8 +16,9 @@ const chipStyle = {
     </StaticChip>
   </div>
   <StaticChip>
-    StaticChip with a long content that doesn't fit into the
-    component's maximum width of 290px
+    Static chip with a
+    reallyReallyLongWeirdWordThatNeedsToBeBrokenToFitInToTheChip and
+    content that doesn't fit in one line and spans multiple lines.
   </StaticChip>
 </>;
 ```

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -49,7 +49,6 @@ exports[`children should match snapshot 1`] = `
   padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
-  max-height: 28px;
 }
 
 .c1:focus {
@@ -85,8 +84,6 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-chip .fi-chip--content {
   display: block;
-  max-width: 100%;
-  white-space: normal;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;
@@ -168,7 +165,6 @@ exports[`classnames should match snapshot 1`] = `
   padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
-  max-height: 28px;
 }
 
 .c1:focus {
@@ -204,8 +200,6 @@ exports[`classnames should match snapshot 1`] = `
 
 .c1.fi-chip .fi-chip--content {
   display: block;
-  max-width: 100%;
-  white-space: normal;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;
@@ -283,7 +277,6 @@ exports[`disabled should match snapshot 1`] = `
   padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
-  max-height: 28px;
 }
 
 .c1:focus {
@@ -319,8 +312,6 @@ exports[`disabled should match snapshot 1`] = `
 
 .c1.fi-chip .fi-chip--content {
   display: block;
-  max-width: 100%;
-  white-space: normal;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -75,15 +75,20 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
   display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
-  display: inline-block;
-  max-width: 270px;
-  white-space: nowrap;
+  display: block;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
   overflow: hidden;
-  text-overflow: ellipsis;
   line-height: 1.5em;
 }
 
@@ -189,15 +194,20 @@ exports[`classnames should match snapshot 1`] = `
 }
 
 .c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
   display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
-  display: inline-block;
-  max-width: 270px;
-  white-space: nowrap;
+  display: block;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
   overflow: hidden;
-  text-overflow: ellipsis;
   line-height: 1.5em;
 }
 
@@ -299,15 +309,20 @@ exports[`disabled should match snapshot 1`] = `
 }
 
 .c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
   display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
-  display: inline-block;
-  max-width: 270px;
-  white-space: nowrap;
+  display: block;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
   overflow: hidden;
-  text-overflow: ellipsis;
   line-height: 1.5em;
 }
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -447,7 +447,6 @@ exports[`has matching snapshot 1`] = `
   padding: 2px 10px;
   color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
-  max-height: 28px;
 }
 
 .c9:focus {
@@ -483,8 +482,6 @@ exports[`has matching snapshot 1`] = `
 
 .c9.fi-chip .fi-chip--content {
   display: block;
-  max-width: 100%;
-  white-space: normal;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -473,15 +473,20 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c9.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
   display: inline-block;
 }
 
 .c9.fi-chip .fi-chip--content {
-  display: inline-block;
-  max-width: 270px;
-  white-space: nowrap;
+  display: block;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
   overflow: hidden;
-  text-overflow: ellipsis;
   line-height: 1.5em;
 }
 
@@ -524,7 +529,6 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c9.fi-chip--removable .fi-chip--content {
-  max-width: 248px;
   margin-right: 10px;
 }
 


### PR DESCRIPTION
## Description
This PR change Chip and StaticChip styles to allow content spanning to multiple lines. In addition, ellipsis styles have been removed and long words break to prevent overflow.

Related snapshots have been updated.

## Motivation and Context
Quite often the max-width of the chip was not sufficient for real life use cases and using ellipsis did not solve the issue as users were not able to see the whole text content of a chip.

## How Has This Been Tested?
Tested using MacOs, Chrome and Styleguidist build.

## Screenshots (if appropriate):
![Screenshot 2022-03-11 at 12 35 59](https://user-images.githubusercontent.com/53744258/157856050-1a6372dc-7259-4ec3-897f-a62902617141.png)

![Screenshot 2022-03-11 at 12 36 34](https://user-images.githubusercontent.com/53744258/157856070-90e823f9-19b6-4f28-9400-6f667955b931.png)

![Screenshot 2022-03-11 at 12 50 42](https://user-images.githubusercontent.com/53744258/157856087-266ea7b7-f6df-4449-936b-e2d96edf71c5.png)


## Release notes
Chip & StaticChip
- Add support for multiline content
- Remove ellipsis
