### PR TITLE
[Fix] SingleSelect async support

### DIFF
--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -89,7 +89,10 @@ export interface FilterInputProps extends InternalFilterInputProps<any> {
 
 class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
   componentDidUpdate(prevProps: FilterInputProps) {
-    if (!!this.props.onFilter && prevProps.value !== this.props.value) {
+    if (
+      (!!this.props.onFilter && prevProps.value !== this.props.value) ||
+      prevProps.items !== this.props.items
+    ) {
       const value = !!this.props.value ? this.props.value.toString() : '';
       this.props.onFilter(
         this.filterItems(this.props.items, this.props.filterFunc, value),

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -141,13 +141,18 @@ class BaseSingleSelect<T> extends Component<
     const selectedItemChanged =
       'selectedItem' in nextProps &&
       selectedItem?.uniqueItemId !== prevState.selectedItem?.uniqueItemId;
+
     if (selectedItemChanged || propItems !== prevState.initialItems) {
       const resolvedSelectedItem =
         'selectedItem' in nextProps ? selectedItem : prevState.selectedItem;
+      const resolvedInputValue = selectedItemChanged
+        ? resolvedSelectedItem?.labelText
+        : prevState.filterInputValue;
+
       return {
         selectedItem: resolvedSelectedItem,
         filteredItems: propItems,
-        filterInputValue: resolvedSelectedItem?.labelText || '',
+        filterInputValue: resolvedInputValue,
         filterMode: prevState.filterMode,
         initialItems: propItems,
       };


### PR DESCRIPTION
## Description
SingleSelect had some undesired behavior when loading list of options asynchronously. When the new list was loaded, the previous selection appeared in the input even if there was some filter text in there. This PR fixes the issue. 

As changes were made to FilterInput, MultiSelect was possibly affected as well, but I did not encounter any adverse side effects upon testing.

## Motivation and Context
This was a bug reported by a service using the components.

## How Has This Been Tested?
So far in styleguidist (Win + Chrome) with delayed changes to the item list applied to simulate asynchronous content.

## Release notes
### SingleSelect
* Improve behaviour with asynchronous content
