### PR TITLE
[Fix] Notification button styles and structure

### DIFF
--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -13,7 +13,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   padding-bottom: 10px;
   &.fi-notification {
     & .fi-notification_style-wrapper {
-      padding: 0 33px 10px 41px;
+      padding: 0 32px 10px 40px;
       display: flex;
       align-items: flex-start;
       overflow: hidden;
@@ -35,7 +35,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       margin-bottom: ${theme.spacing.xxs};
     }
     & .fi-notification_action-element-wrapper {
-      padding: 20px 26px 19px 87px;
+      padding: 20px 26px 19px 84px;
       & .fi-button {
         margin-top: ${theme.spacing.xs};
         margin-right: ${theme.spacing.s};
@@ -58,7 +58,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       display: inline-block;
       padding: 7px;
       margin-top: 11px;
-      margin-right: ${theme.spacing.xs};
       border: 1px solid transparent;
       border-radius: ${theme.radius.basic};
       white-space: nowrap;

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -8,10 +8,14 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};
   border-radius: 4px;
+  display: block;
   justify-content: space-between;
   padding-bottom: 10px;
   &.fi-notification {
-    & .fi-notification_element-wrapper {
+    & .fi-notification_style-wrapper {
+      padding: 0 33px 10px 41px;
+      display: flex;
+      align-items: flex-start;
       overflow: hidden;
     }
 
@@ -28,6 +32,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
     & .fi-notification_heading {
       ${font(theme)('bodySemiBold')}
+      margin-bottom: ${theme.spacing.xxs};
     }
     & .fi-notification_action-element-wrapper {
       padding: 20px 26px 19px 87px;
@@ -41,7 +46,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
     .fi-notification_icon-wrapper {
       padding-top: 20px;
-      flex: 0;
+      flex: none;
       & .fi-notification_icon {
         height: 24px;
         width: 24px;
@@ -80,12 +85,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       &:hover {
         border-color: ${theme.colors.blackBase};
       }
-    }
-    & .fi-notification_style-wrapper {
-      padding: 0 33px 10px 41px;
-      display: flex;
-      align-items: flex-start;
-      overflow: hidden;
     }
 
     /* Status variant styles */

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -16,20 +16,18 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     & .fi-notification_text-content-wrapper {
-      padding-top: 18px;
+      padding-top: 20px;
       padding-left: 20px;
       flex-grow: 1;
       & .fi-notification_content {
         vertical-align: middle;
         & .fi-notification_contentWrapper {
-          padding-top: 3px;
           ${font(theme)('bodyTextSmall')}
         }
       }
     }
     & .fi-notification_heading {
       ${font(theme)('bodySemiBold')}
-      margin: 1px 0 0 0;
     }
     & .fi-notification_action-element-wrapper {
       padding: 20px 26px 19px 87px;
@@ -42,7 +40,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
     .fi-notification_icon-wrapper {
-      padding-top: 21px;
+      padding-top: 20px;
       flex: 0;
       & .fi-notification_icon {
         height: 24px;
@@ -51,26 +49,21 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
     & .fi-notification_close-button {
       ${font(theme)('bodyTextSmall')}
-      flex: 1 0 auto;
-      flex-wrap: nowrap;
-      display: flex;
-      box-sizing: border-box;
+      height: 40px;
+      display: inline-block;
+      padding: 7px;
       margin-top: 11px;
-      margin-right: -5px;
-      margin-bottom: 0;
-      max-width: 50%;
-      min-width: 40px;
-      text-align: right;
-      padding: 7px 8px;
+      margin-right: ${theme.spacing.xs};
       border: 1px solid transparent;
       border-radius: ${theme.radius.basic};
+      white-space: nowrap;
       text-transform: uppercase;
-      flex-grow: 0;
+
       & .fi-icon {
         width: 14px;
         height: 14px;
-        margin-top: 6px;
-        padding-left: 7px;
+        margin-left: ${theme.spacing.xxs};
+        transform: translateY(0.1em);
       }
 
       &:focus-visible {
@@ -119,13 +112,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         flex-direction: column;
       }
       & .fi-notification_close-button {
-        justify-content: flex-end;
-        flex-direction: row;
-        padding: 13px;
         margin: 3px;
-        svg {
-          padding: 0;
-          margin: 0;
+        & .fi-icon {
+          margin-right: ${theme.spacing.xxs};
         }
       }
       & .fi-notification_style-wrapper {

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -18,7 +18,6 @@ import { baseStyles } from './Notification.baseStyles';
 
 export const baseClassName = 'fi-notification';
 export const notificationClassNames = {
-  elementWrapper: `${baseClassName}_element-wrapper`,
   styleWrapper: `${baseClassName}_style-wrapper`,
   content: `${baseClassName}_content`,
   contentWrapper: `${baseClassName}_contentWrapper`,
@@ -102,65 +101,54 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
           },
         )}
       >
-        <HtmlDiv
-          className={notificationClassNames.elementWrapper}
-          style={style}
-        >
-          <HtmlDiv
-            className={notificationClassNames.styleWrapper}
-            style={style}
-          >
-            <HtmlDiv className={notificationClassNames.iconWrapper}>
-              <Icon
-                icon={variantIcon}
-                className={notificationClassNames.icon}
-              />
-            </HtmlDiv>
+        <HtmlDiv className={notificationClassNames.styleWrapper} style={style}>
+          <HtmlDiv className={notificationClassNames.iconWrapper}>
+            <Icon icon={variantIcon} className={notificationClassNames.icon} />
+          </HtmlDiv>
 
-            <HtmlDiv
-              className={notificationClassNames.textContentWrapper}
-              id={id}
-              aria-live={ariaLiveMode}
-            >
-              <HtmlDiv className={notificationClassNames.content}>
-                {headingText && (
-                  <Heading
-                    variant={headingVariant}
-                    className={notificationClassNames.heading}
-                  >
-                    {headingText}
-                  </Heading>
-                )}
-                <HtmlDiv className={notificationClassNames.contentWrapper}>
-                  {children}
-                </HtmlDiv>
+          <HtmlDiv
+            className={notificationClassNames.textContentWrapper}
+            id={id}
+            aria-live={ariaLiveMode}
+          >
+            <HtmlDiv className={notificationClassNames.content}>
+              {headingText && (
+                <Heading
+                  variant={headingVariant}
+                  className={notificationClassNames.heading}
+                >
+                  {headingText}
+                </Heading>
+              )}
+              <HtmlDiv className={notificationClassNames.contentWrapper}>
+                {children}
               </HtmlDiv>
             </HtmlDiv>
-            <HtmlButton
-              className={classnames(
-                notificationClassNames.closeButton,
-                customCloseButtonClassName,
-              )}
-              {...getConditionalAriaProp('aria-label', [
-                smallScreen ? closeText : undefined,
-              ])}
-              {...getConditionalAriaProp('aria-describedby', [
-                id,
-                closeButtonPropsAriaDescribedBy,
-              ])}
-              onClick={onCloseButtonClick}
-              {...closeButtonPassProps}
-            >
-              {!smallScreen ? closeText : ''}
-              <Icon icon="close" />
-            </HtmlButton>
           </HtmlDiv>
-          {actionElements && (
-            <HtmlDiv className={notificationClassNames.actionElementWrapper}>
-              {actionElements}
-            </HtmlDiv>
-          )}
+          <HtmlButton
+            className={classnames(
+              notificationClassNames.closeButton,
+              customCloseButtonClassName,
+            )}
+            {...getConditionalAriaProp('aria-label', [
+              smallScreen ? closeText : undefined,
+            ])}
+            {...getConditionalAriaProp('aria-describedby', [
+              id,
+              closeButtonPropsAriaDescribedBy,
+            ])}
+            onClick={onCloseButtonClick}
+            {...closeButtonPassProps}
+          >
+            {!smallScreen ? closeText : ''}
+            <Icon icon="close" />
+          </HtmlButton>
         </HtmlDiv>
+        {actionElements && (
+          <HtmlDiv className={notificationClassNames.actionElementWrapper}>
+            {actionElements}
+          </HtmlDiv>
+        )}
       </HtmlDivWithRef>
     );
   }

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -453,7 +453,7 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-notification .fi-notification_text-content-wrapper {
-  padding-top: 18px;
+  padding-top: 20px;
   padding-left: 20px;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -466,7 +466,6 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-notification .fi-notification_text-content-wrapper .fi-notification_content .fi-notification_contentWrapper {
-  padding-top: 3px;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -496,7 +495,6 @@ exports[`props children should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
-  margin: 1px 0 0 0;
 }
 
 .c1.fi-notification .fi-notification_action-element-wrapper {
@@ -513,7 +511,7 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-notification .fi-notification_icon-wrapper {
-  padding-top: 21px;
+  padding-top: 20px;
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
@@ -538,38 +536,24 @@ exports[`props children should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  box-sizing: border-box;
+  height: 40px;
+  display: inline-block;
+  padding: 7px;
   margin-top: 11px;
-  margin-right: -5px;
-  margin-bottom: 0;
-  max-width: 50%;
-  min-width: 40px;
-  text-align: right;
-  padding: 7px 8px;
+  margin-right: 10px;
   border: 1px solid transparent;
   border-radius: 2px;
+  white-space: nowrap;
   text-transform: uppercase;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
 }
 
 .c1.fi-notification .fi-notification_close-button .fi-icon {
   width: 14px;
   height: 14px;
-  margin-top: 6px;
-  padding-left: 7px;
+  margin-left: 5px;
+  -webkit-transform: translateY(0.1em);
+  -ms-transform: translateY(0.1em);
+  transform: translateY(0.1em);
 }
 
 .c1.fi-notification .fi-notification_close-button:focus-visible {
@@ -648,20 +632,11 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-notification.fi-notification--small-screen .fi-notification_close-button {
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  padding: 13px;
   margin: 3px;
 }
 
-.c1.fi-notification.fi-notification--small-screen .fi-notification_close-button svg {
-  padding: 0;
-  margin: 0;
+.c1.fi-notification.fi-notification--small-screen .fi-notification_close-button .fi-icon {
+  margin-right: 5px;
 }
 
 .c1.fi-notification.fi-notification--small-screen .fi-notification_style-wrapper {

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -441,6 +441,7 @@ exports[`props children should match snapshot 1`] = `
   width: 100%;
   box-shadow: 0px 4px 8px 0px rgba(41,41,41,0.14);
   border-radius: 4px;
+  display: block;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -448,7 +449,16 @@ exports[`props children should match snapshot 1`] = `
   padding-bottom: 10px;
 }
 
-.c1.fi-notification .fi-notification_element-wrapper {
+.c1.fi-notification .fi-notification_style-wrapper {
+  padding: 0 33px 10px 41px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   overflow: hidden;
 }
 
@@ -495,6 +505,7 @@ exports[`props children should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
+  margin-bottom: 5px;
 }
 
 .c1.fi-notification .fi-notification_action-element-wrapper {
@@ -512,9 +523,9 @@ exports[`props children should match snapshot 1`] = `
 
 .c1.fi-notification .fi-notification_icon-wrapper {
   padding-top: 20px;
-  -webkit-flex: 0;
-  -ms-flex: 0;
-  flex: 0;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
 }
 
 .c1.fi-notification .fi-notification_icon-wrapper .fi-notification_icon {
@@ -585,19 +596,6 @@ exports[`props children should match snapshot 1`] = `
   border-color: hsl(0,0%,16%);
 }
 
-.c1.fi-notification .fi-notification_style-wrapper {
-  padding: 0 33px 10px 41px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  overflow: hidden;
-}
-
 .c1.fi-notification--neutral {
   border-top: 4px solid hsl(196,77%,44%);
 }
@@ -663,77 +661,73 @@ exports[`props children should match snapshot 1`] = `
     class="c0 fi-notification fi-notification--neutral c1"
   >
     <div
-      class="c2 fi-notification_element-wrapper"
+      class="c2 fi-notification_style-wrapper"
     >
       <div
-        class="c2 fi-notification_style-wrapper"
+        class="c2 fi-notification_icon-wrapper"
+      >
+        <svg
+          aria-hidden="true"
+          class="fi-icon c3 fi-notification_icon"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            class="fi-icon-base-fill"
+            d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0zm0 2C6.486 2 2 6.486 2 12s4.486 10 10 10 10-4.486 10-10S17.514 2 12 2zm.003 8a1 1 0 011 1v6h1a1 1 0 010 2H10a1 1 0 010-2h1v-5h-1a1 1 0 010-2h2.003zm-.501-5a1.5 1.5 0 01.145 2.994L11.502 8H11.5a1.5 1.5 0 110-3h.002z"
+            fill="#222"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <div
+        aria-live="polite"
+        class="c2 fi-notification_text-content-wrapper"
+        id="7"
       >
         <div
-          class="c2 fi-notification_icon-wrapper"
+          class="c2 fi-notification_content"
         >
-          <svg
-            aria-hidden="true"
-            class="fi-icon c3 fi-notification_icon"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
+          <h2
+            class="c4 fi-heading c5 fi-notification_heading fi-heading--h2"
           >
-            <path
-              class="fi-icon-base-fill"
-              d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0zm0 2C6.486 2 2 6.486 2 12s4.486 10 10 10 10-4.486 10-10S17.514 2 12 2zm.003 8a1 1 0 011 1v6h1a1 1 0 010 2H10a1 1 0 010-2h1v-5h-1a1 1 0 010-2h2.003zm-.501-5a1.5 1.5 0 01.145 2.994L11.502 8H11.5a1.5 1.5 0 110-3h.002z"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </div>
-        <div
-          aria-live="polite"
-          class="c2 fi-notification_text-content-wrapper"
-          id="7"
-        >
+            Lorem ipsum dolor sit
+          </h2>
           <div
-            class="c2 fi-notification_content"
+            class="c2 fi-notification_contentWrapper"
           >
-            <h2
-              class="c4 fi-heading c5 fi-notification_heading fi-heading--h2"
-            >
-              Lorem ipsum dolor sit
-            </h2>
-            <div
-              class="c2 fi-notification_contentWrapper"
-            >
-              <div>
-                Test notification
-              </div>
+            <div>
+              Test notification
             </div>
           </div>
         </div>
-        <button
-          aria-describedby="7"
-          class="c6 fi-notification_close-button"
-          type="button"
-        >
-          Close
-          <svg
-            aria-hidden="true"
-            class="fi-icon c3"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fi-icon-base-fill"
-              d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </button>
       </div>
+      <button
+        aria-describedby="7"
+        class="c6 fi-notification_close-button"
+        type="button"
+      >
+        Close
+        <svg
+          aria-hidden="true"
+          class="fi-icon c3"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            class="fi-icon-base-fill"
+            d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+            fill="#222"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </button>
     </div>
   </section>
 </div>

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -450,7 +450,7 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-notification .fi-notification_style-wrapper {
-  padding: 0 33px 10px 41px;
+  padding: 0 32px 10px 40px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -509,7 +509,7 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-notification .fi-notification_action-element-wrapper {
-  padding: 20px 26px 19px 87px;
+  padding: 20px 26px 19px 84px;
 }
 
 .c1.fi-notification .fi-notification_action-element-wrapper .fi-button {
@@ -551,7 +551,6 @@ exports[`props children should match snapshot 1`] = `
   display: inline-block;
   padding: 7px;
   margin-top: 11px;
-  margin-right: 10px;
   border: 1px solid transparent;
   border-radius: 2px;
   white-space: nowrap;


### PR DESCRIPTION
## Description
This PR fixes an issue with the Notification close button, where the text would span multiple lines and the icon size would change when the content was long. It also removes some unnecessary elements and styling from Notification.

## Motivation and Context
It was a bug and it was reported from multiple sources.

## How Has This Been Tested?
Tested in styleguidist with different widths and content sizes. On Windows + Chrome.

## Release notes
### Notification
* Fix button styling and clean up internal structure
