### PR TITLE
[Fix] StaticChip property extension

### DIFF
--- a/src/core/Chip/StaticChip/StaticChip.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
-import { HtmlSpan } from '../../../reset';
+import { HtmlSpan, HtmlSpanProps } from '../../../reset';
 import {
   BaseChipProps,
   baseClassName,
@@ -10,7 +10,9 @@ import {
 import { staticChipBaseStyles } from './StaticChip.baseStyles';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 
-export interface StaticChipProps extends BaseChipProps {}
+export interface StaticChipProps
+  extends BaseChipProps,
+    Omit<HtmlSpanProps, 'children'> {}
 
 class BaseChip extends Component<StaticChipProps> {
   render() {


### PR DESCRIPTION
## Description
StaticChip is semantically a `span` element, yet it did not extend `HtmlSpanProps` as it should have. This PR fixes that issue, so the properties and typings are correct in the future. 

Couldn't figure out if there are some other span props aside from children that we need to omit. Spend a moment to think about that when reviewing.

## Motivation and Context
This was bug that needed to be fixed.

## How Has This Been Tested?
Tested in a Next.js test project in order to check typings and to see if the IDE suggestions work correctly. Worked as it should.

## Release notes
### StaticChip
* Update props to extend span props
