### PR TITLE
[Feature] Disable coverage collection fo Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
 
-  collectCoverage: true,
+  collectCoverage: false,
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
   collectCoverageFrom: [


### PR DESCRIPTION
We were not utilizing the coverage reports and it just caused unwanted
delays for testing. It can be enabled again if there will rise actual
need for it.

<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Disable Jest coverage report.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

We were not utilizing the coverage reports and it just caused unwanted delays for testing. It can be enabled again if there will rise actual need for it.

## How This Can Be Tested?

Before you checkout this PR branch, run `yarn test` in some other branch, e.g `develop`.
You can see that the coverage report will be run after the tests.

Then checkout this PR and after running the tests you can no longer see the coverage report and it will finish sooner.


## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

_No need to have in release notes as this affects only internal developing of the library._