### PR TITLE
[Fix] Toast, Notification and Textarea background color

### DIFF
--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -37,6 +37,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       padding: 8px 14px 13px 10px;
       ${theme.typography.bodyTextSmall};
       width: 100%;
+      background-color: ${theme.colors.whiteBase};
 
       &:focus {
         outline: none;

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -214,6 +214,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   width: 100%;
+  background-color: hsl(0,0%,100%);
 }
 
 .c1.fi-textarea .fi-textarea_textarea:focus {

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -11,6 +11,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   display: block;
   justify-content: space-between;
   padding-bottom: 10px;
+  background-color: ${theme.colors.whiteBase};
   &.fi-notification {
     & .fi-notification_style-wrapper {
       padding: 0 32px 10px 40px;

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -11,8 +11,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   display: block;
   justify-content: space-between;
   padding-bottom: 10px;
-  background-color: ${theme.colors.whiteBase};
+
   &.fi-notification {
+    background-color: ${theme.colors.whiteBase};
     & .fi-notification_style-wrapper {
       padding: 0 32px 10px 40px;
       display: flex;

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -447,6 +447,7 @@ exports[`props children should match snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding-bottom: 10px;
+  background-color: hsl(0,0%,100%);
 }
 
 .c1.fi-notification .fi-notification_style-wrapper {

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -447,6 +447,9 @@ exports[`props children should match snapshot 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding-bottom: 10px;
+}
+
+.c1.fi-notification {
   background-color: hsl(0,0%,100%);
 }
 

--- a/src/core/Toast/Toast.baseStyles.tsx
+++ b/src/core/Toast/Toast.baseStyles.tsx
@@ -10,31 +10,31 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   box-shadow: ${theme.shadows.wideBoxShadow};
   border-radius: 4px;
   overflow: hidden;
-  background-color: ${theme.colors.whiteBase};
-
-  & .fi-toast-wrapper {
-    padding: 20px 15px;
-
-    display: flex;
-    align-items: flex-start;
-    & .fi-icon .fi-icon-base-fill {
-      fill: ${theme.colors.successBase};
-    }
-    & .fi-toast-content-wrapper {
-      vertical-align: middle;
-      ${font(theme)('bodyTextSmall')}
-    }
-    & .fi-toast-heading {
-      ${font(theme)('bodySemiBold')}
-      margin-top: -1px;
-      padding-bottom: ${theme.spacing.xxs};
-    }
-    & .fi-toast_icon-wrapper {
-      flex: 0;
-      padding-right: ${theme.spacing.xs};
-      & .fi-toast_icon {
-        height: 24px;
-        width: 24px;
+  &.fi-toast {
+    background-color: ${theme.colors.whiteBase};
+    & .fi-toast-wrapper {
+      padding: 20px 15px;
+      display: flex;
+      align-items: flex-start;
+      & .fi-icon .fi-icon-base-fill {
+        fill: ${theme.colors.successBase};
+      }
+      & .fi-toast-content-wrapper {
+        vertical-align: middle;
+        ${font(theme)('bodyTextSmall')}
+      }
+      & .fi-toast-heading {
+        ${font(theme)('bodySemiBold')}
+        margin-top: -1px;
+        padding-bottom: ${theme.spacing.xxs};
+      }
+      & .fi-toast_icon-wrapper {
+        flex: 0;
+        padding-right: ${theme.spacing.xs};
+        & .fi-toast_icon {
+          height: 24px;
+          width: 24px;
+        }
       }
     }
   }

--- a/src/core/Toast/Toast.baseStyles.tsx
+++ b/src/core/Toast/Toast.baseStyles.tsx
@@ -10,6 +10,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   box-shadow: ${theme.shadows.wideBoxShadow};
   border-radius: 4px;
   overflow: hidden;
+  background-color: ${theme.colors.whiteBase};
 
   & .fi-toast-wrapper {
     padding: 20px 15px;

--- a/src/core/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/core/Toast/__snapshots__/Toast.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`props children should match snapshot 1`] = `
   box-shadow: 0px 4px 8px 0px rgba(41,41,41,0.14);
   border-radius: 4px;
   overflow: hidden;
+  background-color: hsl(0,0%,100%);
 }
 
 .c1 .fi-toast-wrapper {

--- a/src/core/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/core/Toast/__snapshots__/Toast.test.tsx.snap
@@ -103,10 +103,13 @@ exports[`props children should match snapshot 1`] = `
   box-shadow: 0px 4px 8px 0px rgba(41,41,41,0.14);
   border-radius: 4px;
   overflow: hidden;
+}
+
+.c1.fi-toast {
   background-color: hsl(0,0%,100%);
 }
 
-.c1 .fi-toast-wrapper {
+.c1.fi-toast .fi-toast-wrapper {
   padding: 20px 15px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -118,11 +121,11 @@ exports[`props children should match snapshot 1`] = `
   align-items: flex-start;
 }
 
-.c1 .fi-toast-wrapper .fi-icon .fi-icon-base-fill {
+.c1.fi-toast .fi-toast-wrapper .fi-icon .fi-icon-base-fill {
   fill: hsl(166,90%,34%);
 }
 
-.c1 .fi-toast-wrapper .fi-toast-content-wrapper {
+.c1.fi-toast .fi-toast-wrapper .fi-toast-content-wrapper {
   vertical-align: middle;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -139,7 +142,7 @@ exports[`props children should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c1 .fi-toast-wrapper .fi-toast-heading {
+.c1.fi-toast .fi-toast-wrapper .fi-toast-heading {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -157,14 +160,14 @@ exports[`props children should match snapshot 1`] = `
   padding-bottom: 5px;
 }
 
-.c1 .fi-toast-wrapper .fi-toast_icon-wrapper {
+.c1.fi-toast .fi-toast-wrapper .fi-toast_icon-wrapper {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
   padding-right: 10px;
 }
 
-.c1 .fi-toast-wrapper .fi-toast_icon-wrapper .fi-toast_icon {
+.c1.fi-toast .fi-toast-wrapper .fi-toast_icon-wrapper .fi-toast_icon {
   height: 24px;
   width: 24px;
 }


### PR DESCRIPTION
## Description
This PR adds background `whiteBase` as background color to Toast, Notification and the input element in Textarea. Previously those took on the background color of their parent, which was not in line with how the rest of the components work. 

## Motivation and Context
Component styles should behave predictably across the library.

## How Has This Been Tested?
Tested in styleguidist on Chrome on windows by putting the components inside a div with a background color.

## Release notes
### Toast
* Add `whiteBase` as default background color 
### Notification
* Add `whiteBase` as default background color
### Textarea
* Add background color for the input element
