### PR TITLE
[Fix] Minification bug from styled-components

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,7 +44,10 @@ const plugins = (tsConfig, extractCSS) => [
       presets: ['@babel/preset-env', '@babel/preset-react'],
       plugins: [
         '@babel/plugin-transform-runtime',
-        ['styled-components', { ssr: true, displayName: false }],
+        [
+          'styled-components',
+          { ssr: true, displayName: false, minify: false }
+        ],
       ],
     },
     include: ['**/*.ts', '**/*.tsx'],


### PR DESCRIPTION
## Description

There is a bug in babel-plugin-styled-components' minification feature. It accidentally mutates some selectors by removing significant space.

There is selector `& :not(:last-child)` in FilterInput.baseStyles.tsx. After minification it will turn into `&:not(:last-child)` which is not the same selector any more.

Fixed this by disabling minification for now. I think it will take some time until that original bug will be fixed and we can't wait until that.

This bug can't be found from examples in Styleguidist as it builds components with different configuration (probably with Webpack and not Rollup).

## Motivation and Context

This is caused by my previous PR #588 as it added babel-plugin-styled-components to build config. I anticipate that that this broke at least SingleSelect component from all who use this library. And that's why I think this is important to fix.

It is not causing problems for us in [vrk-yti/yti-terminology-ui](https://github.com/VRK-YTI/yti-terminology-ui/tree/v2) right now as we don't use SingleSelect yet. But it will prevent us from using SingleSelect in future. That's not very big problem for us as we are currently using another select component.

## How Has This Been Tested?

Tested by inspecting diff in dist directory. Also tested with vrk-yti/yti-terminology-ui.

Here is also an example diff of dist/esm/core/Form/FilterInput/FilterInput.baseStyles.tsx: https://www.diffchecker.com/Oe9jwHM4

## Screenshots

![image](https://user-images.githubusercontent.com/1504091/161932528-a5900dce-2c13-4740-a95f-87fc79a47b05.png)

The bug only affected SingleSelect but not MultiSelect.

## Release notes

### SingleSelect

Fix styles of SingleSelect