### PR TITLE
[Fix] Update babel-plugin-styled-components to 2.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "7.0.0-beta.1-babel",
+  "version": "7.0.0-beta.1",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "7.0.0-beta.1",
+  "version": "7.0.0-beta.1-babel",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -181,5 +181,8 @@
     {
       "path": "dist/suomifi-ui-components.esm.js"
     }
-  ]
+  ],
+  "resolutions": {
+    "babel-plugin-styled-components": "2.0.7"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,10 +2951,10 @@ babel-plugin-polyfill-regenerator@^0.3.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
 
-"babel-plugin-styled-components@>= 1.12.0":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz#6f76c7f7224b7af7edc24a4910351948c691fc90"
-  integrity sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==
+babel-plugin-styled-components@2.0.7, "babel-plugin-styled-components@>= 1.12.0":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
+  integrity sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.0"
     "@babel/helper-module-imports" "^7.16.0"


### PR DESCRIPTION
## Description
The recent changes to the build configuration caused some styles to be broken. The cause was tracked down to be `babel-plugin-styled-components` which didn't handle some styles correctly. The bug was reported in an issue and the developers released a patch shortly after fixing the issue.

This PR updates the `babel-plugin-styled-components` to its latest version of 2.0.7, which seems to be fixing the issue.

## Motivation and Context
There was a bug and this update fixes it.

## How Has This Been Tested?
Tested in a CRA project on Windows with Chrome and Firefox.

## Release notes
### Dependencies
* Resolve `babel-plugin-styled-components` version to 2.0.7
