### PR TITLE
[Fix] Remove parted member from code owners list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @LJKaski @ketsappi @valger11
+*       @LJKaski @ketsappi


### PR DESCRIPTION
## Description
This PR removes a previous member of the team from the code owners list.

## Motivation and Context
Former members should no longer be marked as code owners.

## Release notes
### Other changes:
* Update github code owners list
