### PR TITLE
[Feature] Disabled state to SingleSelect & MultiSelect

### DIFF
--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -88,6 +88,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       color: ${theme.colors.depthBase};
       background-color: ${theme.colors.depthLight3};
       border-color: ${theme.colors.depthLight1};
+      cursor: not-allowed;
     }
   }
 

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -311,6 +311,7 @@ exports[`snapshot matches 1`] = `
   color: hsl(202,7%,67%);
   background-color: hsl(202,7%,97%);
   border-color: hsl(202,7%,80%);
+  cursor: not-allowed;
 }
 
 .c1.fi-filter-input--label-align-left .fi-filter-input_wrapper {

--- a/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
+++ b/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
@@ -25,4 +25,16 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
   }
+
+  &[disabled],
+  &:disabled {
+    cursor: not-allowed;
+    &.fi-input-clear-button {
+      & .fi-input-clear-button_icon {
+        & .fi-icon-base-fill {
+          fill: ${theme.colors.depthBase};
+        }
+      }
+    }
+  }
 `;

--- a/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
+++ b/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
@@ -24,12 +24,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         fill: ${theme.colors.highlightDark1};
       }
     }
-  }
 
-  &[disabled],
-  &:disabled {
-    cursor: not-allowed;
-    &.fi-input-clear-button {
+    &[disabled],
+    &:disabled {
+      cursor: not-allowed;
       & .fi-input-clear-button_icon {
         & .fi-icon-base-fill {
           fill: ${theme.colors.depthBase};

--- a/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
+++ b/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
@@ -20,12 +20,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         fill: ${theme.colors.blackBase};
       }
     }
-  }
 
-  &[disabled],
-  &:disabled {
-    cursor: not-allowed;
-    &.fi-input-toggle-button {
+    &[disabled],
+    &:disabled {
+      cursor: not-allowed;
       & .fi-input-toggle-button_icon {
         & .fi-icon-base-fill {
           fill: ${theme.colors.depthBase};

--- a/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
+++ b/src/core/Form/InputToggleButton/InputToggleButton.baseStyles.ts
@@ -21,4 +21,16 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
   }
+
+  &[disabled],
+  &:disabled {
+    cursor: not-allowed;
+    &.fi-input-toggle-button {
+      & .fi-input-toggle-button_icon {
+        & .fi-icon-base-fill {
+          fill: ${theme.colors.depthBase};
+        }
+      }
+    }
+  }
 `;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -269,6 +269,16 @@ exports[`snapshot should have matching default structure 1`] = `
   z-index: 9999;
 }
 
+.c6[disabled],
+.c6:disabled {
+  cursor: not-allowed;
+}
+
+.c6[disabled].fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill,
+.c6:disabled.fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,67%);
+}
+
 .c6.fi-input-clear-button {
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -269,16 +269,6 @@ exports[`snapshot should have matching default structure 1`] = `
   z-index: 9999;
 }
 
-.c6[disabled],
-.c6:disabled {
-  cursor: not-allowed;
-}
-
-.c6[disabled].fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill,
-.c6:disabled.fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill {
-  fill: hsl(202,7%,67%);
-}
-
 .c6.fi-input-clear-button {
   display: -webkit-box;
   display: -webkit-flex;
@@ -293,6 +283,16 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c6.fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill {
   fill: hsl(212,63%,37%);
+}
+
+.c6[disabled],
+.c6:disabled {
+  cursor: not-allowed;
+}
+
+.c6[disabled].fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill,
+.c6:disabled.fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,67%);
 }
 
 .c1 {

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -285,13 +285,13 @@ exports[`snapshot should have matching default structure 1`] = `
   fill: hsl(212,63%,37%);
 }
 
-.c6[disabled],
-.c6:disabled {
+.c6.fi-input-clear-button[disabled],
+.c6.fi-input-clear-button:disabled {
   cursor: not-allowed;
 }
 
-.c6[disabled].fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill,
-.c6:disabled.fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill {
+.c6.fi-input-clear-button[disabled] .fi-input-clear-button_icon .fi-icon-base-fill,
+.c6.fi-input-clear-button:disabled .fi-input-clear-button_icon .fi-icon-base-fill {
   fill: hsl(202,7%,67%);
 }
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -169,9 +169,9 @@ const foods = [
       items={foods}
       labelText="Food"
       visualPlaceholder="Selection disabled"
-      ariaSelectedAmountText=""
-      ariaOptionsAvailableText=""
-      ariaOptionChipRemovedText=""
+      ariaSelectedAmountText="foods selected"
+      ariaOptionsAvailableText="options available"
+      ariaOptionChipRemovedText="removed"
     />
 </>
 ```

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -169,7 +169,7 @@ const foods = [
       items={foods}
       labelText="Food"
       visualPlaceholder="Selection disabled"
-      ariaSelectedAmountText="foods selected"
+      ariaSelectedAmountText="items selected"
       ariaOptionsAvailableText="options available"
       ariaOptionChipRemovedText="removed"
     />

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -148,3 +148,30 @@ const animals = [
     <button onClick={() => setSelectedAnimals([{ labelText: 'Snail', uniqueItemId: 'snail-321' }])}>Snail</button>
 </>
 ```
+
+### Disabled
+
+```
+const foods = [
+  {
+    labelText: 'Pizza',
+    uniqueItemId: 'pizza-123'
+  },
+  {
+    labelText: 'Burger',
+    uniqueItemId: 'burger-321'
+  }
+];
+
+<>
+    <MultiSelect
+      disabled={true}
+      items={foods}
+      labelText="Food"
+      visualPlaceholder="Selection disabled"
+      ariaSelectedAmountText=""
+      ariaOptionsAvailableText=""
+      ariaOptionChipRemovedText=""
+    />
+</>
+```

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -640,3 +640,28 @@ describe('status', () => {
     expect(container.firstChild).toHaveClass('fi-multiselect--error');
   });
 });
+
+describe('disabled', () => {
+  it('should not be interactive while disabled', async () => {
+    const { getAllByRole, container } = render(
+      <MultiSelect
+        disabled={true}
+        labelText="Tools"
+        items={tools}
+        noItemsText="No items"
+        ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
+      />,
+    );
+
+    const toggleBtn = container.querySelector('.fi-input-toggle-button');
+    expect(toggleBtn).not.toBe(null);
+    if (toggleBtn) {
+      await act(async () => {
+        fireEvent.click(toggleBtn);
+      });
+      expect(() => getAllByRole('option')).toThrowError();
+    }
+  });
+});

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -104,6 +104,8 @@ export interface MultiSelectProps<T extends MultiSelectData> {
    * E.g 'removed' as prop value would result in '{option} removed' being read by screen reader upon removal.
    */
   ariaOptionChipRemovedText: string;
+  /** Disable the input */
+  disabled?: boolean;
 }
 
 interface MultiSelectState<T extends MultiSelectData> {
@@ -378,6 +380,13 @@ class BaseMultiSelect<T> extends Component<
     }
   }
 
+  private disableItems(items: MultiSelectData[]): MultiSelectData[] {
+    return items.map((item) => ({
+      ...item,
+      disabled: true,
+    }));
+  }
+
   render() {
     const {
       filteredItems,
@@ -414,6 +423,7 @@ class BaseMultiSelect<T> extends Component<
       ariaSelectedAmountText,
       ariaOptionsAvailableText,
       ariaOptionChipRemovedText,
+      disabled,
       ...passProps
     } = this.props;
 
@@ -484,6 +494,7 @@ class BaseMultiSelect<T> extends Component<
                   status={status}
                   statusText={statusText}
                   aria-controls={popoverItemListId}
+                  disabled={disabled}
                 >
                   <InputToggleButton
                     open={showPopover}
@@ -491,6 +502,7 @@ class BaseMultiSelect<T> extends Component<
                     onClick={(event) => this.handleToggleButtonClick(event)}
                     aria-hidden={true}
                     tabIndex={-1}
+                    disabled={disabled}
                   />
                 </FilterInput>
               )}
@@ -541,7 +553,9 @@ class BaseMultiSelect<T> extends Component<
             {chipListVisible && (
               <MultiSelectChipList
                 sourceRef={this.filterInputRef}
-                selectedItems={selectedItems}
+                selectedItems={
+                  disabled ? this.disableItems(selectedItems) : selectedItems
+                }
                 ariaChipActionLabel={ariaChipActionLabel}
                 onClick={(item: MultiSelectData & T) => {
                   if (!!this.chipRemovalAnnounceTimeOut) {
@@ -561,7 +575,9 @@ class BaseMultiSelect<T> extends Component<
             )}
             <MultiSelectRemoveAllButton
               className={multiSelectClassNames.removeAllButton}
-              selectedItems={selectedItems}
+              selectedItems={
+                disabled ? this.disableItems(selectedItems) : selectedItems
+              }
               onClick={this.handleRemoveAllSelections}
             >
               {removeAllButtonLabel}

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -380,12 +380,11 @@ class BaseMultiSelect<T> extends Component<
     }
   }
 
-  private disableItems(items: MultiSelectData[]): MultiSelectData[] {
-    return items.map((item) => ({
+  private disableItems = (items: MultiSelectData[]): MultiSelectData[] =>
+    items.map((item) => ({
       ...item,
       disabled: true,
     }));
-  }
 
   render() {
     const {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -824,13 +824,13 @@ exports[`has matching snapshot 1`] = `
   fill: hsl(0,0%,16%);
 }
 
-.c7[disabled],
-.c7:disabled {
+.c7.fi-input-toggle-button[disabled],
+.c7.fi-input-toggle-button:disabled {
   cursor: not-allowed;
 }
 
-.c7[disabled].fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill,
-.c7:disabled.fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill {
+.c7.fi-input-toggle-button[disabled] .fi-input-toggle-button_icon .fi-icon-base-fill,
+.c7.fi-input-toggle-button:disabled .fi-input-toggle-button_icon .fi-icon-base-fill {
   fill: hsl(202,7%,67%);
 }
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -376,6 +376,7 @@ exports[`has matching snapshot 1`] = `
   color: hsl(202,7%,67%);
   background-color: hsl(202,7%,97%);
   border-color: hsl(202,7%,80%);
+  cursor: not-allowed;
 }
 
 .c2.fi-filter-input--label-align-left .fi-filter-input_wrapper {
@@ -821,6 +822,16 @@ exports[`has matching snapshot 1`] = `
 
 .c7.fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill {
   fill: hsl(0,0%,16%);
+}
+
+.c7[disabled],
+.c7:disabled {
+  cursor: not-allowed;
+}
+
+.c7[disabled].fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill,
+.c7:disabled.fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,67%);
 }
 
 .c1 {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -176,3 +176,35 @@ const animals = [
   </button>
 </>;
 ```
+
+### Disabled with a preselected value
+
+```js
+import { SingleSelect } from 'suomifi-ui-components';
+const foods = [
+  {
+    labelText: 'Pizza',
+    uniqueItemId: 'pizza-123'
+  },
+  {
+    labelText: 'Burger',
+    uniqueItemId: 'burger-123'
+  }
+];
+const defaultSelectedFood = {
+  labelText: 'Pizza',
+  uniqueItemId: 'pizza-123'
+};
+
+<>
+  <SingleSelect
+    disabled={true}
+    labelText="Food"
+    clearButtonLabel="Clear selection"
+    items={foods}
+    selectedItem={defaultSelectedFood}
+    noItemsText="No matching options"
+    ariaOptionsAvailableText="Options available"
+  />
+</>;
+```

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -376,7 +376,7 @@ describe('status', () => {
 
 describe('disabled', () => {
   it('should not be interactive while disabled', async () => {
-    const { getByRole, queryAllByRole } = render(
+    const { getByRole, getAllByRole } = render(
       <SingleSelect
         disabled={true}
         labelText="Tools"
@@ -390,7 +390,6 @@ describe('disabled', () => {
     await act(async () => {
       fireEvent.click(input);
     });
-    const options = queryAllByRole('option');
-    expect(options).toEqual([]);
+    expect(() => getAllByRole('option')).toThrowError();
   });
 });

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -265,6 +265,7 @@ test('option: should be selected when clicked', async () => {
     await act(async () => {
       fireEvent.click(input);
     });
+
     const option = await waitFor(() => getByText('Rake'));
     await act(async () => {
       fireEvent.click(option);
@@ -370,5 +371,26 @@ describe('status', () => {
       />,
     );
     expect(container.firstChild).toHaveClass('fi-single-select--error');
+  });
+});
+
+describe('disabled', () => {
+  it('should not be interactive while disabled', async () => {
+    const { getByRole, queryAllByRole } = render(
+      <SingleSelect
+        disabled={true}
+        labelText="Tools"
+        clearButtonLabel="Clear selection"
+        items={tools}
+        noItemsText="No matching options"
+        ariaOptionsAvailableText="Options available"
+      />,
+    );
+    const input = getByRole('textbox');
+    await act(async () => {
+      fireEvent.click(input);
+    });
+    const options = queryAllByRole('option');
+    expect(options).toEqual([]);
   });
 });

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -84,6 +84,8 @@ export interface SingleSelectProps<T extends SingleSelectData> {
   selectedItem?: T & SingleSelectData;
   /** Selecting the item will send event with the id */
   onItemSelect?: (uniqueItemId: string | null) => void;
+  /** Disable the input */
+  disabled?: boolean;
 }
 
 interface SingleSelectState<T extends SingleSelectData> {
@@ -354,6 +356,7 @@ class BaseSingleSelect<T> extends Component<
       clearButtonLabel,
       ariaOptionsAvailableText,
       onItemSelect,
+      disabled,
       ...passProps
     } = this.props;
 
@@ -419,6 +422,7 @@ class BaseSingleSelect<T> extends Component<
               visualPlaceholder={!selectedItem ? visualPlaceholder : ''}
               status={status}
               statusText={statusText}
+              disabled={disabled}
             >
               {!!selectedItem && (
                 <HtmlDiv className={singleSelectClassNames.clearButtonWrapper}>
@@ -427,6 +431,7 @@ class BaseSingleSelect<T> extends Component<
                     onClick={() => this.handleItemSelection(null)}
                     onBlur={this.handleBlur}
                     label={clearButtonLabel}
+                    disabled={disabled}
                   />
                 </HtmlDiv>
               )}
@@ -445,6 +450,7 @@ class BaseSingleSelect<T> extends Component<
                 }}
                 aria-hidden={true}
                 tabIndex={-1}
+                disabled={disabled}
               />
             </FilterInput>
           )}

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -397,6 +397,7 @@ exports[`has matching snapshot 1`] = `
   color: hsl(202,7%,67%);
   background-color: hsl(202,7%,97%);
   border-color: hsl(202,7%,80%);
+  cursor: not-allowed;
 }
 
 .c2.fi-filter-input--label-align-left .fi-filter-input_wrapper {
@@ -485,6 +486,16 @@ exports[`has matching snapshot 1`] = `
   z-index: 9999;
 }
 
+.c8[disabled],
+.c8:disabled {
+  cursor: not-allowed;
+}
+
+.c8[disabled].fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill,
+.c8:disabled.fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,67%);
+}
+
 .c8.fi-input-clear-button {
   display: -webkit-box;
   display: -webkit-flex;
@@ -514,6 +525,16 @@ exports[`has matching snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c11[disabled],
+.c11:disabled {
+  cursor: not-allowed;
+}
+
+.c11[disabled].fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill,
+.c11:disabled.fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,67%);
 }
 
 .c11.fi-input-toggle-button {

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -502,13 +502,13 @@ exports[`has matching snapshot 1`] = `
   fill: hsl(212,63%,37%);
 }
 
-.c8[disabled],
-.c8:disabled {
+.c8.fi-input-clear-button[disabled],
+.c8.fi-input-clear-button:disabled {
   cursor: not-allowed;
 }
 
-.c8[disabled].fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill,
-.c8:disabled.fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill {
+.c8.fi-input-clear-button[disabled] .fi-input-clear-button_icon .fi-icon-base-fill,
+.c8.fi-input-clear-button:disabled .fi-input-clear-button_icon .fi-icon-base-fill {
   fill: hsl(202,7%,67%);
 }
 
@@ -545,13 +545,13 @@ exports[`has matching snapshot 1`] = `
   fill: hsl(0,0%,16%);
 }
 
-.c11[disabled],
-.c11:disabled {
+.c11.fi-input-toggle-button[disabled],
+.c11.fi-input-toggle-button:disabled {
   cursor: not-allowed;
 }
 
-.c11[disabled].fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill,
-.c11:disabled.fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill {
+.c11.fi-input-toggle-button[disabled] .fi-input-toggle-button_icon .fi-icon-base-fill,
+.c11.fi-input-toggle-button:disabled .fi-input-toggle-button_icon .fi-icon-base-fill {
   fill: hsl(202,7%,67%);
 }
 

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -486,16 +486,6 @@ exports[`has matching snapshot 1`] = `
   z-index: 9999;
 }
 
-.c8[disabled],
-.c8:disabled {
-  cursor: not-allowed;
-}
-
-.c8[disabled].fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill,
-.c8:disabled.fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill {
-  fill: hsl(202,7%,67%);
-}
-
 .c8.fi-input-clear-button {
   display: -webkit-box;
   display: -webkit-flex;
@@ -512,6 +502,16 @@ exports[`has matching snapshot 1`] = `
   fill: hsl(212,63%,37%);
 }
 
+.c8[disabled],
+.c8:disabled {
+  cursor: not-allowed;
+}
+
+.c8[disabled].fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill,
+.c8:disabled.fi-input-clear-button .fi-input-clear-button_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,67%);
+}
+
 .c11 {
   width: 20px;
   height: 20px;
@@ -525,16 +525,6 @@ exports[`has matching snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c11[disabled],
-.c11:disabled {
-  cursor: not-allowed;
-}
-
-.c11[disabled].fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill,
-.c11:disabled.fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill {
-  fill: hsl(202,7%,67%);
 }
 
 .c11.fi-input-toggle-button {
@@ -553,6 +543,16 @@ exports[`has matching snapshot 1`] = `
 
 .c11.fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill {
   fill: hsl(0,0%,16%);
+}
+
+.c11[disabled],
+.c11:disabled {
+  cursor: not-allowed;
+}
+
+.c11[disabled].fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill,
+.c11:disabled.fi-input-toggle-button .fi-input-toggle-button_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,67%);
 }
 
 .c1 {


### PR DESCRIPTION
## Description

This PR adds the disabled state to SingleSelect and MultiSelect. The disabled prop is optional and is passed further into subcomponents like FIlterInput, InputClearButton and InputToggleButton to provide correct behavior. 

When disabled, the components are non-focusable and out of the tab order. In MultiSelect, however, the chip list items are still focusable (assuming that there are preselected values in the input).

## Related Issue

This PR is built on top the commits of PR #600 which adds the InputToggleButton to MultiSelect.

## Motivation and Context

There is a need to use these components in a disabled state.

## How Has This Been Tested?

On Mac. Chrome, Safari, Firefox. VoiceOver. In Styleguidist. 

## Screenshots

SingleSelect
<img width="381" alt="image" src="https://user-images.githubusercontent.com/17459942/165071302-57ca7e95-8cf3-4c52-aba7-ab9597491498.png">

MultiSelect
<img width="354" alt="image" src="https://user-images.githubusercontent.com/17459942/165071375-d45eb7ed-6642-4a93-ad23-b1ac329895a7.png">
<img width="336" alt="image" src="https://user-images.githubusercontent.com/17459942/165071601-dd0de92f-558f-413d-b35c-1043afb8efda.png">


## Release notes

### SingleSelect
* Add optional prop `disabled`

### MultiSelect
* Add optional prop `disabled`
