### PR TITLE
[Fix] Expander group - CSS selector for .fi-icon

### DIFF
--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -22,9 +22,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       transition: margin ${`${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction}`};
 
-      & .fi-icon {
-        color: ${theme.colors.highlightBase};
-      }
       & > {
         border-radius: 0;
       }

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -155,10 +155,6 @@ exports[`Basic expander group should match snapshot 1`] = `
   transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
 }
 
-.c1 > .fi-expander-group_expanders .fi-expander .fi-icon {
-  color: hsl(212,63%,45%);
-}
-
 .c1 > .fi-expander-group_expanders .fi-expander > {
   border-radius: 0;
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where a generic CSS selector in Expander group component targeted all icons (.fi-icon) inside the Expander component and changed their color. This misbehaving CSS selector can be removed altogether since the correct color for the toggle icon is inherited from its parent. 

## Motivation and Context

Component stylings need to be robust and predictable and not cause side effects.

## How Has This Been Tested?

On MacOS: Chrome, Safari & Firefox. Manually in Styleguidist.

## Release notes

### Expander group
* Fix CSS selector which targeted all `.fi-icon` elements inside the component and determined their color
