### PR TITLE
[Fix] Add ceiling to React peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
   "peerDependencies": {
     "@types/styled-components": ">=5.1.9",
     "@types/warning": ">=3.0.0",
-    "react": ">=16.8.0",
+    "react": ">=16.8.0 < 18",
     "styled-components": ">=5.2.1"
   },
   "lint-staged": {


### PR DESCRIPTION
## Description
This PR adds a higher limit for the React peer dependency version, marking that the library does not currently fully support React 18.

## Motivation and Context
It should be clear which environments the library can be used in.

## Release notes
### Dependencies
* Add ceiling to React peer dependency version range
