### PR TITLE
[Fix] Remove background color from Toggle components

### DIFF
--- a/src/core/Form/Toggle/ToggleBase/Toggle.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleBase/Toggle.baseStyles.tsx
@@ -14,7 +14,6 @@ export const focusOverrides = css`
 export const toggleBaseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  background-color: ${theme.colors.whiteBase};
   padding-left: 50px;
   position: relative;
   cursor: pointer;

--- a/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -267,7 +267,6 @@ exports[`Basic ToggleButton should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  background-color: hsl(0,0%,100%);
   padding-left: 50px;
   position: relative;
   cursor: pointer;

--- a/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
@@ -272,7 +272,6 @@ exports[`Basic ToggleInput should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  background-color: hsl(0,0%,100%);
   padding-left: 50px;
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
Remove the white background color from ToggleButton and ToggleInput

## Motivation and Context

Allows users to decide what color the background is.

## How Has This Been Tested?
With Firefox and Chrome.

## Screenshots (if appropriate):
![Screenshot 2022-04-29 at 10 32 18](https://user-images.githubusercontent.com/14258876/165902390-7bedff96-69b7-4857-9640-f3088f9466a9.png)

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
