### PR TITLE
[Fix] Link styles specificity

### DIFF
--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -183,7 +183,6 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c7 {
-  color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -197,37 +196,40 @@ exports[`calling render with the same component on the same container does not r
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c7.fi-link {
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c7:hover,
-.c7:active,
-.c7:focus,
-.c7:focus-within {
+.c7.fi-link:hover,
+.c7.fi-link:active,
+.c7.fi-link:focus,
+.c7.fi-link:focus-within {
   color: hsl(212,63%,45%);
 }
 
-.c7:focus,
-.c7:focus-within {
+.c7.fi-link:focus,
+.c7.fi-link:focus-within {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c7:focus {
+.c7.fi-link:focus {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
 }
 
-.c7:hover,
-.c7:active {
+.c7.fi-link:hover,
+.c7.fi-link:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c7:visited {
+.c7.fi-link:visited {
   color: hsl(284,36%,45%);
 }
 

--- a/src/core/Link/BaseLink/BaseLink.baseStyles.ts
+++ b/src/core/Link/BaseLink/BaseLink.baseStyles.ts
@@ -4,26 +4,28 @@ import { element, font } from '../../theme/reset';
 import { allStates } from '../../../utils/css';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  ${element(theme)}
   ${font(theme)('bodyText')}
-  ${allStates(`color: ${theme.colors.highlightBase};`)}
-  color: ${theme.colors.highlightBase};
-  text-decoration: none;
 
-  &:focus,
-  &:focus-within {
+  &.fi-link {
+    ${allStates(`color: ${theme.colors.highlightBase};`)}
+    color: ${theme.colors.highlightBase};
     text-decoration: none;
-  }
 
-  &:focus {
-    ${theme.focus.boxShadowFocus}
-  }
+    &:focus,
+    &:focus-within {
+      text-decoration: none;
+    }
 
-  &:hover,
-  &:active {
-    text-decoration: underline;
-  }
-  &:visited {
-    color: ${theme.colors.accentTertiaryDark1};
+    &:focus {
+      ${theme.focus.boxShadowFocus}
+    }
+
+    &:hover,
+    &:active {
+      text-decoration: underline;
+    }
+    &:visited {
+      color: ${theme.colors.accentTertiaryDark1};
+    }
   }
 `;

--- a/src/core/Link/BaseLink/BaseLink.baseStyles.ts
+++ b/src/core/Link/BaseLink/BaseLink.baseStyles.ts
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { element, font } from '../../theme/reset';
+import { font } from '../../theme/reset';
 import { allStates } from '../../../utils/css';
 
 export const baseStyles = (theme: SuomifiTheme) => css`

--- a/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
+++ b/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
@@ -105,7 +105,6 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c1 {
-  color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -119,37 +118,40 @@ exports[`calling render with the same component on the same container does not r
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c1.fi-link {
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c1:hover,
-.c1:active,
-.c1:focus,
-.c1:focus-within {
+.c1.fi-link:hover,
+.c1.fi-link:active,
+.c1.fi-link:focus,
+.c1.fi-link:focus-within {
   color: hsl(212,63%,45%);
 }
 
-.c1:focus,
-.c1:focus-within {
+.c1.fi-link:focus,
+.c1.fi-link:focus-within {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c1:focus {
+.c1.fi-link:focus {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
 }
 
-.c1:hover,
-.c1:active {
+.c1.fi-link:hover,
+.c1.fi-link:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c1:visited {
+.c1.fi-link:visited {
   color: hsl(284,36%,45%);
 }
 

--- a/src/core/Link/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link/Link.baseStyles.ts
@@ -2,6 +2,6 @@ import { SuomifiTheme } from '../../theme';
 import { css } from 'styled-components';
 import { baseStyles } from '../BaseLink/BaseLink.baseStyles';
 
-export const ExternalLinkStyles = (theme: SuomifiTheme) => css`
+export const LinkStyles = (theme: SuomifiTheme) => css`
   ${baseStyles(theme)}
 `;

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { baseStyles } from '../BaseLink/BaseLink.baseStyles';
+import { LinkStyles } from '../Link/Link.baseStyles';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlA } from '../../../reset';
 import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
@@ -22,7 +22,7 @@ const StyledLink = styled(
     />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme }) => LinkStyles(theme)}
 `;
 
 /**

--- a/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
@@ -40,7 +40,6 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c1 {
-  color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -54,37 +53,40 @@ exports[`calling render with the same component on the same container does not r
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c1.fi-link {
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c1:hover,
-.c1:active,
-.c1:focus,
-.c1:focus-within {
+.c1.fi-link:hover,
+.c1.fi-link:active,
+.c1.fi-link:focus,
+.c1.fi-link:focus-within {
   color: hsl(212,63%,45%);
 }
 
-.c1:focus,
-.c1:focus-within {
+.c1.fi-link:focus,
+.c1.fi-link:focus-within {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c1:focus {
+.c1.fi-link:focus {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
 }
 
-.c1:hover,
-.c1:active {
+.c1.fi-link:hover,
+.c1.fi-link:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c1:visited {
+.c1.fi-link:visited {
   color: hsl(284,36%,45%);
 }
 

--- a/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
+++ b/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
@@ -40,7 +40,6 @@ exports[`should match snapshot 1`] = `
 }
 
 .c1 {
-  color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -54,42 +53,44 @@ exports[`should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c1.fi-link {
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c1:hover,
-.c1:active,
-.c1:focus,
-.c1:focus-within {
+.c1.fi-link:hover,
+.c1.fi-link:active,
+.c1.fi-link:focus,
+.c1.fi-link:focus-within {
   color: hsl(212,63%,45%);
 }
 
-.c1:focus,
-.c1:focus-within {
+.c1.fi-link:focus,
+.c1.fi-link:focus-within {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c1:focus {
+.c1.fi-link:focus {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
 }
 
-.c1:hover,
-.c1:active {
+.c1.fi-link:hover,
+.c1.fi-link:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c1:visited {
+.c1.fi-link:visited {
   color: hsl(284,36%,45%);
 }
 
 .c2 {
-  color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -103,37 +104,40 @@ exports[`should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c2.fi-link {
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c2:hover,
-.c2:active,
-.c2:focus,
-.c2:focus-within {
+.c2.fi-link:hover,
+.c2.fi-link:active,
+.c2.fi-link:focus,
+.c2.fi-link:focus-within {
   color: hsl(212,63%,45%);
 }
 
-.c2:focus,
-.c2:focus-within {
+.c2.fi-link:focus,
+.c2.fi-link:focus-within {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c2:focus {
+.c2.fi-link:focus {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
 }
 
-.c2:hover,
-.c2:active {
+.c2.fi-link:hover,
+.c2.fi-link:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c2:visited {
+.c2.fi-link:visited {
   color: hsl(284,36%,45%);
 }
 


### PR DESCRIPTION
## Description

This PR moves the styles of `<Link>` component inside `.fi-link` class to avoid same specificity issues with `<a>` element reset styles. 

Also fixed issue with a redundant file `src/core/Link/Link/Link.baseStyles.ts` which now exports correctly named styles. 

## Motivation and Context

Suomi-fi library stylings should be predictable and robust. Component styles should be more important than HTML reset styles. 

## How Has This Been Tested?

On MacOS, Styleguidist, Chrome, Safari & Firefox

## Release notes

### Link
* Fix CSS specificity issue which caused unpredictable component styling
