### PR TITLE
[Feature] Raise suomifi-icons version to 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "react-popper": "2.2.5",
     "react-svg": "14.1.14",
     "suomifi-design-tokens": "3.2.0",
-    "suomifi-icons": "^6.1.0"
+    "suomifi-icons": "^6.2.0"
   },
   "peerDependencies": {
     "@types/styled-components": ">=5.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11021,10 +11021,10 @@ suomifi-design-tokens@3.2.0:
   resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-3.2.0.tgz#62e8dcef327a1dca080cef0ceadd39196bdf5d66"
   integrity sha512-M/bFDY1DpogqwDQ80SL6RnCp+k2gd8wcti06eoW4ql3G1zVPxCX2YFBcDvG8p84agXNzxJWASkM0Qy1pi+/SWQ==
 
-suomifi-icons@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-6.1.0.tgz#9232473a7896818a67d1fbac3e68775d260c4cb3"
-  integrity sha512-plJc4nG8DR8Rv7dnZFvIgbX0GrnG3GWBMXCbd/yd54o76cmgAJfRZARziqCXqKwx13i8YmejdCJEgrFgHBW/CA==
+suomifi-icons@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-6.2.0.tgz#661fc2327a42dfa5e0cfc6d560d22c5caff1b122"
+  integrity sha512-KrZTTm8+PqUaKOgGD5+SiWcE1XbSBw5EqKRitbPBxbDUT/a+1eywUM/6CBnPH4wjbkdlq75b2Z1ML19yuBGjMA==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

This PR updates suomifi-icons version to 6.2.0. This version adds the loading spinner icon. 

## How Has This Been Tested?

On MacOS, Styleguidist, Chrome, Safari & Firefox

## Release notes
*  Update suomifi-icons version to 6.2.0
