### PR TITLE
[Fix] Radio button icon background color

### DIFF
--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -95,6 +95,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         position: absolute;
         & .fi-icon-radio-base {
           stroke: ${theme.colors.depthDark3};
+          fill: ${theme.colors.whiteBase};
         }
       }
       &:checked {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c1.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -506,6 +507,7 @@ exports[`className should match snapshot 1`] = `
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c1.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -821,6 +823,7 @@ exports[`disabled should match snapshot 1`] = `
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c1.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -1137,6 +1140,7 @@ exports[`hintText should match snapshot 1`] = `
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c1.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -1459,6 +1463,7 @@ exports[`id should match snapshot 1`] = `
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c1.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -1774,6 +1779,7 @@ exports[`name should match snapshot 1`] = `
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c1.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -2090,6 +2096,7 @@ exports[`value should match snapshot 1`] = `
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c1.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -2405,6 +2412,7 @@ exports[`variant should match snapshot 1`] = `
 
 .c1.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c1.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -282,6 +282,7 @@ exports[`default, with only required props should match snapshot 1`] = `
 
 .c5.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c5.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -807,6 +808,7 @@ exports[`props className should match snapshot 1`] = `
 
 .c5.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c5.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -1332,6 +1334,7 @@ exports[`props defaultValue should match snapshot 1`] = `
 
 .c5.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c5.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -1858,6 +1861,7 @@ exports[`props hintText should match snapshot 1`] = `
 
 .c5.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c5.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -2388,6 +2392,7 @@ exports[`props id should match snapshot 1`] = `
 
 .c5.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c5.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -2913,6 +2918,7 @@ exports[`props label should match snapshot 1`] = `
 
 .c5.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c5.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -3450,6 +3456,7 @@ exports[`props labelMode should match snapshot 1`] = `
 
 .c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -3975,6 +3982,7 @@ exports[`props name should match snapshot 1`] = `
 
 .c5.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c5.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
@@ -4500,6 +4508,7 @@ exports[`props value should match snapshot 1`] = `
 
 .c5.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
 }
 
 .c5.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {


### PR DESCRIPTION
## Description

This PR adds a white fill color to radio button icon's `.fi-icon-radio-base` class, effectively making the SVG opaque

## Motivation and Context

Radio button should be usable and visually pleasing on non-white backgrounds

## How Has This Been Tested?

On MacOS, Styleguidist, Chrome, Safari & Firefox

## Screenshots (if appropriate):

<img width="279" alt="Screenshot 2022-05-03 at 13 33 10" src="https://user-images.githubusercontent.com/17459942/166448670-27e1948a-aa69-4a8b-ad34-2daaaf23219b.png">
<img width="219" alt="Screenshot 2022-05-03 at 13 33 40" src="https://user-images.githubusercontent.com/17459942/166448689-776aefaf-95eb-4f57-bd48-d7d0b87e6560.png">


## Release notes

### RadioButton
* Add white background to RadioButton icon
