### PR TITLE
[Fix] SingleSelect controlled state bug

### DIFF
--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -138,6 +138,7 @@ const animals = [
     clearButtonLabel="Clear selection"
     items={animals}
     selectedItem={selectedAnimal}
+    onClearSelection={() => setSelectedAnimal(null)}
     noItemsText="No matching options"
     visualPlaceholder="Try to choose animal"
     ariaOptionsAvailableText="Options available"
@@ -173,9 +174,6 @@ const animals = [
     }
   >
     Snail
-  </button>
-  <button onClick={() => setSelectedAnimal(null)}>
-    Clear selection
   </button>
 </>;
 ```

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -174,6 +174,9 @@ const animals = [
   >
     Snail
   </button>
+  <button onClick={() => setSelectedAnimal(null)}>
+    Clear selection
+  </button>
 </>;
 ```
 

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -131,7 +131,7 @@ describe('Controlled', () => {
     );
 
     await act(async () => {
-      const { getByRole, getByText } = render(singleSelect);
+      const { getByRole, getByText, rerender } = render(singleSelect);
       expect(getByRole('textbox')).toHaveValue('Powersaw');
       const input = getByRole('textbox');
       await act(async () => {
@@ -140,6 +140,21 @@ describe('Controlled', () => {
       const item = await waitFor(() => getByText('Powersaw'));
       expect(item).toHaveAttribute('aria-disabled');
       expect(item).toHaveClass('fi-select-item--disabled');
+
+      rerender(
+        <SingleSelect
+          selectedItem={null}
+          labelText="SingleSelect"
+          clearButtonLabel="Clear selection"
+          items={tools}
+          visualPlaceholder="Choose your tool"
+          noItemsText="No items"
+          defaultSelectedItem={defaultSelectedTool}
+          ariaOptionsAvailableText="Options available"
+        />,
+      );
+      const rerenderedInput = getByRole('textbox');
+      expect(rerenderedInput).toHaveValue('');
     });
   });
 

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -86,6 +86,8 @@ export interface SingleSelectProps<T extends SingleSelectData> {
   onItemSelect?: (uniqueItemId: string | null) => void;
   /** Disable the input */
   disabled?: boolean;
+  /** Event sent when the button which clears the input is clicked */
+  onClearSelection?: () => void;
 }
 
 interface SingleSelectState<T extends SingleSelectData> {
@@ -357,6 +359,7 @@ class BaseSingleSelect<T> extends Component<
       ariaOptionsAvailableText,
       onItemSelect,
       disabled,
+      onClearSelection,
       ...passProps
     } = this.props;
 
@@ -428,7 +431,12 @@ class BaseSingleSelect<T> extends Component<
                 <HtmlDiv className={singleSelectClassNames.clearButtonWrapper}>
                   <InputClearButton
                     forwardedRef={this.clearButtonRef}
-                    onClick={() => this.handleItemSelection(null)}
+                    onClick={() => {
+                      if (!!onClearSelection) {
+                        onClearSelection();
+                      }
+                      this.handleItemSelection(null);
+                    }}
                     onBlur={this.handleBlur}
                     label={clearButtonLabel}
                     disabled={disabled}

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -148,7 +148,7 @@ class BaseSingleSelect<T> extends Component<
       const resolvedSelectedItem =
         'selectedItem' in nextProps ? selectedItem : prevState.selectedItem;
       const resolvedInputValue = selectedItemChanged
-        ? selectedItem?.labelText || ''
+        ? resolvedSelectedItem?.labelText || ''
         : prevState.filterInputValue;
 
       return {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -148,7 +148,7 @@ class BaseSingleSelect<T> extends Component<
       const resolvedSelectedItem =
         'selectedItem' in nextProps ? selectedItem : prevState.selectedItem;
       const resolvedInputValue = selectedItemChanged
-        ? resolvedSelectedItem?.labelText
+        ? selectedItem?.labelText || ''
         : prevState.filterInputValue;
 
       return {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -81,12 +81,12 @@ export interface SingleSelectProps<T extends SingleSelectData> {
   /** Status text to be shown below the component and hint text. Use e.g. for validation error */
   statusText?: string;
   /** Controlled items; if item is in array, it is selected. If item has disabled: true, it will be disabled. */
-  selectedItem?: T & SingleSelectData;
+  selectedItem?: (T & SingleSelectData) | null;
   /** Selecting the item will send event with the id */
   onItemSelect?: (uniqueItemId: string | null) => void;
   /** Disable the input */
   disabled?: boolean;
-  /** Event sent when the button which clears the input is clicked */
+  /** This function is called when the button which clears the input is clicked */
   onClearSelection?: () => void;
 }
 


### PR DESCRIPTION
## Description

This PR fixes a bug in SingleSelect. The bug was as thus: When the component was in controlled state, and its `selectedItem` was changed from a defined value to `null`, the previous value was still present in the text input field. This was due to `filterInputValue` not being handled correctly in `getDerivedStateFromProps` hook. 

## Motivation and Context

Components should work predictably and without bugs in all use cases.

## How Has This Been Tested?

On MacOS: Chrome, Safari, Firefox. Styleguidist. 

## Release notes

### SingleSelect
* Fix an issue regarding controlled state nullification
* Add `onClearSelection()` prop