### PR TITLE
[Fix] Notification accessibility

### DIFF
--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -8,13 +8,13 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};
   border-radius: 4px;
-  justify-content: space-between;
   padding-bottom: 10px;
 
   &.fi-notification {
     background-color: ${theme.colors.whiteBase};
     display: flex;
     flex-direction: column-reverse;
+    justify-content: space-between;
     & .fi-notification_style-wrapper {
       padding: 0 32px 10px 40px;
       display: flex;

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -8,17 +8,27 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};
   border-radius: 4px;
-  display: block;
   justify-content: space-between;
   padding-bottom: 10px;
 
   &.fi-notification {
     background-color: ${theme.colors.whiteBase};
+    display: flex;
+    flex-direction: column-reverse;
     & .fi-notification_style-wrapper {
       padding: 0 32px 10px 40px;
       display: flex;
       align-items: flex-start;
       overflow: hidden;
+    }
+
+    & .fi-notification_icon-wrapper {
+      padding-top: 20px;
+      flex: none;
+      & .fi-notification_icon {
+        height: 24px;
+        width: 24px;
+      }
     }
 
     & .fi-notification_text-content-wrapper {
@@ -46,14 +56,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         margin-top: 0;
       }
     }
-    .fi-notification_icon-wrapper {
-      padding-top: 20px;
-      flex: none;
-      & .fi-notification_icon {
-        height: 24px;
-        width: 24px;
-      }
-    }
+
     & .fi-notification_close-button {
       ${font(theme)('bodyTextSmall')}
       height: 40px;

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -13,7 +13,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-notification {
     background-color: ${theme.colors.whiteBase};
     display: flex;
-    flex-direction: column-reverse;
+    flex-direction: column;
     justify-content: space-between;
     & .fi-notification_style-wrapper {
       padding: 0 32px 10px 40px;

--- a/src/core/Notification/Notification.md
+++ b/src/core/Notification/Notification.md
@@ -6,7 +6,7 @@ import {
 } from 'suomifi-ui-components';
 
 <>
-  <Notification closeText="Close">
+  <Notification closeText="Close" accessibilityLabel="Ilmoitus">
     This is a notification text.
   </Notification>
   <Notification

--- a/src/core/Notification/Notification.md
+++ b/src/core/Notification/Notification.md
@@ -2,11 +2,12 @@
 import {
   Notification,
   Button,
-  Paragraph
+  Paragraph,
+  Link
 } from 'suomifi-ui-components';
 
 <>
-  <Notification closeText="Close" accessibilityLabel="Ilmoitus">
+  <Notification closeText="Close">
     This is a notification text.
   </Notification>
   <Notification
@@ -16,17 +17,16 @@ import {
     smallScreen
   >
     This is a small screen error notification text.
+    <Link href="#">Link to somewhere</Link>
   </Notification>
   <Notification
-    id="notification-1"
+    id="notification-id"
     closeText="Close"
     headingText="Notification heading"
     headingVariant="h3"
     actionElements={
       <>
-        <Button variant="secondary" aria-describedby="notification-1">
-          Action button
-        </Button>
+        <Button variant="secondary">Action button</Button>
       </>
     }
   >

--- a/src/core/Notification/Notification.md
+++ b/src/core/Notification/Notification.md
@@ -15,6 +15,7 @@ import {
     headingText="Error notification"
     closeText="Close"
     smallScreen
+    closeButtonProps={{ 'aria-label': 'Custom close button label' }}
   >
     This is a small screen error notification text.
     <Link href="#">Link to somewhere</Link>

--- a/src/core/Notification/Notification.md
+++ b/src/core/Notification/Notification.md
@@ -2,8 +2,7 @@
 import {
   Notification,
   Button,
-  Paragraph,
-  Link
+  Paragraph
 } from 'suomifi-ui-components';
 
 <>
@@ -15,16 +14,15 @@ import {
     headingText="Error notification"
     closeText="Close"
     smallScreen
-    closeButtonProps={{ 'aria-label': 'Custom close button label' }}
   >
     This is a small screen error notification text.
-    <Link href="#">Link to somewhere</Link>
   </Notification>
   <Notification
     id="notification-id"
     closeText="Close"
     headingText="Notification heading"
     headingVariant="h3"
+    closeButtonProps={{ 'aria-label': 'Custom close button label' }}
     actionElements={
       <>
         <Button variant="secondary">Action button</Button>

--- a/src/core/Notification/Notification.test.tsx
+++ b/src/core/Notification/Notification.test.tsx
@@ -95,6 +95,7 @@ describe('props', () => {
         closeText="Close"
         closeButtonProps={{
           'aria-labelledby': 'test-element',
+          'aria-label': 'test-label',
           disabled: true,
           className: 'testClass',
         }}
@@ -112,6 +113,7 @@ describe('props', () => {
         'aria-labelledby',
         'test-element',
       );
+      expect(getByRole('button')).toHaveAttribute('aria-label', 'test-label');
       expect(getByRole('button')).toHaveAttribute('disabled');
       expect(getByRole('button')).toHaveTextContent('Close');
     });
@@ -136,6 +138,37 @@ describe('props', () => {
       expect(container.querySelector('#testId')).toHaveAttribute(
         'aria-live',
         'off',
+      );
+    });
+  });
+
+  describe('regionAriaLabel', () => {
+    const NotificationWithRegionAriaLabel = (
+      <Notification
+        closeText="Close"
+        regionAriaLabel="test-label"
+        headingText="Lorem ipsum dolor sit"
+      >
+        Testcontent
+      </Notification>
+    );
+
+    const NotificationWithoutRegionAriaLabel = (
+      <Notification closeText="Close" headingText="Lorem ipsum dolor sit">
+        Testcontent
+      </Notification>
+    );
+
+    it('should have specified aria-label', () => {
+      const { getByRole } = render(NotificationWithRegionAriaLabel);
+      expect(getByRole('region')).toHaveAttribute('aria-label', 'test-label');
+    });
+
+    it('should use headingText as fallback aria-label', () => {
+      const { getByRole } = render(NotificationWithoutRegionAriaLabel);
+      expect(getByRole('region')).toHaveAttribute(
+        'aria-label',
+        'Lorem ipsum dolor sit',
       );
     });
   });

--- a/src/core/Notification/Notification.test.tsx
+++ b/src/core/Notification/Notification.test.tsx
@@ -118,29 +118,6 @@ describe('props', () => {
       expect(getByRole('button')).toHaveTextContent('Close');
     });
   });
-  describe('ariaLiveMode', () => {
-    const NotificationWithDefaultAriaLiveMode = (
-      <Notification
-        id="testId"
-        closeText="Close"
-        ariaLiveMode="off"
-        headingText="Lorem ipsum dolor sit"
-      >
-        Testcontent
-      </Notification>
-    );
-
-    it('should have specified aria-live mode', () => {
-      const { container } = render(NotificationWithDefaultAriaLiveMode);
-      expect(container.querySelector('#testId')).toHaveClass(
-        'fi-notification_text-content-wrapper',
-      );
-      expect(container.querySelector('#testId')).toHaveAttribute(
-        'aria-live',
-        'off',
-      );
-    });
-  });
 
   describe('regionAriaLabel', () => {
     const NotificationWithRegionAriaLabel = (

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -15,6 +15,7 @@ import { Heading } from '../Heading/Heading';
 import { AutoId } from '../utils/AutoId/AutoId';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
 import { baseStyles } from './Notification.baseStyles';
+import { VisuallyHidden } from '../..';
 
 export const baseClassName = 'fi-notification';
 export const notificationClassNames = {
@@ -57,6 +58,9 @@ export interface NotificationProps extends HtmlDivWithRefProps {
   closeButtonProps?: Omit<HtmlButtonProps, 'onClick' | 'aria-label'>;
   /** Use small screen styling */
   smallScreen?: boolean;
+  /** A label to help screen reader users distinguish notification from the rest of the page content.
+   * Should simply be the localized word "notification". Will be followed by string ": " */
+  accessibilityLabel?: string;
 }
 interface InnerRef {
   forwardedRef: React.RefObject<HTMLDivElement>;
@@ -66,6 +70,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
   render() {
     const {
       className,
+      accessibilityLabel,
       ariaLiveMode = 'polite',
       status = 'neutral',
       headingText,
@@ -101,6 +106,11 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
           },
         )}
       >
+        {actionElements && (
+          <HtmlDiv className={notificationClassNames.actionElementWrapper}>
+            {actionElements}
+          </HtmlDiv>
+        )}
         <HtmlDiv className={notificationClassNames.styleWrapper} style={style}>
           <HtmlDiv className={notificationClassNames.iconWrapper}>
             <Icon icon={variantIcon} className={notificationClassNames.icon} />
@@ -111,6 +121,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
             id={id}
             aria-live={ariaLiveMode}
           >
+            <VisuallyHidden>{`${accessibilityLabel}: `}</VisuallyHidden>
             <HtmlDiv className={notificationClassNames.content}>
               {headingText && (
                 <Heading
@@ -144,11 +155,6 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
             <Icon icon="close" />
           </HtmlButton>
         </HtmlDiv>
-        {actionElements && (
-          <HtmlDiv className={notificationClassNames.actionElementWrapper}>
-            {actionElements}
-          </HtmlDiv>
-        )}
       </HtmlDivWithRef>
     );
   }

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -54,7 +54,7 @@ export interface NotificationProps extends HtmlDivWithRefProps {
   /** Click handler for the close button */
   onCloseButtonClick?: () => void;
   /** Custom props passed to the close button */
-  closeButtonProps?: Omit<HtmlButtonProps, 'onClick' | 'aria-label'>;
+  closeButtonProps?: Omit<HtmlButtonProps, 'onClick'>;
   /** Use small screen styling */
   smallScreen?: boolean;
   /** Label for the notification region for screen reader users.
@@ -90,6 +90,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
     const {
       className: customCloseButtonClassName,
       'aria-describedby': closeButtonPropsAriaDescribedBy,
+      'aria-label': closeButtonPropsAriaLabel,
       ...closeButtonPassProps
     } = closeButtonProps;
     const variantIcon = status === 'neutral' ? 'info' : 'error';
@@ -139,7 +140,8 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
               customCloseButtonClassName,
             )}
             {...getConditionalAriaProp('aria-label', [
-              smallScreen ? closeText : undefined,
+              closeButtonPropsAriaLabel ||
+                (smallScreen ? closeText : undefined),
             ])}
             {...getConditionalAriaProp('aria-describedby', [
               closeButtonPropsAriaDescribedBy,

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -57,6 +57,10 @@ export interface NotificationProps extends HtmlDivWithRefProps {
   closeButtonProps?: Omit<HtmlButtonProps, 'onClick' | 'aria-label'>;
   /** Use small screen styling */
   smallScreen?: boolean;
+  /** Label for the notification region for screen reader users.
+   * If one is not provided, `headingText` or finally notification content will be used as the label.
+   */
+  regionAriaLabel?: string;
 }
 
 interface InnerRef {
@@ -79,6 +83,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
       closeButtonProps = {},
       headingVariant = 'h2',
       style,
+      regionAriaLabel,
       ...passProps
     } = this.props;
 
@@ -93,7 +98,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
       <HtmlDivWithRef
         as="section"
         role="region"
-        aria-label={headingText || children}
+        aria-label={regionAriaLabel || headingText || children}
         {...passProps}
         className={classnames(
           baseClassName,

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -35,10 +35,6 @@ export interface NotificationProps extends HtmlDivWithRefProps {
    * @default 'neutral'
    */
   status?: 'neutral' | 'error';
-  /** Set aria-live mode for the Notification text content and heading.
-   * @default 'polite'
-   */
-  ariaLiveMode?: 'polite' | 'assertive' | 'off';
   /** Heading for the Notification */
   headingText?: string;
   /** Main content of the Notification */
@@ -71,7 +67,6 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
   render() {
     const {
       className,
-      ariaLiveMode = 'polite',
       status = 'neutral',
       headingText,
       children,
@@ -118,7 +113,6 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
           <HtmlDiv
             className={notificationClassNames.textContentWrapper}
             id={id}
-            aria-live={ariaLiveMode}
           >
             <HtmlDiv className={notificationClassNames.content}>
               {headingText && (

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -15,7 +15,6 @@ import { Heading } from '../Heading/Heading';
 import { AutoId } from '../utils/AutoId/AutoId';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
 import { baseStyles } from './Notification.baseStyles';
-import { VisuallyHidden } from '../..';
 
 export const baseClassName = 'fi-notification';
 export const notificationClassNames = {
@@ -58,10 +57,8 @@ export interface NotificationProps extends HtmlDivWithRefProps {
   closeButtonProps?: Omit<HtmlButtonProps, 'onClick' | 'aria-label'>;
   /** Use small screen styling */
   smallScreen?: boolean;
-  /** A label to help screen reader users distinguish notification from the rest of the page content.
-   * Should simply be the localized word "notification". Will be followed by string ": " */
-  accessibilityLabel?: string;
 }
+
 interface InnerRef {
   forwardedRef: React.RefObject<HTMLDivElement>;
 }
@@ -70,7 +67,6 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
   render() {
     const {
       className,
-      accessibilityLabel,
       ariaLiveMode = 'polite',
       status = 'neutral',
       headingText,
@@ -96,6 +92,8 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
     return (
       <HtmlDivWithRef
         as="section"
+        role="region"
+        aria-label={headingText || children}
         {...passProps}
         className={classnames(
           baseClassName,
@@ -106,11 +104,6 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
           },
         )}
       >
-        {actionElements && (
-          <HtmlDiv className={notificationClassNames.actionElementWrapper}>
-            {actionElements}
-          </HtmlDiv>
-        )}
         <HtmlDiv className={notificationClassNames.styleWrapper} style={style}>
           <HtmlDiv className={notificationClassNames.iconWrapper}>
             <Icon icon={variantIcon} className={notificationClassNames.icon} />
@@ -121,7 +114,6 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
             id={id}
             aria-live={ariaLiveMode}
           >
-            <VisuallyHidden>{`${accessibilityLabel}: `}</VisuallyHidden>
             <HtmlDiv className={notificationClassNames.content}>
               {headingText && (
                 <Heading
@@ -145,7 +137,6 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
               smallScreen ? closeText : undefined,
             ])}
             {...getConditionalAriaProp('aria-describedby', [
-              id,
               closeButtonPropsAriaDescribedBy,
             ])}
             onClick={onCloseButtonClick}
@@ -155,6 +146,11 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
             <Icon icon="close" />
           </HtmlButton>
         </HtmlDiv>
+        {actionElements && (
+          <HtmlDiv className={notificationClassNames.actionElementWrapper}>
+            {actionElements}
+          </HtmlDiv>
+        )}
       </HtmlDivWithRef>
     );
   }

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -695,7 +695,6 @@ exports[`props children should match snapshot 1`] = `
         </svg>
       </div>
       <div
-        aria-live="polite"
         class="c2 fi-notification_text-content-wrapper"
         id="7"
       >

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -441,16 +441,22 @@ exports[`props children should match snapshot 1`] = `
   width: 100%;
   box-shadow: 0px 4px 8px 0px rgba(41,41,41,0.14);
   border-radius: 4px;
-  display: block;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
   padding-bottom: 10px;
 }
 
 .c1.fi-notification {
   background-color: hsl(0,0%,100%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
 .c1.fi-notification .fi-notification_style-wrapper {
@@ -464,6 +470,18 @@ exports[`props children should match snapshot 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   overflow: hidden;
+}
+
+.c1.fi-notification .fi-notification_icon-wrapper {
+  padding-top: 20px;
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+}
+
+.c1.fi-notification .fi-notification_icon-wrapper .fi-notification_icon {
+  height: 24px;
+  width: 24px;
 }
 
 .c1.fi-notification .fi-notification_text-content-wrapper {
@@ -523,18 +541,6 @@ exports[`props children should match snapshot 1`] = `
 
 .c1.fi-notification .fi-notification_action-element-wrapper .fi-button:first-child {
   margin-top: 0;
-}
-
-.c1.fi-notification .fi-notification_icon-wrapper {
-  padding-top: 20px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c1.fi-notification .fi-notification_icon-wrapper .fi-notification_icon {
-  height: 24px;
-  width: 24px;
 }
 
 .c1.fi-notification .fi-notification_close-button {
@@ -661,7 +667,9 @@ exports[`props children should match snapshot 1`] = `
 
 <div>
   <section
+    aria-label="Lorem ipsum dolor sit"
     class="c0 fi-notification fi-notification--neutral c1"
+    role="region"
   >
     <div
       class="c2 fi-notification_style-wrapper"
@@ -709,7 +717,6 @@ exports[`props children should match snapshot 1`] = `
         </div>
       </div>
       <button
-        aria-describedby="7"
         class="c6 fi-notification_close-button"
         type="button"
       >


### PR DESCRIPTION
## Description
This PR changes the way accessibility is taken into account in Notification. The Notification now has `role="region"` which allows the main container to have its own `aria-label` as well as to inform screen reader users upon entering and leaving the element making it clear that the notification is its own entity and thus providing context for the internal interactive elements.

Furthermore, the `ariaLiveMode` prop was discarded, as it is not used in most cases and can still be added by targeting the main content area via id if needed.

## Motivation and Context
Notification had some accessibility issues, and this should fix them. The changes will need to be validated before publishing though.

## How Has This Been Tested?
So far in styleguidist using Chrome and Firefox on Windows. Will need to be tested in another project and on mobile before merging.

## Release notes
### Notification
* **Breaking change:** Rehaul accessibility features
  * Remove `ariaLiveMode` prop
  * Add `role="region"` for the main container
  * Add `regionAriaLabel` prop
