### PR TITLE
[Fix] BaseChip styling cleanup

### DIFF
--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -5,20 +5,6 @@ import { element, font } from '../../theme/reset';
 export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('actionElementInnerTextBold')}
-  border-radius: 14px;
-  padding: ${theme.spacing.insetXxs} ${theme.spacing.insetL};
-  color: ${theme.colors.whiteBase};
-  background: ${theme.colors.highlightBase};
-
-  &:focus {
-    outline: 0;
-    position: relative;
-
-    &::after {
-      ${theme.focus.absoluteFocus}
-      border-radius: 16px;
-    }
-  }
 
   &.fi-chip {
     border-radius: 14px;
@@ -27,6 +13,16 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
     background: ${theme.colors.highlightBase};
     max-height: 100%;
     display: inline-block;
+
+    &:focus {
+      outline: 0;
+      position: relative;
+
+      &::after {
+        ${theme.focus.absoluteFocus}
+        border-radius: 16px;
+      }
+    }
 
     & .fi-chip--content {
       display: block;

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -98,10 +98,6 @@ exports[`children should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
 }
 
 .c1:focus {
@@ -305,10 +301,6 @@ exports[`classnames should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
 }
 
 .c1:focus {
@@ -508,10 +500,6 @@ exports[`disabled should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
 }
 
 .c1:focus {

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -100,12 +100,21 @@ exports[`children should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1:focus {
+.c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
+  display: inline-block;
+}
+
+.c1.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c1:focus::after {
+.c1.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -120,15 +129,6 @@ exports[`children should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 100%;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -303,12 +303,21 @@ exports[`classnames should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1:focus {
+.c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
+  display: inline-block;
+}
+
+.c1.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c1:focus::after {
+.c1.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -323,15 +332,6 @@ exports[`classnames should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 100%;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -502,12 +502,21 @@ exports[`disabled should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1:focus {
+.c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
+  display: inline-block;
+}
+
+.c1.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c1:focus::after {
+.c1.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -522,15 +531,6 @@ exports[`disabled should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 100%;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -47,12 +47,21 @@ exports[`children should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1:focus {
+.c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
+  display: inline-block;
+}
+
+.c1.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c1:focus::after {
+.c1.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -67,15 +76,6 @@ exports[`children should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 100%;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -159,12 +159,21 @@ exports[`classnames should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1:focus {
+.c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
+  display: inline-block;
+}
+
+.c1.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c1:focus::after {
+.c1.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -179,15 +188,6 @@ exports[`classnames should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 100%;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {
@@ -267,12 +267,21 @@ exports[`disabled should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1:focus {
+.c1.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
+  display: inline-block;
+}
+
+.c1.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c1:focus::after {
+.c1.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -287,15 +296,6 @@ exports[`disabled should match snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c1.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 100%;
-  display: inline-block;
 }
 
 .c1.fi-chip .fi-chip--content {

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -45,10 +45,6 @@ exports[`children should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
 }
 
 .c1:focus {
@@ -161,10 +157,6 @@ exports[`classnames should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
 }
 
 .c1:focus {
@@ -273,10 +265,6 @@ exports[`disabled should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
 }
 
 .c1:focus {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -444,10 +444,6 @@ exports[`has matching snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
 }
 
 .c12:focus {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -446,12 +446,21 @@ exports[`has matching snapshot 1`] = `
   font-weight: 600;
 }
 
-.c12:focus {
+.c12.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
+  display: inline-block;
+}
+
+.c12.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c12:focus::after {
+.c12.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -466,15 +475,6 @@ exports[`has matching snapshot 1`] = `
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
   border-radius: 16px;
-}
-
-.c12.fi-chip {
-  border-radius: 14px;
-  padding: 2px 10px;
-  color: hsl(0,0%,100%);
-  background: hsl(212,63%,45%);
-  max-height: 100%;
-  display: inline-block;
 }
 
 .c12.fi-chip .fi-chip--content {


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
Clean up the duplicate CSS code in BaseChip component. 
Also move focus related styling so it's inside fi-chip class.

## Motivation and Context
Makes the CSS code easier to read and modify.

## How Has This Been Tested?
MacOs: Firefox, Chrome. Styleguidist, CRA. 

## Release notes
- Cleaned up the styling code of BaseChip component
<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
