### PR TITLE
[Fix] ExternalLink new window props

### DIFF
--- a/src/core/Link/ExternalLink/ExternalLink.test.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.test.tsx
@@ -6,7 +6,6 @@ import { ExternalLink } from './ExternalLink';
 
 const TestExternalLink = (
   <ExternalLink
-    toNewWindow
     href="/"
     data-testid="test-link"
     labelNewWindow="Opens in a new window"

--- a/src/core/Link/ExternalLink/ExternalLink.test.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.test.tsx
@@ -6,6 +6,7 @@ import { ExternalLink } from './ExternalLink';
 
 const TestExternalLink = (
   <ExternalLink
+    toNewWindow
     href="/"
     data-testid="test-link"
     labelNewWindow="Opens in a new window"

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { default as styled } from 'styled-components';
-import { getLogger } from '../../../utils/log';
 import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { Icon } from '../../Icon/Icon';
@@ -12,16 +11,26 @@ import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
 const iconClassName = 'fi-link_icon';
 const externalClassName = 'fi-link--external';
 
-export interface ExternalLinkProps extends BaseLinkProps {
-  /** Translated explanation of 'opens to a new window' */
-  labelNewWindow: string;
+type newWindowProps =
+  | {
+      toNewWindow: true;
+      labelNewWindow: string;
+    }
+  | {
+      toNewWindow: false;
+      labelNewWindow?: never;
+    };
+
+interface InternalExternalLinkProps extends BaseLinkProps {
   /** Hide the icon */
   hideIcon?: boolean;
-  /** Open to a new window
-   * @default true
-   */
-  toNewWindow?: boolean;
+  /** Open to a new window */
+  toNewWindow: boolean;
+  /** Translated explanation of 'opens to a new window' */
+  labelNewWindow?: string;
 }
+
+export type ExternalLinkProps = newWindowProps & InternalExternalLinkProps;
 
 class BaseExternalLink extends Component<ExternalLinkProps> {
   render() {
@@ -29,7 +38,7 @@ class BaseExternalLink extends Component<ExternalLinkProps> {
       asProp,
       children,
       className,
-      toNewWindow = true,
+      toNewWindow,
       labelNewWindow,
       hideIcon,
       ...passProps
@@ -71,20 +80,10 @@ const StyledExternalLink = styled(
  */
 export class ExternalLink extends Component<ExternalLinkProps> {
   render() {
-    const { labelNewWindow, ...passProps } = this.props;
-    if (!labelNewWindow) {
-      getLogger().warn(
-        'External link needs a translated description of link opening to a new window',
-      );
-    }
     return (
       <SuomifiThemeConsumer>
         {({ suomifiTheme }) => (
-          <StyledExternalLink
-            theme={suomifiTheme}
-            labelNewWindow={labelNewWindow}
-            {...passProps}
-          />
+          <StyledExternalLink theme={suomifiTheme} {...this.props} />
         )}
       </SuomifiThemeConsumer>
     );

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -13,19 +13,19 @@ const externalClassName = 'fi-link--external';
 
 type newWindowProps =
   | {
-      toNewWindow: true;
-      labelNewWindow: string;
-    }
-  | {
       toNewWindow: false;
       labelNewWindow?: never;
+    }
+  | {
+      toNewWindow?: true;
+      labelNewWindow: string;
     };
 
 interface InternalExternalLinkProps extends BaseLinkProps {
   /** Hide the icon */
   hideIcon?: boolean;
   /** Open to a new window */
-  toNewWindow: boolean;
+  toNewWindow?: boolean;
   /** Translated explanation of 'opens to a new window' */
   labelNewWindow?: string;
 }

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -38,7 +38,7 @@ class BaseExternalLink extends Component<ExternalLinkProps> {
       asProp,
       children,
       className,
-      toNewWindow,
+      toNewWindow = true,
       labelNewWindow,
       hideIcon,
       ...passProps

--- a/src/core/Link/Link/Link.md
+++ b/src/core/Link/Link/Link.md
@@ -48,7 +48,6 @@ import { ExternalLink } from 'suomifi-ui-components';
 <>
   <ExternalLink
     href="https://designsystem.suomi.fi/fi/"
-    toNewWindow
     labelNewWindow="Opens to a new window"
   >
     External link opens to new window
@@ -56,7 +55,6 @@ import { ExternalLink } from 'suomifi-ui-components';
   <ExternalLink
     href="https://designsystem.suomi.fi/fi/"
     toNewWindow={false}
-    labelNewWindow="Opens to same window"
   >
     External link in same window
   </ExternalLink>


### PR DESCRIPTION
## Description
This PR addresses an issue where ExternalLink would have a required prop `labelNewWindow` even when `toNewWindow` prop was set to false. The solution utilizes conditional props to change the logic as follows:
  * if `toNewWindow` is true, which is also the default value, `labelNewWindow` must be set as well
  * if `toNewWindow` is false, `labelNewWindow` cannot be set.

## Motivation and Context
A redundant prop was required when `toNewWindow` was set to false

## How Has This Been Tested?
Tested in styleguidist on Chrome as well as in a CRA project on Chrome. Also checked that VSCode tooltips show and support the new logic.

## Release notes
### ExternalLink
  * **Breaking change:** `labelNewWindow` no longer required or allowed when `toNewWindow` is set to false
