### PR TITLE
[Fix] API documentation styling

### DIFF
--- a/.styleguidist/styleguidist.styles.js
+++ b/.styleguidist/styleguidist.styles.js
@@ -71,7 +71,7 @@ module.exports = {
     type: {
       display: 'block',
       overflowY: 'auto',
-      maxHeight: '6em',
+      maxHeight: '144px',
       minWidth: '20vw',
     },
   },

--- a/.styleguidist/styleguidist.styles.js
+++ b/.styleguidist/styleguidist.styles.js
@@ -78,17 +78,8 @@ module.exports = {
   Table: {
     cell: {
       position: 'relative',
-      '&:after': {
-        display: 'block',
-        content: '""',
-        position: 'absolute',
-        top: '0',
-        height: '100%',
-        width: '100%',
-        background:
-          'linear-gradient(180deg, rgba(255, 255, 255, 0) 0, rgba(255, 255, 255, 0) 4.5em, rgba(255, 255, 255, 1) 6em)',
-        pointerEvents: 'none',
-      },
+      borderBottom: '1px solid #e8e8e8',
+      lineHeight: '24px',
     },
   },
   Playground: {


### PR DESCRIPTION
## Description
This PR improves the readability of the API descriptions in styleguidist. Previously there was an unnecessary fade at the bottom of the prop descriptions. This PR removes that and adds lines between props as well as vertically aligns content in rows.

## Motivation and Context
API descriptions should be clear and easily readable and skimmable.

## How Has This Been Tested?
By running styleguidist on Chrome on Windows

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/54316341/169514454-5f6ca8df-4e69-436e-8dbb-b04d321d9c01.png)


## Release notes
### General changes
* Improve API documentation readability in Styleguidist
