### PR TITLE
[Feature] CheckboxGroup status & status text

### DIFF
--- a/src/core/Form/Checkbox/Checkbox.md
+++ b/src/core/Form/Checkbox/Checkbox.md
@@ -63,6 +63,8 @@ import React from 'react';
   <CheckboxGroup
     labelText="Checkboxes in group"
     groupHintText="Example hint text"
+    groupStatus="error"
+    groupStatusText="Example status text"
   >
     <Checkbox defaultChecked hintText="Example hint text">
       Regular checkbox that is checked and has a hint text

--- a/src/core/Form/Checkbox/Checkbox.md
+++ b/src/core/Form/Checkbox/Checkbox.md
@@ -66,9 +66,11 @@ import React from 'react';
     groupStatus="error"
     groupStatusText="Please choose at least one"
   >
-    <Checkbox defaultChecked>By email</Checkbox>
+    <Checkbox defaultChecked hintText="24/7">
+      By email
+    </Checkbox>
 
-    <Checkbox hintText="We will call at office hours (08:00 - 16:00)">
+    <Checkbox hintText="We will call at office hours">
       By phone
     </Checkbox>
 

--- a/src/core/Form/Checkbox/Checkbox.md
+++ b/src/core/Form/Checkbox/Checkbox.md
@@ -61,20 +61,20 @@ import React from 'react';
 
 <>
   <CheckboxGroup
-    labelText="Checkboxes in group"
-    groupHintText="Example hint text"
+    labelText="How You want to be contacted"
+    groupHintText="You can choose more than one"
     groupStatus="error"
-    groupStatusText="Example status text"
+    groupStatusText="Please choose at least one"
   >
-    <Checkbox defaultChecked hintText="Example hint text">
-      Regular checkbox that is checked and has a hint text
+    <Checkbox defaultChecked>By email</Checkbox>
+
+    <Checkbox hintText="We will call at office hours (08:00 - 16:00)">
+      By phone
     </Checkbox>
 
-    <Checkbox hintText="Example hint text">
-      Regular checkbox with a hint text
+    <Checkbox hintText="We will knock twice">
+      By personal visit
     </Checkbox>
-
-    <Checkbox>Regular checkbox</Checkbox>
   </CheckboxGroup>
 </>;
 ```

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -253,19 +253,19 @@ const StyledCheckbox = styled(
 
 export const Checkbox = forwardRef(
   (props: CheckboxProps, ref: React.RefObject<HTMLInputElement>) => {
-    const { id: propId, ...passProps } = props;
+    const { id: propId, status: propStatus, ...passProps } = props;
     return (
       <SuomifiThemeConsumer>
         {({ suomifiTheme }) => (
           <AutoId id={propId}>
             {(id) => (
               <CheckboxGroupConsumer>
-                {({ status }) => (
+                {({ status: groupStatus }) => (
                   <StyledCheckbox
                     theme={suomifiTheme}
                     id={id}
                     forwardedRef={ref}
-                    status={status}
+                    status={!!propStatus ? propStatus : groupStatus}
                     {...passProps}
                   />
                 )}

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -10,6 +10,7 @@ import { HtmlLabel, HtmlDiv, HtmlInput } from '../../../reset';
 import { Icon } from '../../Icon/Icon';
 import { StatusText } from '../StatusText/StatusText';
 import { HintText } from '../HintText/HintText';
+import { CheckboxGroupConsumer } from './CheckboxGroup';
 import { baseStyles } from './Checkbox.baseStyles';
 
 const baseClassName = 'fi-checkbox';
@@ -258,12 +259,17 @@ export const Checkbox = forwardRef(
         {({ suomifiTheme }) => (
           <AutoId id={propId}>
             {(id) => (
-              <StyledCheckbox
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+              <CheckboxGroupConsumer>
+                {({ status }) => (
+                  <StyledCheckbox
+                    theme={suomifiTheme}
+                    id={id}
+                    forwardedRef={ref}
+                    status={status}
+                    {...passProps}
+                  />
+                )}
+              </CheckboxGroupConsumer>
             )}
           </AutoId>
         )}

--- a/src/core/Form/Checkbox/CheckboxGroup.test.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Checkbox } from './Checkbox';
 import { CheckboxGroup } from './CheckboxGroup';
 
@@ -101,6 +101,57 @@ describe('props', () => {
       const { getByText } = render(OptionalTextGroup);
       const optionalText = getByText('(optional)');
       expect(optionalText).not.toEqual(null);
+    });
+  });
+
+  describe('groupStatusText', () => {
+    const StatusGroup = (
+      <CheckboxGroup labelText="Label" groupStatusText="All good!">
+        {CheckboxChilds}
+      </CheckboxGroup>
+    );
+
+    it('has the given text', () => {
+      render(StatusGroup);
+      expect(screen.getByText('All good!')).not.toBeNull();
+    });
+  });
+
+  describe('groupStatus', () => {
+    const StatusGroup = (
+      <CheckboxGroup labelText="Label" groupStatus="error">
+        {CheckboxChilds}
+      </CheckboxGroup>
+    );
+
+    const StatusGroupOneDifferent = (
+      <CheckboxGroup labelText="Label" groupStatus="error">
+        <Checkbox key={1} id={`test-id-${1}`}>
+          {`Label text ${1}`}
+        </Checkbox>
+        <Checkbox key={2} id={`test-id-${2}`} status="default">
+          {`Label text ${2}`}
+        </Checkbox>
+        <Checkbox key={3} id={`test-id-${3}`}>
+          {`Label text ${3}`}
+        </Checkbox>
+      </CheckboxGroup>
+    );
+
+    it('has Checkboxes with the error statuses', () => {
+      render(StatusGroup);
+      const fieldset = screen.getByRole('group');
+      expect(fieldset.querySelectorAll('.fi-status-text--error')).toHaveLength(
+        3,
+      );
+    });
+
+    it('has two in error state; not overriding individual Checkbox prop', () => {
+      render(StatusGroupOneDifferent);
+      const fieldset = screen.getByRole('group');
+      expect(fieldset.querySelectorAll('.fi-status-text--error')).toHaveLength(
+        2,
+      );
     });
   });
 });

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -50,6 +50,15 @@ export interface CheckboxGroupProps {
   groupStatusText?: string;
 }
 
+export interface CheckboxGroupProviderState {
+  status?: CheckboxGroupStatus;
+}
+
+const defaultProviderValue: CheckboxGroupProviderState = {};
+
+const { Provider, Consumer: CheckboxGroupConsumer } =
+  React.createContext(defaultProviderValue);
+
 class BaseCheckboxGroup extends Component<
   CheckboxGroupProps & SuomifiThemeProp
 > {
@@ -92,7 +101,13 @@ class BaseCheckboxGroup extends Component<
             {groupHintText && <HintText>{groupHintText}</HintText>}
           </HtmlLegend>
           <HtmlDiv className={checkboxGroupClassNames.container}>
-            {children}
+            <Provider
+              value={{
+                status: groupStatus,
+              }}
+            >
+              {children}
+            </Provider>
           </HtmlDiv>
         </HtmlFieldSet>
         <StatusText
@@ -136,3 +151,5 @@ export class CheckboxGroup extends Component<CheckboxGroupProps> {
     );
   }
 }
+
+export { CheckboxGroupConsumer };

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -1,20 +1,25 @@
 import React, { Component, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
+import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlDiv, HtmlFieldSet, HtmlLegend } from '../../../reset';
+import { InputStatus } from '../types';
 import { Label } from '../Label/Label';
 import { HintText } from '../HintText/HintText';
+import { StatusText } from '../StatusText/StatusText';
 import { CheckboxProps } from './Checkbox';
 import { baseStyles } from './CheckboxGroup.baseStyles';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import classnames from 'classnames';
 
 const baseClassName = 'fi-checkbox-group';
 const checkboxGroupClassNames = {
   legend: `${baseClassName}_legend`,
   labelIsVisible: `${baseClassName}_label--visible`,
   container: `${baseClassName}_container`,
+  statusTextHasContent: `${baseClassName}_statusText--has-content`,
 };
+
+type CheckboxGroupStatus = Exclude<InputStatus, 'success'>;
 
 export interface CheckboxGroupProps {
   /** Custom classname to extend or customize */
@@ -36,6 +41,13 @@ export interface CheckboxGroupProps {
    * If no id is specified, one will be generated
    */
   id?: string;
+  /**
+   * 'default' | 'error'
+   * @default default
+   */
+  groupStatus?: CheckboxGroupStatus;
+  /** Status text to be shown below the component and hint text. Use e.g. for validation error */
+  groupStatusText?: string;
 }
 
 class BaseCheckboxGroup extends Component<
@@ -51,8 +63,12 @@ class BaseCheckboxGroup extends Component<
       optionalText,
       groupHintText,
       id,
+      groupStatus = 'default',
+      groupStatusText,
       ...passProps
     } = this.props;
+
+    const statusTextId = !!groupStatusText ? `${id}-statusText` : undefined;
 
     return (
       <HtmlDiv
@@ -79,6 +95,15 @@ class BaseCheckboxGroup extends Component<
             {children}
           </HtmlDiv>
         </HtmlFieldSet>
+        <StatusText
+          className={classnames({
+            [checkboxGroupClassNames.statusTextHasContent]: !!groupStatusText,
+          })}
+          id={statusTextId}
+          status={groupStatus}
+        >
+          {groupStatusText}
+        </StatusText>
       </HtmlDiv>
     );
   }

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -11,7 +11,7 @@ import { StatusText } from '../StatusText/StatusText';
 import { CheckboxProps } from './Checkbox';
 import { baseStyles } from './CheckboxGroup.baseStyles';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { VisuallyHidden } from '../../..';
+import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 
 const baseClassName = 'fi-checkbox-group';
 const checkboxGroupClassNames = {

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
+import { getConditionalAriaProp } from '../../../utils/aria';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlDiv, HtmlFieldSet, HtmlLegend } from '../../../reset';
 import { InputStatus } from '../types';
@@ -10,6 +11,7 @@ import { StatusText } from '../StatusText/StatusText';
 import { CheckboxProps } from './Checkbox';
 import { baseStyles } from './CheckboxGroup.baseStyles';
 import { AutoId } from '../../utils/AutoId/AutoId';
+import { VisuallyHidden } from '../../..';
 
 const baseClassName = 'fi-checkbox-group';
 const checkboxGroupClassNames = {
@@ -100,6 +102,11 @@ class BaseCheckboxGroup extends Component<
               {labelText}
             </Label>
             {groupHintText && <HintText>{groupHintText}</HintText>}
+            {groupStatusText && (
+              <VisuallyHidden
+                {...getConditionalAriaProp('aria-labelledby', [statusTextId])}
+              />
+            )}
           </HtmlLegend>
           <HtmlDiv className={checkboxGroupClassNames.container}>
             <Provider

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -47,7 +47,7 @@ export interface CheckboxGroupProps {
    * @default default
    */
   groupStatus?: CheckboxGroupStatus;
-  /** Status text to be shown below the component and hint text. Use e.g. for validation error */
+  /** Status text to be shown below the component. Use e.g. for validation error */
   groupStatusText?: string;
 }
 

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -42,6 +42,7 @@ export interface CheckboxGroupProps {
    */
   id?: string;
   /**
+   * Status for the group. Will be passed to children.
    * 'default' | 'error'
    * @default default
    */

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -503,6 +503,11 @@ exports[`default, with only required props should match snapshot 1`] = `
         </div>
       </div>
     </fieldset>
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      class="c6 c10 fi-status-text"
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Add `groupStatus` and `groupStatusText` props.
`groupStatus` will affect the children Checkboxes by passing the status to them.

If individual Checkbox has given `status` already it will be overriding the group's `groupStatus`.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Able to give status for every Checkbox that are children of the group.


## How Has This Been Tested?
So far locally in styleguidist

## Screenshots:
```
// Props given
groupStatus="error"
groupStatusText="Please choose at least one"
```

![image](https://user-images.githubusercontent.com/53757053/171385541-c24f4c28-26a9-42d7-b080-37302d97b1ab.png)




## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### CheckboxGroup (#624)
- Add `groupStatus` and `groupStatusText` props.