### PR TITLE
[BreakingChange] Add ref suport for components

### DIFF
--- a/src/core/Alert/Alert/Alert.md
+++ b/src/core/Alert/Alert/Alert.md
@@ -1,8 +1,11 @@
 ```js
 import { Alert } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
 
 <>
-  <Alert closeText="Close" smallScreen>
+  <Alert closeText="Close" smallScreen ref={exampleRef}>
     The service will be temporarily unavailable on 5.6.2021 at 21.00 –
     23.59 due to maintenance.
   </Alert>

--- a/src/core/Alert/Alert/Alert.tsx
+++ b/src/core/Alert/Alert/Alert.tsx
@@ -39,7 +39,7 @@ export interface AlertProps extends HtmlDivWithRefProps {
   onCloseButtonClick?: () => void;
   /** Custom props passed to the close button */
   closeButtonProps?: Omit<HtmlButtonProps, 'onClick' | 'aria-label'>;
-  /** Ref is passed to the outer div element. Alternative for React `ref` attribute. */
+  /** Ref is passed to the root div element. Alternative for React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 

--- a/src/core/Alert/Alert/Alert.tsx
+++ b/src/core/Alert/Alert/Alert.tsx
@@ -39,13 +39,11 @@ export interface AlertProps extends HtmlDivWithRefProps {
   onCloseButtonClick?: () => void;
   /** Custom props passed to the close button */
   closeButtonProps?: Omit<HtmlButtonProps, 'onClick' | 'aria-label'>;
+  /** Ref is passed to the outer div element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
-}
-
-class BaseAlert extends Component<AlertProps & InnerRef> {
+class BaseAlert extends Component<AlertProps> {
   render() {
     const {
       className,
@@ -112,12 +110,10 @@ class BaseAlert extends Component<AlertProps & InnerRef> {
   }
 }
 
-const StyledAlert = styled(
-  (props: AlertProps & InnerRef & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
-    return <BaseAlert {...passProps} />;
-  },
-)`
+const StyledAlert = styled((props: AlertProps & SuomifiThemeProp) => {
+  const { theme, ...passProps } = props;
+  return <BaseAlert {...passProps} />;
+})`
   ${({ theme }) => baseStyles(theme)}
 `;
 

--- a/src/core/Alert/InlineAlert/InlineAlert.md
+++ b/src/core/Alert/InlineAlert/InlineAlert.md
@@ -1,8 +1,11 @@
 ```js
 import { InlineAlert } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
 
 <>
-  <InlineAlert labelText="Info">
+  <InlineAlert labelText="Info" ref={exampleRef}>
     Make sure that your name is typed exactly as it appears in your
     identification.
   </InlineAlert>

--- a/src/core/Block/Block.md
+++ b/src/core/Block/Block.md
@@ -6,6 +6,15 @@ import { Block } from 'suomifi-ui-components';
 
 ```js
 import { Block } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
+
+<Block ref={exampleRef}>Block with ref</Block>;
+```
+
+```js
+import { Block } from 'suomifi-ui-components';
 
 <Block padding="xxxl" style={{ border: '1px solid red' }}>
   Block with xl-padding

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React, { Component, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SpacingWithoutInsetProp } from '../theme/utils/spacing';
 import { baseStyles } from './Block.baseStyles';
-import { HtmlDiv, HtmlDivProps } from '../../reset';
+import { HtmlDivWithRef, HtmlDivProps } from '../../reset';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
 
 const baseClassName = 'fi-block';
@@ -44,7 +44,11 @@ export interface BlockProps extends HtmlDivProps {
   variant?: 'default' | 'section' | 'header' | 'nav' | 'main' | 'footer';
 }
 
-class SemanticBlock extends Component<BlockProps> {
+interface InternalBlockProps extends BlockProps {
+  forwardedRef: React.RefObject<HTMLDivElement>;
+}
+
+class SemanticBlock extends Component<InternalBlockProps> {
   render() {
     const {
       className,
@@ -66,7 +70,8 @@ class SemanticBlock extends Component<BlockProps> {
       ...passProps
     } = this.props;
     const ComponentVariant =
-      !variant || variant === 'default' ? HtmlDiv : variant;
+      !variant || variant === 'default' ? HtmlDivWithRef : variant;
+
     return (
       <ComponentVariant
         {...passProps}
@@ -96,7 +101,7 @@ class SemanticBlock extends Component<BlockProps> {
   }
 }
 
-const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
+const StyledBlock = styled((props: InternalBlockProps & SuomifiThemeProp) => {
   const { theme, ...passProps } = props;
   return <SemanticBlock {...passProps} />;
 })`
@@ -106,10 +111,14 @@ const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
 /**
  * Used in displaying a generic piece of HTML e.g. a div
  */
-const Block = (props: BlockProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledBlock theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
+const Block = forwardRef(
+  (props: BlockProps, ref: React.RefObject<HTMLDivElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledBlock theme={suomifiTheme} forwardedRef={ref} {...props} />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 Block.displayName = 'Block';

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -42,13 +42,11 @@ export interface BlockProps extends HtmlDivProps {
    * @default default
    */
   variant?: 'default' | 'section' | 'header' | 'nav' | 'main' | 'footer';
-}
-
-interface InnerRef {
+  /** Ref is forwarded to the inner element. Alternative for React `ref` attribute. */
   forwardedRef?: React.Ref<HTMLDivElement>;
 }
 
-class SemanticBlock extends Component<BlockProps & InnerRef> {
+class SemanticBlock extends Component<BlockProps> {
   render() {
     const {
       className,
@@ -104,7 +102,7 @@ class SemanticBlock extends Component<BlockProps & InnerRef> {
   }
 }
 
-const StyledBlock = styled((props: SuomifiThemeProp & InnerRef) => {
+const StyledBlock = styled((props: SuomifiThemeProp) => {
   const { theme, ...passProps } = props;
   return <SemanticBlock {...passProps} />;
 })`

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -42,8 +42,8 @@ export interface BlockProps extends HtmlDivProps {
    * @default default
    */
   variant?: 'default' | 'section' | 'header' | 'nav' | 'main' | 'footer';
-  /** Ref is forwarded to the inner element. Alternative for React `ref` attribute. */
-  forwardedRef?: React.Ref<HTMLDivElement>;
+  /** Ref is forwarded to the block element. All variants are supported. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLElement>;
 }
 
 class SemanticBlock extends Component<BlockProps> {
@@ -112,15 +112,13 @@ const StyledBlock = styled((props: SuomifiThemeProp) => {
 /**
  * Used in displaying a generic piece of HTML e.g. a div
  */
-const Block = forwardRef(
-  (props: BlockProps, ref: React.Ref<HTMLDivElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledBlock theme={suomifiTheme} forwardedRef={ref} {...props} />
-      )}
-    </SuomifiThemeConsumer>
-  ),
-);
+const Block = forwardRef((props: BlockProps, ref: React.Ref<HTMLElement>) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledBlock theme={suomifiTheme} forwardedRef={ref} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+));
 
 Block.displayName = 'Block';
 export { Block };

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -3,7 +3,7 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SpacingWithoutInsetProp } from '../theme/utils/spacing';
 import { baseStyles } from './Block.baseStyles';
-import { HtmlDivWithRef, HtmlDivProps } from '../../reset';
+import { HtmlDivWithNativeRef, HtmlDivProps } from '../../reset';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
 
 const baseClassName = 'fi-block';
@@ -44,11 +44,11 @@ export interface BlockProps extends HtmlDivProps {
   variant?: 'default' | 'section' | 'header' | 'nav' | 'main' | 'footer';
 }
 
-interface InternalBlockProps extends BlockProps {
-  forwardedRef: React.RefObject<HTMLDivElement>;
+interface InnerRef {
+  forwardedRef?: React.Ref<HTMLDivElement>;
 }
 
-class SemanticBlock extends Component<InternalBlockProps> {
+class SemanticBlock extends Component<BlockProps & InnerRef> {
   render() {
     const {
       className,
@@ -67,13 +67,16 @@ class SemanticBlock extends Component<InternalBlockProps> {
       pl,
       px,
       py,
+      forwardedRef,
       ...passProps
     } = this.props;
+
     const ComponentVariant =
-      !variant || variant === 'default' ? HtmlDivWithRef : variant;
+      !variant || variant === 'default' ? HtmlDivWithNativeRef : variant;
 
     return (
       <ComponentVariant
+        ref={forwardedRef}
         {...passProps}
         className={classnames(baseClassName, className, {
           [`${baseClassName}--padding-${padding}`]: !!padding,
@@ -101,7 +104,7 @@ class SemanticBlock extends Component<InternalBlockProps> {
   }
 }
 
-const StyledBlock = styled((props: InternalBlockProps & SuomifiThemeProp) => {
+const StyledBlock = styled((props: SuomifiThemeProp & InnerRef) => {
   const { theme, ...passProps } = props;
   return <SemanticBlock {...passProps} />;
 })`
@@ -112,7 +115,7 @@ const StyledBlock = styled((props: InternalBlockProps & SuomifiThemeProp) => {
  * Used in displaying a generic piece of HTML e.g. a div
  */
 const Block = forwardRef(
-  (props: BlockProps, ref: React.RefObject<HTMLDivElement>) => (
+  (props: BlockProps, ref: React.Ref<HTMLDivElement>) => (
     <SuomifiThemeConsumer>
       {({ suomifiTheme }) => (
         <StyledBlock theme={suomifiTheme} forwardedRef={ref} {...props} />

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -13,7 +13,7 @@ type ButtonVariant =
   | 'secondaryNoBorder'
   | 'link';
 
-interface InternalButtonProps
+export interface ButtonProps
   extends Omit<HtmlButtonProps, 'aria-disabled' | 'onClick'> {
   /**
    * 'default' | 'inverted' | 'secondary' | 'secondaryNoBorder' | 'link'
@@ -55,15 +55,8 @@ interface InternalButtonProps
    *  @default void
    */
   onClick?: (event: React.MouseEvent) => void;
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLButtonElement>;
-}
-
-export interface ButtonProps extends InternalButtonProps {
-  /** Ref object to be passed to the input element */
-  ref?: React.RefObject<HTMLButtonElement>;
+  /** Ref object is passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
 
 const baseClassName = 'fi-button';
@@ -72,7 +65,7 @@ const iconClassName = `${baseClassName}_icon`;
 const iconRightClassName = `${baseClassName}_icon--right`;
 const fullWidthClassName = `${baseClassName}--fullwidth`;
 
-class BaseButton extends Component<ButtonProps & InnerRef> {
+class BaseButton extends Component<ButtonProps> {
   render() {
     const {
       fullWidth,
@@ -138,10 +131,7 @@ class BaseButton extends Component<ButtonProps & InnerRef> {
 }
 
 const StyledButton = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalButtonProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: ButtonProps & SuomifiThemeProp) => (
     <BaseButton {...passProps} />
   ),
 )`

--- a/src/core/Chip/Chip/Chip.tsx
+++ b/src/core/Chip/Chip/Chip.tsx
@@ -19,7 +19,7 @@ const chipButtonClassNames = {
   icon: `${baseClassName}--icon`,
 };
 
-interface InternalChipProps
+export interface ChipProps
   extends BaseChipProps,
     Omit<
       HtmlButtonProps,
@@ -38,18 +38,10 @@ interface InternalChipProps
   actionLabel?: string;
   /** Soft disable the chip to allow tab-focus, but disable onClick functionality */
   'aria-disabled'?: boolean;
+  /** Ref is passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLButtonElement>;
-}
-
-export interface ChipProps extends InternalChipProps {
-  /** Ref object to be passed to the button element */
-  ref?: React.RefObject<HTMLButtonElement>;
-}
-
-class DefaultChip extends Component<ChipProps & InnerRef> {
+class DefaultChip extends Component<ChipProps> {
   render() {
     const {
       className,
@@ -106,10 +98,7 @@ class DefaultChip extends Component<ChipProps & InnerRef> {
 }
 
 const StyledChip = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalChipProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: ChipProps & SuomifiThemeProp) => (
     <DefaultChip {...passProps} />
   ),
 )`

--- a/src/core/Chip/StaticChip/StaticChip.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.tsx
@@ -12,7 +12,10 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 
 export interface StaticChipProps
   extends BaseChipProps,
-    Omit<HtmlSpanProps, 'children'> {}
+    Omit<HtmlSpanProps, 'children'> {
+  /** Ref is forwarded to the span element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
+}
 
 class BaseChip extends Component<StaticChipProps> {
   render() {

--- a/src/core/Chip/StaticChip/StaticChip.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, forwardRef } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
@@ -39,10 +39,14 @@ const StyledChip = styled(
   ${({ theme }) => staticChipBaseStyles(theme)}
 `;
 
-const StaticChip = (props: StaticChipProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledChip theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
+const StaticChip = forwardRef(
+  (props: StaticChipProps, ref: React.RefObject<HTMLSpanElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledChip theme={suomifiTheme} forwardedRef={ref} {...props} />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 StaticChip.displayName = 'StaticChip';

--- a/src/core/Chip/StaticChip/StaticChip.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.tsx
@@ -40,7 +40,7 @@ const StyledChip = styled(
 `;
 
 const StaticChip = forwardRef(
-  (props: StaticChipProps, ref: React.RefObject<HTMLSpanElement>) => (
+  (props: StaticChipProps, ref: React.Ref<HTMLSpanElement>) => (
     <SuomifiThemeConsumer>
       {({ suomifiTheme }) => (
         <StyledChip theme={suomifiTheme} forwardedRef={ref} {...props} />

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -43,7 +43,7 @@ interface DropdownState {
   selectedValue: string | undefined;
 }
 
-interface InternalDropdownProps {
+export interface DropdownProps {
   /**
    * Unique id
    * If no id is specified, one will be generated automatically
@@ -86,15 +86,8 @@ interface InternalDropdownProps {
     | ReactElement<DropdownItemProps>;
   /** Callback that fires when the dropdown value changes. */
   onChange?(newValue: string): void;
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
-}
-
-export interface DropdownProps extends InternalDropdownProps {
-  /** Ref object to be passed to the input element */
-  ref?: React.RefObject<HTMLDivElement>;
+  /** Ref object to be passed to the input element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
 const ListBoxContextWrapper = (props: {
@@ -159,7 +152,7 @@ const ListBoxContextWrapper = (props: {
   );
 };
 
-class BaseDropdown extends Component<DropdownProps & InnerRef> {
+class BaseDropdown extends Component<DropdownProps> {
   state: DropdownState = {
     selectedValue:
       'value' in this.props
@@ -173,7 +166,7 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
 
   popoverRef: React.RefObject<HTMLDivElement>;
 
-  constructor(props: DropdownProps & InnerRef) {
+  constructor(props: DropdownProps) {
     super(props);
     this.buttonRef = React.createRef();
     this.popoverRef = React.createRef();
@@ -314,10 +307,7 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
 }
 
 const StyledDropdown = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalDropdownProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: DropdownProps & SuomifiThemeProp) => (
     <BaseDropdown {...passProps} />
   ),
 )`

--- a/src/core/Expander/Expander/Expander.tsx
+++ b/src/core/Expander/Expander/Expander.tsx
@@ -1,8 +1,8 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { HtmlDiv } from '../../../reset';
+import { HtmlDivWithRef } from '../../../reset';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import {
   ExpanderGroupConsumer,
@@ -76,12 +76,18 @@ interface BaseExpanderProps extends ExpanderProps {
   consumer: ExpanderGroupProviderState;
 }
 
-class BaseExpander extends Component<BaseExpanderProps & SuomifiThemeProp> {
+interface InnerRef {
+  forwardedRef: React.Ref<HTMLDivElement>;
+}
+
+class BaseExpander extends Component<
+  BaseExpanderProps & SuomifiThemeProp & InnerRef
+> {
   state: ExpanderState = {
     openState: this.props.defaultOpen || false,
   };
 
-  constructor(props: BaseExpanderProps & SuomifiThemeProp) {
+  constructor(props: BaseExpanderProps & SuomifiThemeProp & InnerRef) {
     super(props);
     if (!!props.id) {
       const defaultOpen =
@@ -158,7 +164,7 @@ class BaseExpander extends Component<BaseExpanderProps & SuomifiThemeProp> {
     const openState = open !== undefined ? !!open : this.state.openState;
 
     return (
-      <HtmlDiv
+      <HtmlDivWithRef
         id={id}
         {...passProps}
         className={classnames(className, baseClassName, {
@@ -175,7 +181,7 @@ class BaseExpander extends Component<BaseExpanderProps & SuomifiThemeProp> {
         >
           {children}
         </ExpanderProvider>
-      </HtmlDiv>
+      </HtmlDivWithRef>
     );
   }
 }
@@ -192,29 +198,32 @@ interface ExpanderState {
  * <i class="semantics" />
  * Hide or show content with always visible title
  */
-const Expander = (props: ExpanderProps) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <ExpanderGroupConsumer>
-              {(consumer) => (
-                <StyledExpander
-                  theme={suomifiTheme}
-                  id={id}
-                  {...passProps}
-                  consumer={consumer}
-                />
-              )}
-            </ExpanderGroupConsumer>
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const Expander = forwardRef(
+  (props: ExpanderProps, ref: React.Ref<HTMLDivElement>) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <ExpanderGroupConsumer>
+                {(consumer) => (
+                  <StyledExpander
+                    theme={suomifiTheme}
+                    id={id}
+                    forwardedRef={ref}
+                    {...passProps}
+                    consumer={consumer}
+                  />
+                )}
+              </ExpanderGroupConsumer>
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 Expander.displayName = 'Expander';
 export { Expander, ExpanderConsumer, ExpanderProvider };

--- a/src/core/Expander/Expander/Expander.tsx
+++ b/src/core/Expander/Expander/Expander.tsx
@@ -55,6 +55,8 @@ export interface ExpanderProps {
   open?: boolean;
   /** Event handler to execute when clicked */
   onOpenChange?: (open: boolean) => void;
+  /** Ref is forwarded to wrapping div element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLDivElement>;
 }
 
 export interface ExpanderTitleBaseProps {
@@ -76,18 +78,12 @@ interface BaseExpanderProps extends ExpanderProps {
   consumer: ExpanderGroupProviderState;
 }
 
-interface InnerRef {
-  forwardedRef: React.Ref<HTMLDivElement>;
-}
-
-class BaseExpander extends Component<
-  BaseExpanderProps & SuomifiThemeProp & InnerRef
-> {
+class BaseExpander extends Component<BaseExpanderProps & SuomifiThemeProp> {
   state: ExpanderState = {
     openState: this.props.defaultOpen || false,
   };
 
-  constructor(props: BaseExpanderProps & SuomifiThemeProp & InnerRef) {
+  constructor(props: BaseExpanderProps & SuomifiThemeProp) {
     super(props);
     if (!!props.id) {
       const defaultOpen =

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Basic expander shoud match snapshot 1`] = `
-.c4 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -27,30 +27,59 @@ exports[`Basic expander shoud match snapshot 1`] = `
   cursor: pointer;
 }
 
-.c4:-moz-focusring {
+.c5:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
-.c4::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
 
-.c4::-webkit-file-upload-button {
+.c5::-webkit-file-upload-button {
   -webkit-appearance: button;
   font: inherit;
 }
 
-.c4::-webkit-inner-spin-button {
+.c5::-webkit-inner-spin-button {
   height: auto;
 }
 
-.c4::-webkit-outer-spin-button {
+.c5::-webkit-outer-spin-button {
   height: auto;
 }
 
-.c4::before,
-.c4::after {
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -83,7 +112,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -107,8 +136,8 @@ exports[`Basic expander shoud match snapshot 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
@@ -145,7 +174,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   opacity: 0;
 }
 
-.c6 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -178,15 +207,15 @@ exports[`Basic expander shoud match snapshot 1`] = `
   will-change: transition,height;
 }
 
-.c6.fi-expander {
+.c7.fi-expander {
   display: block;
 }
 
-.c6:not(.fi-expander_content--no-padding) {
+.c7:not(.fi-expander_content--no-padding) {
   padding: 0 16px;
 }
 
-.c6.fi-expander_content--open {
+.c7.fi-expander_content--open {
   visibility: visible;
   height: auto;
   border-top-left-radius: 0;
@@ -195,38 +224,38 @@ exports[`Basic expander shoud match snapshot 1`] = `
   animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
 }
 
-.c6.fi-expander_content--open:not(.fi-expander_content--no-padding) {
+.c7.fi-expander_content--open:not(.fi-expander_content--no-padding) {
   padding-top: 0;
   padding-right: 20px;
   padding-bottom: 20px;
   padding-left: 20px;
 }
 
-.c5 {
+.c6 {
   vertical-align: baseline;
 }
 
-.c5.fi-icon {
+.c6.fi-icon {
   display: inline-block;
 }
 
-.c5 .fi-icon-base-fill {
+.c6 .fi-icon-base-fill {
   fill: currentColor;
 }
 
-.c5 .fi-icon-base-stroke {
+.c6 .fi-icon-base-stroke {
   stroke: currentColor;
 }
 
-.c5.fi-icon--cursor-pointer {
+.c6.fi-icon--cursor-pointer {
   cursor: pointer;
 }
 
-.c5.fi-icon--cursor-pointer * {
+.c6.fi-icon--cursor-pointer * {
   cursor: inherit;
 }
 
-.c2 {
+.c3 {
   color: hsl(0,0%,16%);
   position: relative;
   width: 100%;
@@ -236,17 +265,17 @@ exports[`Basic expander shoud match snapshot 1`] = `
   border-radius: inherit;
 }
 
-.c2.fi-expander_title-button {
+.c3.fi-expander_title-button {
   display: block;
 }
 
-.c2.fi-expander_title-button--open {
+.c3.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.c2 .fi-expander_title-button_button {
+.c3 .fi-expander_title-button_button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -284,15 +313,15 @@ exports[`Basic expander shoud match snapshot 1`] = `
   padding: 17px 60px 16px 20px;
 }
 
-.c2 .fi-expander_title-button_button:focus {
+.c3 .fi-expander_title-button_button:focus {
   outline: 0;
 }
 
-.c2 .fi-expander_title-button_button:focus-within {
+.c3 .fi-expander_title-button_button:focus-within {
   outline: 0;
 }
 
-.c2 .fi-expander_title-button_button:focus-within:after {
+.c3 .fi-expander_title-button_button:focus-within:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -308,26 +337,26 @@ exports[`Basic expander shoud match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c2 .fi-expander_title-button_button:not(:focus-visible) {
+.c3 .fi-expander_title-button_button:not(:focus-visible) {
   outline: 0;
 }
 
-.c2 .fi-expander_title-button_button:not(:focus-visible):after {
+.c3 .fi-expander_title-button_button:not(:focus-visible):after {
   content: none;
 }
 
-.c2 .fi-expander_title-button_button * {
+.c3 .fi-expander_title-button_button * {
   cursor: pointer;
 }
 
-.c2 .fi-expander_title-button_button:hover,
-.c2 .fi-expander_title-button_button:active,
-.c2 .fi-expander_title-button_button:focus,
-.c2 .fi-expander_title-button_button:focus-within {
+.c3 .fi-expander_title-button_button:hover,
+.c3 .fi-expander_title-button_button:active,
+.c3 .fi-expander_title-button_button:focus,
+.c3 .fi-expander_title-button_button:focus-within {
   cursor: pointer;
 }
 
-.c2 .fi-expander_title-button-icon {
+.c3 .fi-expander_title-button-icon {
   position: absolute;
   top: 0;
   right: 0;
@@ -336,8 +365,8 @@ exports[`Basic expander shoud match snapshot 1`] = `
   margin: 20px;
 }
 
-.c2 .fi-expander_title-button--open .fi-expander_title-button-icon,
-.c2 .fi-expander_title-button-icon--open {
+.c3 .fi-expander_title-button--open .fi-expander_title-button-icon,
+.c3 .fi-expander_title-button-icon--open {
   -webkit-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
   transform: rotate(-180deg);
@@ -348,27 +377,27 @@ exports[`Basic expander shoud match snapshot 1`] = `
   id="4"
 >
   <div
-    class="c0 c2 fi-expander_title-button"
+    class="c2 c3 fi-expander_title-button"
     data-testid="expander-title"
   >
     <span
-      class="c3"
+      class="c4"
     >
       <button
         aria-controls="4_content"
         aria-expanded="false"
-        class="c4 fi-expander_title-button_button"
+        class="c5 fi-expander_title-button_button"
         type="button"
       >
         <span
-          class="c3"
+          class="c4"
           id="4_title"
         >
           Test expander
         </span>
         <svg
           aria-hidden="true"
-          class="fi-icon c5 fi-expander_title-button-icon"
+          class="fi-icon c6 fi-expander_title-button-icon"
           focusable="false"
           height="1em"
           viewBox="0 0 24 24"
@@ -388,7 +417,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="4_title"
-    class="c0 c6 fi-expander_content"
+    class="c2 c7 fi-expander_content"
     id="4_content"
     role="region"
   >

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv, HtmlButton, HtmlButtonProps, HtmlSpan } from '../../../reset';
@@ -55,6 +55,10 @@ interface ExpanderGroupState {
   expanderGroupOpenState: ExpanderGroupTargetOpenState;
 }
 
+interface InnerRef {
+  forwardedRef: React.Ref<HTMLButtonElement>;
+}
+
 export interface ExpanderGroupProviderState {
   onExpanderOpenChange: (id: string, newState: boolean | undefined) => void;
   expanderGroupOpenState: ExpanderGroupTargetOpenState;
@@ -71,7 +75,7 @@ const { Provider, Consumer: ExpanderGroupConsumer } =
   React.createContext(defaultProviderValue);
 
 class BaseExpanderGroup extends Component<
-  ExpanderGroupProps & SuomifiThemeProp
+  ExpanderGroupProps & SuomifiThemeProp & InnerRef
 > {
   state: ExpanderGroupState = {
     allOpen: undefined,
@@ -145,6 +149,7 @@ class BaseExpanderGroup extends Component<
       ariaCloseAllText,
       showToggleAllButton = true,
       toggleAllButtonProps,
+      forwardedRef,
       ...passProps
     } = this.props;
     const { expanderGroupOpenState, allOpen } = this.state;
@@ -164,6 +169,7 @@ class BaseExpanderGroup extends Component<
               openAllButtonClassName,
             )}
             aria-expanded={allOpen}
+            forwardedRef={forwardedRef}
           >
             <HtmlSpan aria-hidden={true}>
               {allOpen ? closeAllText : openAllText}
@@ -198,12 +204,19 @@ const StyledExpanderGroup = styled(BaseExpanderGroup)`
  * <i class="semantics" />
  * Wrapper for multiple expanders with Open/Close All button
  */
-const ExpanderGroup = (props: ExpanderGroupProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledExpanderGroup theme={suomifiTheme} {...props} />
-    )}
-  </SuomifiThemeConsumer>
+
+const ExpanderGroup = forwardRef(
+  (props: ExpanderGroupProps, ref: React.Ref<HTMLButtonElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledExpanderGroup
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 ExpanderGroup.displayName = 'ExpanderGroup';

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -38,6 +38,8 @@ export interface ExpanderGroupProps {
     | 'onKeyUp'
     | 'onKeyDown'
   >;
+  /** Ref is forwarded to button element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLButtonElement>;
 }
 
 interface ExpanderOpenStates {
@@ -53,10 +55,6 @@ interface ExpanderGroupState {
   allOpen: boolean | undefined;
   /** State change transition request */
   expanderGroupOpenState: ExpanderGroupTargetOpenState;
-}
-
-interface InnerRef {
-  forwardedRef: React.Ref<HTMLButtonElement>;
 }
 
 export interface ExpanderGroupProviderState {
@@ -75,7 +73,7 @@ const { Provider, Consumer: ExpanderGroupConsumer } =
   React.createContext(defaultProviderValue);
 
 class BaseExpanderGroup extends Component<
-  ExpanderGroupProps & SuomifiThemeProp & InnerRef
+  ExpanderGroupProps & SuomifiThemeProp
 > {
   state: ExpanderGroupState = {
     allOpen: undefined,

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -83,6 +83,35 @@ exports[`Basic expander group should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -243,7 +272,7 @@ exports[`Basic expander group should match snapshot 1`] = `
   content: none;
 }
 
-.c5 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -267,16 +296,16 @@ exports[`Basic expander group should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c5.fi-expander {
+.c6.fi-expander {
   display: block;
 }
 
-.c5:before {
+.c6:before {
   background-color: hsl(212,63%,98%);
   opacity: 0;
 }
 
-.c8 {
+.c9 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -309,15 +338,15 @@ exports[`Basic expander group should match snapshot 1`] = `
   will-change: transition,height;
 }
 
-.c8.fi-expander {
+.c9.fi-expander {
   display: block;
 }
 
-.c8:not(.fi-expander_content--no-padding) {
+.c9:not(.fi-expander_content--no-padding) {
   padding: 0 16px;
 }
 
-.c8.fi-expander_content--open {
+.c9.fi-expander_content--open {
   visibility: visible;
   height: auto;
   border-top-left-radius: 0;
@@ -326,38 +355,38 @@ exports[`Basic expander group should match snapshot 1`] = `
   animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
 }
 
-.c8.fi-expander_content--open:not(.fi-expander_content--no-padding) {
+.c9.fi-expander_content--open:not(.fi-expander_content--no-padding) {
   padding-top: 0;
   padding-right: 20px;
   padding-bottom: 20px;
   padding-left: 20px;
 }
 
-.c7 {
+.c8 {
   vertical-align: baseline;
 }
 
-.c7.fi-icon {
+.c8.fi-icon {
   display: inline-block;
 }
 
-.c7 .fi-icon-base-fill {
+.c8 .fi-icon-base-fill {
   fill: currentColor;
 }
 
-.c7 .fi-icon-base-stroke {
+.c8 .fi-icon-base-stroke {
   stroke: currentColor;
 }
 
-.c7.fi-icon--cursor-pointer {
+.c8.fi-icon--cursor-pointer {
   cursor: pointer;
 }
 
-.c7.fi-icon--cursor-pointer * {
+.c8.fi-icon--cursor-pointer * {
   cursor: inherit;
 }
 
-.c6 {
+.c7 {
   color: hsl(0,0%,16%);
   position: relative;
   width: 100%;
@@ -367,17 +396,17 @@ exports[`Basic expander group should match snapshot 1`] = `
   border-radius: inherit;
 }
 
-.c6.fi-expander_title-button {
+.c7.fi-expander_title-button {
   display: block;
 }
 
-.c6.fi-expander_title-button--open {
+.c7.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.c6 .fi-expander_title-button_button {
+.c7 .fi-expander_title-button_button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -415,15 +444,15 @@ exports[`Basic expander group should match snapshot 1`] = `
   padding: 17px 60px 16px 20px;
 }
 
-.c6 .fi-expander_title-button_button:focus {
+.c7 .fi-expander_title-button_button:focus {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button_button:focus-within {
+.c7 .fi-expander_title-button_button:focus-within {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button_button:focus-within:after {
+.c7 .fi-expander_title-button_button:focus-within:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -439,26 +468,26 @@ exports[`Basic expander group should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c6 .fi-expander_title-button_button:not(:focus-visible) {
+.c7 .fi-expander_title-button_button:not(:focus-visible) {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button_button:not(:focus-visible):after {
+.c7 .fi-expander_title-button_button:not(:focus-visible):after {
   content: none;
 }
 
-.c6 .fi-expander_title-button_button * {
+.c7 .fi-expander_title-button_button * {
   cursor: pointer;
 }
 
-.c6 .fi-expander_title-button_button:hover,
-.c6 .fi-expander_title-button_button:active,
-.c6 .fi-expander_title-button_button:focus,
-.c6 .fi-expander_title-button_button:focus-within {
+.c7 .fi-expander_title-button_button:hover,
+.c7 .fi-expander_title-button_button:active,
+.c7 .fi-expander_title-button_button:focus,
+.c7 .fi-expander_title-button_button:focus-within {
   cursor: pointer;
 }
 
-.c6 .fi-expander_title-button-icon {
+.c7 .fi-expander_title-button-icon {
   position: absolute;
   top: 0;
   right: 0;
@@ -467,8 +496,8 @@ exports[`Basic expander group should match snapshot 1`] = `
   margin: 20px;
 }
 
-.c6 .fi-expander_title-button--open .fi-expander_title-button-icon,
-.c6 .fi-expander_title-button-icon--open {
+.c7 .fi-expander_title-button--open .fi-expander_title-button-icon,
+.c7 .fi-expander_title-button-icon--open {
   -webkit-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
   transform: rotate(-180deg);
@@ -498,11 +527,11 @@ exports[`Basic expander group should match snapshot 1`] = `
     class="c0 fi-expander-group_expanders"
   >
     <div
-      class="c0 c5 fi-expander"
+      class="c5 c6 fi-expander"
       id="id-first"
     >
       <div
-        class="c0 c6 fi-expander_title-button"
+        class="c0 c7 fi-expander_title-button"
         data-testid="expander-title-1"
       >
         <span
@@ -522,7 +551,7 @@ exports[`Basic expander group should match snapshot 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="fi-icon c7 fi-expander_title-button-icon"
+              class="fi-icon c8 fi-expander_title-button-icon"
               focusable="false"
               height="1em"
               viewBox="0 0 24 24"
@@ -542,7 +571,7 @@ exports[`Basic expander group should match snapshot 1`] = `
       <div
         aria-hidden="true"
         aria-labelledby="id-first_title"
-        class="c0 c8 fi-expander_content"
+        class="c0 c9 fi-expander_content"
         id="id-first_content"
         role="region"
       >
@@ -550,11 +579,11 @@ exports[`Basic expander group should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="c0 c5 fi-expander"
+      class="c5 c6 fi-expander"
       id="id-second"
     >
       <div
-        class="c0 c6 fi-expander_title-button"
+        class="c0 c7 fi-expander_title-button"
         data-testid="expander-title-2"
       >
         <span
@@ -574,7 +603,7 @@ exports[`Basic expander group should match snapshot 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="fi-icon c7 fi-expander_title-button-icon"
+              class="fi-icon c8 fi-expander_title-button-icon"
               focusable="false"
               height="1em"
               viewBox="0 0 24 24"
@@ -594,7 +623,7 @@ exports[`Basic expander group should match snapshot 1`] = `
       <div
         aria-hidden="true"
         aria-labelledby="id-second_title"
-        class="c0 c8 fi-expander_content"
+        class="c0 c9 fi-expander_content"
         id="id-second_content"
         role="region"
       >

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv, HtmlButton, HtmlButtonProps, HtmlSpan } from '../../../reset';
@@ -32,12 +32,18 @@ export interface ExpanderTitleButtonProps {
   >;
 }
 
+interface InnerRef {
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
+}
+
 interface InternalExpanderTitleButtonProps
   extends ExpanderTitleButtonProps,
     ExpanderTitleBaseProps,
     SuomifiThemeProp {}
 
-class BaseExpanderTitleButton extends Component<InternalExpanderTitleButtonProps> {
+class BaseExpanderTitleButton extends Component<
+  InternalExpanderTitleButtonProps & InnerRef
+> {
   render() {
     const {
       asHeading,
@@ -46,6 +52,7 @@ class BaseExpanderTitleButton extends Component<InternalExpanderTitleButtonProps
       theme,
       toggleButtonProps,
       consumer,
+      forwardedRef,
       ...passProps
     } = this.props;
 
@@ -58,6 +65,7 @@ class BaseExpanderTitleButton extends Component<InternalExpanderTitleButtonProps
       >
         <HtmlSpan {...(!!asHeading ? { as: asHeading } : {})}>
           <HtmlButton
+            forwardedRef={forwardedRef}
             {...toggleButtonProps}
             onClick={consumer.onToggleExpander}
             aria-expanded={!!consumer.open}
@@ -86,20 +94,26 @@ const StyledExpanderTitle = styled(BaseExpanderTitleButton)`
  * <i class="semantics" />
  * Expander title button for static title content and toggle for content visiblity
  */
-const ExpanderTitleButton = (props: ExpanderTitleButtonProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <ExpanderConsumer>
-        {(consumer) => (
-          <StyledExpanderTitle
-            theme={suomifiTheme}
-            consumer={consumer}
-            {...props}
-          />
-        )}
-      </ExpanderConsumer>
-    )}
-  </SuomifiThemeConsumer>
+const ExpanderTitleButton = forwardRef(
+  (
+    props: ExpanderTitleButtonProps,
+    ref: React.RefObject<HTMLButtonElement>,
+  ) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <ExpanderConsumer>
+          {(consumer) => (
+            <StyledExpanderTitle
+              theme={suomifiTheme}
+              consumer={consumer}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </ExpanderConsumer>
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 ExpanderTitleButton.displayName = 'ExpanderTitleButton';

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
@@ -30,9 +30,7 @@ export interface ExpanderTitleButtonProps {
     | 'onKeyUp'
     | 'onKeyDown'
   >;
-}
-
-interface InnerRef {
+  /** Ref is forwarded to the button element. Alternative for React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
 
@@ -41,9 +39,7 @@ interface InternalExpanderTitleButtonProps
     ExpanderTitleBaseProps,
     SuomifiThemeProp {}
 
-class BaseExpanderTitleButton extends Component<
-  InternalExpanderTitleButtonProps & InnerRef
-> {
+class BaseExpanderTitleButton extends Component<InternalExpanderTitleButtonProps> {
   render() {
     const {
       asHeading,

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -91,10 +91,8 @@ interface InternalCheckboxProps extends StatusTextCommonProps {
   name?: string;
   /** Value */
   value?: string;
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLInputElement>;
+  /** Ref object to be passed to the input element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
 export interface CheckboxProps extends InternalCheckboxProps {
@@ -102,7 +100,7 @@ export interface CheckboxProps extends InternalCheckboxProps {
   ref?: React.RefObject<HTMLInputElement>;
 }
 
-class BaseCheckbox extends Component<CheckboxProps & InnerRef> {
+class BaseCheckbox extends Component<CheckboxProps> {
   state = {
     checkedState: !!this.props.checked || !!this.props.defaultChecked,
   };
@@ -241,10 +239,7 @@ class BaseCheckbox extends Component<CheckboxProps & InnerRef> {
 }
 
 const StyledCheckbox = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalCheckboxProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: InternalCheckboxProps & SuomifiThemeProp) => (
     <BaseCheckbox {...passProps} />
   ),
 )`

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -1,9 +1,14 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
-import { HtmlDiv, HtmlFieldSet, HtmlLegend } from '../../../reset';
+import {
+  HtmlDiv,
+  HtmlDivWithRef,
+  HtmlFieldSet,
+  HtmlLegend,
+} from '../../../reset';
 import { InputStatus } from '../types';
 import { Label } from '../Label/Label';
 import { HintText } from '../HintText/HintText';
@@ -57,13 +62,17 @@ export interface CheckboxGroupProviderState {
   status?: CheckboxGroupStatus;
 }
 
+interface InnerRef {
+  forwardedRef: React.RefObject<HTMLDivElement>;
+}
+
 const defaultProviderValue: CheckboxGroupProviderState = {};
 
 const { Provider, Consumer: CheckboxGroupConsumer } =
   React.createContext(defaultProviderValue);
 
 class BaseCheckboxGroup extends Component<
-  CheckboxGroupProps & SuomifiThemeProp
+  CheckboxGroupProps & SuomifiThemeProp & InnerRef
 > {
   render() {
     const {
@@ -83,7 +92,7 @@ class BaseCheckboxGroup extends Component<
     const statusTextId = !!groupStatusText ? `${id}-statusText` : undefined;
 
     return (
-      <HtmlDiv
+      <HtmlDivWithRef
         className={classnames(baseClassName, className)}
         id={id}
         {...passProps}
@@ -127,7 +136,7 @@ class BaseCheckboxGroup extends Component<
         >
           {groupStatusText}
         </StatusText>
-      </HtmlDiv>
+      </HtmlDivWithRef>
     );
   }
 }
@@ -139,20 +148,27 @@ const StyledCheckboxGroup = styled(BaseCheckboxGroup)`
 /**
  * Use for grouping Checkboxes.
  */
-const CheckboxGroup = (props: CheckboxGroupProps) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledCheckboxGroup theme={suomifiTheme} id={id} {...passProps} />
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const CheckboxGroup = forwardRef(
+  (props: CheckboxGroupProps, ref: React.RefObject<HTMLDivElement>) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <StyledCheckboxGroup
+                theme={suomifiTheme}
+                id={id}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 CheckboxGroup.displayName = 'CheckboxGroup';
 

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -56,14 +56,12 @@ export interface CheckboxGroupProps {
   groupStatus?: CheckboxGroupStatus;
   /** Status text to be shown below the component. Use e.g. for validation error */
   groupStatusText?: string;
+  /** Ref is forwarded to the wrapping div element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLDivElement>;
 }
 
 export interface CheckboxGroupProviderState {
   status?: CheckboxGroupStatus;
-}
-
-interface InnerRef {
-  forwardedRef: React.Ref<HTMLDivElement>;
 }
 
 const defaultProviderValue: CheckboxGroupProviderState = {};
@@ -72,7 +70,7 @@ const { Provider, Consumer: CheckboxGroupConsumer } =
   React.createContext(defaultProviderValue);
 
 class BaseCheckboxGroup extends Component<
-  CheckboxGroupProps & SuomifiThemeProp & InnerRef
+  CheckboxGroupProps & SuomifiThemeProp
 > {
   render() {
     const {

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -56,7 +56,7 @@ export interface CheckboxGroupProps {
   groupStatus?: CheckboxGroupStatus;
   /** Status text to be shown below the component. Use e.g. for validation error */
   groupStatusText?: string;
-  /** Ref is forwarded to the wrapping div element. Alternative for React `ref` attribute. */
+  /** Ref is forwarded to the root div element. Alternative for React `ref` attribute. */
   forwardedRef?: React.Ref<HTMLDivElement>;
 }
 

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -63,7 +63,7 @@ export interface CheckboxGroupProviderState {
 }
 
 interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
+  forwardedRef: React.Ref<HTMLDivElement>;
 }
 
 const defaultProviderValue: CheckboxGroupProviderState = {};
@@ -149,7 +149,7 @@ const StyledCheckboxGroup = styled(BaseCheckboxGroup)`
  * Use for grouping Checkboxes.
  */
 const CheckboxGroup = forwardRef(
-  (props: CheckboxGroupProps, ref: React.RefObject<HTMLDivElement>) => {
+  (props: CheckboxGroupProps, ref: React.Ref<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
       <SuomifiThemeConsumer>

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -1,6 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`default, with only required props should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -27,35 +56,6 @@ exports[`default, with only required props should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -167,7 +167,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -191,8 +191,8 @@ exports[`default, with only required props should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -223,7 +223,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(3,59%,48%);
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -242,14 +242,14 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -425,10 +425,10 @@ exports[`default, with only required props should match snapshot 1`] = `
         class="c3 fi-checkbox-group_legend"
       >
         <div
-          class="c4 c5 fi-checkbox-group_label--visible fi-label"
+          class="c0 c4 fi-checkbox-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="1"
           >
             Label
@@ -436,10 +436,10 @@ exports[`default, with only required props should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-checkbox-group_container"
+        class="c6 fi-checkbox-group_container"
       >
         <div
-          class="c0 fi-checkbox_container c7 fi-checkbox"
+          class="c6 fi-checkbox_container c7 fi-checkbox"
         >
           <input
             aria-invalid="false"
@@ -456,11 +456,11 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c6 c10 fi-status-text"
+            class="c5 c10 fi-status-text"
           />
         </div>
         <div
-          class="c0 fi-checkbox_container c7 fi-checkbox"
+          class="c6 fi-checkbox_container c7 fi-checkbox"
         >
           <input
             aria-invalid="false"
@@ -477,11 +477,11 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c6 c10 fi-status-text"
+            class="c5 c10 fi-status-text"
           />
         </div>
         <div
-          class="c0 fi-checkbox_container c7 fi-checkbox"
+          class="c6 fi-checkbox_container c7 fi-checkbox"
         >
           <input
             aria-invalid="false"
@@ -498,7 +498,7 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c6 c10 fi-status-text"
+            class="c5 c10 fi-status-text"
           />
         </div>
       </div>
@@ -506,7 +506,7 @@ exports[`default, with only required props should match snapshot 1`] = `
     <span
       aria-atomic="true"
       aria-live="polite"
-      class="c6 c10 fi-status-text"
+      class="c5 c10 fi-status-text"
     />
   </div>
 </div>

--- a/src/core/Form/HintText/HintText.tsx
+++ b/src/core/Form/HintText/HintText.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
@@ -34,21 +34,27 @@ const StyledHintText = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const HintText = (props: HintTextProps) => {
-  const { children, ...passProps } = props;
-  if (!children) {
-    return null;
-  }
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledHintText theme={suomifiTheme} {...passProps}>
-          {children}
-        </StyledHintText>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const HintText = forwardRef(
+  (props: HintTextProps, ref: React.RefObject<HTMLSpanElement>) => {
+    const { children, ...passProps } = props;
+    if (!children) {
+      return null;
+    }
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledHintText
+            forwardedRef={ref}
+            theme={suomifiTheme}
+            {...passProps}
+          >
+            {children}
+          </StyledHintText>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 HintText.displayName = 'HintText';
 export { HintText };

--- a/src/core/Form/HintText/HintText.tsx
+++ b/src/core/Form/HintText/HintText.tsx
@@ -14,6 +14,9 @@ export interface HintTextProps extends HtmlSpanProps {
   children?: ReactNode;
   /** Custom class name for styling and customizing  */
   className?: string;
+
+  /** Ref is forwarded to the span element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
 const StyledHintText = styled(
@@ -35,7 +38,7 @@ const StyledHintText = styled(
 `;
 
 const HintText = forwardRef(
-  (props: HintTextProps, ref: React.RefObject<HTMLSpanElement>) => {
+  (props: HintTextProps, ref: React.Ref<HTMLSpanElement>) => {
     const { children, ...passProps } = props;
     if (!children) {
       return null;

--- a/src/core/Form/RadioButton/RadioButton.tsx
+++ b/src/core/Form/RadioButton/RadioButton.tsx
@@ -24,7 +24,7 @@ const radioButtonClassNames = {
   checked: `${baseClassName}--checked`,
 };
 
-interface InternalRadioButtonProps {
+export interface RadioButtonProps {
   /** Custom classname to extend or customize */
   className?: string;
   /** Label for element content */
@@ -57,22 +57,16 @@ interface InternalRadioButtonProps {
    * Screen readers will ignore children as label if id is provided.
    */
   'aria-labelledby'?: string;
+
+  /** Ref object to be passed to the input element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
 interface RadioButtonState {
   checkedState: boolean;
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLInputElement>;
-}
-
-export interface RadioButtonProps extends InternalRadioButtonProps {
-  /** Ref object to be passed to the input element */
-  ref?: React.RefObject<HTMLInputElement>;
-}
-
-class BaseRadioButton extends Component<RadioButtonProps & InnerRef> {
+class BaseRadioButton extends Component<RadioButtonProps> {
   state = {
     checkedState: !!this.props.checked,
   };
@@ -164,10 +158,7 @@ class BaseRadioButton extends Component<RadioButtonProps & InnerRef> {
 }
 
 const StyledRadioButton = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalRadioButtonProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: RadioButtonProps & SuomifiThemeProp) => (
     <BaseRadioButton {...passProps} />
   ),
 )`

--- a/src/core/Form/RadioButton/RadioButtonGroup.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.tsx
@@ -1,7 +1,12 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
-import { HtmlDiv, HtmlFieldSet, HtmlLegend } from '../../../reset';
+import {
+  HtmlDiv,
+  HtmlDivWithRef,
+  HtmlFieldSet,
+  HtmlLegend,
+} from '../../../reset';
 import { Label } from '../Label/Label';
 import { HintText } from '../HintText/HintText';
 import { RadioButtonProps } from './RadioButton';
@@ -60,8 +65,12 @@ export interface RadioButtonGroupState {
   selectedValue?: string;
 }
 
+interface InnerRef {
+  forwardedRef: React.RefObject<HTMLDivElement>;
+}
+
 class BaseRadioButtonGroup extends Component<
-  RadioButtonGroupProps & SuomifiThemeProp
+  RadioButtonGroupProps & SuomifiThemeProp & InnerRef
 > {
   state: RadioButtonGroupState = {
     selectedValue: this.props.value || this.props.defaultValue,
@@ -104,7 +113,7 @@ class BaseRadioButtonGroup extends Component<
     } = this.props;
 
     return (
-      <HtmlDiv
+      <HtmlDivWithRef
         className={classnames(baseClassName, className)}
         id={id}
         {...passProps}
@@ -137,7 +146,7 @@ class BaseRadioButtonGroup extends Component<
             </Provider>
           </HtmlDiv>
         </HtmlFieldSet>
-      </HtmlDiv>
+      </HtmlDivWithRef>
     );
   }
 }
@@ -151,24 +160,27 @@ const StyledRadioButtonGroup = styled(BaseRadioButtonGroup)`
  * Always overrides nested RadioButtons' name, checked and defaultChecked props.
  * Use RadioButtonGroup's name, value and defaultValue instead.
  */
-const RadioButtonGroup = (props: RadioButtonGroupProps) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledRadioButtonGroup
-              theme={suomifiTheme}
-              id={id}
-              {...passProps}
-            />
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const RadioButtonGroup = forwardRef(
+  (props: RadioButtonGroupProps, ref: React.RefObject<HTMLDivElement>) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <StyledRadioButtonGroup
+                theme={suomifiTheme}
+                id={id}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 RadioButtonGroup.displayName = 'RadioButtonGroup';
 

--- a/src/core/Form/RadioButton/RadioButtonGroup.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.tsx
@@ -48,7 +48,7 @@ export interface RadioButtonGroupProps {
   defaultValue?: string;
   /** Callback for RadioButtonGroup selected changes. */
   onChange?: (value: string) => void;
-  /** Ref is forwarded to the wrapping div element. Alternative for React `ref` attribute. */
+  /** Ref is forwarded to the root div element. Alternative for React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 

--- a/src/core/Form/RadioButton/RadioButtonGroup.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.tsx
@@ -48,6 +48,8 @@ export interface RadioButtonGroupProps {
   defaultValue?: string;
   /** Callback for RadioButtonGroup selected changes. */
   onChange?: (value: string) => void;
+  /** Ref is forwarded to the wrapping div element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
 export interface RadioButtonGroupProviderState {
@@ -65,12 +67,8 @@ export interface RadioButtonGroupState {
   selectedValue?: string;
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
-}
-
 class BaseRadioButtonGroup extends Component<
-  RadioButtonGroupProps & SuomifiThemeProp & InnerRef
+  RadioButtonGroupProps & SuomifiThemeProp
 > {
   state: RadioButtonGroupState = {
     selectedValue: this.props.value || this.props.defaultValue,

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -1,6 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`default, with only required props should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -27,35 +56,6 @@ exports[`default, with only required props should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -167,7 +167,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -191,8 +191,8 @@ exports[`default, with only required props should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -212,7 +212,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -231,14 +231,14 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -441,10 +441,10 @@ exports[`default, with only required props should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -452,10 +452,10 @@ exports[`default, with only required props should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -465,7 +465,7 @@ exports[`default, with only required props should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -503,7 +503,7 @@ exports[`default, with only required props should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -513,7 +513,7 @@ exports[`default, with only required props should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -551,7 +551,7 @@ exports[`default, with only required props should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -561,7 +561,7 @@ exports[`default, with only required props should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -605,6 +605,35 @@ exports[`default, with only required props should match snapshot 1`] = `
 `;
 
 exports[`props className should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -631,35 +660,6 @@ exports[`props className should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -771,7 +771,7 @@ exports[`props className should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -795,8 +795,8 @@ exports[`props className should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -816,7 +816,7 @@ exports[`props className should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -835,14 +835,14 @@ exports[`props className should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -1045,10 +1045,10 @@ exports[`props className should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -1056,10 +1056,10 @@ exports[`props className should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1069,7 +1069,7 @@ exports[`props className should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1107,7 +1107,7 @@ exports[`props className should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1117,7 +1117,7 @@ exports[`props className should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1155,7 +1155,7 @@ exports[`props className should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1165,7 +1165,7 @@ exports[`props className should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1209,6 +1209,35 @@ exports[`props className should match snapshot 1`] = `
 `;
 
 exports[`props defaultValue should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1235,35 +1264,6 @@ exports[`props defaultValue should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -1375,7 +1375,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1399,8 +1399,8 @@ exports[`props defaultValue should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -1420,7 +1420,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1439,14 +1439,14 @@ exports[`props defaultValue should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -1649,10 +1649,10 @@ exports[`props defaultValue should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -1660,10 +1660,10 @@ exports[`props defaultValue should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1673,7 +1673,7 @@ exports[`props defaultValue should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1711,7 +1711,7 @@ exports[`props defaultValue should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1721,7 +1721,7 @@ exports[`props defaultValue should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1759,7 +1759,7 @@ exports[`props defaultValue should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
+          class="c6 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
         >
           <input
             checked=""
@@ -1770,7 +1770,7 @@ exports[`props defaultValue should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1814,6 +1814,35 @@ exports[`props defaultValue should match snapshot 1`] = `
 `;
 
 exports[`props hintText should match snapshot 1`] = `
+.c7 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c7::before,
+.c7::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1840,35 +1869,6 @@ exports[`props hintText should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -1980,7 +1980,7 @@ exports[`props hintText should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2004,12 +2004,12 @@ exports[`props hintText should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -2026,7 +2026,7 @@ exports[`props hintText should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-hint-text {
+.c6.fi-hint-text {
   display: block;
 }
 
@@ -2046,7 +2046,7 @@ exports[`props hintText should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2065,14 +2065,14 @@ exports[`props hintText should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -2275,26 +2275,26 @@ exports[`props hintText should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
           </label>
         </div>
         <span
-          class="c6 c7 fi-hint-text"
+          class="c5 c6 fi-hint-text"
         >
           Example hint text
         </span>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c7 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -2304,7 +2304,7 @@ exports[`props hintText should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2342,7 +2342,7 @@ exports[`props hintText should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -2352,7 +2352,7 @@ exports[`props hintText should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2390,7 +2390,7 @@ exports[`props hintText should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -2400,7 +2400,7 @@ exports[`props hintText should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2444,6 +2444,35 @@ exports[`props hintText should match snapshot 1`] = `
 `;
 
 exports[`props id should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2470,35 +2499,6 @@ exports[`props id should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -2610,7 +2610,7 @@ exports[`props id should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2634,8 +2634,8 @@ exports[`props id should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -2655,7 +2655,7 @@ exports[`props id should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2674,14 +2674,14 @@ exports[`props id should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -2884,10 +2884,10 @@ exports[`props id should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="good-id"
           >
             Label
@@ -2895,10 +2895,10 @@ exports[`props id should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -2908,7 +2908,7 @@ exports[`props id should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2946,7 +2946,7 @@ exports[`props id should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -2956,7 +2956,7 @@ exports[`props id should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2994,7 +2994,7 @@ exports[`props id should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -3004,7 +3004,7 @@ exports[`props id should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3048,6 +3048,35 @@ exports[`props id should match snapshot 1`] = `
 `;
 
 exports[`props label should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -3074,35 +3103,6 @@ exports[`props label should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -3214,7 +3214,7 @@ exports[`props label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3238,8 +3238,8 @@ exports[`props label should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -3259,7 +3259,7 @@ exports[`props label should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3278,14 +3278,14 @@ exports[`props label should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -3488,10 +3488,10 @@ exports[`props label should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label here
@@ -3499,10 +3499,10 @@ exports[`props label should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -3512,7 +3512,7 @@ exports[`props label should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3550,7 +3550,7 @@ exports[`props label should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -3560,7 +3560,7 @@ exports[`props label should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3598,7 +3598,7 @@ exports[`props label should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -3608,7 +3608,7 @@ exports[`props label should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3652,6 +3652,35 @@ exports[`props label should match snapshot 1`] = `
 `;
 
 exports[`props labelMode should match snapshot 1`] = `
+.c7 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c7::before,
+.c7::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -3678,35 +3707,6 @@ exports[`props labelMode should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -3818,7 +3818,7 @@ exports[`props labelMode should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3842,8 +3842,8 @@ exports[`props labelMode should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -3863,7 +3863,7 @@ exports[`props labelMode should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c7 {
+.c6 {
   position: absolute;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -3875,7 +3875,7 @@ exports[`props labelMode should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3894,14 +3894,14 @@ exports[`props labelMode should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -4104,20 +4104,20 @@ exports[`props labelMode should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-label"
+          class="c0 c4 fi-label"
         >
           <span
-            class="c6 c7 fi-visually-hidden"
+            class="c5 c6 fi-visually-hidden"
           >
             Label here
           </span>
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c7 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -4127,7 +4127,7 @@ exports[`props labelMode should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4165,7 +4165,7 @@ exports[`props labelMode should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -4175,7 +4175,7 @@ exports[`props labelMode should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4213,7 +4213,7 @@ exports[`props labelMode should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -4223,7 +4223,7 @@ exports[`props labelMode should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4267,6 +4267,35 @@ exports[`props labelMode should match snapshot 1`] = `
 `;
 
 exports[`props name should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -4293,35 +4322,6 @@ exports[`props name should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -4433,7 +4433,7 @@ exports[`props name should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4457,8 +4457,8 @@ exports[`props name should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -4478,7 +4478,7 @@ exports[`props name should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -4497,14 +4497,14 @@ exports[`props name should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -4707,10 +4707,10 @@ exports[`props name should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -4718,10 +4718,10 @@ exports[`props name should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -4731,7 +4731,7 @@ exports[`props name should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4769,7 +4769,7 @@ exports[`props name should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -4779,7 +4779,7 @@ exports[`props name should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4817,7 +4817,7 @@ exports[`props name should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -4827,7 +4827,7 @@ exports[`props name should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4871,6 +4871,35 @@ exports[`props name should match snapshot 1`] = `
 `;
 
 exports[`props value should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -4897,35 +4926,6 @@ exports[`props value should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -5037,7 +5037,7 @@ exports[`props value should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -5061,8 +5061,8 @@ exports[`props value should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -5082,7 +5082,7 @@ exports[`props value should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -5101,14 +5101,14 @@ exports[`props value should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -5312,10 +5312,10 @@ exports[`props value should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -5323,10 +5323,10 @@ exports[`props value should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -5336,7 +5336,7 @@ exports[`props value should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -5374,7 +5374,7 @@ exports[`props value should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
+          class="c6 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
         >
           <input
             checked=""
@@ -5385,7 +5385,7 @@ exports[`props value should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -5423,7 +5423,7 @@ exports[`props value should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -5433,7 +5433,7 @@ exports[`props value should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"

--- a/src/core/Form/SearchInput/SearchInput.test.tsx
+++ b/src/core/Form/SearchInput/SearchInput.test.tsx
@@ -214,6 +214,23 @@ describe('props', () => {
       expect(inputElement.value).toBe('new value');
     });
   });
+
+  describe('ref', () => {
+    it('ref is forwarded to input', () => {
+      const ref = React.createRef<HTMLInputElement>();
+
+      render(
+        <SearchInput
+          labelText="Debounced search"
+          clearButtonLabel="clear"
+          searchButtonLabel="search"
+          ref={ref}
+        />,
+      );
+
+      expect(ref.current?.tagName).toBe('INPUT');
+    });
+  });
 });
 
 describe('states', () => {

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -84,6 +84,8 @@ export interface SearchInputProps
   onSearch?: (value: SearchInputValue) => void;
   /** Debounce time in milliseconds for onChange function. No debounce is applied if no value is given. */
   debounce?: number;
+  /** Ref is forwarded to input element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
 const baseClassName = 'fi-search-input';

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -4,6 +4,7 @@ import React, {
   createRef,
   FocusEvent,
   ReactNode,
+  forwardRef,
 } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
@@ -112,7 +113,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
     value: this.props.value || this.props.defaultValue || '',
   };
 
-  private inputRef = createRef<HTMLInputElement>();
+  private inputRef = this.props.forwardedRef || createRef<HTMLInputElement>();
 
   static getDerivedStateFromProps(
     nextProps: SearchInputProps,
@@ -146,6 +147,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
       fullWidth,
       debounce,
       theme,
+      forwardedRef, // Taking this out so it's not passed "twice" to HtmlInput
       'aria-describedby': ariaDescribedBy,
       statusTextAriaLiveMode = 'assertive',
       ...passProps
@@ -304,20 +306,27 @@ const StyledSearchInput = styled(BaseSearchInput)`
  * Use for user inputting search text.
  * Props other than specified explicitly are passed on to underlying input element.
  */
-const SearchInput = (props: SearchInputProps) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledSearchInput theme={suomifiTheme} id={id} {...passProps} />
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const SearchInput = forwardRef(
+  (props: SearchInputProps, ref: React.RefObject<HTMLInputElement>) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <StyledSearchInput
+                theme={suomifiTheme}
+                id={id}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 SearchInput.displayName = 'SearchInput';
 export { SearchInput };

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -735,3 +735,25 @@ describe('custom item addition mode', () => {
     }
   });
 });
+
+describe('forward ref', () => {
+  it('ref is forwarded to input', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(
+      <MultiSelect
+        id="123"
+        labelText="MultiSelect"
+        items={[]}
+        noItemsText="No items"
+        visualPlaceholder="Select item(s)"
+        status="error"
+        ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
+        ref={ref}
+      />,
+    );
+
+    expect(ref.current?.tagName).toBe('INPUT');
+  });
+});

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -601,6 +601,7 @@ class BaseMultiSelect<T> extends Component<
       allowItemAddition,
       itemAdditionHelpText,
       items, // Only destructured away so they don't end up in the DOM
+      forwardedRef, // Only destructured away so it doesn't end up in the DOM
       ...passProps
     } = this.props;
 
@@ -864,29 +865,35 @@ const StyledMultiSelect = styled(BaseMultiSelect)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const MultiSelect = forwardRef(
-  <T,>(
-    props: MultiSelectProps<T & MultiSelectData>,
-    ref: React.RefObject<HTMLInputElement>,
-  ) => {
-    const { id: propId, ...passProps } = props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledMultiSelect
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
+function MultiSelectInner<T>(
+  props: MultiSelectProps<T & MultiSelectData>,
+  ref: React.RefObject<HTMLInputElement>,
+) {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <StyledMultiSelect
+              theme={suomifiTheme}
+              id={id}
+              forwardedRef={ref}
+              {...passProps}
+            />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+}
+
+// Type assertion is needed to set the function signature with generic T type.
+export const MultiSelect = forwardRef(MultiSelectInner) as <T>(
+  props: MultiSelectProps<T & MultiSelectData> & {
+    ref?: React.ForwardedRef<HTMLInputElement>;
   },
-);
-MultiSelect.displayName = 'MultiSelect';
-export { MultiSelect };
+) => ReturnType<typeof MultiSelectInner>;
+
+// Because of type assertion the displayName has to be set like this
+(MultiSelect as React.FC).displayName = 'MultiSelect';

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../../theme';
@@ -184,8 +184,12 @@ interface MultiSelectState<T extends MultiSelectData> {
   chipRemovalAnnounceText: string;
 }
 
+interface InnerRef {
+  forwardedRef: React.RefObject<HTMLInputElement>;
+}
+
 class BaseMultiSelect<T> extends Component<
-  MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp
+  MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp & InnerRef
 > {
   private popoverListRef: React.RefObject<HTMLUListElement>;
 
@@ -196,10 +200,16 @@ class BaseMultiSelect<T> extends Component<
   private chipRemovalAnnounceTimeOut: ReturnType<typeof setTimeout> | null =
     null;
 
-  constructor(props: MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp) {
+  constructor(
+    props: MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp & InnerRef,
+  ) {
     super(props);
     this.popoverListRef = React.createRef();
-    this.filterInputRef = React.createRef();
+
+    this.filterInputRef = this.props.forwardedRef
+      ? this.props.forwardedRef
+      : React.createRef();
+
     this.toggleButtonRef = React.createRef();
   }
 
@@ -854,20 +864,29 @@ const StyledMultiSelect = styled(BaseMultiSelect)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const MultiSelect = <T,>(props: MultiSelectProps<T & MultiSelectData>) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledMultiSelect theme={suomifiTheme} id={id} {...passProps} />
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
-
+const MultiSelect = forwardRef(
+  <T,>(
+    props: MultiSelectProps<T & MultiSelectData>,
+    ref: React.RefObject<HTMLInputElement>,
+  ) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <StyledMultiSelect
+                theme={suomifiTheme}
+                id={id}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 MultiSelect.displayName = 'MultiSelect';
 export { MultiSelect };

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -144,6 +144,8 @@ interface InternalMultiSelectProps<T extends MultiSelectData> {
   onRemoveAll?: () => void;
   /** Disable the input */
   disabled?: boolean;
+  /** Ref object to be passed to the input element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
 type AllowItemAdditionProps =
@@ -184,12 +186,8 @@ interface MultiSelectState<T extends MultiSelectData> {
   chipRemovalAnnounceText: string;
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLInputElement>;
-}
-
 class BaseMultiSelect<T> extends Component<
-  MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp & InnerRef
+  MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp
 > {
   private popoverListRef: React.RefObject<HTMLUListElement>;
 
@@ -200,9 +198,7 @@ class BaseMultiSelect<T> extends Component<
   private chipRemovalAnnounceTimeOut: ReturnType<typeof setTimeout> | null =
     null;
 
-  constructor(
-    props: MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp & InnerRef,
-  ) {
+  constructor(props: MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp) {
     super(props);
     this.popoverListRef = React.createRef();
 

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -462,3 +462,25 @@ describe('custom item addition mode', () => {
     }
   });
 });
+
+describe('forward ref', () => {
+  it('ref is forwarded to input', () => {
+    const ref = React.createRef<HTMLInputElement>();
+
+    render(
+      <SingleSelect
+        labelText="SingleSelect"
+        clearButtonLabel="Clear selection"
+        items={tools}
+        defaultSelectedItem={defaultSelectedTool}
+        noItemsText="No items"
+        visualPlaceholder="Select item"
+        ariaOptionsAvailableText="Options available"
+        ref={ref}
+      />,
+    );
+
+    expect(ref.current?.tagName).toBe('INPUT');
+    expect(ref.current?.value).toBe('Hammer');
+  });
+});

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -469,6 +469,7 @@ class BaseSingleSelect<T> extends Component<
       allowItemAddition,
       itemAdditionHelpText,
       items, // Only destructured away so they don't end up in the DOM
+      forwardedRef, // Only destructured away so it doesn't end up in the DOM
       ...passProps
     } = this.props;
 
@@ -670,30 +671,35 @@ const StyledSingleSelect = styled(BaseSingleSelect)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const SingleSelect = forwardRef(
-  <T,>(
-    props: SingleSelectProps<T & SingleSelectData>,
-    ref: React.RefObject<HTMLInputElement>,
-  ) => {
-    const { id: propId, ...passProps } = props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledSingleSelect
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  },
-);
+function SingleSelectInner<T>(
+  props: SingleSelectProps<T & SingleSelectData>,
+  ref: React.RefObject<HTMLInputElement>,
+) {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <StyledSingleSelect
+              theme={suomifiTheme}
+              id={id}
+              forwardedRef={ref}
+              {...passProps}
+            />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+}
 
-SingleSelect.displayName = 'SingleSelect';
-export { SingleSelect };
+// Type assertion is needed to set the function signature with generic T type.
+export const SingleSelect = forwardRef(SingleSelectInner) as <T>(
+  props: SingleSelectProps<T & SingleSelectData> & {
+    ref?: React.ForwardedRef<HTMLInputElement>;
+  },
+) => ReturnType<typeof SingleSelectInner>;
+
+// Because of type assertion the displayName has to be set like this
+(SingleSelect as React.FC).displayName = 'SingleSelect';

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv } from '../../../../reset';
@@ -122,8 +122,12 @@ interface SingleSelectState<T extends SingleSelectData> {
   initialItems: T[];
 }
 
+interface InnerRef {
+  forwardedRef: React.RefObject<HTMLInputElement>;
+}
+
 class BaseSingleSelect<T> extends Component<
-  SingleSelectProps<T & SingleSelectData> & SuomifiThemeProp
+  SingleSelectProps<T & SingleSelectData> & SuomifiThemeProp & InnerRef
 > {
   private popoverListRef: React.RefObject<HTMLUListElement>;
 
@@ -136,11 +140,18 @@ class BaseSingleSelect<T> extends Component<
   private preventShowPopoverOnInputFocus = false;
 
   constructor(
-    props: SingleSelectProps<T & SingleSelectData> & SuomifiThemeProp,
+    props: SingleSelectProps<T & SingleSelectData> &
+      SuomifiThemeProp &
+      InnerRef,
   ) {
     super(props);
     this.popoverListRef = React.createRef();
-    this.filterInputRef = React.createRef();
+
+    if (this.props.forwardedRef) {
+      this.filterInputRef = this.props.forwardedRef;
+    } else {
+      this.filterInputRef = React.createRef();
+    }
     this.toggleButtonRef = React.createRef();
     this.clearButtonRef = React.createRef();
   }
@@ -659,20 +670,30 @@ const StyledSingleSelect = styled(BaseSingleSelect)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const SingleSelect = <T,>(props: SingleSelectProps<T & SingleSelectData>) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledSingleSelect theme={suomifiTheme} id={id} {...passProps} />
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const SingleSelect = forwardRef(
+  <T,>(
+    props: SingleSelectProps<T & SingleSelectData>,
+    ref: React.RefObject<HTMLInputElement>,
+  ) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <StyledSingleSelect
+                theme={suomifiTheme}
+                id={id}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 SingleSelect.displayName = 'SingleSelect';
 export { SingleSelect };

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -85,6 +85,8 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
   onItemSelect?: (uniqueItemId: string | null) => void;
   /** Disable the input */
   disabled?: boolean;
+  /** Ref is forwarded to the input element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
 type AllowItemAdditionProps =
@@ -122,12 +124,8 @@ interface SingleSelectState<T extends SingleSelectData> {
   initialItems: T[];
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLInputElement>;
-}
-
 class BaseSingleSelect<T> extends Component<
-  SingleSelectProps<T & SingleSelectData> & SuomifiThemeProp & InnerRef
+  SingleSelectProps<T & SingleSelectData> & SuomifiThemeProp
 > {
   private popoverListRef: React.RefObject<HTMLUListElement>;
 
@@ -140,9 +138,7 @@ class BaseSingleSelect<T> extends Component<
   private preventShowPopoverOnInputFocus = false;
 
   constructor(
-    props: SingleSelectProps<T & SingleSelectData> &
-      SuomifiThemeProp &
-      InnerRef,
+    props: SingleSelectProps<T & SingleSelectData> & SuomifiThemeProp,
   ) {
     super(props);
     this.popoverListRef = React.createRef();

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -27,10 +27,8 @@ export interface StatusTextProps extends HtmlSpanProps {
    * @default polite
    */
   ariaLiveMode?: AriaLiveMode;
-}
-
-interface InnerRef {
-  forwardedRef: React.Ref<HTMLSpanElement>;
+  /** Ref is forwarded to the span element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
 const StyledStatusText = styled(
@@ -42,7 +40,7 @@ const StyledStatusText = styled(
     theme,
     ariaLiveMode = 'polite',
     ...passProps
-  }: StatusTextProps & InnerRef & SuomifiThemeProp) => {
+  }: StatusTextProps & SuomifiThemeProp) => {
     const ariaLiveProp = !disabled
       ? { 'aria-live': ariaLiveMode }
       : { 'aria-live': 'off' };

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -30,7 +30,7 @@ export interface StatusTextProps extends HtmlSpanProps {
 }
 
 interface InnerRef {
-  forwardedRef: React.RefObject<HTMLSpanElement>;
+  forwardedRef: React.Ref<HTMLSpanElement>;
 }
 
 const StyledStatusText = styled(
@@ -65,7 +65,7 @@ const StyledStatusText = styled(
 `;
 
 const StatusText = forwardRef<HTMLSpanElement, StatusTextProps>(
-  (props: StatusTextProps, ref: React.RefObject<HTMLSpanElement>) => {
+  (props: StatusTextProps, ref: React.Ref<HTMLSpanElement>) => {
     const { children, ...passProps } = props;
     return (
       <SuomifiThemeConsumer>

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
@@ -29,6 +29,10 @@ export interface StatusTextProps extends HtmlSpanProps {
   ariaLiveMode?: AriaLiveMode;
 }
 
+interface InnerRef {
+  forwardedRef: React.RefObject<HTMLSpanElement>;
+}
+
 const StyledStatusText = styled(
   ({
     className,
@@ -38,7 +42,7 @@ const StyledStatusText = styled(
     theme,
     ariaLiveMode = 'polite',
     ...passProps
-  }: StatusTextProps & SuomifiThemeProp) => {
+  }: StatusTextProps & InnerRef & SuomifiThemeProp) => {
     const ariaLiveProp = !disabled
       ? { 'aria-live': ariaLiveMode }
       : { 'aria-live': 'off' };
@@ -60,18 +64,24 @@ const StyledStatusText = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const StatusText = (props: StatusTextProps) => {
-  const { children, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledStatusText theme={suomifiTheme} {...passProps}>
-          {children}
-        </StyledStatusText>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const StatusText = forwardRef<HTMLSpanElement, StatusTextProps>(
+  (props: StatusTextProps, ref: React.RefObject<HTMLSpanElement>) => {
+    const { children, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledStatusText
+            forwardedRef={ref}
+            theme={suomifiTheme}
+            {...passProps}
+          >
+            {children}
+          </StyledStatusText>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 StatusText.displayName = 'StatusText';
 export { StatusText };

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -85,14 +85,11 @@ export interface TextareaProps
   fullWidth?: boolean;
   /** Textarea container div props */
   containerProps?: Omit<HtmlDivProps, 'className'>;
+  /** Ref is passed to the textarea element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLTextAreaElement>;
 }
 
-interface InnerRef {
-  /** Ref object to be passed to the textarea element */
-  forwardedRef: React.Ref<HTMLTextAreaElement>;
-}
-
-class BaseTextarea extends Component<TextareaProps & InnerRef> {
+class BaseTextarea extends Component<TextareaProps> {
   render() {
     const {
       id,
@@ -172,7 +169,7 @@ class BaseTextarea extends Component<TextareaProps & InnerRef> {
 }
 
 const StyledTextarea = styled(
-  ({ theme, ...passProps }: TextareaProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: TextareaProps & SuomifiThemeProp) => (
     <BaseTextarea {...passProps} />
   ),
 )`

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -37,7 +37,7 @@ const textareaClassNames = {
 
 type TextareaStatus = Exclude<InputStatus, 'success'>;
 
-interface InternalTextareaProps
+export interface TextareaProps
   extends StatusTextCommonProps,
     Omit<HtmlTextareaProps, 'placeholder'> {
   /** Custom classname to extend or customize */
@@ -88,12 +88,8 @@ interface InternalTextareaProps
 }
 
 interface InnerRef {
-  forwardedRef: React.RefObject<HTMLTextAreaElement>;
-}
-
-export interface TextareaProps extends InternalTextareaProps {
   /** Ref object to be passed to the textarea element */
-  ref?: React.RefObject<HTMLTextAreaElement>;
+  forwardedRef: React.Ref<HTMLTextAreaElement>;
 }
 
 class BaseTextarea extends Component<TextareaProps & InnerRef> {
@@ -176,10 +172,7 @@ class BaseTextarea extends Component<TextareaProps & InnerRef> {
 }
 
 const StyledTextarea = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalTextareaProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: TextareaProps & InnerRef & SuomifiThemeProp) => (
     <BaseTextarea {...passProps} />
   ),
 )`

--- a/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
@@ -22,19 +22,14 @@ export interface ToggleButtonProps
     Omit<HtmlButtonProps, 'onClick' | 'type'> {
   /** Event handler to execute when clicked */
   onClick?: (checked: boolean) => void;
-  /** Ref object to be passed to the button element */
-  ref?: React.RefObject<HTMLButtonElement>;
+  /** Ref object to be passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLButtonElement>;
-}
-
 interface ToggleState {
   toggleState: boolean;
 }
 
-class BaseToggleButton extends Component<ToggleButtonProps & InnerRef> {
+class BaseToggleButton extends Component<ToggleButtonProps> {
   state: ToggleState = {
     toggleState: !!this.props.checked || !!this.props.defaultChecked,
   };
@@ -112,7 +107,7 @@ class BaseToggleButton extends Component<ToggleButtonProps & InnerRef> {
 }
 
 const StyledToggleButton = styled(
-  (props: ToggleBaseProps & InnerRef & SuomifiThemeProp) => {
+  (props: ToggleBaseProps & SuomifiThemeProp) => {
     const { theme, ...passProps } = props;
     return <BaseToggleButton {...passProps} />;
   },

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
@@ -34,13 +34,11 @@ export interface ToggleInputProps
   name?: string;
   /** Event handler to execute when clicked */
   onChange?: (checked: boolean) => void;
+  /** Ref object is passed to the input element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLInputElement>;
-}
-
-class BaseToggleInput extends Component<ToggleInputProps & InnerRef> {
+class BaseToggleInput extends Component<ToggleInputProps> {
   state: ToggleState = {
     toggleState: !!this.props.checked || !!this.props.defaultChecked,
   };
@@ -121,7 +119,7 @@ class BaseToggleInput extends Component<ToggleInputProps & InnerRef> {
 }
 
 const StyledToggleInput = styled(
-  (props: ToggleBaseProps & InnerRef & SuomifiThemeProp) => {
+  (props: ToggleBaseProps & SuomifiThemeProp) => {
     const { theme, ...passProps } = props;
     return <BaseToggleInput {...passProps} />;
   },

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
@@ -34,8 +34,6 @@ export interface ToggleInputProps
   name?: string;
   /** Event handler to execute when clicked */
   onChange?: (checked: boolean) => void;
-  /** Ref object to be passed to the input element */
-  ref?: React.RefObject<HTMLInputElement>;
 }
 
 interface InnerRef {

--- a/src/core/Heading/Heading.md
+++ b/src/core/Heading/Heading.md
@@ -1,8 +1,13 @@
 ```js
 import { Heading } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
 
 <>
-  <Heading variant="h1">h1 text</Heading>
+  <Heading variant="h1" ref={exampleRef}>
+    h1 text
+  </Heading>
   <Heading variant="h2">h2 text</Heading>
   <Heading variant="h3" as="h2">
     h3 as h2 text

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -25,10 +25,11 @@ export interface HeadingProps extends HtmlHProps {
   className?: string;
   /** Render the heading as another element e.g. h3 as h2. Will override semantics derived from variant prop but keep the variant styles. */
   as?: asPropType;
+  /** Ref object is passed to the heading element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLHeadingElement>;
 }
 
 interface InternalHeadingProps extends HeadingProps, SuomifiThemeProp {
-  forwardedRef?: React.RefObject<HTMLHeadingElement>;
   asProp?: asPropType;
 }
 

--- a/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode, Fragment } from 'react';
+import React, { Component, ReactNode, Fragment, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import {
@@ -51,13 +51,20 @@ export interface LanguageMenuProps {
     | undefined;
 }
 
-class BaseLanguageMenu extends Component<LanguageMenuProps & SuomifiThemeProp> {
+interface InnerRef {
+  forwardedRef: React.Ref<HTMLButtonElement>;
+}
+
+class BaseLanguageMenu extends Component<
+  LanguageMenuProps & SuomifiThemeProp & InnerRef
+> {
   render() {
     const {
       children,
       name,
       className,
       theme,
+      forwardedRef,
       languageMenuButtonClassName: menuButtonClassName,
       languageMenuOpenButtonClassName: menuButtonOpenClassName,
       ...passProps
@@ -73,6 +80,7 @@ class BaseLanguageMenu extends Component<LanguageMenuProps & SuomifiThemeProp> {
           {({ isOpen }: { isOpen: boolean }) => (
             <Fragment>
               <MenuButton
+                ref={forwardedRef}
                 {...passProps}
                 className={classnames(
                   menuButtonClassName,
@@ -92,7 +100,7 @@ class BaseLanguageMenu extends Component<LanguageMenuProps & SuomifiThemeProp> {
   }
 }
 const StyledLanguageMenu = styled(
-  (props: LanguageMenuProps & SuomifiThemeProp) => (
+  (props: LanguageMenuProps & SuomifiThemeProp & InnerRef) => (
     <BaseLanguageMenu {...props} />
   ),
 )`
@@ -164,33 +172,37 @@ const StyledMenuPopover = styled(
  * <i class="semantics" />
  * Use for dropdown menu.
  */
-const LanguageMenu = (props: LanguageMenuProps) => {
-  const { children, name, className, ...passProps } = props;
-  const languageMenuButtonClassName = classnames(
-    languageMenuClassNames.button,
-    languageMenuClassNames.buttonLang,
-    className,
-  );
 
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledLanguageMenu
-          theme={suomifiTheme}
-          {...passProps}
-          name={languageName(name)}
-          languageMenuButtonClassName={languageMenuButtonClassName}
-          languageMenuOpenButtonClassName={languageMenuClassNames.buttonOpen}
-        >
-          {LanguageMenuPopoverWithProps(
-            children,
-            languageMenuClassNames.itemLang,
-          )}
-        </StyledLanguageMenu>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const LanguageMenu = forwardRef(
+  (props: LanguageMenuProps, ref: React.Ref<HTMLButtonElement>) => {
+    const { children, name, className, ...passProps } = props;
+    const languageMenuButtonClassName = classnames(
+      languageMenuClassNames.button,
+      languageMenuClassNames.buttonLang,
+      className,
+    );
+
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledLanguageMenu
+            theme={suomifiTheme}
+            forwardedRef={ref}
+            {...passProps}
+            name={languageName(name)}
+            languageMenuButtonClassName={languageMenuButtonClassName}
+            languageMenuOpenButtonClassName={languageMenuClassNames.buttonOpen}
+          >
+            {LanguageMenuPopoverWithProps(
+              children,
+              languageMenuClassNames.itemLang,
+            )}
+          </StyledLanguageMenu>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 LanguageMenu.displayName = 'LanguageMenu';
 export { LanguageMenu };

--- a/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
@@ -49,15 +49,11 @@ export interface LanguageMenuProps {
     | Array<React.ReactElement<LanguageMenuPopoverItemsProps>>
     | null
     | undefined;
+  /** Ref is passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLButtonElement>;
 }
 
-interface InnerRef {
-  forwardedRef: React.Ref<HTMLButtonElement>;
-}
-
-class BaseLanguageMenu extends Component<
-  LanguageMenuProps & SuomifiThemeProp & InnerRef
-> {
+class BaseLanguageMenu extends Component<LanguageMenuProps & SuomifiThemeProp> {
   render() {
     const {
       children,
@@ -100,7 +96,7 @@ class BaseLanguageMenu extends Component<
   }
 }
 const StyledLanguageMenu = styled(
-  (props: LanguageMenuProps & SuomifiThemeProp & InnerRef) => (
+  (props: LanguageMenuProps & SuomifiThemeProp) => (
     <BaseLanguageMenu {...props} />
   ),
 )`

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -33,7 +33,7 @@ interface InternalExternalLinkProps extends BaseLinkProps {
 export type ExternalLinkProps = newWindowProps & InternalExternalLinkProps;
 
 interface InnerRef {
-  forwardedRef?: React.RefObject<HTMLParagraphElement>;
+  forwardedRef?: React.Ref<HTMLAnchorElement>;
 }
 
 class BaseExternalLink extends Component<ExternalLinkProps> {
@@ -83,7 +83,7 @@ const StyledExternalLink = styled(
  * Used for adding a external site link
  */
 const ExternalLink = forwardRef(
-  (props: ExternalLinkProps, ref: React.RefObject<HTMLAnchorElement>) => (
+  (props: ExternalLinkProps, ref: React.Ref<HTMLAnchorElement>) => (
     <SuomifiThemeConsumer>
       {({ suomifiTheme }) => (
         <StyledExternalLink

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -28,13 +28,11 @@ interface InternalExternalLinkProps extends BaseLinkProps {
   toNewWindow?: boolean;
   /** Translated explanation of 'opens to a new window' */
   labelNewWindow?: string;
+  /** Ref is passed to the anchor element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLAnchorElement>;
 }
 
 export type ExternalLinkProps = newWindowProps & InternalExternalLinkProps;
-
-interface InnerRef {
-  forwardedRef?: React.Ref<HTMLAnchorElement>;
-}
 
 class BaseExternalLink extends Component<ExternalLinkProps> {
   render() {
@@ -70,7 +68,7 @@ class BaseExternalLink extends Component<ExternalLinkProps> {
 }
 
 const StyledExternalLink = styled(
-  (props: ExternalLinkProps & SuomifiThemeProp & InnerRef) => {
+  (props: ExternalLinkProps & SuomifiThemeProp) => {
     const { theme, ...passProps } = props;
     return <BaseExternalLink {...passProps} />;
   },

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
@@ -31,6 +31,10 @@ interface InternalExternalLinkProps extends BaseLinkProps {
 }
 
 export type ExternalLinkProps = newWindowProps & InternalExternalLinkProps;
+
+interface InnerRef {
+  forwardedRef?: React.RefObject<HTMLParagraphElement>;
+}
 
 class BaseExternalLink extends Component<ExternalLinkProps> {
   render() {
@@ -66,7 +70,7 @@ class BaseExternalLink extends Component<ExternalLinkProps> {
 }
 
 const StyledExternalLink = styled(
-  (props: ExternalLinkProps & SuomifiThemeProp) => {
+  (props: ExternalLinkProps & SuomifiThemeProp & InnerRef) => {
     const { theme, ...passProps } = props;
     return <BaseExternalLink {...passProps} />;
   },
@@ -78,13 +82,18 @@ const StyledExternalLink = styled(
  * <i class="semantics" />
  * Used for adding a external site link
  */
-
-const ExternalLink = (props: ExternalLinkProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledExternalLink theme={suomifiTheme} {...props} />
-    )}
-  </SuomifiThemeConsumer>
+const ExternalLink = forwardRef(
+  (props: ExternalLinkProps, ref: React.RefObject<HTMLAnchorElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledExternalLink
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 ExternalLink.displayName = 'ExternalLink';

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { LinkStyles } from '../Link/Link.baseStyles';
@@ -8,13 +8,12 @@ import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
 
 export interface LinkProps extends BaseLinkProps {}
 
+interface InternalLinkProps extends LinkProps, SuomifiThemeProp {
+  forwardedRef?: React.RefObject<HTMLAnchorElement>;
+}
+
 const StyledLink = styled(
-  ({
-    asProp,
-    className,
-    theme,
-    ...passProps
-  }: LinkProps & SuomifiThemeProp) => (
+  ({ asProp, className, theme, ...passProps }: InternalLinkProps) => (
     <HtmlA
       {...passProps}
       className={classnames(baseClassName, className)}
@@ -29,10 +28,14 @@ const StyledLink = styled(
  * <i class="semantics" />
  * Used for adding a link
  */
-const Link = (props: LinkProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledLink theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
+const Link = forwardRef(
+  (props: LinkProps, ref: React.RefObject<HTMLAnchorElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledLink theme={suomifiTheme} forwardedRef={ref} {...props} />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 Link.displayName = 'Link';

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -6,14 +6,18 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlA } from '../../../reset';
 import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
 
-export interface LinkProps extends BaseLinkProps {}
-
-interface InternalLinkProps extends LinkProps, SuomifiThemeProp {
+export interface LinkProps extends BaseLinkProps {
+  /** Ref  is passed to the anchor element. Alternative to React `ref` attribute. */
   forwardedRef?: React.Ref<HTMLAnchorElement>;
 }
 
 const StyledLink = styled(
-  ({ asProp, className, theme, ...passProps }: InternalLinkProps) => (
+  ({
+    asProp,
+    className,
+    theme,
+    ...passProps
+  }: LinkProps & SuomifiThemeProp) => (
     <HtmlA
       {...passProps}
       className={classnames(baseClassName, className)}

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -9,7 +9,7 @@ import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
 export interface LinkProps extends BaseLinkProps {}
 
 interface InternalLinkProps extends LinkProps, SuomifiThemeProp {
-  forwardedRef?: React.RefObject<HTMLAnchorElement>;
+  forwardedRef?: React.Ref<HTMLAnchorElement>;
 }
 
 const StyledLink = styled(
@@ -29,7 +29,7 @@ const StyledLink = styled(
  * Used for adding a link
  */
 const Link = forwardRef(
-  (props: LinkProps, ref: React.RefObject<HTMLAnchorElement>) => (
+  (props: LinkProps, ref: React.Ref<HTMLAnchorElement>) => (
     <SuomifiThemeConsumer>
       {({ suomifiTheme }) => (
         <StyledLink theme={suomifiTheme} forwardedRef={ref} {...props} />

--- a/src/core/Link/SkipLink/SkipLink.tsx
+++ b/src/core/Link/SkipLink/SkipLink.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { Link } from '../Link/Link';
@@ -10,10 +10,16 @@ const skipClassName = 'fi-link--skip';
 
 export interface SkipLinkProps extends BaseLinkProps {}
 
-const StyledSkipLink = styled((props: SkipLinkProps & SuomifiThemeProp) => {
-  const { theme, ...passProps } = props;
-  return <Link {...passProps} />;
-})`
+interface InnerRef {
+  forwardedRef?: React.RefObject<HTMLParagraphElement>;
+}
+
+const StyledSkipLink = styled(
+  (props: SkipLinkProps & SuomifiThemeProp & InnerRef) => {
+    const { theme, ...passProps } = props;
+    return <Link {...passProps} />;
+  },
+)`
   ${({ theme }) => SkipLinkStyles(theme)}
 `;
 
@@ -21,20 +27,23 @@ const StyledSkipLink = styled((props: SkipLinkProps & SuomifiThemeProp) => {
  * <i class="semantics" />
  * Used for adding skip link for keyboard and screenreader users
  */
-const SkipLink = (props: SkipLinkProps) => {
-  const { className, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledSkipLink
-          theme={suomifiTheme}
-          {...passProps}
-          className={classnames(className, skipClassName)}
-        />
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const SkipLink = forwardRef(
+  (props: SkipLinkProps, ref: React.RefObject<HTMLAnchorElement>) => {
+    const { className, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledSkipLink
+            theme={suomifiTheme}
+            forwardedRef={ref}
+            {...passProps}
+            className={classnames(className, skipClassName)}
+          />
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 SkipLink.displayName = 'SkipLink';
 export { SkipLink };

--- a/src/core/Link/SkipLink/SkipLink.tsx
+++ b/src/core/Link/SkipLink/SkipLink.tsx
@@ -8,18 +8,15 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 
 const skipClassName = 'fi-link--skip';
 
-export interface SkipLinkProps extends BaseLinkProps {}
-
-interface InnerRef {
+export interface SkipLinkProps extends BaseLinkProps {
+  /** Ref  is passed to the anchor element. Alternative to React `ref` attribute. */
   forwardedRef?: React.Ref<HTMLAnchorElement>;
 }
 
-const StyledSkipLink = styled(
-  (props: SkipLinkProps & SuomifiThemeProp & InnerRef) => {
-    const { theme, ...passProps } = props;
-    return <Link {...passProps} />;
-  },
-)`
+const StyledSkipLink = styled((props: SkipLinkProps & SuomifiThemeProp) => {
+  const { theme, ...passProps } = props;
+  return <Link {...passProps} />;
+})`
   ${({ theme }) => SkipLinkStyles(theme)}
 `;
 

--- a/src/core/Link/SkipLink/SkipLink.tsx
+++ b/src/core/Link/SkipLink/SkipLink.tsx
@@ -11,7 +11,7 @@ const skipClassName = 'fi-link--skip';
 export interface SkipLinkProps extends BaseLinkProps {}
 
 interface InnerRef {
-  forwardedRef?: React.RefObject<HTMLParagraphElement>;
+  forwardedRef?: React.Ref<HTMLAnchorElement>;
 }
 
 const StyledSkipLink = styled(
@@ -28,7 +28,7 @@ const StyledSkipLink = styled(
  * Used for adding skip link for keyboard and screenreader users
  */
 const SkipLink = forwardRef(
-  (props: SkipLinkProps, ref: React.RefObject<HTMLAnchorElement>) => {
+  (props: SkipLinkProps, ref: React.Ref<HTMLAnchorElement>) => {
     const { className, ...passProps } = props;
     return (
       <SuomifiThemeConsumer>

--- a/src/core/LoadingSpinner/LoadingSpinner.md
+++ b/src/core/LoadingSpinner/LoadingSpinner.md
@@ -1,5 +1,8 @@
 ```js
 import { LoadingSpinner } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
 
 <>
   <div>
@@ -8,6 +11,7 @@ import { LoadingSpinner } from 'suomifi-ui-components';
       variant="normal"
       textAlign="right"
       text="Loading"
+      ref={exampleRef}
     />
     <br />
     <LoadingSpinner status="success" text="Loading finished" />

--- a/src/core/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.tsx
@@ -32,10 +32,10 @@ export interface LoadingSpinnerProps {
    * @default 'normal'
    */
   variant?: 'normal' | 'small';
+  /** Ref to be passed to the wrapping div element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLDivElement>;
 }
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
-}
+
 const baseClassName = 'fi-loadingSpinner';
 
 export const loadingSpinnerClassNames = {
@@ -49,7 +49,7 @@ export const loadingSpinnerClassNames = {
   icon: `${baseClassName}_icon`,
 };
 
-class BaseLoadingSpinner extends Component<LoadingSpinnerProps & InnerRef> {
+class BaseLoadingSpinner extends Component<LoadingSpinnerProps> {
   render() {
     const {
       className,
@@ -101,7 +101,7 @@ class BaseLoadingSpinner extends Component<LoadingSpinnerProps & InnerRef> {
   }
 }
 const StyledLoadingSpinner = styled(
-  (props: LoadingSpinnerProps & InnerRef & SuomifiThemeProp) => {
+  (props: LoadingSpinnerProps & SuomifiThemeProp) => {
     const { theme, ...passProps } = props;
     return <BaseLoadingSpinner {...passProps} />;
   },
@@ -109,7 +109,7 @@ const StyledLoadingSpinner = styled(
   ${({ theme }) => baseStyles(theme)};
 `;
 const LoadingSpinner = forwardRef(
-  (props: LoadingSpinnerProps, ref: React.RefObject<HTMLDivElement>) => {
+  (props: LoadingSpinnerProps, ref: React.Ref<HTMLDivElement>) => {
     const { ...passProps } = props;
     return (
       <SuomifiThemeConsumer>

--- a/src/core/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.tsx
@@ -32,7 +32,7 @@ export interface LoadingSpinnerProps {
    * @default 'normal'
    */
   variant?: 'normal' | 'small';
-  /** Ref to be passed to the wrapping div element. Alternative to React `ref` attribute. */
+  /** Ref to be passed to the root div element. Alternative to React `ref` attribute. */
   forwardedRef?: React.Ref<HTMLDivElement>;
 }
 

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SpacingWithoutInsetProp } from '../theme/utils/spacing';
@@ -15,13 +15,17 @@ export interface ParagraphProps extends HtmlPProps {
   marginBottomSpacing?: SpacingWithoutInsetProp;
 }
 
+interface InnerRef {
+  forwardedRef?: React.RefObject<HTMLParagraphElement>;
+}
+
 const StyledParagraph = styled(
   ({
     marginBottomSpacing,
     className,
     theme,
     ...passProps
-  }: ParagraphProps & SuomifiThemeProp) => (
+  }: ParagraphProps & SuomifiThemeProp & InnerRef) => (
     <HtmlP
       className={classnames(baseClassName, className, {
         [`${baseClassName}--margin-${marginBottomSpacing}`]:
@@ -37,10 +41,14 @@ const StyledParagraph = styled(
 /**
  * Used for displaying a <p> element with correct styles
  */
-const Paragraph = (props: ParagraphProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledParagraph theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
+const Paragraph = forwardRef<HTMLParagraphElement, ParagraphProps>(
+  (props, ref) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledParagraph theme={suomifiTheme} forwardedRef={ref} {...props} />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 Paragraph.displayName = 'Paragraph';

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -16,7 +16,7 @@ export interface ParagraphProps extends HtmlPProps {
 }
 
 interface InnerRef {
-  forwardedRef?: React.RefObject<HTMLParagraphElement>;
+  forwardedRef?: React.Ref<HTMLParagraphElement>;
 }
 
 const StyledParagraph = styled(

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -13,9 +13,7 @@ export interface ParagraphProps extends HtmlPProps {
   color?: ColorProp;
   /** Spacing token for bottom margin */
   marginBottomSpacing?: SpacingWithoutInsetProp;
-}
-
-interface InnerRef {
+  /** Ref object is passed to the paragraph element. Alternative to React `ref` attribute. */
   forwardedRef?: React.Ref<HTMLParagraphElement>;
 }
 
@@ -25,7 +23,7 @@ const StyledParagraph = styled(
     className,
     theme,
     ...passProps
-  }: ParagraphProps & SuomifiThemeProp & InnerRef) => (
+  }: ParagraphProps & SuomifiThemeProp) => (
     <HtmlP
       className={classnames(baseClassName, className, {
         [`${baseClassName}--margin-${marginBottomSpacing}`]:

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -29,58 +29,33 @@ export interface TextProps extends InternalTextProps {
   ref?: React.RefObject<HTMLSpanElement>;
 }
 
-class BaseText extends Component<TextProps & InnerRef> {
-  render() {
-    const {
-      id,
-      className,
-      children,
-      forwardedRef,
-      variant = 'body',
-      smallScreen,
-      color,
-
-      ...passProps
-    } = this.props;
-
-    return (
-      <HtmlSpan
-        {...passProps}
-        className={classnames(
-          baseClassName,
-          className,
-          [`${baseClassName}--${variant}`],
-          {
-            [smallScreenClassName]: smallScreen,
-          },
-        )}
-      />
-    );
-  }
-}
-
 const StyledText = styled(
   ({
     theme,
+    className,
+    variant,
+    smallScreen,
     ...passProps
   }: InternalTextProps & InnerRef & SuomifiThemeProp) => (
-    <BaseText {...passProps} />
+    <HtmlSpan
+      {...passProps}
+      className={classnames(
+        baseClassName,
+        className,
+        [`${baseClassName}--${variant}`],
+        {
+          [smallScreenClassName]: smallScreen,
+        },
+      )}
+    />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${(props) => baseStyles(props)}
 `;
 
 /**
  * Used for displaying text with correct fonts
  */
-/*
-const Text = (props: TextProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledText theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
-);
-*/
-
 const Text = forwardRef<HTMLSpanElement, TextProps>(
   (props: TextProps, ref: React.Ref<HTMLSpanElement>) => {
     const { id: propId, ...passProps } = props;

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -31,10 +31,11 @@ export interface TextProps extends InternalTextProps {
 
 const StyledText = styled(
   ({
-    theme,
-    className,
-    variant,
+    variant = 'body',
     smallScreen,
+    className,
+    theme,
+    color,
     ...passProps
   }: InternalTextProps & InnerRef & SuomifiThemeProp) => (
     <HtmlSpan

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Component } from 'react';
+import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { ColorProp, SuomifiThemeConsumer, SuomifiThemeProp } from '../theme';

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -18,8 +18,6 @@ export interface TextProps extends HtmlSpanProps {
    * @default body
    */
   variant?: 'body' | 'lead' | 'bold';
-  /** Ref object to be passed to the element */
-  ref?: React.RefObject<HTMLSpanElement>;
 }
 
 const StyledText = styled(

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -18,6 +18,8 @@ export interface TextProps extends HtmlSpanProps {
    * @default body
    */
   variant?: 'body' | 'lead' | 'bold';
+  /** Ref is passed to the span element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
 const StyledText = styled(

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, Component } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { ColorProp, SuomifiThemeConsumer, SuomifiThemeProp } from '../theme';
@@ -8,7 +8,7 @@ import { HtmlSpan, HtmlSpanProps } from '../../reset';
 const baseClassName = 'fi-text';
 const smallScreenClassName = `${baseClassName}--small-screen`;
 
-export interface TextProps extends HtmlSpanProps {
+interface InternalTextProps extends HtmlSpanProps {
   /** Change font to smaller screen size and style */
   smallScreen?: boolean;
   /** Change color for text from theme colors */
@@ -20,38 +20,78 @@ export interface TextProps extends HtmlSpanProps {
   variant?: 'body' | 'lead' | 'bold';
 }
 
+interface InnerRef {
+  forwardedRef: React.RefObject<HTMLSpanElement>;
+}
+
+export interface TextProps extends InternalTextProps {
+  /** Ref object to be passed to the element */
+  ref?: React.RefObject<HTMLSpanElement>;
+}
+
+class BaseText extends Component<TextProps & InnerRef> {
+  render() {
+    const {
+      id,
+      className,
+      children,
+      forwardedRef,
+      variant = 'body',
+      smallScreen,
+      color,
+
+      ...passProps
+    } = this.props;
+
+    return (
+      <HtmlSpan
+        {...passProps}
+        className={classnames(
+          baseClassName,
+          className,
+          [`${baseClassName}--${variant}`],
+          {
+            [smallScreenClassName]: smallScreen,
+          },
+        )}
+      />
+    );
+  }
+}
+
 const StyledText = styled(
   ({
-    variant = 'body',
-    smallScreen,
-    className,
     theme,
-    color,
     ...passProps
-  }: TextProps & SuomifiThemeProp) => (
-    <HtmlSpan
-      {...passProps}
-      className={classnames(
-        baseClassName,
-        className,
-        [`${baseClassName}--${variant}`],
-        {
-          [smallScreenClassName]: smallScreen,
-        },
-      )}
-    />
+  }: InternalTextProps & InnerRef & SuomifiThemeProp) => (
+    <BaseText {...passProps} />
   ),
 )`
-  ${(props) => baseStyles(props)}
+  ${({ theme }) => baseStyles(theme)}
 `;
 
 /**
  * Used for displaying text with correct fonts
  */
+/*
 const Text = (props: TextProps) => (
   <SuomifiThemeConsumer>
     {({ suomifiTheme }) => <StyledText theme={suomifiTheme} {...props} />}
   </SuomifiThemeConsumer>
+);
+*/
+
+const Text = forwardRef<HTMLSpanElement, TextProps>(
+  (props: TextProps, ref: React.Ref<HTMLSpanElement>) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledText theme={suomifiTheme} forwardedRef={ref} {...passProps} />
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
 );
 
 Text.displayName = 'Text';

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -8,7 +8,7 @@ import { HtmlSpan, HtmlSpanProps } from '../../reset';
 const baseClassName = 'fi-text';
 const smallScreenClassName = `${baseClassName}--small-screen`;
 
-interface InternalTextProps extends HtmlSpanProps {
+export interface TextProps extends HtmlSpanProps {
   /** Change font to smaller screen size and style */
   smallScreen?: boolean;
   /** Change color for text from theme colors */
@@ -18,13 +18,6 @@ interface InternalTextProps extends HtmlSpanProps {
    * @default body
    */
   variant?: 'body' | 'lead' | 'bold';
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLSpanElement>;
-}
-
-export interface TextProps extends InternalTextProps {
   /** Ref object to be passed to the element */
   ref?: React.RefObject<HTMLSpanElement>;
 }
@@ -37,7 +30,7 @@ const StyledText = styled(
     theme,
     color,
     ...passProps
-  }: InternalTextProps & InnerRef & SuomifiThemeProp) => (
+  }: TextProps & SuomifiThemeProp) => (
     <HtmlSpan
       {...passProps}
       className={classnames(
@@ -59,7 +52,7 @@ const StyledText = styled(
  */
 const Text = forwardRef<HTMLSpanElement, TextProps>(
   (props: TextProps, ref: React.Ref<HTMLSpanElement>) => {
-    const { id: propId, ...passProps } = props;
+    const { ...passProps } = props;
     return (
       <SuomifiThemeConsumer>
         {({ suomifiTheme }) => (

--- a/src/core/Toast/Toast.tsx
+++ b/src/core/Toast/Toast.tsx
@@ -25,10 +25,10 @@ export interface ToastProps {
   headingVariant?: Exclude<hLevels, 'h1'>;
   /** Unique id */
   id?: string;
+  /** Ref to be passed to the wrapping div element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLDivElement>;
 }
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
-}
+
 const baseClassName = 'fi-toast';
 export const toastClassNames = {
   styleWrapper: `${baseClassName}-wrapper`,
@@ -37,7 +37,7 @@ export const toastClassNames = {
   icon: `${baseClassName}_icon`,
   iconWrapper: `${baseClassName}_icon-wrapper`,
 };
-class BaseToast extends Component<ToastProps & InnerRef> {
+class BaseToast extends Component<ToastProps> {
   render() {
     const {
       ariaLiveMode = 'polite',
@@ -79,17 +79,15 @@ class BaseToast extends Component<ToastProps & InnerRef> {
     );
   }
 }
-const StyledToast = styled(
-  (props: ToastProps & InnerRef & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
-    return <BaseToast {...passProps} />;
-  },
-)`
+const StyledToast = styled((props: ToastProps & SuomifiThemeProp) => {
+  const { theme, ...passProps } = props;
+  return <BaseToast {...passProps} />;
+})`
   ${({ theme }) => baseStyles(theme)};
 `;
 
 const Toast = forwardRef(
-  (props: ToastProps, ref: React.RefObject<HTMLDivElement>) => {
+  (props: ToastProps, ref: React.Ref<HTMLDivElement>) => {
     const { ...passProps } = props;
     return (
       <SuomifiThemeConsumer>

--- a/src/core/Toast/Toast.tsx
+++ b/src/core/Toast/Toast.tsx
@@ -25,7 +25,7 @@ export interface ToastProps {
   headingVariant?: Exclude<hLevels, 'h1'>;
   /** Unique id */
   id?: string;
-  /** Ref to be passed to the wrapping div element. Alternative to React `ref` attribute. */
+  /** Ref to be passed to the root div element. Alternative to React `ref` attribute. */
   forwardedRef?: React.Ref<HTMLDivElement>;
 }
 

--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -1,10 +1,4 @@
-import React, {
-  Component,
-  ReactNode,
-  forwardRef,
-  RefObject,
-  createRef,
-} from 'react';
+import React, { Component, ReactNode, forwardRef, createRef } from 'react';
 import classnames from 'classnames';
 import { TooltipContent } from './TooltipContent/TooltipContent';
 import { TooltipToggleButton } from './TooltipToggleButton/TooltipToggleButton';
@@ -36,10 +30,8 @@ export interface TooltipProps {
   onToggleButtonClick?: (event: React.MouseEvent) => void;
   /** Event handler for close button click */
   onCloseButtonClick?: (event: React.MouseEvent) => void;
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLButtonElement>;
+  /** Ref object to be passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
 
 type TooltipState = {
@@ -49,9 +41,7 @@ type TooltipState = {
   anchorRefObserver: ResizeObserver | null;
 };
 
-class BaseTooltip extends Component<
-  TooltipProps & InnerRef & { className?: string }
-> {
+class BaseTooltip extends Component<TooltipProps & { className?: string }> {
   state: TooltipState = {
     open: false,
     contentArrowOffsetPx: 0,
@@ -59,11 +49,11 @@ class BaseTooltip extends Component<
     anchorRefObserver: null,
   };
 
-  private toggleButtonRef: RefObject<HTMLButtonElement>;
+  private toggleButtonRef: React.RefObject<HTMLButtonElement>;
 
-  private contentRef: RefObject<HTMLDivElement>;
+  private contentRef: React.RefObject<HTMLDivElement>;
 
-  constructor(props: TooltipProps & InnerRef) {
+  constructor(props: TooltipProps) {
     super(props);
     this.toggleButtonRef = createRef();
     this.contentRef = createRef();
@@ -157,12 +147,14 @@ class BaseTooltip extends Component<
     } = this.props;
 
     const open = 'open' in this.props ? propsOpen : this.state.open;
+    // Remove the possibility to have undefined forwardedRef as a parameter for forkRefs
+    const definedRef = forwardedRef || null;
 
     return (
       <>
         <TooltipToggleButton
           className={classnames(baseClassName, toggleButtonClassName)}
-          ref={forkRefs(this.toggleButtonRef, forwardedRef)}
+          ref={forkRefs(this.toggleButtonRef, definedRef)}
           aria-label={ariaToggleButtonLabelText}
           aria-expanded={open}
           onClick={this.handleToggleClick}

--- a/src/core/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/core/VisuallyHidden/VisuallyHidden.tsx
@@ -5,6 +5,8 @@ import { HtmlSpan, HtmlSpanProps } from '../../reset/HtmlSpan/HtmlSpan';
 
 export interface VisuallyHiddenProps extends HtmlSpanProps {
   className?: string;
+  /** Ref is passed to the span element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
 const baseClassName = 'fi-visually-hidden';

--- a/src/core/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/core/VisuallyHidden/VisuallyHidden.tsx
@@ -23,7 +23,7 @@ const StyledVisuallyHidden = styled((props: VisuallyHiddenProps) => (
 `;
 
 const VisuallyHidden = forwardRef(
-  (props: VisuallyHiddenProps, ref: React.RefObject<HTMLSpanElement>) => {
+  (props: VisuallyHiddenProps, ref: React.Ref<HTMLSpanElement>) => {
     const { className, ...passProps } = props;
     return (
       <StyledVisuallyHidden

--- a/src/core/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/core/VisuallyHidden/VisuallyHidden.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlSpan, HtmlSpanProps } from '../../reset/HtmlSpan/HtmlSpan';
@@ -22,15 +22,18 @@ const StyledVisuallyHidden = styled((props: VisuallyHiddenProps) => (
   overflow: hidden;
 `;
 
-const VisuallyHidden = (props: VisuallyHiddenProps) => {
-  const { className, ...passProps } = props;
-  return (
-    <StyledVisuallyHidden
-      {...passProps}
-      className={classnames(baseClassName, className)}
-    />
-  );
-};
+const VisuallyHidden = forwardRef(
+  (props: VisuallyHiddenProps, ref: React.RefObject<HTMLSpanElement>) => {
+    const { className, ...passProps } = props;
+    return (
+      <StyledVisuallyHidden
+        forwardedRef={ref}
+        {...passProps}
+        className={classnames(baseClassName, className)}
+      />
+    );
+  },
+);
 
 VisuallyHidden.displayName = 'VisuallyHidden';
 export { VisuallyHidden };

--- a/src/reset/HtmlA/HtmlA.tsx
+++ b/src/reset/HtmlA/HtmlA.tsx
@@ -10,6 +10,11 @@ export interface HtmlAProps
   as?: asPropType;
 }
 
+export interface HtmlAWithRefProps extends HtmlAProps {
+  /** Ref object for the heading element */
+  forwardedRef?: React.RefObject<HTMLAnchorElement>;
+}
+
 const aResets = css`
   ${resets.normalize.html}
   ${resets.normalize.a}
@@ -19,8 +24,10 @@ const aResets = css`
   text-decoration: underline;
 `;
 
-const Ahref = styled.a`
+const Ahref = styled.a<HtmlAWithRefProps>`
   ${aResets}
 `;
 
-export const HtmlA = (props: HtmlAProps) => <Ahref {...props} />;
+export const HtmlA = ({ forwardedRef, ...passProps }: HtmlAWithRefProps) => (
+  <Ahref ref={forwardedRef} {...passProps} />
+);

--- a/src/reset/HtmlA/HtmlA.tsx
+++ b/src/reset/HtmlA/HtmlA.tsx
@@ -11,8 +11,8 @@ export interface HtmlAProps
 }
 
 export interface HtmlAWithRefProps extends HtmlAProps {
-  /** Ref object for the heading element */
-  forwardedRef?: React.RefObject<HTMLAnchorElement>;
+  /** Ref for the heading element */
+  forwardedRef?: React.Ref<HTMLAnchorElement>;
 }
 
 const aResets = css`

--- a/src/reset/HtmlDiv/HtmlDiv.tsx
+++ b/src/reset/HtmlDiv/HtmlDiv.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { HTMLProps, forwardRef } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
 import { asPropType } from '../../utils/typescript';
@@ -25,7 +25,7 @@ export const HtmlDiv = styled(Div)`
 `;
 
 export interface HtmlDivWithRefProps extends HtmlDivProps {
-  /** Ref object for the input element */
+  /** Ref object for the div element */
   forwardedRef?: React.Ref<HTMLDivElement>;
 }
 
@@ -36,3 +36,10 @@ const DivWithRef = ({ forwardedRef, ...passProps }: HtmlDivWithRefProps) => (
 export const HtmlDivWithRef = styled(DivWithRef)`
   ${divResets}
 `;
+
+/** Passing the ref with name 'ref' needs the forwardRef function */
+export const HtmlDivWithNativeRef = forwardRef(
+  (props: HtmlDivProps, ref: React.Ref<HTMLDivElement>) => (
+    <HtmlDivWithRef forwardedRef={ref} {...props} />
+  ),
+);

--- a/src/reset/HtmlDiv/HtmlDiv.tsx
+++ b/src/reset/HtmlDiv/HtmlDiv.tsx
@@ -39,7 +39,7 @@ export const HtmlDivWithRef = styled(DivWithRef)`
 
 /** Passing the ref with name 'ref' needs the forwardRef function */
 export const HtmlDivWithNativeRef = forwardRef(
-  (props: HtmlDivProps, ref: React.Ref<HTMLDivElement>) => (
+  (props: HtmlDivProps, ref: React.Ref<HTMLElement>) => (
     <HtmlDivWithRef forwardedRef={ref} {...props} />
   ),
 );

--- a/src/reset/HtmlP/HtmlP.tsx
+++ b/src/reset/HtmlP/HtmlP.tsx
@@ -10,7 +10,7 @@ export interface HtmlPProps
 
 interface InnerRef {
   /** Forwarded ref object for the paragraph element */
-  forwardedRef: React.RefObject<HTMLParagraphElement>;
+  forwardedRef: React.Ref<HTMLParagraphElement>;
 }
 
 const spanResets = css`

--- a/src/reset/HtmlP/HtmlP.tsx
+++ b/src/reset/HtmlP/HtmlP.tsx
@@ -8,6 +8,11 @@ export interface HtmlPProps
   as?: asPropType;
 }
 
+interface InnerRef {
+  /** Forwarded ref object for the paragraph element */
+  forwardedRef: React.RefObject<HTMLParagraphElement>;
+}
+
 const spanResets = css`
   ${resets.normalize.html}
   ${resets.common}
@@ -18,7 +23,9 @@ const spanResets = css`
   white-space: normal;
 `;
 
-const Span = (props: HtmlPProps) => <p {...props} />;
+const Span = ({ forwardedRef, ...passProps }: HtmlPProps & InnerRef) => (
+  <p ref={forwardedRef} {...passProps} />
+);
 
 export const HtmlP = styled(Span)`
   ${spanResets}

--- a/src/reset/HtmlSpan/HtmlSpan.tsx
+++ b/src/reset/HtmlSpan/HtmlSpan.tsx
@@ -7,6 +7,10 @@ export interface HtmlSpanProps
   extends Omit<HTMLProps<HTMLSpanElement>, 'ref' | 'as'> {
   as?: asPropType;
 }
+export interface HtmlSpanWithRefProps extends HtmlSpanProps {
+  /** Ref object for the span element */
+  forwardedRef?: React.RefObject<HTMLSpanElement>;
+}
 
 const spanResets = css`
   ${resets.normalize.html}
@@ -18,7 +22,9 @@ const spanResets = css`
   white-space: normal;
 `;
 
-const Span = (props: HtmlSpanProps) => <span {...props} />;
+const Span = ({ forwardedRef, ...passProps }: HtmlSpanWithRefProps) => (
+  <span ref={forwardedRef} {...passProps} />
+);
 
 export const HtmlSpan = styled(Span)`
   ${spanResets}

--- a/src/reset/HtmlSpan/HtmlSpan.tsx
+++ b/src/reset/HtmlSpan/HtmlSpan.tsx
@@ -7,9 +7,9 @@ export interface HtmlSpanProps
   extends Omit<HTMLProps<HTMLSpanElement>, 'ref' | 'as'> {
   as?: asPropType;
 }
-export interface HtmlSpanWithRefProps extends HtmlSpanProps {
+interface HtmlSpanWithRefProps extends HtmlSpanProps {
   /** Ref object for the span element */
-  forwardedRef?: React.RefObject<HTMLSpanElement>;
+  forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
 const spanResets = css`

--- a/src/reset/HtmlTextarea/HtmlTextarea.tsx
+++ b/src/reset/HtmlTextarea/HtmlTextarea.tsx
@@ -7,7 +7,7 @@ export interface HtmlTextareaProps
   extends Omit<HTMLProps<HTMLTextAreaElement>, 'ref' | 'as'> {
   as?: asPropType;
   /** Ref object passed to the element */
-  forwardedRef?: React.RefObject<HTMLTextAreaElement>;
+  forwardedRef?: React.Ref<HTMLTextAreaElement>;
 }
 
 const textareaResets = css`

--- a/src/reset/index.ts
+++ b/src/reset/index.ts
@@ -5,6 +5,7 @@ export {
   HtmlDivProps,
   HtmlDivWithRef,
   HtmlDivWithRefProps,
+  HtmlDivWithNativeRef,
 } from './HtmlDiv/HtmlDiv';
 export { HtmlFieldSet, HtmlFieldSetProps } from './HtmlFieldSet/HtmlFieldSet';
 export { HtmlH, HtmlHProps, HtmlHWithRefProps, hLevels } from './HtmlH/HtmlH';


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
Add ref support for components that don't yet have it
<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes https://jira.dvv.fi/browse/SFIDS-610

## Motivation and Context
Adding ref forwarding to components where it seems viable.
Having unified system of forwarding refs should make using the components easier and also reduces complexity of the codebase a bit.
<!-- Why is this change required? What problem does it solve? -->

- Ref forwarding with `ref` attribute is added to components where it seemed viable
- Also the `forwardedRef` prop is kept in or added to the api even though it's not actually needed. It works just like `ref` does.
  -  Because of the components inner structure the `forwardedRef` prop would be available to use even if it's not "visible". 
  - It would have needed additional complexity to prevent usage of the `forwardedRef`
  - React/Styleguidist don't show ref or it's type. With `forwardedRef` in the api we can show the ref type in Styleguidist documentation.
- Some of the component examples are updated to include usage of `ref`
- Ref is usually passed to the most "important" part of the component. For example button or input that can have focus. When there is none the ref is passed to the root element. This is decided case by case.

**Added forward ref support**
Block
StaticChip
Expander
ExpanderGroup
ExpanderTitleButton
CheckboxGroup
HintText
RadioButtonGroup
SearchInput
MultiSelect
SingleSelect
StatusText
Textarea
ToggleInput
LanguageMenu
ExternalLink
Link
SkipLink
Paragraph
Text
VisuallyHidden

**Components that previously had support for React ref now also have forwardedRef prop visible.**
Button
Heading
Tooltip
ToggleButton
LoadingSpinner
CheckBox
RadioButton
Chip
Toast
Dropdown



## How Has This Been Tested?

With CRA project, Styleguidist, unit tests

Example of testing Text component in the project. Add these to some other component:
```
// in constructor
    this.textRef = React.createRef();

// in template
        <Text
          color="depthBase"
          ref={this.textRef}
          onClick={() => console.log(this.textRef?.current)}
        >
          foo
        </Text>
```


## Screenshots (if appropriate):

## Release notes
- React ref forwarding support is added to multiple components
<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
