### PR TITLE
[Feature] Styleguidist menu: remove Modules & Primitive categories and sort components alphabetically

### DIFF
--- a/.styleguidist/ComponentsList.tsx
+++ b/.styleguidist/ComponentsList.tsx
@@ -21,10 +21,13 @@ export default class ComponentsList extends Component<ComponentsListProps> {
 
     if (hide) return null;
 
+    const shouldSortAlphabetically =
+      items.length > 0 && items[0].sections?.length === 0;
+
     return (
       <DefaultComponentsList
         {...passProps}
-        items={hashPath.length === 2 ? sortItems(items) : items}
+        items={shouldSortAlphabetically ? sortItems(items) : items}
       />
     );
   }

--- a/.styleguidist/modules.md
+++ b/.styleguidist/modules.md
@@ -1,1 +1,0 @@
-Collection of suomi.fi styleguide specific components with accessibility and suomi.fi-styles.

--- a/.styleguidist/primitive.md
+++ b/.styleguidist/primitive.md
@@ -1,1 +1,0 @@
-Collection of primitive components to give the basic of accessibility and suomi.fi-styles.

--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -152,13 +152,6 @@ module.exports = {
                 'SingleSelect/SingleSelect',
               ]),
             },
-          ],
-          expand: true,
-        },
-        {
-          name: 'Modules',
-          content: './.styleguidist/modules.md',
-          sections: [
             {
               name: 'Breadcrumb',
               components: getComponentWithVariants('Breadcrumb')([

--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -82,129 +82,122 @@ module.exports = {
     {
       name: 'Components',
       content: './.styleguidist/components.md',
+      components: getComponents(primitiveComponents),
       sections: [
         {
-          name: 'Primitive',
-          content: './.styleguidist/primitive.md',
-          components: getComponents(primitiveComponents),
-          sections: [
-            {
-              name: 'Toggle',
-              components: getComponentWithVariants('Form/Toggle')([
-                'ToggleButton/ToggleButton',
-                'ToggleInput/ToggleInput',
-              ]),
-            },
-            {
-              name: 'Text',
-              components: getComponents(['Text', 'Paragraph']),
-            },
-            {
-              name: 'Alert',
-              components: getComponentWithVariants('Alert')([
-                'Alert/Alert',
-                'InlineAlert/InlineAlert',
-              ]),
-            },
+          name: 'Toggle',
+          components: getComponentWithVariants('Form/Toggle')([
+            'ToggleButton/ToggleButton',
+            'ToggleInput/ToggleInput',
+          ]),
+        },
+        {
+          name: 'Text',
+          components: getComponents(['Text', 'Paragraph']),
+        },
+        {
+          name: 'Alert',
+          components: getComponentWithVariants('Alert')([
+            'Alert/Alert',
+            'InlineAlert/InlineAlert',
+          ]),
+        },
 
-            {
-              name: 'Checkbox',
-              components: getComponentWithVariants('Form/Checkbox')([
-                'Checkbox',
-                'CheckboxGroup',
-              ]),
-            },
-            {
-              name: 'RadioButton',
-              components: getComponentWithVariants('Form/RadioButton')([
-                'RadioButton',
-                'RadioButtonGroup',
-              ]),
-            },
-            {
-              name: 'Link',
-              components: getComponentWithVariants('Link')([
-                'Link/Link',
-                'SkipLink/SkipLink',
-                'ExternalLink/ExternalLink',
-              ]),
-            },
-            {
-              name: 'Chip',
-              components: getComponentWithVariants('Chip')([
-                'Chip/Chip',
-                'StaticChip/StaticChip',
-              ]),
-            },
-            {
-              name: 'Icon',
-              components: getComponents(['Icon', 'StaticIcon', 'LogoIcon']),
-            },
-            {
-              name: 'MultiSelect',
-              components: getComponentWithVariants('Form/Select')([
-                'MultiSelect/MultiSelect/MultiSelect',
-              ]),
-            },
-            {
-              name: 'SingleSelect',
-              components: getComponentWithVariants('Form/Select')([
-                'SingleSelect/SingleSelect',
-              ]),
-            },
-            {
-              name: 'Breadcrumb',
-              components: getComponentWithVariants('Breadcrumb')([
-                'Breadcrumb/Breadcrumb',
-                'BreadcrumbLink/BreadcrumbLink',
-              ]),
-            },
-            {
-              name: 'Dropdown',
-              components: getComponentWithVariants('Dropdown')([
-                'Dropdown/Dropdown',
-                'DropdownItem/DropdownItem',
-              ]),
-            },
-            {
-              name: 'LanguageMenu',
-              components: getComponentWithVariants('LanguageMenu')([
-                'LanguageMenu/LanguageMenu',
-                'LanguageMenuItem/LanguageMenuItem',
-                'LanguageMenuLink/LanguageMenuLink',
-              ]),
-            },
-            {
-              name: 'Notification',
-              components: getComponents(['Notification']),
-            },
-            {
-              name: 'Expander',
-              components: getComponentWithVariants('Expander')([
-                'Expander/Expander',
-                'ExpanderGroup/ExpanderGroup',
-                'ExpanderTitle/ExpanderTitle',
-                'ExpanderTitleButton/ExpanderTitleButton',
-                'ExpanderContent/ExpanderContent',
-              ]),
-            },
-            {
-              name: 'Modal',
-              components: getComponentWithVariants('Modal')([
-                'Modal/Modal',
-                'ModalContent/ModalContent',
-                'ModalFooter/ModalFooter',
-              ]),
-            },
-            {
-              name: 'Toast',
-              components: getComponents(['Toast']),
-            },
-          ],
-          expand: true,
+        {
+          name: 'Checkbox',
+          components: getComponentWithVariants('Form/Checkbox')([
+            'Checkbox',
+            'CheckboxGroup',
+          ]),
+        },
+        {
+          name: 'RadioButton',
+          components: getComponentWithVariants('Form/RadioButton')([
+            'RadioButton',
+            'RadioButtonGroup',
+          ]),
+        },
+        {
+          name: 'Link',
+          components: getComponentWithVariants('Link')([
+            'Link/Link',
+            'SkipLink/SkipLink',
+            'ExternalLink/ExternalLink',
+          ]),
+        },
+        {
+          name: 'Chip',
+          components: getComponentWithVariants('Chip')([
+            'Chip/Chip',
+            'StaticChip/StaticChip',
+          ]),
+        },
+        {
+          name: 'Icon',
+          components: getComponents(['Icon', 'StaticIcon', 'LogoIcon']),
+        },
+        {
+          name: 'MultiSelect',
+          components: getComponentWithVariants('Form/Select')([
+            'MultiSelect/MultiSelect/MultiSelect',
+          ]),
+        },
+        {
+          name: 'SingleSelect',
+          components: getComponentWithVariants('Form/Select')([
+            'SingleSelect/SingleSelect',
+          ]),
+        },
+        {
+          name: 'Breadcrumb',
+          components: getComponentWithVariants('Breadcrumb')([
+            'Breadcrumb/Breadcrumb',
+            'BreadcrumbLink/BreadcrumbLink',
+          ]),
+        },
+        {
+          name: 'Dropdown',
+          components: getComponentWithVariants('Dropdown')([
+            'Dropdown/Dropdown',
+            'DropdownItem/DropdownItem',
+          ]),
+        },
+        {
+          name: 'LanguageMenu',
+          components: getComponentWithVariants('LanguageMenu')([
+            'LanguageMenu/LanguageMenu',
+            'LanguageMenuItem/LanguageMenuItem',
+            'LanguageMenuLink/LanguageMenuLink',
+          ]),
+        },
+        {
+          name: 'Notification',
+          components: getComponents(['Notification']),
+        },
+        {
+          name: 'Expander',
+          components: getComponentWithVariants('Expander')([
+            'Expander/Expander',
+            'ExpanderGroup/ExpanderGroup',
+            'ExpanderTitle/ExpanderTitle',
+            'ExpanderTitleButton/ExpanderTitleButton',
+            'ExpanderContent/ExpanderContent',
+          ]),
+        },
+        {
+          name: 'Modal',
+          components: getComponentWithVariants('Modal')([
+            'Modal/Modal',
+            'ModalContent/ModalContent',
+            'ModalFooter/ModalFooter',
+          ]),
+        },
+        {
+          name: 'Toast',
+          components: getComponents(['Toast']),
         },
       ],
-      sectionDepth: 2,
+      sectionDepth: 1,
       expand: true,
     },
   ],


### PR DESCRIPTION
## Description

This PR changes the Styleguidist navigation and structure. 
  - Removed the Modules and Primitive categories altogether and moved all components under the Components heading
  - Components are displayed in an alphabetical order

## Motivation and Context

We want our documentation to be clearer and make it easier to find what you are looking for

## Screenshots:
<img width="191" alt="image" src="https://user-images.githubusercontent.com/17459942/170700214-d0ff900d-342b-4698-a5cd-9e3a1c6a25f4.png">


## Release notes

### General changes
* Remove subsections from Styleguidist components menu and put all components under one heading
* Order components alphabetically in Styleguidist menu
