### PR TITLE
[Fix] Adjust label classnames

### DIFF
--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -30,35 +30,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -88,7 +59,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c3.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -102,20 +73,15 @@ exports[`Basic dropdown should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -268,16 +234,16 @@ exports[`Basic dropdown should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <div
-        class="c3 c4 fi-dropdown_label--visible fi-label-text"
+      <label
+        class="c2 c3 fi-dropdown_label--visible fi-label"
+        id="test-id-label"
       >
-        <label
-          class="c0 fi-label-text_label-span"
-          id="test-id-label"
+        <span
+          class="c0 fi-label_label-span"
         >
           Dropdown test
-        </label>
-      </div>
+        </span>
+      </label>
       <div
         data-reach-listbox-input=""
         data-state="closed"
@@ -339,35 +305,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -397,7 +334,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c3.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -411,20 +348,15 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -578,16 +510,16 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <div
-        class="c3 c4 fi-dropdown_label--visible fi-label-text"
+      <label
+        class="c2 c3 fi-dropdown_label--visible fi-label"
+        id="test-id-label"
       >
-        <label
-          class="c0 fi-label-text_label-span"
-          id="test-id-label"
+        <span
+          class="c0 fi-label_label-span"
         >
           Dropdown test
-        </label>
-      </div>
+        </span>
+      </label>
       <div
         data-reach-listbox-input=""
         data-state="closed"
@@ -649,35 +581,6 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -707,7 +610,7 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c3.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -721,20 +624,15 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -887,16 +785,16 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <div
-        class="c3 c4 fi-dropdown_label--visible fi-label-text"
+      <label
+        class="c2 c3 fi-dropdown_label--visible fi-label"
+        id="test-id-label"
       >
-        <label
-          class="c0 fi-label-text_label-span"
-          id="test-id-label"
+        <span
+          class="c0 fi-label_label-span"
         >
           Dropdown test
-        </label>
-      </div>
+        </span>
+      </label>
       <div
         data-reach-listbox-input=""
         data-state="closed"
@@ -958,35 +856,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1016,7 +885,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c3.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1030,20 +899,15 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -1196,16 +1060,16 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <div
-        class="c3 c4 fi-dropdown_label--visible fi-label-text"
+      <label
+        class="c2 c3 fi-dropdown_label--visible fi-label"
+        id="test-id-label"
       >
-        <label
-          class="c0 fi-label-text_label-span"
-          id="test-id-label"
+        <span
+          class="c0 fi-label_label-span"
         >
           Dropdown test
-        </label>
-      </div>
+        </span>
+      </label>
       <div
         data-reach-listbox-input=""
         data-state="closed"
@@ -1267,35 +1131,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1325,7 +1160,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c4 {
   position: absolute;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -1337,7 +1172,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c3.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1351,20 +1186,15 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -1517,15 +1347,16 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <div
-        class="c3 c4 fi-label-text"
+      <label
+        class="c2 c3 fi-label"
+        id="test-id-label"
       >
         <span
-          class="c0 c5 fi-visually-hidden"
+          class="c0 c4 fi-visually-hidden"
         >
           Dropdown test
         </span>
-      </div>
+      </label>
       <div
         data-reach-listbox-input=""
         data-state="closed"

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-labe .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -77,7 +77,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -334,7 +334,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-labe .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -352,7 +352,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -610,7 +610,7 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-labe .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -628,7 +628,7 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -885,7 +885,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-labe .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -903,7 +903,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -1172,7 +1172,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c3.fi-labe .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1190,7 +1190,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -30,6 +30,35 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -59,7 +88,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -73,15 +102,20 @@ exports[`Basic dropdown should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c4.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -234,16 +268,16 @@ exports[`Basic dropdown should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <label
-        class="c2 c3 fi-dropdown_label--visible fi-label"
-        id="test-id-label"
+      <div
+        class="c3 c4 fi-dropdown_label--visible fi-label"
       >
-        <span
+        <label
           class="c0 fi-label_label-span"
+          id="test-id-label"
         >
           Dropdown test
-        </span>
-      </label>
+        </label>
+      </div>
       <div
         data-reach-listbox-input=""
         data-state="closed"
@@ -305,6 +339,35 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -334,7 +397,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -348,15 +411,20 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c4.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -510,16 +578,16 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <label
-        class="c2 c3 fi-dropdown_label--visible fi-label"
-        id="test-id-label"
+      <div
+        class="c3 c4 fi-dropdown_label--visible fi-label"
       >
-        <span
+        <label
           class="c0 fi-label_label-span"
+          id="test-id-label"
         >
           Dropdown test
-        </span>
-      </label>
+        </label>
+      </div>
       <div
         data-reach-listbox-input=""
         data-state="closed"
@@ -581,6 +649,35 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -610,7 +707,7 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -624,15 +721,20 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c4.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -785,16 +887,16 @@ exports[`Dropdown as action menu should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <label
-        class="c2 c3 fi-dropdown_label--visible fi-label"
-        id="test-id-label"
+      <div
+        class="c3 c4 fi-dropdown_label--visible fi-label"
       >
-        <span
+        <label
           class="c0 fi-label_label-span"
+          id="test-id-label"
         >
           Dropdown test
-        </span>
-      </label>
+        </label>
+      </div>
       <div
         data-reach-listbox-input=""
         data-state="closed"
@@ -856,6 +958,35 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -885,7 +1016,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -899,15 +1030,20 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c4.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -1060,16 +1196,16 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <label
-        class="c2 c3 fi-dropdown_label--visible fi-label"
-        id="test-id-label"
+      <div
+        class="c3 c4 fi-dropdown_label--visible fi-label"
       >
-        <span
+        <label
           class="c0 fi-label_label-span"
+          id="test-id-label"
         >
           Dropdown test
-        </span>
-      </label>
+        </label>
+      </div>
       <div
         data-reach-listbox-input=""
         data-state="closed"
@@ -1131,6 +1267,35 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1160,7 +1325,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
+.c5 {
   position: absolute;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -1172,7 +1337,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1186,15 +1351,20 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c4.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
 }
 
 .c1.fi-dropdown {
@@ -1347,16 +1517,15 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
     <div
       class="c2"
     >
-      <label
-        class="c2 c3 fi-label"
-        id="test-id-label"
+      <div
+        class="c3 c4 fi-label"
       >
         <span
-          class="c0 c4 fi-visually-hidden"
+          class="c0 c5 fi-visually-hidden"
         >
           Dropdown test
         </span>
-      </label>
+      </div>
       <div
         data-reach-listbox-input=""
         data-state="closed"

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -329,7 +329,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   border-width: 2px;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -347,7 +347,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -30,6 +30,35 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -55,7 +84,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c7 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -78,17 +107,17 @@ exports[`default, with only required props should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c7::before,
-.c7::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c8 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -108,8 +137,8 @@ exports[`default, with only required props should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::before,
-.c8::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -138,7 +167,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -162,12 +191,42 @@ exports[`default, with only required props should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c5::before,
-.c5::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c9 {
+.c5.fi-label .fi-label_label-span {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  display: inline-block;
+  vertical-align: middle;
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c10 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -186,172 +245,12 @@ exports[`default, with only required props should match snapshot 1`] = `
   line-height: 20px;
 }
 
-.c9.fi-status-text {
+.c10.fi-status-text {
   display: block;
 }
 
-.c9.fi-status-text.fi-status-text--error {
+.c10.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c6 {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c6 .fi-checkbox_label {
-  position: relative;
-  display: block;
-  padding-left: 25px;
-  cursor: pointer;
-  line-height: 27px;
-}
-
-.c6 .fi-checkbox_label::before {
-  content: '';
-  position: absolute;
-  left: 0px;
-  top: 5px;
-  box-sizing: border-box;
-  height: 18px;
-  width: 18px;
-  border: 1px solid hsl(201,7%,58%);
-  border-radius: 2px;
-  background-color: hsl(0,0%,100%);
-}
-
-.c6 .fi-checkbox_icon {
-  position: absolute;
-  height: 10px;
-  width: 10px;
-  left: 4px;
-  top: 9px;
-}
-
-.c6:focus-within .fi-checkbox_label::before {
-  outline: 0;
-  border-radius: 2px;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-}
-
-.c6 .fi-checkbox_input {
-  position: absolute;
-  opacity: 0;
-  z-index: -9999;
-}
-
-.c6 .fi-hint-text {
-  padding-left: 25px;
-  color: hsl(202,7%,40%);
-}
-
-.c6 .fi-status-text {
-  line-height: 18px;
-}
-
-.c6 .fi-status-text.fi-checkbox_statusText--has-content {
-  margin-top: 5px;
-}
-
-.c6.fi-checkbox--large .fi-checkbox_label {
-  padding-left: 40px;
-  line-height: 30px;
-}
-
-.c6.fi-checkbox--large .fi-checkbox_label::before {
-  content: '';
-  position: absolute;
-  left: 0px;
-  top: 0px;
-  box-sizing: border-box;
-  height: 30px;
-  width: 30px;
-  color: hsl(201,7%,58%);
-  border: 2px solid;
-}
-
-.c6.fi-checkbox--large .fi-checkbox_label .fi-checkbox_icon {
-  height: 20px;
-  width: 20px;
-  left: 5px;
-  top: 4px;
-}
-
-.c6.fi-checkbox--large .fi-hint-text {
-  padding-left: 40px;
-}
-
-.c6.fi-checkbox--checked .fi-checkbox_label::before {
-  border-color: hsl(212,63%,45%);
-}
-
-.c6.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(212,63%,45%);
-}
-
-.c6.fi-checkbox--error .fi-checkbox_label::before {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c6.fi-checkbox--error .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(3,59%,48%);
-}
-
-.c6.fi-checkbox--disabled .fi-checkbox_label {
-  cursor: not-allowed;
-  color: hsl(202,7%,67%);
-}
-
-.c6.fi-checkbox--disabled .fi-checkbox_label::before {
-  background-color: hsl(202,7%,97%);
-  border-color: hsl(202,7%,80%);
-  border-width: 1px;
-}
-
-.c6.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(202,7%,80%);
-}
-
-.c6.fi-checkbox--disabled.fi-checkbox--large .fi-checkbox_label::before {
-  border-width: 2px;
-}
-
-.c4.fi-label .fi-label_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: block;
-  color: hsl(0,0%,16%);
-}
-
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
 }
 
 .c1 {
@@ -379,6 +278,141 @@ exports[`default, with only required props should match snapshot 1`] = `
   margin-bottom: 15px;
 }
 
+.c7 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c7 .fi-checkbox_label {
+  position: relative;
+  display: block;
+  padding-left: 25px;
+  cursor: pointer;
+  line-height: 27px;
+}
+
+.c7 .fi-checkbox_label::before {
+  content: '';
+  position: absolute;
+  left: 0px;
+  top: 5px;
+  box-sizing: border-box;
+  height: 18px;
+  width: 18px;
+  border: 1px solid hsl(201,7%,58%);
+  border-radius: 2px;
+  background-color: hsl(0,0%,100%);
+}
+
+.c7 .fi-checkbox_icon {
+  position: absolute;
+  height: 10px;
+  width: 10px;
+  left: 4px;
+  top: 9px;
+}
+
+.c7:focus-within .fi-checkbox_label::before {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c7 .fi-checkbox_input {
+  position: absolute;
+  opacity: 0;
+  z-index: -9999;
+}
+
+.c7 .fi-hint-text {
+  padding-left: 25px;
+  color: hsl(202,7%,40%);
+}
+
+.c7 .fi-status-text {
+  line-height: 18px;
+}
+
+.c7 .fi-status-text.fi-checkbox_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c7.fi-checkbox--large .fi-checkbox_label {
+  padding-left: 40px;
+  line-height: 30px;
+}
+
+.c7.fi-checkbox--large .fi-checkbox_label::before {
+  content: '';
+  position: absolute;
+  left: 0px;
+  top: 0px;
+  box-sizing: border-box;
+  height: 30px;
+  width: 30px;
+  color: hsl(201,7%,58%);
+  border: 2px solid;
+}
+
+.c7.fi-checkbox--large .fi-checkbox_label .fi-checkbox_icon {
+  height: 20px;
+  width: 20px;
+  left: 5px;
+  top: 4px;
+}
+
+.c7.fi-checkbox--large .fi-hint-text {
+  padding-left: 40px;
+}
+
+.c7.fi-checkbox--checked .fi-checkbox_label::before {
+  border-color: hsl(212,63%,45%);
+}
+
+.c7.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(212,63%,45%);
+}
+
+.c7.fi-checkbox--error .fi-checkbox_label::before {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c7.fi-checkbox--error .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(3,59%,48%);
+}
+
+.c7.fi-checkbox--disabled .fi-checkbox_label {
+  cursor: not-allowed;
+  color: hsl(202,7%,67%);
+}
+
+.c7.fi-checkbox--disabled .fi-checkbox_label::before {
+  background-color: hsl(202,7%,97%);
+  border-color: hsl(202,7%,80%);
+  border-width: 1px;
+}
+
+.c7.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,80%);
+}
+
+.c7.fi-checkbox--disabled.fi-checkbox--large .fi-checkbox_label::before {
+  border-width: 2px;
+}
+
 <div>
   <div
     class="c0 fi-checkbox-group c1"
@@ -390,31 +424,31 @@ exports[`default, with only required props should match snapshot 1`] = `
       <legend
         class="c3 fi-checkbox-group_legend"
       >
-        <label
-          class="c0 c4 fi-checkbox-group_label--visible fi-label"
-          for="1"
+        <div
+          class="c4 c5 fi-checkbox-group_label--visible fi-label"
         >
-          <span
-            class="c5 fi-label_label-span"
+          <label
+            class="c6 fi-label_label-span"
+            for="1"
           >
             Label
-          </span>
-        </label>
+          </label>
+        </div>
       </legend>
       <div
         class="c0 fi-checkbox-group_container"
       >
         <div
-          class="c0 fi-checkbox_container c6 fi-checkbox"
+          class="c0 fi-checkbox_container c7 fi-checkbox"
         >
           <input
             aria-invalid="false"
-            class="c7 fi-checkbox_input"
+            class="c8 fi-checkbox_input"
             id="test-id-1"
             type="checkbox"
           />
           <label
-            class="c8 fi-checkbox_label"
+            class="c9 fi-checkbox_label"
             for="test-id-1"
           >
             Label text 1
@@ -422,20 +456,20 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c5 c9 fi-status-text"
+            class="c6 c10 fi-status-text"
           />
         </div>
         <div
-          class="c0 fi-checkbox_container c6 fi-checkbox"
+          class="c0 fi-checkbox_container c7 fi-checkbox"
         >
           <input
             aria-invalid="false"
-            class="c7 fi-checkbox_input"
+            class="c8 fi-checkbox_input"
             id="test-id-2"
             type="checkbox"
           />
           <label
-            class="c8 fi-checkbox_label"
+            class="c9 fi-checkbox_label"
             for="test-id-2"
           >
             Label text 2
@@ -443,20 +477,20 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c5 c9 fi-status-text"
+            class="c6 c10 fi-status-text"
           />
         </div>
         <div
-          class="c0 fi-checkbox_container c6 fi-checkbox"
+          class="c0 fi-checkbox_container c7 fi-checkbox"
         >
           <input
             aria-invalid="false"
-            class="c7 fi-checkbox_input"
+            class="c8 fi-checkbox_input"
             id="test-id-3"
             type="checkbox"
           />
           <label
-            class="c8 fi-checkbox_label"
+            class="c9 fi-checkbox_label"
             for="test-id-3"
           >
             Label text 3
@@ -464,11 +498,16 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c5 c9 fi-status-text"
+            class="c6 c10 fi-status-text"
           />
         </div>
       </div>
     </fieldset>
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      class="c6 c10 fi-status-text"
+    />
   </div>
 </div>
 `;

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -30,35 +30,6 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -84,7 +55,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -107,17 +78,17 @@ exports[`default, with only required props should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c8::before,
-.c8::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c9 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -137,8 +108,8 @@ exports[`default, with only required props should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c9::before,
-.c9::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
@@ -167,7 +138,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -191,42 +162,12 @@ exports[`default, with only required props should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
-  color: hsl(0,0%,16%);
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c10 {
+.c9 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -245,12 +186,172 @@ exports[`default, with only required props should match snapshot 1`] = `
   line-height: 20px;
 }
 
-.c10.fi-status-text {
+.c9.fi-status-text {
   display: block;
 }
 
-.c10.fi-status-text.fi-status-text--error {
+.c9.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
+}
+
+.c6 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c6 .fi-checkbox_label {
+  position: relative;
+  display: block;
+  padding-left: 25px;
+  cursor: pointer;
+  line-height: 27px;
+}
+
+.c6 .fi-checkbox_label::before {
+  content: '';
+  position: absolute;
+  left: 0px;
+  top: 5px;
+  box-sizing: border-box;
+  height: 18px;
+  width: 18px;
+  border: 1px solid hsl(201,7%,58%);
+  border-radius: 2px;
+  background-color: hsl(0,0%,100%);
+}
+
+.c6 .fi-checkbox_icon {
+  position: absolute;
+  height: 10px;
+  width: 10px;
+  left: 4px;
+  top: 9px;
+}
+
+.c6:focus-within .fi-checkbox_label::before {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c6 .fi-checkbox_input {
+  position: absolute;
+  opacity: 0;
+  z-index: -9999;
+}
+
+.c6 .fi-hint-text {
+  padding-left: 25px;
+  color: hsl(202,7%,40%);
+}
+
+.c6 .fi-status-text {
+  line-height: 18px;
+}
+
+.c6 .fi-status-text.fi-checkbox_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c6.fi-checkbox--large .fi-checkbox_label {
+  padding-left: 40px;
+  line-height: 30px;
+}
+
+.c6.fi-checkbox--large .fi-checkbox_label::before {
+  content: '';
+  position: absolute;
+  left: 0px;
+  top: 0px;
+  box-sizing: border-box;
+  height: 30px;
+  width: 30px;
+  color: hsl(201,7%,58%);
+  border: 2px solid;
+}
+
+.c6.fi-checkbox--large .fi-checkbox_label .fi-checkbox_icon {
+  height: 20px;
+  width: 20px;
+  left: 5px;
+  top: 4px;
+}
+
+.c6.fi-checkbox--large .fi-hint-text {
+  padding-left: 40px;
+}
+
+.c6.fi-checkbox--checked .fi-checkbox_label::before {
+  border-color: hsl(212,63%,45%);
+}
+
+.c6.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(212,63%,45%);
+}
+
+.c6.fi-checkbox--error .fi-checkbox_label::before {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c6.fi-checkbox--error .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(3,59%,48%);
+}
+
+.c6.fi-checkbox--disabled .fi-checkbox_label {
+  cursor: not-allowed;
+  color: hsl(202,7%,67%);
+}
+
+.c6.fi-checkbox--disabled .fi-checkbox_label::before {
+  background-color: hsl(202,7%,97%);
+  border-color: hsl(202,7%,80%);
+  border-width: 1px;
+}
+
+.c6.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,80%);
+}
+
+.c6.fi-checkbox--disabled.fi-checkbox--large .fi-checkbox_label::before {
+  border-width: 2px;
+}
+
+.c4.fi-labe .fi-label_label-span {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  display: block;
+  color: hsl(0,0%,16%);
+}
+
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 .c1 {
@@ -278,141 +379,6 @@ exports[`default, with only required props should match snapshot 1`] = `
   margin-bottom: 15px;
 }
 
-.c7 {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c7 .fi-checkbox_label {
-  position: relative;
-  display: block;
-  padding-left: 25px;
-  cursor: pointer;
-  line-height: 27px;
-}
-
-.c7 .fi-checkbox_label::before {
-  content: '';
-  position: absolute;
-  left: 0px;
-  top: 5px;
-  box-sizing: border-box;
-  height: 18px;
-  width: 18px;
-  border: 1px solid hsl(201,7%,58%);
-  border-radius: 2px;
-  background-color: hsl(0,0%,100%);
-}
-
-.c7 .fi-checkbox_icon {
-  position: absolute;
-  height: 10px;
-  width: 10px;
-  left: 4px;
-  top: 9px;
-}
-
-.c7:focus-within .fi-checkbox_label::before {
-  outline: 0;
-  border-radius: 2px;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-}
-
-.c7 .fi-checkbox_input {
-  position: absolute;
-  opacity: 0;
-  z-index: -9999;
-}
-
-.c7 .fi-hint-text {
-  padding-left: 25px;
-  color: hsl(202,7%,40%);
-}
-
-.c7 .fi-status-text {
-  line-height: 18px;
-}
-
-.c7 .fi-status-text.fi-checkbox_statusText--has-content {
-  margin-top: 5px;
-}
-
-.c7.fi-checkbox--large .fi-checkbox_label {
-  padding-left: 40px;
-  line-height: 30px;
-}
-
-.c7.fi-checkbox--large .fi-checkbox_label::before {
-  content: '';
-  position: absolute;
-  left: 0px;
-  top: 0px;
-  box-sizing: border-box;
-  height: 30px;
-  width: 30px;
-  color: hsl(201,7%,58%);
-  border: 2px solid;
-}
-
-.c7.fi-checkbox--large .fi-checkbox_label .fi-checkbox_icon {
-  height: 20px;
-  width: 20px;
-  left: 5px;
-  top: 4px;
-}
-
-.c7.fi-checkbox--large .fi-hint-text {
-  padding-left: 40px;
-}
-
-.c7.fi-checkbox--checked .fi-checkbox_label::before {
-  border-color: hsl(212,63%,45%);
-}
-
-.c7.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(212,63%,45%);
-}
-
-.c7.fi-checkbox--error .fi-checkbox_label::before {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c7.fi-checkbox--error .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(3,59%,48%);
-}
-
-.c7.fi-checkbox--disabled .fi-checkbox_label {
-  cursor: not-allowed;
-  color: hsl(202,7%,67%);
-}
-
-.c7.fi-checkbox--disabled .fi-checkbox_label::before {
-  background-color: hsl(202,7%,97%);
-  border-color: hsl(202,7%,80%);
-  border-width: 1px;
-}
-
-.c7.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(202,7%,80%);
-}
-
-.c7.fi-checkbox--disabled.fi-checkbox--large .fi-checkbox_label::before {
-  border-width: 2px;
-}
-
 <div>
   <div
     class="c0 fi-checkbox-group c1"
@@ -424,31 +390,31 @@ exports[`default, with only required props should match snapshot 1`] = `
       <legend
         class="c3 fi-checkbox-group_legend"
       >
-        <div
-          class="c4 c5 fi-checkbox-group_label--visible fi-label-text"
+        <label
+          class="c0 c4 fi-checkbox-group_label--visible fi-label"
+          for="1"
         >
-          <label
-            class="c6 fi-label-text_label-span"
-            for="1"
+          <span
+            class="c5 fi-label_label-span"
           >
             Label
-          </label>
-        </div>
+          </span>
+        </label>
       </legend>
       <div
         class="c0 fi-checkbox-group_container"
       >
         <div
-          class="c0 fi-checkbox_container c7 fi-checkbox"
+          class="c0 fi-checkbox_container c6 fi-checkbox"
         >
           <input
             aria-invalid="false"
-            class="c8 fi-checkbox_input"
+            class="c7 fi-checkbox_input"
             id="test-id-1"
             type="checkbox"
           />
           <label
-            class="c9 fi-checkbox_label"
+            class="c8 fi-checkbox_label"
             for="test-id-1"
           >
             Label text 1
@@ -456,20 +422,20 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c6 c10 fi-status-text"
+            class="c5 c9 fi-status-text"
           />
         </div>
         <div
-          class="c0 fi-checkbox_container c7 fi-checkbox"
+          class="c0 fi-checkbox_container c6 fi-checkbox"
         >
           <input
             aria-invalid="false"
-            class="c8 fi-checkbox_input"
+            class="c7 fi-checkbox_input"
             id="test-id-2"
             type="checkbox"
           />
           <label
-            class="c9 fi-checkbox_label"
+            class="c8 fi-checkbox_label"
             for="test-id-2"
           >
             Label text 2
@@ -477,20 +443,20 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c6 c10 fi-status-text"
+            class="c5 c9 fi-status-text"
           />
         </div>
         <div
-          class="c0 fi-checkbox_container c7 fi-checkbox"
+          class="c0 fi-checkbox_container c6 fi-checkbox"
         >
           <input
             aria-invalid="false"
-            class="c8 fi-checkbox_input"
+            class="c7 fi-checkbox_input"
             id="test-id-3"
             type="checkbox"
           />
           <label
-            class="c9 fi-checkbox_label"
+            class="c8 fi-checkbox_label"
             for="test-id-3"
           >
             Label text 3
@@ -498,16 +464,11 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c6 c10 fi-status-text"
+            class="c5 c9 fi-status-text"
           />
         </div>
       </div>
     </fieldset>
-    <span
-      aria-atomic="true"
-      aria-live="polite"
-      class="c6 c10 fi-status-text"
-    />
   </div>
 </div>
 `;

--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -98,12 +98,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       flex-direction: row;
       align-items: flex-start;
 
-      & .fi-label-text {
+      & .fi-label {
         padding-right: ${theme.spacing.insetL};
         padding-top: ${theme.spacing.insetM};
         align-self: flex-start;
 
-        & .fi-label-text_label-span {
+        & .fi-label_label-span {
           margin-bottom: 0;
         }
       }

--- a/src/core/Form/FilterInput/FilterInput.test.tsx
+++ b/src/core/Form/FilterInput/FilterInput.test.tsx
@@ -140,7 +140,7 @@ describe('props', () => {
         />,
       );
       const label = getByText('Label');
-      expect(label).toHaveClass('fi-label-text_label-span');
+      expect(label).toHaveClass('fi-label_label-span');
     });
   });
 
@@ -156,7 +156,7 @@ describe('props', () => {
         />,
       );
       const optionalText = getByText('(Optional)');
-      expect(optionalText).toHaveClass('fi-label-text_optionalText');
+      expect(optionalText).toHaveClass('fi-label_optional-text');
     });
   });
 
@@ -172,7 +172,7 @@ describe('props', () => {
         />,
       );
       const label = getByText('Label');
-      expect(label).toHaveClass('fi-label-text_label-span');
+      expect(label).toHaveClass('fi-label_label-span');
     });
 
     it('should be hidden', () => {

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -30,36 +30,7 @@ exports[`snapshot matches 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
-.c5 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -82,17 +53,17 @@ exports[`snapshot matches 1`] = `
   max-width: 100%;
 }
 
-.c5::-webkit-input-placeholder {
+.c4::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c5::before,
-.c5::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
-.c4 {
+.c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -116,12 +87,12 @@ exports[`snapshot matches 1`] = `
   white-space: normal;
 }
 
-.c4::before,
-.c4::after {
+.c3::before,
+.c3::after {
   box-sizing: border-box;
 }
 
-.c3.fi-label-text .fi-label-text_label-span {
+.c2.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -135,23 +106,18 @@ exports[`snapshot matches 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c2.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c3.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c6 {
+.c5 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -170,11 +136,11 @@ exports[`snapshot matches 1`] = `
   line-height: 20px;
 }
 
-.c6.fi-status-text {
+.c5.fi-status-text {
   display: block;
 }
 
-.c6.fi-status-text.fi-status-text--error {
+.c5.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
 }
 
@@ -362,7 +328,7 @@ exports[`snapshot matches 1`] = `
   align-items: flex-start;
 }
 
-.c1.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label-text {
+.c1.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label {
   padding-right: 10px;
   padding-top: 8px;
   -webkit-align-self: flex-start;
@@ -370,7 +336,7 @@ exports[`snapshot matches 1`] = `
   align-self: flex-start;
 }
 
-.c1.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label-text .fi-label-text_label-span {
+.c1.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label .fi-label_label-span {
   margin-bottom: 0;
 }
 
@@ -380,16 +346,16 @@ exports[`snapshot matches 1`] = `
   <div
     class="c0 fi-filter-input_wrapper"
   >
-    <div
-      class="c2 c3 fi-filter-input_label--visible fi-label-text"
+    <label
+      class="c0 c2 fi-filter-input_label--visible fi-label"
+      id="1-label"
     >
-      <label
-        class="c4 fi-label-text_label-span"
-        id="1-label"
+      <span
+        class="c3 fi-label_label-span"
       >
         Label
-      </label>
-    </div>
+      </span>
+    </label>
     <div
       class="c0 fi-filter-input_functionalityContainer"
     >
@@ -403,7 +369,7 @@ exports[`snapshot matches 1`] = `
           aria-multiline="false"
           autocapitalize="none"
           autocomplete="off"
-          class="c5 fi-filter-input_input"
+          class="c4 fi-filter-input_input"
           id="1"
           spellcheck="false"
           type="text"
@@ -412,7 +378,7 @@ exports[`snapshot matches 1`] = `
       <span
         aria-atomic="true"
         aria-live="assertive"
-        class="c4 c6 fi-status-text"
+        class="c3 c5 fi-status-text"
       />
     </div>
   </div>

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`snapshot matches 1`] = `
   box-sizing: border-box;
 }
 
-.c2.fi-labe .fi-label_label-span {
+.c2.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -110,7 +110,7 @@ exports[`snapshot matches 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c2.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c2.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -30,7 +30,36 @@ exports[`snapshot matches 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -53,17 +82,17 @@ exports[`snapshot matches 1`] = `
   max-width: 100%;
 }
 
-.c4::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c4::before,
-.c4::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c3 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -87,12 +116,12 @@ exports[`snapshot matches 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
-.c2.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -106,18 +135,23 @@ exports[`snapshot matches 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c2.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5 {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c6 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -136,11 +170,11 @@ exports[`snapshot matches 1`] = `
   line-height: 20px;
 }
 
-.c5.fi-status-text {
+.c6.fi-status-text {
   display: block;
 }
 
-.c5.fi-status-text.fi-status-text--error {
+.c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
 }
 
@@ -346,16 +380,16 @@ exports[`snapshot matches 1`] = `
   <div
     class="c0 fi-filter-input_wrapper"
   >
-    <label
-      class="c0 c2 fi-filter-input_label--visible fi-label"
-      id="1-label"
+    <div
+      class="c2 c3 fi-filter-input_label--visible fi-label"
     >
-      <span
-        class="c3 fi-label_label-span"
+      <label
+        class="c4 fi-label_label-span"
+        id="1-label"
       >
         Label
-      </span>
-    </label>
+      </label>
+    </div>
     <div
       class="c0 fi-filter-input_functionalityContainer"
     >
@@ -369,7 +403,7 @@ exports[`snapshot matches 1`] = `
           aria-multiline="false"
           autocapitalize="none"
           autocomplete="off"
-          class="c4 fi-filter-input_input"
+          class="c5 fi-filter-input_input"
           id="1"
           spellcheck="false"
           type="text"
@@ -378,7 +412,7 @@ exports[`snapshot matches 1`] = `
       <span
         aria-atomic="true"
         aria-live="assertive"
-        class="c3 c5 fi-status-text"
+        class="c4 c6 fi-status-text"
       />
     </div>
   </div>

--- a/src/core/Form/Label/Label.baseStyles.tsx
+++ b/src/core/Form/Label/Label.baseStyles.tsx
@@ -3,14 +3,14 @@ import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &.fi-label-text {
-    & .fi-label-text_label-span {
+  &.fi-label {
+    & .fi-label_label-span {
       ${font(theme)('actionElementInnerTextBold')};
       display: inline-block;
       vertical-align: middle;
       color: ${theme.colors.blackBase};
 
-      & .fi-label-text_optionalText {
+      & .fi-label_optional-text {
         ${theme.typography.bodyTextSmall};
       }
       & .fi-tooltip {

--- a/src/core/Form/Label/Label.test.tsx
+++ b/src/core/Form/Label/Label.test.tsx
@@ -18,7 +18,7 @@ describe('props', () => {
         <Label optionalText="optional">Test text</Label>,
       );
       const optionalText = getByText('(optional)');
-      expect(optionalText).toHaveClass('fi-label-text_optionalText');
+      expect(optionalText).toHaveClass('fi-label_optional-text');
     });
   });
 
@@ -42,7 +42,7 @@ describe('props', () => {
     it('should be visible by default', () => {
       const { getByText } = render(<Label>Test text</Label>);
       const label = getByText('Test text');
-      expect(label).toHaveClass('fi-label-text_label-span');
+      expect(label).toHaveClass('fi-label_label-span');
     });
 
     it('should be hidden', () => {

--- a/src/core/Form/Label/Label.tsx
+++ b/src/core/Form/Label/Label.tsx
@@ -51,10 +51,10 @@ export interface LabelProps extends Omit<HtmlSpanProps, 'as'> {
   tooltipComponent?: ReactElement;
 }
 
-const baseClassName = 'fi-label-text';
+const baseClassName = 'fi-label';
 const labelTextClassNames = {
   labelSpan: `${baseClassName}_label-span`,
-  optionalText: `${baseClassName}_optionalText`,
+  optionalText: `${baseClassName}_optional-text`,
 };
 
 const StyledLabel = styled(

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -30,6 +30,35 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -55,7 +84,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c7 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -78,17 +107,17 @@ exports[`default, with only required props should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c7::before,
-.c7::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c9 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -108,8 +137,8 @@ exports[`default, with only required props should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c9::before,
-.c9::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -138,7 +167,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -162,28 +191,12 @@ exports[`default, with only required props should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c5::before,
-.c5::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c8 {
-  vertical-align: baseline;
-}
-
-.c8.fi-static-icon {
-  display: inline-block;
-}
-
-.c8.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c8.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c4.fi-label .fi-label_label-span {
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -197,15 +210,36 @@ exports[`default, with only required props should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-static-icon {
+  display: inline-block;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
 }
 
 .c1 {
@@ -265,7 +299,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c6 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -283,7 +317,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   position: relative;
 }
 
-.c6.fi-radio-button .fi-radio-button_hintText {
+.c7.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -293,7 +327,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c6.fi-radio-button .fi-radio-button_label {
+.c7.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -301,7 +335,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input {
+.c7.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -311,7 +345,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   left: 2px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -320,77 +354,77 @@ exports[`default, with only required props should match snapshot 1`] = `
   position: absolute;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus {
+.c7.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button--large .fi-radio-button_hintText {
+.c7.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input {
+.c7.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_label {
+.c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -406,36 +440,36 @@ exports[`default, with only required props should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <label
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
-          for="test-id"
+        <div
+          class="c4 c5 fi-radio-button-group_label--visible fi-label"
         >
-          <span
-            class="c5 fi-label_label-span"
+          <label
+            class="c6 fi-label_label-span"
+            for="test-id"
           >
             Label
-          </span>
-        </label>
+          </label>
+        </div>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -462,28 +496,28 @@ exports[`default, with only required props should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -510,28 +544,28 @@ exports[`default, with only required props should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -558,7 +592,7 @@ exports[`default, with only required props should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -600,6 +634,35 @@ exports[`props className should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -625,7 +688,7 @@ exports[`props className should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c7 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -648,17 +711,17 @@ exports[`props className should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c7::before,
-.c7::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c9 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -678,8 +741,8 @@ exports[`props className should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c9::before,
-.c9::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -708,7 +771,7 @@ exports[`props className should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -732,28 +795,12 @@ exports[`props className should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c5::before,
-.c5::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c8 {
-  vertical-align: baseline;
-}
-
-.c8.fi-static-icon {
-  display: inline-block;
-}
-
-.c8.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c8.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c4.fi-label .fi-label_label-span {
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -767,15 +814,36 @@ exports[`props className should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-static-icon {
+  display: inline-block;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
 }
 
 .c1 {
@@ -835,7 +903,7 @@ exports[`props className should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c6 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -853,7 +921,7 @@ exports[`props className should match snapshot 1`] = `
   position: relative;
 }
 
-.c6.fi-radio-button .fi-radio-button_hintText {
+.c7.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -863,7 +931,7 @@ exports[`props className should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c6.fi-radio-button .fi-radio-button_label {
+.c7.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -871,7 +939,7 @@ exports[`props className should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input {
+.c7.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -881,7 +949,7 @@ exports[`props className should match snapshot 1`] = `
   left: 2px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -890,77 +958,77 @@ exports[`props className should match snapshot 1`] = `
   position: absolute;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus {
+.c7.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button--large .fi-radio-button_hintText {
+.c7.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input {
+.c7.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_label {
+.c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -976,36 +1044,36 @@ exports[`props className should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <label
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
-          for="test-id"
+        <div
+          class="c4 c5 fi-radio-button-group_label--visible fi-label"
         >
-          <span
-            class="c5 fi-label_label-span"
+          <label
+            class="c6 fi-label_label-span"
+            for="test-id"
           >
             Label
-          </span>
-        </label>
+          </label>
+        </div>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1032,28 +1100,28 @@ exports[`props className should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1080,28 +1148,28 @@ exports[`props className should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1128,7 +1196,7 @@ exports[`props className should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -1170,6 +1238,35 @@ exports[`props defaultValue should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1195,7 +1292,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c7 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1218,17 +1315,17 @@ exports[`props defaultValue should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c7::before,
-.c7::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c9 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1248,8 +1345,8 @@ exports[`props defaultValue should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c9::before,
-.c9::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -1278,7 +1375,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1302,28 +1399,12 @@ exports[`props defaultValue should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c5::before,
-.c5::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c8 {
-  vertical-align: baseline;
-}
-
-.c8.fi-static-icon {
-  display: inline-block;
-}
-
-.c8.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c8.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c4.fi-label .fi-label_label-span {
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1337,15 +1418,36 @@ exports[`props defaultValue should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-static-icon {
+  display: inline-block;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
 }
 
 .c1 {
@@ -1405,7 +1507,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c6 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1423,7 +1525,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   position: relative;
 }
 
-.c6.fi-radio-button .fi-radio-button_hintText {
+.c7.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -1433,7 +1535,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c6.fi-radio-button .fi-radio-button_label {
+.c7.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -1441,7 +1543,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input {
+.c7.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -1451,7 +1553,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   left: 2px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -1460,77 +1562,77 @@ exports[`props defaultValue should match snapshot 1`] = `
   position: absolute;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus {
+.c7.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button--large .fi-radio-button_hintText {
+.c7.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input {
+.c7.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_label {
+.c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -1546,36 +1648,36 @@ exports[`props defaultValue should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <label
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
-          for="test-id"
+        <div
+          class="c4 c5 fi-radio-button-group_label--visible fi-label"
         >
-          <span
-            class="c5 fi-label_label-span"
+          <label
+            class="c6 fi-label_label-span"
+            for="test-id"
           >
             Label
-          </span>
-        </label>
+          </label>
+        </div>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1602,28 +1704,28 @@ exports[`props defaultValue should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1650,29 +1752,29 @@ exports[`props defaultValue should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6 fi-radio-button--checked"
+          class="c0 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
         >
           <input
             checked=""
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1699,7 +1801,7 @@ exports[`props defaultValue should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -1741,6 +1843,35 @@ exports[`props hintText should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1766,7 +1897,7 @@ exports[`props hintText should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1789,17 +1920,17 @@ exports[`props hintText should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c8::before,
-.c8::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
-.c10 {
+.c11 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1819,8 +1950,8 @@ exports[`props hintText should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c10::before,
-.c10::after {
+.c11::before,
+.c11::after {
   box-sizing: border-box;
 }
 
@@ -1849,7 +1980,7 @@ exports[`props hintText should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1873,49 +2004,12 @@ exports[`props hintText should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c5::before,
-.c5::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c6 {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c6.fi-hint-text {
-  display: block;
-}
-
-.c9 {
-  vertical-align: baseline;
-}
-
-.c9.fi-static-icon {
-  display: inline-block;
-}
-
-.c9.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c9.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c4.fi-label .fi-label_label-span {
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1929,15 +2023,57 @@ exports[`props hintText should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c10 {
+  vertical-align: baseline;
+}
+
+.c10.fi-static-icon {
+  display: inline-block;
+}
+
+.c10.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c10.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c7 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c7.fi-hint-text {
+  display: block;
 }
 
 .c1 {
@@ -1997,7 +2133,7 @@ exports[`props hintText should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c8 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -2015,7 +2151,7 @@ exports[`props hintText should match snapshot 1`] = `
   position: relative;
 }
 
-.c7.fi-radio-button .fi-radio-button_hintText {
+.c8.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -2025,7 +2161,7 @@ exports[`props hintText should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-radio-button .fi-radio-button_label {
+.c8.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -2033,7 +2169,7 @@ exports[`props hintText should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input {
+.c8.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -2043,7 +2179,7 @@ exports[`props hintText should match snapshot 1`] = `
   left: 2px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -2052,77 +2188,77 @@ exports[`props hintText should match snapshot 1`] = `
   position: absolute;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
+.c8.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c8.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c8.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button--large .fi-radio-button_hintText {
+.c8.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input {
+.c8.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_label {
+.c8.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -2138,18 +2274,18 @@ exports[`props hintText should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <label
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
-          for="test-id"
+        <div
+          class="c4 c5 fi-radio-button-group_label--visible fi-label"
         >
-          <span
-            class="c5 fi-label_label-span"
+          <label
+            class="c6 fi-label_label-span"
+            for="test-id"
           >
             Label
-          </span>
-        </label>
+          </label>
+        </div>
         <span
-          class="c5 c6 fi-hint-text"
+          class="c6 c7 fi-hint-text"
         >
           Example hint text
         </span>
@@ -2158,21 +2294,21 @@ exports[`props hintText should match snapshot 1`] = `
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c8"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c9 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c10 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -2199,28 +2335,28 @@ exports[`props hintText should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c11 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c8"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c9 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c10 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -2247,28 +2383,28 @@ exports[`props hintText should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c11 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c8"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c9 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c10 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -2295,7 +2431,7 @@ exports[`props hintText should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c11 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -2337,548 +2473,7 @@ exports[`props id should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
-.c7 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  overflow: visible;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline-block;
-  max-width: 100%;
-}
-
-.c7::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
-.c7::before,
-.c7::after {
-  box-sizing: border-box;
-}
-
-.c9 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
-.c9::before,
-.c9::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
-.c5 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c5::before,
-.c5::after {
-  box-sizing: border-box;
-}
-
-.c8 {
-  vertical-align: baseline;
-}
-
-.c8.fi-static-icon {
-  display: inline-block;
-}
-
-.c8.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c8.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c4.fi-label .fi-label_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: block;
-  color: hsl(0,0%,16%);
-}
-
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c1 {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_label {
-  display: block;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_hintText {
-  color: hsl(202,7%,40%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c1 .fi-radio-button-group_container > .fi-radio-button {
-  margin-bottom: 10px;
-}
-
-.c1 .fi-radio-button-group_container > .fi-radio-button:last-child {
-  margin-bottom: 0;
-}
-
-.c1 .fi-radio-button-group_container > .fi-radio-button--large {
-  margin-bottom: 15px;
-}
-
-.c1 .fi-radio-button-group_container > .fi-radio-button--large:first-child {
-  margin-top: 5px;
-}
-
-.c6 {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
-  position: relative;
-}
-
-.c6.fi-radio-button .fi-radio-button_hintText {
-  display: block;
-  padding-left: 26px;
-  color: hsl(202,7%,40%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c6.fi-radio-button .fi-radio-button_label {
-  font-size: 16px;
-  position: relative;
-  cursor: pointer;
-  line-height: 27px;
-  padding-left: 26px;
-}
-
-.c6.fi-radio-button .fi-radio-button_input {
-  opacity: 0;
-  position: absolute;
-  z-index: -9999;
-  height: 18px;
-  width: 18px;
-  top: 5px;
-  left: 2px;
-}
-
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
-  top: 3px;
-  left: 0;
-  margin: 2px;
-  height: 18px;
-  width: 18px;
-  position: absolute;
-}
-
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
-  stroke: hsl(201,7%,58%);
-  fill: hsl(0,0%,100%);
-}
-
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
-  fill: hsl(212,63%,45%);
-}
-
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
-  stroke: hsl(212,63%,45%);
-}
-
-.c6.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
-.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  outline: 0;
-  border-radius: 2px;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  border-radius: 50%;
-}
-
-.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
-  box-shadow: none;
-}
-
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
-  cursor: not-allowed;
-  color: hsl(202,7%,67%);
-}
-
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
-  color: hsl(202,7%,67%);
-  cursor: not-allowed;
-}
-
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
-  fill: hsl(202,7%,97%);
-  stroke: hsl(202,7%,80%);
-}
-
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
-  fill: hsl(202,7%,67%);
-}
-
-.c6.fi-radio-button--large .fi-radio-button_hintText {
-  padding-left: 40px;
-}
-
-.c6.fi-radio-button--large .fi-radio-button_input {
-  top: 2px;
-  left: 2px;
-  height: 30px;
-  width: 30px;
-}
-
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
-  top: 0;
-  left: 0;
-  height: 30px;
-  width: 30px;
-}
-
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
-  height: 30px;
-  width: 30px;
-}
-
-.c6.fi-radio-button--large .fi-radio-button_label {
-  padding-left: 40px;
-  line-height: 34px;
-}
-
-<div>
-  <div
-    class="c0 fi-radio-button-group c1"
-    id="good-id"
-  >
-    <fieldset
-      class="c2"
-    >
-      <legend
-        class="c3 fi-radio-button-group_legend"
-      >
-        <label
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
-          for="good-id"
-        >
-          <span
-            class="c5 fi-label_label-span"
-          >
-            Label
-          </span>
-        </label>
-      </legend>
-      <div
-        class="c0 fi-radio-button-group_container"
-      >
-        <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
-        >
-          <input
-            class="c7 fi-radio-button_input"
-            id="test-id-1"
-            name="name"
-            type="radio"
-            value="1"
-          />
-          <span
-            class="c5 fi-radio-button_icon_wrapper"
-          >
-            <svg
-              aria-hidden="true"
-              class="c8 fi-radio-button_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 18 18"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <circle
-                  class="fi-icon-radio-base"
-                  cx="9"
-                  cy="9"
-                  r="8.5"
-                />
-                <circle
-                  class="fi-icon-radio-checked"
-                  cx="9"
-                  cy="9"
-                  r="4"
-                />
-              </g>
-            </svg>
-          </span>
-          <label
-            class="c9 fi-radio-button_label"
-            for="test-id-1"
-          >
-            Label text 1
-          </label>
-        </div>
-        <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
-        >
-          <input
-            class="c7 fi-radio-button_input"
-            id="test-id-2"
-            name="name"
-            type="radio"
-            value="2"
-          />
-          <span
-            class="c5 fi-radio-button_icon_wrapper"
-          >
-            <svg
-              aria-hidden="true"
-              class="c8 fi-radio-button_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 18 18"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <circle
-                  class="fi-icon-radio-base"
-                  cx="9"
-                  cy="9"
-                  r="8.5"
-                />
-                <circle
-                  class="fi-icon-radio-checked"
-                  cx="9"
-                  cy="9"
-                  r="4"
-                />
-              </g>
-            </svg>
-          </span>
-          <label
-            class="c9 fi-radio-button_label"
-            for="test-id-2"
-          >
-            Label text 2
-          </label>
-        </div>
-        <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
-        >
-          <input
-            class="c7 fi-radio-button_input"
-            id="test-id-3"
-            name="name"
-            type="radio"
-            value="3"
-          />
-          <span
-            class="c5 fi-radio-button_icon_wrapper"
-          >
-            <svg
-              aria-hidden="true"
-              class="c8 fi-radio-button_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 18 18"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <circle
-                  class="fi-icon-radio-base"
-                  cx="9"
-                  cy="9"
-                  r="8.5"
-                />
-                <circle
-                  class="fi-icon-radio-checked"
-                  cx="9"
-                  cy="9"
-                  r="4"
-                />
-              </g>
-            </svg>
-          </span>
-          <label
-            class="c9 fi-radio-button_label"
-            for="test-id-3"
-          >
-            Label text 3
-          </label>
-        </div>
-      </div>
-    </fieldset>
-  </div>
-</div>
-`;
-
-exports[`props label should match snapshot 1`] = `
-.c0 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2902,578 +2497,8 @@ exports[`props label should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c0::before,
-.c0::after {
-  box-sizing: border-box;
-}
-
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
-.c7 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  overflow: visible;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline-block;
-  max-width: 100%;
-}
-
-.c7::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
-.c7::before,
-.c7::after {
-  box-sizing: border-box;
-}
-
-.c9 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
-.c9::before,
-.c9::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  max-width: 100%;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
-.c5 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c5::before,
-.c5::after {
-  box-sizing: border-box;
-}
-
-.c8 {
-  vertical-align: baseline;
-}
-
-.c8.fi-static-icon {
-  display: inline-block;
-}
-
-.c8.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c8.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c4.fi-label .fi-label_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: block;
-  color: hsl(0,0%,16%);
-}
-
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c1 {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_label {
-  display: block;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_hintText {
-  color: hsl(202,7%,40%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c1 .fi-radio-button-group_container > .fi-radio-button {
-  margin-bottom: 10px;
-}
-
-.c1 .fi-radio-button-group_container > .fi-radio-button:last-child {
-  margin-bottom: 0;
-}
-
-.c1 .fi-radio-button-group_container > .fi-radio-button--large {
-  margin-bottom: 15px;
-}
-
-.c1 .fi-radio-button-group_container > .fi-radio-button--large:first-child {
-  margin-top: 5px;
-}
-
-.c6 {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
-  position: relative;
-}
-
-.c6.fi-radio-button .fi-radio-button_hintText {
-  display: block;
-  padding-left: 26px;
-  color: hsl(202,7%,40%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c6.fi-radio-button .fi-radio-button_label {
-  font-size: 16px;
-  position: relative;
-  cursor: pointer;
-  line-height: 27px;
-  padding-left: 26px;
-}
-
-.c6.fi-radio-button .fi-radio-button_input {
-  opacity: 0;
-  position: absolute;
-  z-index: -9999;
-  height: 18px;
-  width: 18px;
-  top: 5px;
-  left: 2px;
-}
-
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
-  top: 3px;
-  left: 0;
-  margin: 2px;
-  height: 18px;
-  width: 18px;
-  position: absolute;
-}
-
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
-  stroke: hsl(201,7%,58%);
-  fill: hsl(0,0%,100%);
-}
-
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
-  fill: hsl(212,63%,45%);
-}
-
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
-  stroke: hsl(212,63%,45%);
-}
-
-.c6.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
-.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  outline: 0;
-  border-radius: 2px;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  border-radius: 50%;
-}
-
-.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
-  box-shadow: none;
-}
-
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
-  cursor: not-allowed;
-  color: hsl(202,7%,67%);
-}
-
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
-  color: hsl(202,7%,67%);
-  cursor: not-allowed;
-}
-
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
-  fill: hsl(202,7%,97%);
-  stroke: hsl(202,7%,80%);
-}
-
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
-  fill: hsl(202,7%,67%);
-}
-
-.c6.fi-radio-button--large .fi-radio-button_hintText {
-  padding-left: 40px;
-}
-
-.c6.fi-radio-button--large .fi-radio-button_input {
-  top: 2px;
-  left: 2px;
-  height: 30px;
-  width: 30px;
-}
-
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
-  top: 0;
-  left: 0;
-  height: 30px;
-  width: 30px;
-}
-
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
-  height: 30px;
-  width: 30px;
-}
-
-.c6.fi-radio-button--large .fi-radio-button_label {
-  padding-left: 40px;
-  line-height: 34px;
-}
-
-<div>
-  <div
-    class="c0 fi-radio-button-group c1"
-    id="test-id"
-  >
-    <fieldset
-      class="c2"
-    >
-      <legend
-        class="c3 fi-radio-button-group_legend"
-      >
-        <label
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
-          for="test-id"
-        >
-          <span
-            class="c5 fi-label_label-span"
-          >
-            Label here
-          </span>
-        </label>
-      </legend>
-      <div
-        class="c0 fi-radio-button-group_container"
-      >
-        <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
-        >
-          <input
-            class="c7 fi-radio-button_input"
-            id="test-id-1"
-            name="name"
-            type="radio"
-            value="1"
-          />
-          <span
-            class="c5 fi-radio-button_icon_wrapper"
-          >
-            <svg
-              aria-hidden="true"
-              class="c8 fi-radio-button_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 18 18"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <circle
-                  class="fi-icon-radio-base"
-                  cx="9"
-                  cy="9"
-                  r="8.5"
-                />
-                <circle
-                  class="fi-icon-radio-checked"
-                  cx="9"
-                  cy="9"
-                  r="4"
-                />
-              </g>
-            </svg>
-          </span>
-          <label
-            class="c9 fi-radio-button_label"
-            for="test-id-1"
-          >
-            Label text 1
-          </label>
-        </div>
-        <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
-        >
-          <input
-            class="c7 fi-radio-button_input"
-            id="test-id-2"
-            name="name"
-            type="radio"
-            value="2"
-          />
-          <span
-            class="c5 fi-radio-button_icon_wrapper"
-          >
-            <svg
-              aria-hidden="true"
-              class="c8 fi-radio-button_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 18 18"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <circle
-                  class="fi-icon-radio-base"
-                  cx="9"
-                  cy="9"
-                  r="8.5"
-                />
-                <circle
-                  class="fi-icon-radio-checked"
-                  cx="9"
-                  cy="9"
-                  r="4"
-                />
-              </g>
-            </svg>
-          </span>
-          <label
-            class="c9 fi-radio-button_label"
-            for="test-id-2"
-          >
-            Label text 2
-          </label>
-        </div>
-        <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
-        >
-          <input
-            class="c7 fi-radio-button_input"
-            id="test-id-3"
-            name="name"
-            type="radio"
-            value="3"
-          />
-          <span
-            class="c5 fi-radio-button_icon_wrapper"
-          >
-            <svg
-              aria-hidden="true"
-              class="c8 fi-radio-button_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 18 18"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <g
-                fill="none"
-                fill-rule="evenodd"
-              >
-                <circle
-                  class="fi-icon-radio-base"
-                  cx="9"
-                  cy="9"
-                  r="8.5"
-                />
-                <circle
-                  class="fi-icon-radio-checked"
-                  cx="9"
-                  cy="9"
-                  r="4"
-                />
-              </g>
-            </svg>
-          </span>
-          <label
-            class="c9 fi-radio-button_label"
-            for="test-id-3"
-          >
-            Label text 3
-          </label>
-        </div>
-      </div>
-    </fieldset>
-  </div>
-</div>
-`;
-
-exports[`props labelMode should match snapshot 1`] = `
-.c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c0::before,
-.c0::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
@@ -3585,7 +2610,7 @@ exports[`props labelMode should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3609,9 +2634,39 @@ exports[`props labelMode should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c5::before,
-.c5::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
+}
+
+.c5.fi-label .fi-label_label-span {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  display: inline-block;
+  vertical-align: middle;
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
 }
 
 .c9 {
@@ -3630,19 +2685,565 @@ exports[`props labelMode should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c6 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
+.c1 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c1.fi-radio-button-group .fi-radio-button-group_label {
+  display: block;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_hintText {
+  color: hsl(202,7%,40%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin-bottom: 10px;
+}
+
+.c1 .fi-radio-button-group_container > .fi-radio-button:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .fi-radio-button-group_container > .fi-radio-button--large {
+  margin-bottom: 15px;
+}
+
+.c1 .fi-radio-button-group_container > .fi-radio-button--large:first-child {
+  margin-top: 5px;
+}
+
+.c7 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  position: relative;
+}
+
+.c7.fi-radio-button .fi-radio-button_hintText {
+  display: block;
+  padding-left: 26px;
+  color: hsl(202,7%,40%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c7.fi-radio-button .fi-radio-button_label {
+  font-size: 16px;
+  position: relative;
+  cursor: pointer;
+  line-height: 27px;
+  padding-left: 26px;
+}
+
+.c7.fi-radio-button .fi-radio-button_input {
+  opacity: 0;
+  position: absolute;
+  z-index: -9999;
+  height: 18px;
+  width: 18px;
+  top: 5px;
+  left: 2px;
+}
+
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+  top: 3px;
+  left: 0;
+  margin: 2px;
+  height: 18px;
+  width: 18px;
+  position: absolute;
+}
+
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+  stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
+}
+
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+  fill: hsl(212,63%,45%);
+}
+
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+  stroke: hsl(212,63%,45%);
+}
+
+.c7.fi-radio-button .fi-radio-button_input:focus {
+  outline: 0;
+}
+
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  border-radius: 50%;
+}
+
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+  box-shadow: none;
+}
+
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+  cursor: not-allowed;
+  color: hsl(202,7%,67%);
+}
+
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+  color: hsl(202,7%,67%);
+  cursor: not-allowed;
+}
+
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+  fill: hsl(202,7%,97%);
+  stroke: hsl(202,7%,80%);
+}
+
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+  fill: hsl(202,7%,67%);
+}
+
+.c7.fi-radio-button--large .fi-radio-button_hintText {
+  padding-left: 40px;
+}
+
+.c7.fi-radio-button--large .fi-radio-button_input {
+  top: 2px;
+  left: 2px;
+  height: 30px;
+  width: 30px;
+}
+
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+  top: 0;
+  left: 0;
+  height: 30px;
+  width: 30px;
+}
+
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+  height: 30px;
+  width: 30px;
+}
+
+.c7.fi-radio-button--large .fi-radio-button_label {
+  padding-left: 40px;
+  line-height: 34px;
+}
+
+<div>
+  <div
+    class="c0 fi-radio-button-group c1"
+    id="good-id"
+  >
+    <fieldset
+      class="c2"
+    >
+      <legend
+        class="c3 fi-radio-button-group_legend"
+      >
+        <div
+          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+        >
+          <label
+            class="c6 fi-label_label-span"
+            for="good-id"
+          >
+            Label
+          </label>
+        </div>
+      </legend>
+      <div
+        class="c0 fi-radio-button-group_container"
+      >
+        <div
+          class="c0 fi-radio-button fi-radio-button_container c7"
+        >
+          <input
+            class="c8 fi-radio-button_input"
+            id="test-id-1"
+            name="name"
+            type="radio"
+            value="1"
+          />
+          <span
+            class="c6 fi-radio-button_icon_wrapper"
+          >
+            <svg
+              aria-hidden="true"
+              class="c9 fi-radio-button_icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 18 18"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <circle
+                  class="fi-icon-radio-base"
+                  cx="9"
+                  cy="9"
+                  r="8.5"
+                />
+                <circle
+                  class="fi-icon-radio-checked"
+                  cx="9"
+                  cy="9"
+                  r="4"
+                />
+              </g>
+            </svg>
+          </span>
+          <label
+            class="c10 fi-radio-button_label"
+            for="test-id-1"
+          >
+            Label text 1
+          </label>
+        </div>
+        <div
+          class="c0 fi-radio-button fi-radio-button_container c7"
+        >
+          <input
+            class="c8 fi-radio-button_input"
+            id="test-id-2"
+            name="name"
+            type="radio"
+            value="2"
+          />
+          <span
+            class="c6 fi-radio-button_icon_wrapper"
+          >
+            <svg
+              aria-hidden="true"
+              class="c9 fi-radio-button_icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 18 18"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <circle
+                  class="fi-icon-radio-base"
+                  cx="9"
+                  cy="9"
+                  r="8.5"
+                />
+                <circle
+                  class="fi-icon-radio-checked"
+                  cx="9"
+                  cy="9"
+                  r="4"
+                />
+              </g>
+            </svg>
+          </span>
+          <label
+            class="c10 fi-radio-button_label"
+            for="test-id-2"
+          >
+            Label text 2
+          </label>
+        </div>
+        <div
+          class="c0 fi-radio-button fi-radio-button_container c7"
+        >
+          <input
+            class="c8 fi-radio-button_input"
+            id="test-id-3"
+            name="name"
+            type="radio"
+            value="3"
+          />
+          <span
+            class="c6 fi-radio-button_icon_wrapper"
+          >
+            <svg
+              aria-hidden="true"
+              class="c9 fi-radio-button_icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 18 18"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <circle
+                  class="fi-icon-radio-base"
+                  cx="9"
+                  cy="9"
+                  r="8.5"
+                />
+                <circle
+                  class="fi-icon-radio-checked"
+                  cx="9"
+                  cy="9"
+                  r="4"
+                />
+              </g>
+            </svg>
+          </span>
+          <label
+            class="c10 fi-radio-button_label"
+            for="test-id-3"
+          >
+            Label text 3
+          </label>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+</div>
+`;
+
+exports[`props label should match snapshot 1`] = `
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c8 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c8::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c8::before,
+.c8::after {
+  box-sizing: border-box;
+}
+
+.c10 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c10::before,
+.c10::after {
+  box-sizing: border-box;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3656,15 +3257,36 @@ exports[`props labelMode should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-static-icon {
+  display: inline-block;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
 }
 
 .c1 {
@@ -3865,16 +3487,16 @@ exports[`props labelMode should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <label
-          class="c0 c4 fi-label"
-          for="test-id"
+        <div
+          class="c4 c5 fi-radio-button-group_label--visible fi-label"
         >
-          <span
-            class="c5 c6 fi-visually-hidden"
+          <label
+            class="c6 fi-label_label-span"
+            for="test-id"
           >
             Label here
-          </span>
-        </label>
+          </label>
+        </div>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
@@ -3890,7 +3512,7 @@ exports[`props labelMode should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3938,7 +3560,7 @@ exports[`props labelMode should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3986,7 +3608,7 @@ exports[`props labelMode should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4018,6 +3640,621 @@ exports[`props labelMode should match snapshot 1`] = `
           </span>
           <label
             class="c10 fi-radio-button_label"
+            for="test-id-3"
+          >
+            Label text 3
+          </label>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+</div>
+`;
+
+exports[`props labelMode should match snapshot 1`] = `
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c9 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c9::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c9::before,
+.c9::after {
+  box-sizing: border-box;
+}
+
+.c11 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c11::before,
+.c11::after {
+  box-sizing: border-box;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c7 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c5.fi-label .fi-label_label-span {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  display: inline-block;
+  vertical-align: middle;
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c10 {
+  vertical-align: baseline;
+}
+
+.c10.fi-static-icon {
+  display: inline-block;
+}
+
+.c10.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c10.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c1 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_label {
+  display: block;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_hintText {
+  color: hsl(202,7%,40%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin-bottom: 10px;
+}
+
+.c1 .fi-radio-button-group_container > .fi-radio-button:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .fi-radio-button-group_container > .fi-radio-button--large {
+  margin-bottom: 15px;
+}
+
+.c1 .fi-radio-button-group_container > .fi-radio-button--large:first-child {
+  margin-top: 5px;
+}
+
+.c8 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  position: relative;
+}
+
+.c8.fi-radio-button .fi-radio-button_hintText {
+  display: block;
+  padding-left: 26px;
+  color: hsl(202,7%,40%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c8.fi-radio-button .fi-radio-button_label {
+  font-size: 16px;
+  position: relative;
+  cursor: pointer;
+  line-height: 27px;
+  padding-left: 26px;
+}
+
+.c8.fi-radio-button .fi-radio-button_input {
+  opacity: 0;
+  position: absolute;
+  z-index: -9999;
+  height: 18px;
+  width: 18px;
+  top: 5px;
+  left: 2px;
+}
+
+.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+  top: 3px;
+  left: 0;
+  margin: 2px;
+  height: 18px;
+  width: 18px;
+  position: absolute;
+}
+
+.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+  stroke: hsl(201,7%,58%);
+  fill: hsl(0,0%,100%);
+}
+
+.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+  fill: hsl(212,63%,45%);
+}
+
+.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+  stroke: hsl(212,63%,45%);
+}
+
+.c8.fi-radio-button .fi-radio-button_input:focus {
+  outline: 0;
+}
+
+.c8.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  border-radius: 50%;
+}
+
+.c8.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+  box-shadow: none;
+}
+
+.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+  cursor: not-allowed;
+  color: hsl(202,7%,67%);
+}
+
+.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+  color: hsl(202,7%,67%);
+  cursor: not-allowed;
+}
+
+.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+  fill: hsl(202,7%,97%);
+  stroke: hsl(202,7%,80%);
+}
+
+.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+  fill: hsl(202,7%,67%);
+}
+
+.c8.fi-radio-button--large .fi-radio-button_hintText {
+  padding-left: 40px;
+}
+
+.c8.fi-radio-button--large .fi-radio-button_input {
+  top: 2px;
+  left: 2px;
+  height: 30px;
+  width: 30px;
+}
+
+.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+  top: 0;
+  left: 0;
+  height: 30px;
+  width: 30px;
+}
+
+.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+  height: 30px;
+  width: 30px;
+}
+
+.c8.fi-radio-button--large .fi-radio-button_label {
+  padding-left: 40px;
+  line-height: 34px;
+}
+
+<div>
+  <div
+    class="c0 fi-radio-button-group c1"
+    id="test-id"
+  >
+    <fieldset
+      class="c2"
+    >
+      <legend
+        class="c3 fi-radio-button-group_legend"
+      >
+        <div
+          class="c4 c5 fi-label"
+        >
+          <span
+            class="c6 c7 fi-visually-hidden"
+          >
+            Label here
+          </span>
+        </div>
+      </legend>
+      <div
+        class="c0 fi-radio-button-group_container"
+      >
+        <div
+          class="c0 fi-radio-button fi-radio-button_container c8"
+        >
+          <input
+            class="c9 fi-radio-button_input"
+            id="test-id-1"
+            name="name"
+            type="radio"
+            value="1"
+          />
+          <span
+            class="c6 fi-radio-button_icon_wrapper"
+          >
+            <svg
+              aria-hidden="true"
+              class="c10 fi-radio-button_icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 18 18"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <circle
+                  class="fi-icon-radio-base"
+                  cx="9"
+                  cy="9"
+                  r="8.5"
+                />
+                <circle
+                  class="fi-icon-radio-checked"
+                  cx="9"
+                  cy="9"
+                  r="4"
+                />
+              </g>
+            </svg>
+          </span>
+          <label
+            class="c11 fi-radio-button_label"
+            for="test-id-1"
+          >
+            Label text 1
+          </label>
+        </div>
+        <div
+          class="c0 fi-radio-button fi-radio-button_container c8"
+        >
+          <input
+            class="c9 fi-radio-button_input"
+            id="test-id-2"
+            name="name"
+            type="radio"
+            value="2"
+          />
+          <span
+            class="c6 fi-radio-button_icon_wrapper"
+          >
+            <svg
+              aria-hidden="true"
+              class="c10 fi-radio-button_icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 18 18"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <circle
+                  class="fi-icon-radio-base"
+                  cx="9"
+                  cy="9"
+                  r="8.5"
+                />
+                <circle
+                  class="fi-icon-radio-checked"
+                  cx="9"
+                  cy="9"
+                  r="4"
+                />
+              </g>
+            </svg>
+          </span>
+          <label
+            class="c11 fi-radio-button_label"
+            for="test-id-2"
+          >
+            Label text 2
+          </label>
+        </div>
+        <div
+          class="c0 fi-radio-button fi-radio-button_container c8"
+        >
+          <input
+            class="c9 fi-radio-button_input"
+            id="test-id-3"
+            name="name"
+            type="radio"
+            value="3"
+          />
+          <span
+            class="c6 fi-radio-button_icon_wrapper"
+          >
+            <svg
+              aria-hidden="true"
+              class="c10 fi-radio-button_icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 18 18"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g
+                fill="none"
+                fill-rule="evenodd"
+              >
+                <circle
+                  class="fi-icon-radio-base"
+                  cx="9"
+                  cy="9"
+                  r="8.5"
+                />
+                <circle
+                  class="fi-icon-radio-checked"
+                  cx="9"
+                  cy="9"
+                  r="4"
+                />
+              </g>
+            </svg>
+          </span>
+          <label
+            class="c11 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -4059,6 +4296,35 @@ exports[`props name should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -4084,7 +4350,7 @@ exports[`props name should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c7 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4107,17 +4373,17 @@ exports[`props name should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c7::before,
-.c7::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c9 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4137,8 +4403,8 @@ exports[`props name should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c9::before,
-.c9::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -4167,7 +4433,7 @@ exports[`props name should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4191,28 +4457,12 @@ exports[`props name should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c5::before,
-.c5::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c8 {
-  vertical-align: baseline;
-}
-
-.c8.fi-static-icon {
-  display: inline-block;
-}
-
-.c8.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c8.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c4.fi-label .fi-label_label-span {
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -4226,15 +4476,36 @@ exports[`props name should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-static-icon {
+  display: inline-block;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
 }
 
 .c1 {
@@ -4294,7 +4565,7 @@ exports[`props name should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c6 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -4312,7 +4583,7 @@ exports[`props name should match snapshot 1`] = `
   position: relative;
 }
 
-.c6.fi-radio-button .fi-radio-button_hintText {
+.c7.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -4322,7 +4593,7 @@ exports[`props name should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c6.fi-radio-button .fi-radio-button_label {
+.c7.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -4330,7 +4601,7 @@ exports[`props name should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input {
+.c7.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -4340,7 +4611,7 @@ exports[`props name should match snapshot 1`] = `
   left: 2px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -4349,77 +4620,77 @@ exports[`props name should match snapshot 1`] = `
   position: absolute;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus {
+.c7.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button--large .fi-radio-button_hintText {
+.c7.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input {
+.c7.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_label {
+.c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -4435,36 +4706,36 @@ exports[`props name should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <label
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
-          for="test-id"
+        <div
+          class="c4 c5 fi-radio-button-group_label--visible fi-label"
         >
-          <span
-            class="c5 fi-label_label-span"
+          <label
+            class="c6 fi-label_label-span"
+            for="test-id"
           >
             Label
-          </span>
-        </label>
+          </label>
+        </div>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-1"
             name="nice-name"
             type="radio"
             value="1"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -4491,28 +4762,28 @@ exports[`props name should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-2"
             name="nice-name"
             type="radio"
             value="2"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -4539,28 +4810,28 @@ exports[`props name should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-3"
             name="nice-name"
             type="radio"
             value="3"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -4587,7 +4858,7 @@ exports[`props name should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -4629,6 +4900,35 @@ exports[`props value should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -4654,7 +4954,7 @@ exports[`props value should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c7 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4677,17 +4977,17 @@ exports[`props value should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c7::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c7::before,
-.c7::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c9 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4707,8 +5007,8 @@ exports[`props value should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c9::before,
-.c9::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -4737,7 +5037,7 @@ exports[`props value should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4761,28 +5061,12 @@ exports[`props value should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c5::before,
-.c5::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c8 {
-  vertical-align: baseline;
-}
-
-.c8.fi-static-icon {
-  display: inline-block;
-}
-
-.c8.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c8.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c4.fi-label .fi-label_label-span {
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -4796,15 +5080,36 @@ exports[`props value should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: block;
+  display: inline-block;
+  vertical-align: middle;
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+}
+
+.c5.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-static-icon {
+  display: inline-block;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
 }
 
 .c1 {
@@ -4864,7 +5169,7 @@ exports[`props value should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c6 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -4882,7 +5187,7 @@ exports[`props value should match snapshot 1`] = `
   position: relative;
 }
 
-.c6.fi-radio-button .fi-radio-button_hintText {
+.c7.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -4892,7 +5197,7 @@ exports[`props value should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c6.fi-radio-button .fi-radio-button_label {
+.c7.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -4900,7 +5205,7 @@ exports[`props value should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input {
+.c7.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -4910,7 +5215,7 @@ exports[`props value should match snapshot 1`] = `
   left: 2px;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -4919,77 +5224,77 @@ exports[`props value should match snapshot 1`] = `
   position: absolute;
 }
 
-.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus {
+.c7.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c6.fi-radio-button--large .fi-radio-button_hintText {
+.c7.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input {
+.c7.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c6.fi-radio-button--large .fi-radio-button_label {
+.c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -5006,36 +5311,36 @@ exports[`props value should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <label
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
-          for="test-id"
+        <div
+          class="c4 c5 fi-radio-button-group_label--visible fi-label"
         >
-          <span
-            class="c5 fi-label_label-span"
+          <label
+            class="c6 fi-label_label-span"
+            for="test-id"
           >
             Label
-          </span>
-        </label>
+          </label>
+        </div>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -5062,29 +5367,29 @@ exports[`props value should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6 fi-radio-button--checked"
+          class="c0 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
         >
           <input
             checked=""
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -5111,28 +5416,28 @@ exports[`props value should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c6"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c7 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c6 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c8 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -5159,7 +5464,7 @@ exports[`props value should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c9 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -201,7 +201,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -753,7 +753,7 @@ exports[`props className should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -771,7 +771,7 @@ exports[`props className should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -1323,7 +1323,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1341,7 +1341,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -1915,7 +1915,7 @@ exports[`props hintText should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1933,7 +1933,7 @@ exports[`props hintText should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -2490,7 +2490,7 @@ exports[`props id should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2508,7 +2508,7 @@ exports[`props id should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -3060,7 +3060,7 @@ exports[`props label should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3078,7 +3078,7 @@ exports[`props label should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -3642,7 +3642,7 @@ exports[`props labelMode should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3660,7 +3660,7 @@ exports[`props labelMode should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -4212,7 +4212,7 @@ exports[`props name should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -4230,7 +4230,7 @@ exports[`props name should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -4782,7 +4782,7 @@ exports[`props value should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c4.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -4800,7 +4800,7 @@ exports[`props value should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -30,35 +30,6 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -84,7 +55,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -107,17 +78,17 @@ exports[`default, with only required props should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c8::before,
-.c8::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c10 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -137,8 +108,8 @@ exports[`default, with only required props should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c10::before,
-.c10::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -167,7 +138,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -191,12 +162,28 @@ exports[`default, with only required props should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
+.c8 {
+  vertical-align: baseline;
+}
+
+.c8.fi-static-icon {
+  display: inline-block;
+}
+
+.c8.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c8.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c4.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -210,36 +197,15 @@ exports[`default, with only required props should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c9 {
-  vertical-align: baseline;
-}
-
-.c9.fi-static-icon {
-  display: inline-block;
-}
-
-.c9.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c9.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c1 {
@@ -299,7 +265,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -317,7 +283,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   position: relative;
 }
 
-.c7.fi-radio-button .fi-radio-button_hintText {
+.c6.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -327,7 +293,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-radio-button .fi-radio-button_label {
+.c6.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -335,7 +301,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input {
+.c6.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -345,7 +311,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   left: 2px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -354,77 +320,77 @@ exports[`default, with only required props should match snapshot 1`] = `
   position: absolute;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
+.c6.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button--large .fi-radio-button_hintText {
+.c6.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input {
+.c6.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_label {
+.c6.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -440,36 +406,36 @@ exports[`default, with only required props should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label-text"
+        <label
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          for="test-id"
         >
-          <label
-            class="c6 fi-label-text_label-span"
-            for="test-id"
+          <span
+            class="c5 fi-label_label-span"
           >
             Label
-          </label>
-        </div>
+          </span>
+        </label>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -496,28 +462,28 @@ exports[`default, with only required props should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -544,28 +510,28 @@ exports[`default, with only required props should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -592,7 +558,7 @@ exports[`default, with only required props should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -634,35 +600,6 @@ exports[`props className should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -688,7 +625,7 @@ exports[`props className should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -711,17 +648,17 @@ exports[`props className should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c8::before,
-.c8::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c10 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -741,8 +678,8 @@ exports[`props className should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c10::before,
-.c10::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -771,7 +708,7 @@ exports[`props className should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -795,12 +732,28 @@ exports[`props className should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
+.c8 {
+  vertical-align: baseline;
+}
+
+.c8.fi-static-icon {
+  display: inline-block;
+}
+
+.c8.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c8.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c4.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -814,36 +767,15 @@ exports[`props className should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c9 {
-  vertical-align: baseline;
-}
-
-.c9.fi-static-icon {
-  display: inline-block;
-}
-
-.c9.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c9.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c1 {
@@ -903,7 +835,7 @@ exports[`props className should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -921,7 +853,7 @@ exports[`props className should match snapshot 1`] = `
   position: relative;
 }
 
-.c7.fi-radio-button .fi-radio-button_hintText {
+.c6.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -931,7 +863,7 @@ exports[`props className should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-radio-button .fi-radio-button_label {
+.c6.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -939,7 +871,7 @@ exports[`props className should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input {
+.c6.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -949,7 +881,7 @@ exports[`props className should match snapshot 1`] = `
   left: 2px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -958,77 +890,77 @@ exports[`props className should match snapshot 1`] = `
   position: absolute;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
+.c6.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button--large .fi-radio-button_hintText {
+.c6.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input {
+.c6.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_label {
+.c6.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -1044,36 +976,36 @@ exports[`props className should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label-text"
+        <label
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          for="test-id"
         >
-          <label
-            class="c6 fi-label-text_label-span"
-            for="test-id"
+          <span
+            class="c5 fi-label_label-span"
           >
             Label
-          </label>
-        </div>
+          </span>
+        </label>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1100,28 +1032,28 @@ exports[`props className should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1148,28 +1080,28 @@ exports[`props className should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1196,7 +1128,7 @@ exports[`props className should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -1238,35 +1170,6 @@ exports[`props defaultValue should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1292,7 +1195,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1315,17 +1218,17 @@ exports[`props defaultValue should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c8::before,
-.c8::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c10 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1345,8 +1248,8 @@ exports[`props defaultValue should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c10::before,
-.c10::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -1375,7 +1278,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1399,12 +1302,28 @@ exports[`props defaultValue should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
+.c8 {
+  vertical-align: baseline;
+}
+
+.c8.fi-static-icon {
+  display: inline-block;
+}
+
+.c8.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c8.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c4.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1418,36 +1337,15 @@ exports[`props defaultValue should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c9 {
-  vertical-align: baseline;
-}
-
-.c9.fi-static-icon {
-  display: inline-block;
-}
-
-.c9.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c9.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c1 {
@@ -1507,7 +1405,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1525,7 +1423,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   position: relative;
 }
 
-.c7.fi-radio-button .fi-radio-button_hintText {
+.c6.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -1535,7 +1433,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-radio-button .fi-radio-button_label {
+.c6.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -1543,7 +1441,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input {
+.c6.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -1553,7 +1451,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   left: 2px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -1562,77 +1460,77 @@ exports[`props defaultValue should match snapshot 1`] = `
   position: absolute;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
+.c6.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button--large .fi-radio-button_hintText {
+.c6.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input {
+.c6.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_label {
+.c6.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -1648,36 +1546,36 @@ exports[`props defaultValue should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label-text"
+        <label
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          for="test-id"
         >
-          <label
-            class="c6 fi-label-text_label-span"
-            for="test-id"
+          <span
+            class="c5 fi-label_label-span"
           >
             Label
-          </label>
-        </div>
+          </span>
+        </label>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1704,28 +1602,28 @@ exports[`props defaultValue should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1752,29 +1650,29 @@ exports[`props defaultValue should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
+          class="c0 fi-radio-button fi-radio-button_container c6 fi-radio-button--checked"
         >
           <input
             checked=""
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -1801,7 +1699,7 @@ exports[`props defaultValue should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -1843,35 +1741,6 @@ exports[`props hintText should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1897,7 +1766,7 @@ exports[`props hintText should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1920,17 +1789,17 @@ exports[`props hintText should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c9::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c9::before,
-.c9::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c11 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1950,8 +1819,8 @@ exports[`props hintText should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c11::before,
-.c11::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -1980,7 +1849,7 @@ exports[`props hintText should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2004,12 +1873,49 @@ exports[`props hintText should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
+.c6 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c6.fi-hint-text {
+  display: block;
+}
+
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-static-icon {
+  display: inline-block;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c4.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2023,57 +1929,15 @@ exports[`props hintText should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
-  color: hsl(0,0%,16%);
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c10 {
-  vertical-align: baseline;
-}
-
-.c10.fi-static-icon {
-  display: inline-block;
-}
-
-.c10.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c10.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c7 {
-  color: hsl(0,0%,16%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c7.fi-hint-text {
   display: block;
+  color: hsl(0,0%,16%);
+}
+
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 .c1 {
@@ -2133,7 +1997,7 @@ exports[`props hintText should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c8 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -2151,7 +2015,7 @@ exports[`props hintText should match snapshot 1`] = `
   position: relative;
 }
 
-.c8.fi-radio-button .fi-radio-button_hintText {
+.c7.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -2161,7 +2025,7 @@ exports[`props hintText should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c8.fi-radio-button .fi-radio-button_label {
+.c7.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -2169,7 +2033,7 @@ exports[`props hintText should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c8.fi-radio-button .fi-radio-button_input {
+.c7.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -2179,7 +2043,7 @@ exports[`props hintText should match snapshot 1`] = `
   left: 2px;
 }
 
-.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -2188,77 +2052,77 @@ exports[`props hintText should match snapshot 1`] = `
   position: absolute;
 }
 
-.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus {
+.c7.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c8.fi-radio-button--large .fi-radio-button_hintText {
+.c7.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_input {
+.c7.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_label {
+.c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -2274,18 +2138,18 @@ exports[`props hintText should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label-text"
+        <label
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          for="test-id"
         >
-          <label
-            class="c6 fi-label-text_label-span"
-            for="test-id"
+          <span
+            class="c5 fi-label_label-span"
           >
             Label
-          </label>
-        </div>
+          </span>
+        </label>
         <span
-          class="c6 c7 fi-hint-text"
+          class="c5 c6 fi-hint-text"
         >
           Example hint text
         </span>
@@ -2294,21 +2158,21 @@ exports[`props hintText should match snapshot 1`] = `
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c9 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c10 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -2335,28 +2199,28 @@ exports[`props hintText should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c11 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c9 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c10 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -2383,28 +2247,28 @@ exports[`props hintText should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c11 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c9 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c10 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -2431,7 +2295,7 @@ exports[`props hintText should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c11 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -2473,35 +2337,6 @@ exports[`props id should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2527,7 +2362,7 @@ exports[`props id should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2550,17 +2385,17 @@ exports[`props id should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c8::before,
-.c8::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c10 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2580,8 +2415,8 @@ exports[`props id should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c10::before,
-.c10::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -2610,7 +2445,7 @@ exports[`props id should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2634,12 +2469,28 @@ exports[`props id should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
+.c8 {
+  vertical-align: baseline;
+}
+
+.c8.fi-static-icon {
+  display: inline-block;
+}
+
+.c8.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c8.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c4.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2653,36 +2504,15 @@ exports[`props id should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c9 {
-  vertical-align: baseline;
-}
-
-.c9.fi-static-icon {
-  display: inline-block;
-}
-
-.c9.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c9.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c1 {
@@ -2742,7 +2572,7 @@ exports[`props id should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -2760,7 +2590,7 @@ exports[`props id should match snapshot 1`] = `
   position: relative;
 }
 
-.c7.fi-radio-button .fi-radio-button_hintText {
+.c6.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -2770,7 +2600,7 @@ exports[`props id should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-radio-button .fi-radio-button_label {
+.c6.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -2778,7 +2608,7 @@ exports[`props id should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input {
+.c6.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -2788,7 +2618,7 @@ exports[`props id should match snapshot 1`] = `
   left: 2px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -2797,77 +2627,77 @@ exports[`props id should match snapshot 1`] = `
   position: absolute;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
+.c6.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button--large .fi-radio-button_hintText {
+.c6.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input {
+.c6.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_label {
+.c6.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -2883,36 +2713,36 @@ exports[`props id should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label-text"
+        <label
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          for="good-id"
         >
-          <label
-            class="c6 fi-label-text_label-span"
-            for="good-id"
+          <span
+            class="c5 fi-label_label-span"
           >
             Label
-          </label>
-        </div>
+          </span>
+        </label>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -2939,28 +2769,28 @@ exports[`props id should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -2987,28 +2817,28 @@ exports[`props id should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -3035,7 +2865,7 @@ exports[`props id should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -3077,35 +2907,6 @@ exports[`props label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -3131,7 +2932,7 @@ exports[`props label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3154,17 +2955,17 @@ exports[`props label should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c8::before,
-.c8::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c10 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3184,8 +2985,8 @@ exports[`props label should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c10::before,
-.c10::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -3214,7 +3015,7 @@ exports[`props label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3238,12 +3039,28 @@ exports[`props label should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
+.c8 {
+  vertical-align: baseline;
+}
+
+.c8.fi-static-icon {
+  display: inline-block;
+}
+
+.c8.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c8.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c4.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3257,36 +3074,15 @@ exports[`props label should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c9 {
-  vertical-align: baseline;
-}
-
-.c9.fi-static-icon {
-  display: inline-block;
-}
-
-.c9.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c9.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c1 {
@@ -3346,7 +3142,7 @@ exports[`props label should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -3364,7 +3160,7 @@ exports[`props label should match snapshot 1`] = `
   position: relative;
 }
 
-.c7.fi-radio-button .fi-radio-button_hintText {
+.c6.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -3374,7 +3170,7 @@ exports[`props label should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-radio-button .fi-radio-button_label {
+.c6.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -3382,7 +3178,7 @@ exports[`props label should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input {
+.c6.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -3392,7 +3188,7 @@ exports[`props label should match snapshot 1`] = `
   left: 2px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -3401,77 +3197,77 @@ exports[`props label should match snapshot 1`] = `
   position: absolute;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
+.c6.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button--large .fi-radio-button_hintText {
+.c6.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input {
+.c6.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_label {
+.c6.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -3487,36 +3283,36 @@ exports[`props label should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label-text"
+        <label
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          for="test-id"
         >
-          <label
-            class="c6 fi-label-text_label-span"
-            for="test-id"
+          <span
+            class="c5 fi-label_label-span"
           >
             Label here
-          </label>
-        </div>
+          </span>
+        </label>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -3543,28 +3339,28 @@ exports[`props label should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -3591,28 +3387,28 @@ exports[`props label should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -3639,7 +3435,7 @@ exports[`props label should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -3681,35 +3477,6 @@ exports[`props labelMode should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -3735,7 +3502,7 @@ exports[`props labelMode should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3758,17 +3525,17 @@ exports[`props labelMode should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c9::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c9::before,
-.c9::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c11 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3788,8 +3555,8 @@ exports[`props labelMode should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c11::before,
-.c11::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -3818,7 +3585,7 @@ exports[`props labelMode should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3842,12 +3609,28 @@ exports[`props labelMode should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c7 {
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-static-icon {
+  display: inline-block;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c6 {
   position: absolute;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -3859,7 +3642,7 @@ exports[`props labelMode should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
+.c4.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3873,36 +3656,15 @@ exports[`props labelMode should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c10 {
-  vertical-align: baseline;
-}
-
-.c10.fi-static-icon {
-  display: inline-block;
-}
-
-.c10.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c10.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c1 {
@@ -3962,7 +3724,7 @@ exports[`props labelMode should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c8 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -3980,7 +3742,7 @@ exports[`props labelMode should match snapshot 1`] = `
   position: relative;
 }
 
-.c8.fi-radio-button .fi-radio-button_hintText {
+.c7.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -3990,7 +3752,7 @@ exports[`props labelMode should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c8.fi-radio-button .fi-radio-button_label {
+.c7.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -3998,7 +3760,7 @@ exports[`props labelMode should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c8.fi-radio-button .fi-radio-button_input {
+.c7.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -4008,7 +3770,7 @@ exports[`props labelMode should match snapshot 1`] = `
   left: 2px;
 }
 
-.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -4017,77 +3779,77 @@ exports[`props labelMode should match snapshot 1`] = `
   position: absolute;
 }
 
-.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus {
+.c7.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c8.fi-radio-button--large .fi-radio-button_hintText {
+.c7.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_input {
+.c7.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_label {
+.c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -4103,35 +3865,36 @@ exports[`props labelMode should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <div
-          class="c4 c5 fi-label-text"
+        <label
+          class="c0 c4 fi-label"
+          for="test-id"
         >
           <span
-            class="c6 c7 fi-visually-hidden"
+            class="c5 c6 fi-visually-hidden"
           >
             Label here
           </span>
-        </div>
+        </label>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c9 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c10 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -4158,28 +3921,28 @@ exports[`props labelMode should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c11 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c9 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c10 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -4206,28 +3969,28 @@ exports[`props labelMode should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c11 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c0 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c9 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c10 fi-radio-button_icon"
+              class="c9 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -4254,7 +4017,7 @@ exports[`props labelMode should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c11 fi-radio-button_label"
+            class="c10 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -4296,35 +4059,6 @@ exports[`props name should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -4350,7 +4084,7 @@ exports[`props name should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4373,17 +4107,17 @@ exports[`props name should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c8::before,
-.c8::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c10 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4403,8 +4137,8 @@ exports[`props name should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c10::before,
-.c10::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -4433,7 +4167,7 @@ exports[`props name should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4457,12 +4191,28 @@ exports[`props name should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
+.c8 {
+  vertical-align: baseline;
+}
+
+.c8.fi-static-icon {
+  display: inline-block;
+}
+
+.c8.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c8.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c4.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -4476,36 +4226,15 @@ exports[`props name should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c9 {
-  vertical-align: baseline;
-}
-
-.c9.fi-static-icon {
-  display: inline-block;
-}
-
-.c9.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c9.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c1 {
@@ -4565,7 +4294,7 @@ exports[`props name should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -4583,7 +4312,7 @@ exports[`props name should match snapshot 1`] = `
   position: relative;
 }
 
-.c7.fi-radio-button .fi-radio-button_hintText {
+.c6.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -4593,7 +4322,7 @@ exports[`props name should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-radio-button .fi-radio-button_label {
+.c6.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -4601,7 +4330,7 @@ exports[`props name should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input {
+.c6.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -4611,7 +4340,7 @@ exports[`props name should match snapshot 1`] = `
   left: 2px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -4620,77 +4349,77 @@ exports[`props name should match snapshot 1`] = `
   position: absolute;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
+.c6.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button--large .fi-radio-button_hintText {
+.c6.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input {
+.c6.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_label {
+.c6.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -4706,36 +4435,36 @@ exports[`props name should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label-text"
+        <label
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          for="test-id"
         >
-          <label
-            class="c6 fi-label-text_label-span"
-            for="test-id"
+          <span
+            class="c5 fi-label_label-span"
           >
             Label
-          </label>
-        </div>
+          </span>
+        </label>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-1"
             name="nice-name"
             type="radio"
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -4762,28 +4491,28 @@ exports[`props name should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-2"
             name="nice-name"
             type="radio"
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -4810,28 +4539,28 @@ exports[`props name should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-3"
             name="nice-name"
             type="radio"
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -4858,7 +4587,7 @@ exports[`props name should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3
@@ -4900,35 +4629,6 @@ exports[`props value should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -4954,7 +4654,7 @@ exports[`props value should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c8 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4977,17 +4677,17 @@ exports[`props value should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c8::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c8::before,
-.c8::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c10 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -5007,8 +4707,8 @@ exports[`props value should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c10::before,
-.c10::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -5037,7 +4737,7 @@ exports[`props value should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -5061,12 +4761,28 @@ exports[`props value should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c5.fi-label-text .fi-label-text_label-span {
+.c8 {
+  vertical-align: baseline;
+}
+
+.c8.fi-static-icon {
+  display: inline-block;
+}
+
+.c8.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c8.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c4.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -5080,36 +4796,15 @@ exports[`props value should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
+  display: block;
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-}
-
-.c5.fi-label-text .fi-label-text_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c9 {
-  vertical-align: baseline;
-}
-
-.c9.fi-static-icon {
-  display: inline-block;
-}
-
-.c9.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c9.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c1 {
@@ -5169,7 +4864,7 @@ exports[`props value should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -5187,7 +4882,7 @@ exports[`props value should match snapshot 1`] = `
   position: relative;
 }
 
-.c7.fi-radio-button .fi-radio-button_hintText {
+.c6.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -5197,7 +4892,7 @@ exports[`props value should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-radio-button .fi-radio-button_label {
+.c6.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -5205,7 +4900,7 @@ exports[`props value should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input {
+.c6.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -5215,7 +4910,7 @@ exports[`props value should match snapshot 1`] = `
   left: 2px;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -5224,77 +4919,77 @@ exports[`props value should match snapshot 1`] = `
   position: absolute;
 }
 
-.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
+.c6.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c6.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c7.fi-radio-button--large .fi-radio-button_hintText {
+.c6.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input {
+.c6.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c6.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c7.fi-radio-button--large .fi-radio-button_label {
+.c6.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -5311,36 +5006,36 @@ exports[`props value should match snapshot 1`] = `
       <legend
         class="c3 fi-radio-button-group_legend"
       >
-        <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label-text"
+        <label
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          for="test-id"
         >
-          <label
-            class="c6 fi-label-text_label-span"
-            for="test-id"
+          <span
+            class="c5 fi-label_label-span"
           >
             Label
-          </label>
-        </div>
+          </span>
+        </label>
       </legend>
       <div
         class="c0 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -5367,29 +5062,29 @@ exports[`props value should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-1"
           >
             Label text 1
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
+          class="c0 fi-radio-button fi-radio-button_container c6 fi-radio-button--checked"
         >
           <input
             checked=""
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -5416,28 +5111,28 @@ exports[`props value should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-2"
           >
             Label text 2
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c0 fi-radio-button fi-radio-button_container c6"
         >
           <input
-            class="c8 fi-radio-button_input"
+            class="c7 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
-              class="c9 fi-radio-button_icon"
+              class="c8 fi-radio-button_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 18 18"
@@ -5464,7 +5159,7 @@ exports[`props value should match snapshot 1`] = `
             </svg>
           </span>
           <label
-            class="c10 fi-radio-button_label"
+            class="c9 fi-radio-button_label"
             for="test-id-3"
           >
             Label text 3

--- a/src/core/Form/SearchInput/SearchInput.test.tsx
+++ b/src/core/Form/SearchInput/SearchInput.test.tsx
@@ -43,7 +43,7 @@ describe('props', () => {
     it('should have label text with correct class and for id', () => {
       const { getByText } = render(TestSearchInput({ id: 'test-id' }));
       const label = getByText('Test search input').closest('label');
-      expect(label).toHaveClass('fi-label');
+      expect(label).toHaveClass('fi-label_label-span');
       expect(label).toHaveAttribute('for', 'test-id');
     });
 

--- a/src/core/Form/SearchInput/SearchInput.test.tsx
+++ b/src/core/Form/SearchInput/SearchInput.test.tsx
@@ -43,7 +43,7 @@ describe('props', () => {
     it('should have label text with correct class and for id', () => {
       const { getByText } = render(TestSearchInput({ id: 'test-id' }));
       const label = getByText('Test search input').closest('label');
-      expect(label?.parentElement).toHaveClass('fi-label-text');
+      expect(label).toHaveClass('fi-label');
       expect(label).toHaveAttribute('for', 'test-id');
     });
 

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -261,6 +261,30 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c10.fi-status-text {
   display: block;
+}
+
+.c9.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c3.fi-label .fi-label_label-span {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  display: block;
+  color: hsl(0,0%,16%);
+}
+
 .c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`snapshot should have matching default structure 1`] = `
   margin-left: 6px;
 }
 
-.c10 {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -261,6 +261,31 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c10.fi-status-text {
   display: block;
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c8 {
+  vertical-align: baseline;
+}
+
+.c8.fi-icon {
+  display: inline-block;
+}
+
+.c8 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c8 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c8.fi-icon--cursor-pointer {
+  cursor: pointer;
 }
 
 .c10.fi-status-text.fi-status-text--error {
@@ -623,12 +648,12 @@ exports[`snapshot should have matching default structure 1`] = `
   <span
     class="c2 fi-search-input_wrapper"
   >
-    <div
-      class="c3 c4 fi-search-input_label--visible fi-label-text"
+    <label
+      class="c0 c3 fi-search-input_label--visible fi-label"
+      for="1"
     >
-      <label
-        class="c2 fi-label-text_label-span"
-        for="1"
+      <span
+        class="c2 fi-label_label-span"
       >
         Test search input
       </label>

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -210,7 +210,7 @@ exports[`snapshot should have matching default structure 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -229,18 +229,18 @@ exports[`snapshot should have matching default structure 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c10 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -261,55 +261,6 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c10.fi-status-text {
   display: block;
-}
-
-.c9.fi-status-text.fi-status-text--error {
-  color: hsl(3,59%,48%);
-}
-
-.c3.fi-label .fi-label_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: block;
-  color: hsl(0,0%,16%);
-}
-
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c8 {
-  vertical-align: baseline;
-}
-
-.c8.fi-icon {
-  display: inline-block;
-}
-
-.c8 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c8 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c8.fi-icon--cursor-pointer {
-  cursor: pointer;
 }
 
 .c10.fi-status-text.fi-status-text--error {
@@ -672,12 +623,12 @@ exports[`snapshot should have matching default structure 1`] = `
   <span
     class="c2 fi-search-input_wrapper"
   >
-    <label
-      class="c0 c3 fi-search-input_label--visible fi-label"
-      for="1"
+    <div
+      class="c3 c4 fi-search-input_label--visible fi-label"
     >
-      <span
+      <label
         class="c2 fi-label_label-span"
+        for="1"
       >
         Test search input
       </label>

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -210,8 +210,7 @@ exports[`has matching snapshot 1`] = `
   overflow: hidden;
 }
 
-.c14 {
-  color: hsl(0,0%,16%);
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -288,11 +287,11 @@ exports[`has matching snapshot 1`] = `
   width: 100%;
 }
 
-.c14.fi-button--inverted {
-  background: none;
-  background-color: hsl(212,63%,45%);
-  border: 1px solid hsl(0,0%,100%);
-  text-shadow: none;
+.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
 }
 
 .c14.fi-button--inverted:hover {
@@ -809,7 +808,7 @@ exports[`has matching snapshot 1`] = `
   align-items: flex-start;
 }
 
-.c2.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label-text {
+.c2.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label {
   padding-right: 10px;
   padding-top: 8px;
   -webkit-align-self: flex-start;
@@ -817,7 +816,7 @@ exports[`has matching snapshot 1`] = `
   align-self: flex-start;
 }
 
-.c2.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label-text .fi-label-text_label-span {
+.c2.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label .fi-label_label-span {
   margin-bottom: 0;
 }
 
@@ -916,12 +915,12 @@ exports[`has matching snapshot 1`] = `
       <div
         class="c0 fi-filter-input_wrapper"
       >
-        <div
-          class="c3 c4 fi-filter-input_label--visible fi-label-text"
+        <label
+          class="c0 c3 fi-filter-input_label--visible fi-label"
+          id="1-label"
         >
-          <label
-            class="c5 fi-label-text_label-span"
-            id="1-label"
+          <span
+            class="c4 fi-label_label-span"
           >
             MultiSelect
           </label>

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -210,7 +210,8 @@ exports[`has matching snapshot 1`] = `
   overflow: hidden;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c14 {
+  color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -287,11 +288,11 @@ exports[`has matching snapshot 1`] = `
   width: 100%;
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
+.c14.fi-button--inverted {
+  background: none;
+  background-color: hsl(212,63%,45%);
+  border: 1px solid hsl(0,0%,100%);
+  text-shadow: none;
 }
 
 .c14.fi-button--inverted:hover {
@@ -432,7 +433,7 @@ exports[`has matching snapshot 1`] = `
   cursor: not-allowed;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -451,14 +452,14 @@ exports[`has matching snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -915,12 +916,12 @@ exports[`has matching snapshot 1`] = `
       <div
         class="c0 fi-filter-input_wrapper"
       >
-        <label
-          class="c0 c3 fi-filter-input_label--visible fi-label"
-          id="1-label"
+        <div
+          class="c3 c4 fi-filter-input_label--visible fi-label"
         >
-          <span
-            class="c4 fi-label_label-span"
+          <label
+            class="c5 fi-label_label-span"
+            id="1-label"
           >
             MultiSelect
           </label>

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -287,7 +287,7 @@ exports[`has matching snapshot 1`] = `
   width: 100%;
 }
 
-.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -210,7 +210,7 @@ exports[`has matching snapshot 1`] = `
   overflow: hidden;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -229,14 +229,14 @@ exports[`has matching snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -629,12 +629,12 @@ exports[`has matching snapshot 1`] = `
     <div
       class="c0 fi-filter-input_wrapper"
     >
-      <label
-        class="c0 c3 fi-filter-input_label--visible fi-label"
-        id="1-label"
+      <div
+        class="c3 c4 fi-filter-input_label--visible fi-label"
       >
-        <span
-          class="c4 fi-label_label-span"
+        <label
+          class="c5 fi-label_label-span"
+          id="1-label"
         >
           SingleSelect
         </label>

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -210,7 +210,7 @@ exports[`has matching snapshot 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -229,7 +229,7 @@ exports[`has matching snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -534,7 +534,7 @@ exports[`has matching snapshot 1`] = `
   align-items: flex-start;
 }
 
-.c2.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label-text {
+.c2.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label {
   padding-right: 10px;
   padding-top: 8px;
   -webkit-align-self: flex-start;
@@ -542,7 +542,7 @@ exports[`has matching snapshot 1`] = `
   align-self: flex-start;
 }
 
-.c2.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label-text .fi-label-text_label-span {
+.c2.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label .fi-label_label-span {
   margin-bottom: 0;
 }
 
@@ -629,12 +629,12 @@ exports[`has matching snapshot 1`] = `
     <div
       class="c0 fi-filter-input_wrapper"
     >
-      <div
-        class="c3 c4 fi-filter-input_label--visible fi-label-text"
+      <label
+        class="c0 c3 fi-filter-input_label--visible fi-label"
+        id="1-label"
       >
-        <label
-          class="c5 fi-label-text_label-span"
-          id="1-label"
+        <span
+          class="c4 fi-label_label-span"
         >
           SingleSelect
         </label>

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -182,7 +182,7 @@ describe('props', () => {
     it('should be found ', () => {
       const { getByText } = render(<TextInput labelText="Test input" />);
       const label = getByText('Test input');
-      expect(label).toHaveClass('fi-label-text_label-span');
+      expect(label).toHaveClass('fi-label_label-span');
     });
   });
 
@@ -192,7 +192,7 @@ describe('props', () => {
         <TextInput labelText="label" optionalText="Optional" />,
       );
       const optionalText = getByText('(Optional)');
-      expect(optionalText).toHaveClass('fi-label-text_optionalText');
+      expect(optionalText).toHaveClass('fi-label_optional-text');
     });
   });
 
@@ -200,7 +200,7 @@ describe('props', () => {
     it('should be visible by default', () => {
       const { getByText } = render(<TextInput labelText="Test input" />);
       const label = getByText('Test input');
-      expect(label).toHaveClass('fi-label-text_label-span');
+      expect(label).toHaveClass('fi-label_label-span');
     });
 
     it('should be hidden', () => {

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`snapshots match error status with statustext 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -140,14 +140,14 @@ exports[`snapshots match error status with statustext 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -357,12 +357,12 @@ exports[`snapshots match error status with statustext 1`] = `
   <span
     class="c2 fi-text-input_wrapper"
   >
-    <label
-      class="c0 c3 fi-text-input_label--visible fi-label"
-      for="test-id2"
+    <div
+      class="c3 c4 fi-text-input_label--visible fi-label"
     >
-      <span
+      <label
         class="c2 fi-label_label-span"
+        for="test-id2"
       >
         Test input
       </label>
@@ -525,7 +525,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   overflow: hidden;
 }
 
-.c3.fi-labe .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -544,14 +544,14 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -761,9 +761,8 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   <span
     class="c2 fi-text-input_wrapper"
   >
-    <label
-      class="c0 c3 fi-label"
-      for="test-id1"
+    <div
+      class="c3 c4 fi-label"
     >
       <span
         class="c2 c5 fi-visually-hidden"
@@ -914,7 +913,7 @@ exports[`snapshots match minimal implementation 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -933,14 +932,14 @@ exports[`snapshots match minimal implementation 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -1150,12 +1149,12 @@ exports[`snapshots match minimal implementation 1`] = `
   <span
     class="c2 fi-text-input_wrapper"
   >
-    <label
-      class="c0 c3 fi-text-input_label--visible fi-label"
-      for="test-id"
+    <div
+      class="c3 c4 fi-text-input_label--visible fi-label"
     >
-      <span
+      <label
         class="c2 fi-label_label-span"
+        for="test-id"
       >
         Test input
       </label>

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`snapshots match error status with statustext 1`] = `
   box-sizing: border-box;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -140,7 +140,7 @@ exports[`snapshots match error status with statustext 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -357,12 +357,12 @@ exports[`snapshots match error status with statustext 1`] = `
   <span
     class="c2 fi-text-input_wrapper"
   >
-    <div
-      class="c3 c4 fi-text-input_label--visible fi-label-text"
+    <label
+      class="c0 c3 fi-text-input_label--visible fi-label"
+      for="test-id2"
     >
-      <label
-        class="c2 fi-label-text_label-span"
-        for="test-id2"
+      <span
+        class="c2 fi-label_label-span"
       >
         Test input
       </label>
@@ -525,7 +525,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c3.fi-labe .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -544,7 +544,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-labe .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -761,8 +761,9 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   <span
     class="c2 fi-text-input_wrapper"
   >
-    <div
-      class="c3 c4 fi-label-text"
+    <label
+      class="c0 c3 fi-label"
+      for="test-id1"
     >
       <span
         class="c2 c5 fi-visually-hidden"
@@ -913,7 +914,7 @@ exports[`snapshots match minimal implementation 1`] = `
   box-sizing: border-box;
 }
 
-.c4.fi-label-text .fi-label-text_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -932,7 +933,7 @@ exports[`snapshots match minimal implementation 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c4.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -1149,12 +1150,12 @@ exports[`snapshots match minimal implementation 1`] = `
   <span
     class="c2 fi-text-input_wrapper"
   >
-    <div
-      class="c3 c4 fi-text-input_label--visible fi-label-text"
+    <label
+      class="c0 c3 fi-text-input_label--visible fi-label"
+      for="test-id"
     >
-      <label
-        class="c2 fi-label-text_label-span"
-        for="test-id"
+      <span
+        class="c2 fi-label_label-span"
       >
         Test input
       </label>

--- a/src/core/Form/Textarea/Textarea.test.tsx
+++ b/src/core/Form/Textarea/Textarea.test.tsx
@@ -31,7 +31,7 @@ describe('props', () => {
     it('should have label text with correct class', () => {
       const { getByText } = render(DefaultTextareaComponent);
       const label = getByText('Label here');
-      expect(label).toHaveClass('fi-label-text_label-span');
+      expect(label).toHaveClass('fi-label_label-span');
     });
 
     it('has user given aria-describedby on textarea', () => {
@@ -213,7 +213,7 @@ describe('props', () => {
         <Textarea labelText="label" optionalText="Optional" />,
       );
       const optionalText = getByText('(Optional)');
-      expect(optionalText).toHaveClass('fi-label-text_optionalText');
+      expect(optionalText).toHaveClass('fi-label_optional-text');
     });
   });
 

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3.fi-label-text .fi-label-text_label-span {
+.c2.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -140,7 +140,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c3.fi-label-text .fi-label-text_label-span .fi-label-text_optionalText {
+.c2.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -316,12 +316,12 @@ exports[`snapshot default structure should match snapshot 1`] = `
 <div
   class="c0 fi-textarea c1"
 >
-  <div
-    class="c2 c3 fi-label-text"
+  <label
+    class="c0 c2 fi-label"
+    for="just-for-snapshot-to-be-same"
   >
-    <label
-      class="c4 fi-label-text_label-span"
-      for="just-for-snapshot-to-be-same"
+    <span
+      class="c3 fi-label_label-span"
     >
       Label text
     </label>

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c2.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -140,14 +140,14 @@ exports[`snapshot default structure should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c2.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c3.fi-label-text .fi-label-text_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -316,12 +316,12 @@ exports[`snapshot default structure should match snapshot 1`] = `
 <div
   class="c0 fi-textarea c1"
 >
-  <label
-    class="c0 c2 fi-label"
-    for="just-for-snapshot-to-be-same"
+  <div
+    class="c2 c3 fi-label"
   >
-    <span
-      class="c3 fi-label_label-span"
+    <label
+      class="c4 fi-label_label-span"
+      for="just-for-snapshot-to-be-same"
     >
       Label text
     </label>


### PR DESCRIPTION
## Description

This PR changes a couple of the `<Label>` component's classnames to follow a more suitable naming convention

## Motivation and Context

We want the CSS classnames to be coherent with each other and follow established naming conventions

## How Has This Been Tested?

Styleguidist

## Release notes

### Label
* **Breaking change**: Rename main class `.fi-label-text` to `.fi-label`
*  **Breaking change**: Rename class `.fi-label-text_optionalText` to `.fi-label_optional-text`
