### PR TITLE
[Feature] Add polymorphic RouterLink component

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -127,6 +127,7 @@ module.exports = {
             'Link/Link',
             'SkipLink/SkipLink',
             'ExternalLink/ExternalLink',
+            'RouterLink/RouterLink',
           ]),
         },
         {

--- a/src/core/Link/Link/Link.md
+++ b/src/core/Link/Link/Link.md
@@ -78,3 +78,29 @@ const Component = ({ children, ...passProps }) => (
   Testing
 </Link>;
 ```
+
+### Router link
+
+This component is mainly intended to be used with external libraries/frameworks.
+
+- Renders as the component of your choice, for example <a href="https://reactrouter.com/docs/en/v6/components/link" target="_blank">React Router Link</a>, but with proper Suomi.fi link styles
+- Full Typescript support for props based on the component passed to `asComponent`
+- Full theme customisation support through `SuomifiThemeProvider`
+
+```js
+import { RouterLink } from 'suomifi-ui-components';
+
+const Component = ({ children, ...passProps }) => (
+  <a {...passProps}>Some component - {children}</a>
+);
+
+<>
+  <RouterLink
+    asComponent={Component}
+    href="https://ironmaiden.com"
+    target="_blank"
+  >
+    Testing
+  </RouterLink>
+</>;
+```

--- a/src/core/Link/RouterLink/RouterLink.baseStyles.ts
+++ b/src/core/Link/RouterLink/RouterLink.baseStyles.ts
@@ -1,0 +1,31 @@
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../theme';
+import { font } from '../../theme/reset';
+import { allStates } from '../../../utils/css';
+
+export const RouterLinkStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodyText')}
+
+  &.fi-link--router {
+    ${allStates(`color: ${theme.colors.highlightBase};`)}
+    color: ${theme.colors.highlightBase};
+    text-decoration: none;
+
+    &:focus,
+    &:focus-within {
+      text-decoration: none;
+    }
+
+    &:focus {
+      ${theme.focus.boxShadowFocus}
+    }
+
+    &:hover,
+    &:active {
+      text-decoration: underline;
+    }
+    &:visited {
+      color: ${theme.colors.accentTertiaryDark1};
+    }
+  }
+`;

--- a/src/core/Link/RouterLink/RouterLink.test.tsx
+++ b/src/core/Link/RouterLink/RouterLink.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axeTest } from '../../../utils/test';
+
+import { RouterLink } from './RouterLink';
+
+const TestRouterLink = (
+  <RouterLink href="/" data-testid="test-link">
+    Hey this is a test
+  </RouterLink>
+);
+
+const RouterLinkAsButton = (
+  <RouterLink asComponent="button">Router link as a button</RouterLink>
+);
+
+test('calling render with the same component on the same container does not remount', () => {
+  const { getByTestId, container } = render(TestRouterLink);
+  expect(container.firstChild).toMatchSnapshot();
+  expect(getByTestId('test-link').textContent).toBe('Hey this is a test');
+});
+
+it('should still have the correct styles applied when rendered as something other than <a> ', () => {
+  const { container } = render(RouterLinkAsButton);
+  expect(container.firstChild).toHaveClass('fi-link--router');
+});
+
+test('should not have basic accessibility issues', axeTest(TestRouterLink));

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -1,0 +1,101 @@
+// import React, { Component, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
+import { default as styled } from 'styled-components';
+import { RouterLinkStyles } from './RouterLink.baseStyles';
+import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import { baseClassName } from '../BaseLink/BaseLink';
+import classnames from 'classnames';
+import { HtmlA } from '../../../reset';
+
+//
+// Source: https://www.benmvp.com/blog/polymorphic-react-components-typescript/
+//
+// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
+// A more precise version of just React.ComponentPropsWithoutRef on its own
+export type PropsOf<
+  C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>,
+> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
+
+type AsProp<C extends React.ElementType> = {
+  /**
+   * An override of the default HTML tag.
+   * Can also be another React component.
+   * @default <a>
+   */
+  asComponent?: C;
+};
+
+/**
+ * Allows for extending a set of props (`ExtendedProps`) by an overriding set of props
+ * (`OverrideProps`), ensuring that any duplicates are overridden by the overriding
+ * set of props.
+ */
+export type ExtendableProps<
+  ExtendedProps = {},
+  OverrideProps = {},
+> = OverrideProps & Omit<ExtendedProps, keyof OverrideProps>;
+
+/**
+ * Allows for inheriting the props from the specified element type so that
+ * props like children, className & style work, as well as element-specific
+ * attributes like aria roles. The component (`C`) must be passed in.
+ */
+export type InheritableElementProps<
+  C extends React.ElementType,
+  Props = {},
+> = ExtendableProps<PropsOf<C>, Props>;
+
+/**
+ * A more sophisticated version of `InheritableElementProps` where
+ * the passed in `as` prop will determine which props can be included
+ */
+export type PolymorphicComponentProps<
+  C extends React.ElementType,
+  Props = {},
+> = InheritableElementProps<C, Props & AsProp<C>>;
+
+//
+//
+//
+
+const routerLinkClassName = `${baseClassName}--router`;
+
+interface Props {
+  /** Custom classname to extend or customize */
+  className?: string;
+  /**
+   * Link element displayed content
+   */
+  children: ReactNode;
+}
+
+export type RouterLinkProps<C extends React.ElementType> =
+  PolymorphicComponentProps<C, Props>;
+
+const PolymorphicLink = <C extends React.ElementType>(
+  props: RouterLinkProps<C> & SuomifiThemeProp,
+) => {
+  const { asComponent, children, className, theme, ...passProps } = props;
+  const Component = asComponent || HtmlA;
+
+  return (
+    <Component
+      className={classnames(routerLinkClassName, className)}
+      {...passProps}
+    >
+      {children}
+    </Component>
+  );
+};
+
+const StyledRouterLink = styled(PolymorphicLink)`
+  ${({ theme }) => RouterLinkStyles(theme)}
+`;
+
+export const RouterLink = <C extends React.ElementType = 'a'>(
+  props: RouterLinkProps<C>,
+) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => <StyledRouterLink theme={suomifiTheme} {...props} />}
+  </SuomifiThemeConsumer>
+);

--- a/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
+++ b/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calling render with the same component on the same container does not remount 1`] = `
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c0:hover,
+.c0:active,
+.c0:focus,
+.c0:focus-within {
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.c1 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c1.fi-link--router {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1.fi-link--router:hover,
+.c1.fi-link--router:active,
+.c1.fi-link--router:focus,
+.c1.fi-link--router:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c1.fi-link--router:focus,
+.c1.fi-link--router:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1.fi-link--router:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c1.fi-link--router:hover,
+.c1.fi-link--router:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--router:visited {
+  color: hsl(284,36%,45%);
+}
+
+<a
+  class="c0 fi-link--router c1"
+  data-testid="test-link"
+  href="/"
+>
+  Hey this is a test
+</a>
+`;

--- a/src/core/Link/index.ts
+++ b/src/core/Link/index.ts
@@ -1,3 +1,4 @@
 export { Link, LinkProps } from './Link/Link';
 export { ExternalLink, ExternalLinkProps } from './ExternalLink/ExternalLink';
 export { SkipLink, SkipLinkProps } from './SkipLink/SkipLink';
+export { RouterLink, RouterLinkProps } from './RouterLink/RouterLink';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,6 +74,8 @@ export {
   ExternalLinkProps,
   SkipLink,
   SkipLinkProps,
+  RouterLink,
+  RouterLinkProps,
 } from './core/Link/';
 export {
   LanguageMenu,


### PR DESCRIPTION
## Description

This PR adds a new component called `<RouterLink`>. The solution is based on the work started in the branch https://github.com/vrk-kpa/suomifi-ui-components/tree/fix/as-prop

As the name suggests, the component is intended to be used with external (routing) libraries. It takes a prop called `asComponent` and renders itself as that component while applying the correct Suomi.fi styles on top of it. 

Features:
- Full Typescript support for props based on the component passed to `asComponent`
- Full theme customisation support through `SuomifiThemeProvider`

Usage example:

```
import { Link as ReactRouterLink } from "react-router-dom";
import { RouterLink } from "suomifi-ui-components";

<RouterLink asComponent={ReactRouterLink} to="/">
  Home
</RouterLink>
```

## Motivation and Context

We want to have a polymorphic link component like this so it can easily be used with all kinds of frameworks while retaining the correct Suomi.fi styles and responding to overrides of the theme (via `SuomifiThemeProvider`). 

This component could also be used in navigation/menu components in this library the future. 

## How Has This Been Tested?

In Gatsby (as GatsbyLink) and in CRA as ReactRouterLink. Various Typescript and rendering scenarios. 

Caveat: This component is pretty much redundant for NextJS projects. Next's Link component is a high order component and does not allow CSS classes to be passed to it which makes the logic of this component dead on arrival. The correct behavior in NextJS projects can be achieved using the basic Link component from suomifi-ui-components like this

```
import Link from "next/link";
import { Link as SuomiFiLink } from "suomifi-ui-components";

<Link href="/someroute" passHref>
  <SuomiFiLink href="/someroute">Suomi.fi styled link with NextJS link behavior</SuomiFiLink>
</Link>
```

## Release notes

### RouterLink
* Introduce polymorphic `<RouterLink>` component
   - Renders as the component of your choice, for example React Router Link but with proper Suomi.fi link styles
   - Full Typescript support for props based on the component passed to `asComponent`
   - Full theme customisation support through `SuomifiThemeProvider`
