### PR TITLE
[Fix] Tooltip arrow borders

### DIFF
--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -84,7 +84,8 @@ class BaseTooltip extends Component<
        */
       const pos =
         this.toggleButtonRef.current.getBoundingClientRect().left -
-        this.contentRef.current.getBoundingClientRect().left;
+        this.contentRef.current.getBoundingClientRect().left -
+        2;
       const max = this.contentRef.current.getBoundingClientRect().width - 17;
       return Math.min(pos, max);
     }

--- a/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
+++ b/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
@@ -25,7 +25,7 @@ export const baseStyles = (arrowOffsetPx: number, theme: SuomifiTheme) => css`
       pointer-events: none;
     }
     &:before {
-      border-bottom-color: ${theme.colors.depthDark2};
+      border-bottom-color: ${theme.colors.blackBase};
       border-width: 9px;
       margin-right: -9px;
       bottom: 100%;

--- a/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
+++ b/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
@@ -20,20 +20,21 @@ export const baseStyles = (arrowOffsetPx: number, theme: SuomifiTheme) => css`
       position: absolute;
       height: 0;
       width: 0;
-      bottom: 100%;
       left: ${arrowOffsetPx}px;
       border: solid transparent;
       pointer-events: none;
     }
     &:before {
       border-bottom-color: ${theme.colors.depthDark2};
-      border-width: 8px;
-      margin-right: -8px;
+      border-width: 9px;
+      margin-right: -9px;
+      bottom: 100%;
     }
     &:after {
       border-bottom-color: ${theme.colors.highlightLight4};
-      border-width: 6.5px;
-      margin-right: -6.5px;
+      border-width: 9px;
+      margin-right: -9px;
+      bottom: calc(100% - 1px);
     }
 
     & .fi-tooltip_close-button {


### PR DESCRIPTION
## Description

This PR fixes an issue with Tooltip's arrow borders.

## Motivation and Context

We want our components to have a professional and polished visual look.

## How Has This Been Tested?

Styleguidist on MacOS Chrome, Safari & Firefox

## Screenshots
Before:
![Screenshot 2022-06-09 at 14 59 16](https://user-images.githubusercontent.com/17459942/173368317-83d1fba9-05ae-49f1-98d1-66f22de69e68.png)

After:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/17459942/173536954-b5e5e797-44fc-48a8-a6b4-f04046b007b4.png">



## Release notes

### Tooltip
* Fix arrow borders visual glitch
