### PR TITLE
[Hotfix] Keyboard event propagation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -297,6 +297,11 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
                   this.buttonRef.current.focus();
                 }
               }}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.stopPropagation();
+                }
+              }}
             >
               <ListBoxContextWrapper scrollContainerRef={this.popoverRef}>
                 {children}

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -172,14 +172,12 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
     };
 
     const onKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
-      event.stopPropagation();
       if (!!this.state.value && event?.key === 'Enter') {
         onSearch();
       }
     };
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-      event.stopPropagation();
       if (event?.key === 'Escape') {
         event.preventDefault();
       }

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -172,12 +172,14 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
     };
 
     const onKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      event.stopPropagation();
       if (!!this.state.value && event?.key === 'Enter') {
         onSearch();
       }
     };
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      event.stopPropagation();
       if (event?.key === 'Escape') {
         event.preventDefault();
       }

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -329,6 +329,7 @@ class BaseMultiSelect<T> extends Component<
       }
 
       case 'Enter': {
+        event.preventDefault();
         if (focusedDescendantId) {
           const focusedItem = items.find(
             ({ uniqueItemId }) => uniqueItemId === focusedDescendantId,

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -297,6 +297,7 @@ class BaseMultiSelect<T> extends Component<
   };
 
   private handleKeyDown = (event: React.KeyboardEvent) => {
+    event.stopPropagation();
     const { filteredItems: items, focusedDescendantId } = this.state;
     const index = items.findIndex(
       ({ uniqueItemId }) => uniqueItemId === focusedDescendantId,

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -296,6 +296,7 @@ class BaseSingleSelect<T> extends Component<
       }
 
       case 'Enter': {
+        event.preventDefault();
         if (focusedDescendantId) {
           const focusedItem = popoverItems.find(
             ({ uniqueItemId }) => uniqueItemId === focusedDescendantId,

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -258,6 +258,7 @@ class BaseSingleSelect<T> extends Component<
   };
 
   private handleKeyDown = (event: React.KeyboardEvent) => {
+    event.stopPropagation();
     const { filteredItems, focusedDescendantId, filterMode } = this.state;
     const popoverItems = !!filterMode ? filteredItems : this.props.items;
     const index = popoverItems.findIndex(

--- a/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
@@ -144,7 +144,15 @@ const LanguageMenuPopoverPosition = (
 
 const StyledMenuPopover = styled(
   ({ theme, children, ...passProps }: MenuPopoverProps & SuomifiThemeProp) => (
-    <MenuPopover {...passProps} position={LanguageMenuPopoverPosition}>
+    <MenuPopover
+      {...passProps}
+      position={LanguageMenuPopoverPosition}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          event.stopPropagation();
+        }
+      }}
+    >
       <MenuItems>{children}</MenuItems>
     </MenuPopover>
   ),


### PR DESCRIPTION
## Description

This PR addresses an issue regarding keyboard events in certain component. The propagation of these events was not addressed which caused unexpected behavior in certain cases. For example, when SingleSelect was used inside a Modal and the escape key was used to close the popover items list, the event was propagated all the way to the Modal component and the Modal was closed. 

## Motivation and Context

We don't want to have any unexpected side effects when using the keyboard to interact with our components

## How Has This Been Tested?

In a CRA app:
 - When used inside a `<Modal>`, make sure escape key only closes the popover, the modal: SingleSelect, MultiSelect, Dropdown, LanguageMenu
 - When used inside a `<form>`, make sure enter keypress does not submit the form: SingleSelect, MultiSelect

## Release notes

### SingleSelect & MultiSelect
* Prevent onKeyDown event from propagating upwards
* Prevent event default when pressing Enter key

### Dropdown & LanguageMenu
* Prevent event propagation when Escape key is pressed
