### PR TITLE
[Hotfix] Keyboard event propagation (from master)

### DIFF
--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -296,6 +296,11 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
                   this.buttonRef.current.focus();
                 }
               }}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.stopPropagation();
+                }
+              }}
             >
               <ListBoxContextWrapper scrollContainerRef={this.popoverRef}>
                 {children}

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -428,6 +428,7 @@ class BaseMultiSelect<T> extends Component<
       }
 
       case 'Enter': {
+        event.preventDefault();
         if (focusedDescendantId) {
           const focusedItem = items.find(
             ({ uniqueItemId }) => uniqueItemId === focusedDescendantId,
@@ -448,6 +449,9 @@ class BaseMultiSelect<T> extends Component<
       }
 
       case 'Escape': {
+        if (this.state.showPopover) {
+          event.stopPropagation();
+        }
         this.setState(
           (
             _prevState: MultiSelectState<T & MultiSelectData>,

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -372,6 +372,7 @@ class BaseSingleSelect<T> extends Component<
       }
 
       case 'Enter': {
+        event.preventDefault();
         if (focusedDescendantId) {
           const focusedItem = popoverItems.find(
             ({ uniqueItemId }) => uniqueItemId === focusedDescendantId,
@@ -391,6 +392,9 @@ class BaseSingleSelect<T> extends Component<
       }
 
       case 'Escape': {
+        if (this.state.showPopover) {
+          event.stopPropagation();
+        }
         if (!this.state.selectedItem) {
           this.setState({ filterInputValue: '' });
         }

--- a/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
@@ -144,7 +144,15 @@ const LanguageMenuPopoverPosition = (
 
 const StyledMenuPopover = styled(
   ({ theme, children, ...passProps }: MenuPopoverProps & SuomifiThemeProp) => (
-    <MenuPopover {...passProps} position={LanguageMenuPopoverPosition}>
+    <MenuPopover
+      {...passProps}
+      position={LanguageMenuPopoverPosition}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          event.stopPropagation();
+        }
+      }}
+    >
       <MenuItems>{children}</MenuItems>
     </MenuPopover>
   ),


### PR DESCRIPTION
## Description
This PR merges into develop the changes from a hotfix done directly into the master branch. The original PR: #639 

## Release notes

### SingleSelect & MultiSelect
* Prevent event propagation when Escape key is pressed to close the popover
* Prevent event default when pressing Enter key

### Dropdown & LanguageMenu
* Prevent event propagation when Escape key is pressed to close the popover
