### PR TITLE
[Fix] Link's styleguidist page

### DIFF
--- a/src/core/Link/Link/Link.md
+++ b/src/core/Link/Link/Link.md
@@ -61,24 +61,6 @@ import { ExternalLink } from 'suomifi-ui-components';
 </>;
 ```
 
-### Change component for the link
-
-```js
-import { Link } from 'suomifi-ui-components';
-
-const Component = ({ children, ...passProps }) => (
-  <a {...passProps}>foo {children} bar</a>
-);
-
-<Link
-  className="test-classname"
-  href="https://www.com/"
-  asProp={Component}
->
-  Testing
-</Link>;
-```
-
 ### Router link
 
 This component is mainly intended to be used with external libraries/frameworks.
@@ -97,7 +79,7 @@ const Component = ({ children, ...passProps }) => (
 <>
   <RouterLink
     asComponent={Component}
-    href="https://ironmaiden.com"
+    href="https://suomi.fi"
     target="_blank"
   >
     Testing


### PR DESCRIPTION
## Description

This PR fixes a couple of minor issues in Link componen's styleguidist page. These issues were introduced in #634 

* Remove example detailing the use of `asProp` for `<Link>` since `<RouterLink>` should now be used for that purpose
* Make the href of the `<RouterLink>` example be more professional :)

## Release notes

None since the issues are not yet part of any release
