### PR TITLE
[Feature] Add displayNames to components

### DIFF
--- a/src/core/Alert/Alert/Alert.tsx
+++ b/src/core/Alert/Alert/Alert.tsx
@@ -102,7 +102,7 @@ const StyledAlert = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export const Alert = forwardRef(
+const Alert = forwardRef(
   (props: AlertProps, ref: React.RefObject<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
@@ -123,3 +123,6 @@ export const Alert = forwardRef(
     );
   },
 );
+
+Alert.displayName = 'Alert';
+export { Alert };

--- a/src/core/Alert/InlineAlert/InlineAlert.tsx
+++ b/src/core/Alert/InlineAlert/InlineAlert.tsx
@@ -82,7 +82,7 @@ const StyledInlineAlert = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export const InlineAlert = forwardRef(
+const InlineAlert = forwardRef(
   (props: InlineAlertProps, ref: React.RefObject<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
@@ -103,3 +103,6 @@ export const InlineAlert = forwardRef(
     );
   },
 );
+
+InlineAlert.displayName = 'InlineAlert';
+export { InlineAlert };

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -46,16 +46,13 @@ const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
 `;
 
 /**
- * Used displaying Block with correct styles
+ * Used in displaying a generic piece of HTML e.g. a <div>
  */
-export class Block extends Component<BlockProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledBlock theme={suomifiTheme} {...this.props} />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const Block = (props: BlockProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => <StyledBlock theme={suomifiTheme} {...props} />}
+  </SuomifiThemeConsumer>
+);
+
+Block.displayName = 'Block';
+export { Block };

--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.tsx
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.tsx
@@ -45,19 +45,20 @@ const StyledBreadcrumb = styled(BaseBreadcrumb)`
  * <i class="semantics" />
  * Used for navigation path
  */
-export class Breadcrumb extends Component<BreadcrumbProps> {
-  render() {
-    const { 'aria-label': ariaLabel, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledBreadcrumb
-            theme={suomifiTheme}
-            {...passProps}
-            {...getConditionalAriaProp('aria-label', [ariaLabel])}
-          />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const Breadcrumb = (props: BreadcrumbProps) => {
+  const { 'aria-label': ariaLabel, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledBreadcrumb
+          theme={suomifiTheme}
+          {...passProps}
+          {...getConditionalAriaProp('aria-label', [ariaLabel])}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+Breadcrumb.displayName = 'Breadcrumb';
+export { Breadcrumb };

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -152,7 +152,7 @@ const StyledButton = styled(
  * <i class="semantics" />
  * Use for inside Application onClick events.<br />
  */
-export const Button = forwardRef(
+const Button = forwardRef(
   (props: ButtonProps, ref: React.RefObject<HTMLButtonElement>) => (
     <SuomifiThemeConsumer>
       {({ suomifiTheme }) => (
@@ -161,3 +161,6 @@ export const Button = forwardRef(
     </SuomifiThemeConsumer>
   ),
 );
+
+Button.displayName = 'Button';
+export { Button };

--- a/src/core/Chip/Chip/Chip.tsx
+++ b/src/core/Chip/Chip/Chip.tsx
@@ -116,7 +116,7 @@ const StyledChip = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export const Chip = forwardRef(
+const Chip = forwardRef(
   (props: ChipProps, ref: React.RefObject<HTMLButtonElement>) => {
     const { ...passProps } = props;
     return (
@@ -128,3 +128,6 @@ export const Chip = forwardRef(
     );
   },
 );
+
+Chip.displayName = 'Chip';
+export { Chip };

--- a/src/core/Chip/ChipList/ChipList.tsx
+++ b/src/core/Chip/ChipList/ChipList.tsx
@@ -39,19 +39,20 @@ const StyledChipList = styled(BaseChipList)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export class ChipList extends Component<ChipListProps> {
-  render() {
-    const { id: propId, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledChipList theme={suomifiTheme} id={id} {...passProps} />
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const ChipList = (props: ChipListProps) => {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <StyledChipList theme={suomifiTheme} id={id} {...passProps} />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+ChipList.displayName = 'ChipList';
+export { ChipList };

--- a/src/core/Chip/StaticChip/StaticChip.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.tsx
@@ -39,15 +39,11 @@ const StyledChip = styled(
   ${({ theme }) => staticChipBaseStyles(theme)}
 `;
 
-export class StaticChip extends Component<StaticChipProps> {
-  render() {
-    const { ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledChip theme={suomifiTheme} {...passProps} />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const StaticChip = (props: StaticChipProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => <StyledChip theme={suomifiTheme} {...props} />}
+  </SuomifiThemeConsumer>
+);
+
+StaticChip.displayName = 'StaticChip';
+export { StaticChip };

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -328,7 +328,7 @@ const StyledDropdown = styled(
  * <i class="semantics" />
  * Use for selectable dropdown with items.
  */
-export const Dropdown = forwardRef(
+const Dropdown = forwardRef(
   (props: DropdownProps, ref: React.RefObject<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
@@ -349,3 +349,6 @@ export const Dropdown = forwardRef(
     );
   },
 );
+
+Dropdown.displayName = 'Dropdown';
+export { Dropdown };

--- a/src/core/Dropdown/DropdownItem/DropdownItem.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.tsx
@@ -29,10 +29,13 @@ const StyledDropdownItem = styled(BaseDropdownItem)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export const DropdownItem = (props: DropdownItemProps) => (
+const DropdownItem = (props: DropdownItemProps) => (
   <SuomifiThemeConsumer>
     {({ suomifiTheme }) => (
       <StyledDropdownItem theme={suomifiTheme} {...props} />
     )}
   </SuomifiThemeConsumer>
 );
+
+DropdownItem.displayName = 'DropdownItem';
+export { DropdownItem };

--- a/src/core/Expander/Expander/Expander.tsx
+++ b/src/core/Expander/Expander/Expander.tsx
@@ -216,4 +216,5 @@ const Expander = (props: ExpanderProps) => {
   );
 };
 
+Expander.displayName = 'Expander';
 export { Expander, ExpanderConsumer, ExpanderProvider };

--- a/src/core/Expander/Expander/Expander.tsx
+++ b/src/core/Expander/Expander/Expander.tsx
@@ -192,30 +192,28 @@ interface ExpanderState {
  * <i class="semantics" />
  * Hide or show content with always visible title
  */
-export class Expander extends Component<ExpanderProps> {
-  render() {
-    const { id: propId, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <ExpanderGroupConsumer>
-                {(consumer) => (
-                  <StyledExpander
-                    theme={suomifiTheme}
-                    id={id}
-                    {...passProps}
-                    consumer={consumer}
-                  />
-                )}
-              </ExpanderGroupConsumer>
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const Expander = (props: ExpanderProps) => {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <ExpanderGroupConsumer>
+              {(consumer) => (
+                <StyledExpander
+                  theme={suomifiTheme}
+                  id={id}
+                  {...passProps}
+                  consumer={consumer}
+                />
+              )}
+            </ExpanderGroupConsumer>
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
 
-export { ExpanderConsumer, ExpanderProvider };
+export { Expander, ExpanderConsumer, ExpanderProvider };

--- a/src/core/Expander/ExpanderContent/ExpanderContent.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.tsx
@@ -72,22 +72,21 @@ const StyledExpanderContent = styled(BaseExpanderContent)`
  * <i class="semantics" />
  * Expander content wrapper, controlled by expander
  */
-export class ExpanderContent extends Component<ExpanderContentProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <ExpanderConsumer>
-            {(consumer) => (
-              <StyledExpanderContent
-                theme={suomifiTheme}
-                consumer={consumer}
-                {...this.props}
-              />
-            )}
-          </ExpanderConsumer>
+const ExpanderContent = (props: ExpanderContentProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <ExpanderConsumer>
+        {(consumer) => (
+          <StyledExpanderContent
+            theme={suomifiTheme}
+            consumer={consumer}
+            {...props}
+          />
         )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+      </ExpanderConsumer>
+    )}
+  </SuomifiThemeConsumer>
+);
+
+ExpanderContent.displayName = 'ExpanderContent';
+export { ExpanderContent };

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -190,16 +190,14 @@ const StyledExpanderGroup = styled(BaseExpanderGroup)`
  * <i class="semantics" />
  * Wrapper for multiple expanders with Open/Close All button
  */
-export class ExpanderGroup extends Component<ExpanderGroupProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledExpanderGroup theme={suomifiTheme} {...this.props} />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const ExpanderGroup = (props: ExpanderGroupProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledExpanderGroup theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
 
-export { ExpanderGroupConsumer };
+ExpanderGroup.displayName = 'ExpanderGroup';
+
+export { ExpanderGroup, ExpanderGroupConsumer };

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -104,22 +104,21 @@ const StyledExpanderTitle = styled(BaseExpanderTitle)`
  * <i class="semantics" />
  * Expander title for focusable content and toggle button for content visiblity
  */
-export class ExpanderTitle extends Component<ExpanderTitleProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <ExpanderConsumer>
-            {(consumer) => (
-              <StyledExpanderTitle
-                theme={suomifiTheme}
-                consumer={consumer}
-                {...this.props}
-              />
-            )}
-          </ExpanderConsumer>
+const ExpanderTitle = (props: ExpanderTitleProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <ExpanderConsumer>
+        {(consumer) => (
+          <StyledExpanderTitle
+            theme={suomifiTheme}
+            consumer={consumer}
+            {...props}
+          />
         )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+      </ExpanderConsumer>
+    )}
+  </SuomifiThemeConsumer>
+);
+
+ExpanderTitle.displayName = 'ExpanderTitle';
+export { ExpanderTitle };

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
@@ -86,22 +86,21 @@ const StyledExpanderTitle = styled(BaseExpanderTitleButton)`
  * <i class="semantics" />
  * Expander title button for static title content and toggle for content visiblity
  */
-export class ExpanderTitleButton extends Component<ExpanderTitleButtonProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <ExpanderConsumer>
-            {(consumer) => (
-              <StyledExpanderTitle
-                theme={suomifiTheme}
-                consumer={consumer}
-                {...this.props}
-              />
-            )}
-          </ExpanderConsumer>
+const ExpanderTitleButton = (props: ExpanderTitleButtonProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <ExpanderConsumer>
+        {(consumer) => (
+          <StyledExpanderTitle
+            theme={suomifiTheme}
+            consumer={consumer}
+            {...props}
+          />
         )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+      </ExpanderConsumer>
+    )}
+  </SuomifiThemeConsumer>
+);
+
+ExpanderTitleButton.displayName = 'ExpanderTitleButton';
+export { ExpanderTitleButton };

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -251,7 +251,7 @@ const StyledCheckbox = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export const Checkbox = forwardRef(
+const Checkbox = forwardRef(
   (props: CheckboxProps, ref: React.RefObject<HTMLInputElement>) => {
     const { id: propId, status: propStatus, ...passProps } = props;
     return (
@@ -277,3 +277,6 @@ export const Checkbox = forwardRef(
     );
   },
 );
+
+Checkbox.displayName = 'Checkbox';
+export { Checkbox };

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -139,25 +139,21 @@ const StyledCheckboxGroup = styled(BaseCheckboxGroup)`
 /**
  * Use for grouping Checkboxes.
  */
-export class CheckboxGroup extends Component<CheckboxGroupProps> {
-  render() {
-    const { id: propId, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledCheckboxGroup
-                theme={suomifiTheme}
-                id={id}
-                {...passProps}
-              />
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const CheckboxGroup = (props: CheckboxGroupProps) => {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <StyledCheckboxGroup theme={suomifiTheme} id={id} {...passProps} />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
 
-export { CheckboxGroupConsumer };
+CheckboxGroup.displayName = 'CheckboxGroup';
+
+export { CheckboxGroup, CheckboxGroupConsumer };

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -251,7 +251,7 @@ const StyledFilterInput = styled(BaseFilterInputWrapper)`
  * Use for filtering.
  * Props other than specified explicitly are passed on to underlying input element.
  */
-export const FilterInput = forwardRef(
+const FilterInput = forwardRef(
   (props: FilterInputProps, ref: React.RefObject<HTMLInputElement>) => {
     const { id: propId, ...passProps } = props;
     return (
@@ -272,3 +272,6 @@ export const FilterInput = forwardRef(
     );
   },
 );
+
+FilterInput.displayName = 'FilterInput';
+export { FilterInput };

--- a/src/core/Form/HintText/HintText.tsx
+++ b/src/core/Form/HintText/HintText.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
@@ -33,20 +33,22 @@ const StyledHintText = styled(
 )`
   ${({ theme }) => baseStyles(theme)}
 `;
-export class HintText extends Component<HintTextProps> {
-  render() {
-    const { children, ...passProps } = this.props;
-    if (!children) {
-      return null;
-    }
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledHintText theme={suomifiTheme} {...passProps}>
-            {children}
-          </StyledHintText>
-        )}
-      </SuomifiThemeConsumer>
-    );
+
+const HintText = (props: HintTextProps) => {
+  const { children, ...passProps } = props;
+  if (!children) {
+    return null;
   }
-}
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledHintText theme={suomifiTheme} {...passProps}>
+          {children}
+        </StyledHintText>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+HintText.displayName = 'HintText';
+export { HintText };

--- a/src/core/Form/InputClearButton/InputClearButton.tsx
+++ b/src/core/Form/InputClearButton/InputClearButton.tsx
@@ -45,14 +45,13 @@ const StyledInputClearButton = styled(BaseInputClearButton)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export class InputClearButton extends Component<InputClearButtonProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledInputClearButton theme={suomifiTheme} {...this.props} />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const InputClearButton = (props: InputClearButtonProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledInputClearButton theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+InputClearButton.displayName = 'InputClearButton';
+export { InputClearButton };

--- a/src/core/Form/InputToggleButton/InputToggleButton.tsx
+++ b/src/core/Form/InputToggleButton/InputToggleButton.tsx
@@ -57,7 +57,7 @@ const StyledInputToggleButton = styled(BaseInputToggleButton)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export const InputToggleButton = forwardRef(
+const InputToggleButton = forwardRef(
   (props: InputToggleButtonProps, ref: RefObject<HTMLButtonElement>) => (
     <SuomifiThemeConsumer>
       {({ suomifiTheme }) => (
@@ -70,3 +70,6 @@ export const InputToggleButton = forwardRef(
     </SuomifiThemeConsumer>
   ),
 );
+
+InputToggleButton.displayName = 'InputToggleButton';
+export { InputToggleButton };

--- a/src/core/Form/Label/Label.tsx
+++ b/src/core/Form/Label/Label.tsx
@@ -1,7 +1,6 @@
 import React, {
   ReactElement,
   SetStateAction,
-  Component,
   ReactNode,
   useState,
   isValidElement,
@@ -128,14 +127,11 @@ const StyledLabel = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export class Label extends Component<LabelProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledLabel theme={suomifiTheme} {...this.props} />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const Label = (props: LabelProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => <StyledLabel theme={suomifiTheme} {...props} />}
+  </SuomifiThemeConsumer>
+);
+
+Label.displayName = 'Label';
+export { Label };

--- a/src/core/Form/RadioButton/RadioButton.tsx
+++ b/src/core/Form/RadioButton/RadioButton.tsx
@@ -174,7 +174,7 @@ const StyledRadioButton = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export const RadioButton = forwardRef(
+const RadioButton = forwardRef(
   (props: RadioButtonProps, ref: React.RefObject<HTMLInputElement>) => {
     const { id: propId, onChange, ...passProps } = props;
     return (
@@ -213,3 +213,6 @@ export const RadioButton = forwardRef(
     );
   },
 );
+
+RadioButton.displayName = 'RadioButton';
+export { RadioButton };

--- a/src/core/Form/RadioButton/RadioButtonGroup.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.tsx
@@ -151,25 +151,25 @@ const StyledRadioButtonGroup = styled(BaseRadioButtonGroup)`
  * Always overrides nested RadioButtons' name, checked and defaultChecked props.
  * Use RadioButtonGroup's name, value and defaultValue instead.
  */
-export class RadioButtonGroup extends Component<RadioButtonGroupProps> {
-  render() {
-    const { id: propId, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledRadioButtonGroup
-                theme={suomifiTheme}
-                id={id}
-                {...passProps}
-              />
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const RadioButtonGroup = (props: RadioButtonGroupProps) => {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <StyledRadioButtonGroup
+              theme={suomifiTheme}
+              id={id}
+              {...passProps}
+            />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
 
-export { RadioButtonGroupConsumer };
+RadioButtonGroup.displayName = 'RadioButtonGroup';
+
+export { RadioButtonGroup, RadioButtonGroupConsumer };

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -298,20 +298,20 @@ const StyledSearchInput = styled(BaseSearchInput)`
  * Use for user inputting search text.
  * Props other than specified explicitly are passed on to underlying input element.
  */
-export class SearchInput extends Component<SearchInputProps> {
-  render() {
-    const { id: propId, ...passProps } = this.props;
+const SearchInput = (props: SearchInputProps) => {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <StyledSearchInput theme={suomifiTheme} id={id} {...passProps} />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
 
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledSearchInput theme={suomifiTheme} id={id} {...passProps} />
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+SearchInput.displayName = 'SearchInput';
+export { SearchInput };

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -788,21 +788,20 @@ const StyledMultiSelect = styled(BaseMultiSelect)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export class MultiSelect<T> extends Component<
-  MultiSelectProps<T & MultiSelectData>
-> {
-  render() {
-    const { id: propId, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledMultiSelect theme={suomifiTheme} id={id} {...passProps} />
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const MultiSelect = <T,>(props: MultiSelectProps<T & MultiSelectData>) => {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <StyledMultiSelect theme={suomifiTheme} id={id} {...passProps} />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+MultiSelect.displayName = 'MultiSelect';
+export { MultiSelect };

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -659,21 +659,20 @@ const StyledSingleSelect = styled(BaseSingleSelect)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export class SingleSelect<T> extends Component<
-  SingleSelectProps<T & SingleSelectData>
-> {
-  render() {
-    const { id: propId, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledSingleSelect theme={suomifiTheme} id={id} {...passProps} />
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const SingleSelect = <T,>(props: SingleSelectProps<T & SingleSelectData>) => {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <StyledSingleSelect theme={suomifiTheme} id={id} {...passProps} />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+SingleSelect.displayName = 'SingleSelect';
+export { SingleSelect };

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
@@ -60,17 +60,18 @@ const StyledStatusText = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export class StatusText extends Component<StatusTextProps> {
-  render() {
-    const { children, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledStatusText theme={suomifiTheme} {...passProps}>
-            {children}
-          </StyledStatusText>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const StatusText = (props: StatusTextProps) => {
+  const { children, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledStatusText theme={suomifiTheme} {...passProps}>
+          {children}
+        </StyledStatusText>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+StatusText.displayName = 'StatusText';
+export { StatusText };

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -207,7 +207,7 @@ const StyledTextInput = styled(
  * Props other than specified explicitly are passed on to underlying input element.
  * @component
  */
-export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   (props: TextInputProps, ref: React.Ref<HTMLInputElement>) => {
     const { id: propId, ...passProps } = props;
     return (
@@ -228,3 +228,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     );
   },
 );
+
+TextInput.displayName = 'TextInput';
+export { TextInput };

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -180,7 +180,7 @@ const StyledTextarea = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export const Textarea = forwardRef(
+const Textarea = forwardRef(
   (props: TextareaProps, ref: React.Ref<HTMLTextAreaElement>) => {
     const { id: propId, ...passProps } = props;
     return (
@@ -201,3 +201,6 @@ export const Textarea = forwardRef(
     );
   },
 );
+
+Textarea.displayName = 'Textarea';
+export { Textarea };

--- a/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
@@ -125,7 +125,7 @@ const StyledToggleButton = styled(
  * Use for toggling application state.
  * Additional props are passed to the button element.
  */
-export const ToggleButton = forwardRef(
+const ToggleButton = forwardRef(
   (props: ToggleButtonProps, ref: React.RefObject<HTMLButtonElement>) => {
     const { id: propId, ...passProps } = props;
     return (
@@ -146,3 +146,6 @@ export const ToggleButton = forwardRef(
     );
   },
 );
+
+ToggleButton.displayName = 'ToggleButton';
+export { ToggleButton };

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
@@ -136,7 +136,7 @@ const StyledToggleInput = styled(
  * Use for toggling form selection
  * Additional props are passed to the checkbox input element.
  */
-export const ToggleInput = forwardRef(
+const ToggleInput = forwardRef(
   (props: ToggleInputProps, ref: React.RefObject<HTMLInputElement>) => {
     const { id: propId, ...passProps } = props;
     return (
@@ -157,3 +157,6 @@ export const ToggleInput = forwardRef(
     );
   },
 );
+
+ToggleInput.displayName = 'ToggleInput';
+export { ToggleInput };

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -68,7 +68,7 @@ const StyledHeading = styled(
  * <i class="semantics" />
  * Used displaying headings with correct fonts
  */
-export const Heading = forwardRef(
+const Heading = forwardRef(
   (props: HeadingProps, ref: React.RefObject<HTMLHeadingElement>) => {
     const { as, variant, ...passProps } = props;
     if (!variant) {
@@ -92,3 +92,6 @@ export const Heading = forwardRef(
     );
   },
 );
+
+Heading.displayName = 'Heading';
+export { Heading };

--- a/src/core/Icon/Icon.tsx
+++ b/src/core/Icon/Icon.tsx
@@ -1,8 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SuomifiIcon, SuomifiIconInterface } from 'suomifi-icons';
-import { getLogger } from '../../utils/log';
 import { ariaLabelOrHidden, ariaFocusableNoLabel } from '../../utils/aria';
 import { iconBaseStyles } from './Icon.baseStyles';
 
@@ -27,21 +26,6 @@ export interface IconBaseProps {
 
 export interface IconProps extends IconBaseProps, SuomifiIconInterface {}
 
-export const iconLogger = (
-  ariaLabel: string | undefined,
-  className: string | undefined,
-) => {
-  getLogger().warn(
-    `Icon ERROR${
-      !!ariaLabel
-        ? ` with aria-label: ${ariaLabel}`
-        : !!className
-        ? ` with className: ${className}`
-        : ''
-    }`,
-  );
-};
-
 /**
  * Apply Suomifi styles to Icon
  */
@@ -60,20 +44,7 @@ const StyledSuomifiIcon = styled(
   ${iconBaseStyles}
 `;
 
-/**
- * General icon-component
- */
-export class Icon extends Component<IconProps> {
-  render() {
-    const { icon, ...passProps } = this.props;
-    const { className, ariaLabel } = this.props;
+const Icon = (props: IconProps) => <StyledSuomifiIcon {...props} />;
 
-    if (icon !== undefined) {
-      return <StyledSuomifiIcon {...passProps} icon={icon} />;
-    }
-
-    iconLogger(ariaLabel, className);
-
-    return;
-  }
-}
+Icon.displayName = 'Icon';
+export { Icon };

--- a/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
@@ -164,32 +164,33 @@ const StyledMenuPopover = styled(
  * <i class="semantics" />
  * Use for dropdown menu.
  */
-export class LanguageMenu extends Component<LanguageMenuProps> {
-  render() {
-    const { children, name, className, ...passProps } = this.props;
-    const languageMenuButtonClassName = classnames(
-      languageMenuClassNames.button,
-      languageMenuClassNames.buttonLang,
-      className,
-    );
+const LanguageMenu = (props: LanguageMenuProps) => {
+  const { children, name, className, ...passProps } = props;
+  const languageMenuButtonClassName = classnames(
+    languageMenuClassNames.button,
+    languageMenuClassNames.buttonLang,
+    className,
+  );
 
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledLanguageMenu
-            theme={suomifiTheme}
-            {...passProps}
-            name={languageName(name)}
-            languageMenuButtonClassName={languageMenuButtonClassName}
-            languageMenuOpenButtonClassName={languageMenuClassNames.buttonOpen}
-          >
-            {LanguageMenuPopoverWithProps(
-              children,
-              languageMenuClassNames.itemLang,
-            )}
-          </StyledLanguageMenu>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledLanguageMenu
+          theme={suomifiTheme}
+          {...passProps}
+          name={languageName(name)}
+          languageMenuButtonClassName={languageMenuButtonClassName}
+          languageMenuOpenButtonClassName={languageMenuClassNames.buttonOpen}
+        >
+          {LanguageMenuPopoverWithProps(
+            children,
+            languageMenuClassNames.itemLang,
+          )}
+        </StyledLanguageMenu>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+LanguageMenu.displayName = 'LanguageMenu';
+export { LanguageMenu };

--- a/src/core/LanguageMenu/LanguageMenuItem/LanguageMenuItem.tsx
+++ b/src/core/LanguageMenu/LanguageMenuItem/LanguageMenuItem.tsx
@@ -11,7 +11,7 @@ export interface LanguageMenuItemProps {
   className?: string;
 }
 
-export const LanguageMenuItem = ({
+const LanguageMenuItem = ({
   selected,
   className,
   ...passProps
@@ -23,3 +23,6 @@ export const LanguageMenuItem = ({
     })}
   />
 );
+
+LanguageMenuItem.displayName = 'LanguageMenuItem';
+export { LanguageMenuItem };

--- a/src/core/LanguageMenu/LanguageMenuLink/LanguageMenuLink.tsx
+++ b/src/core/LanguageMenu/LanguageMenuLink/LanguageMenuLink.tsx
@@ -12,7 +12,7 @@ export interface LanguageMenuLinkProps {
   className?: string;
 }
 
-export const LanguageMenuLink = ({
+const LanguageMenuLink = ({
   selected,
   className,
   ...passProps
@@ -24,3 +24,6 @@ export const LanguageMenuLink = ({
     })}
   />
 );
+
+LanguageMenuLink.displayName = 'LanguageMenuLink';
+export { LanguageMenuLink };

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -78,14 +78,14 @@ const StyledExternalLink = styled(
  * <i class="semantics" />
  * Used for adding a external site link
  */
-export class ExternalLink extends Component<ExternalLinkProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledExternalLink theme={suomifiTheme} {...this.props} />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+
+const ExternalLink = (props: ExternalLinkProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledExternalLink theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+ExternalLink.displayName = 'ExternalLink';
+export { ExternalLink };

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { LinkStyles } from '../Link/Link.baseStyles';
@@ -29,14 +29,11 @@ const StyledLink = styled(
  * <i class="semantics" />
  * Used for adding a link
  */
-export class Link extends Component<LinkProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledLink theme={suomifiTheme} {...this.props} />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const Link = (props: LinkProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => <StyledLink theme={suomifiTheme} {...props} />}
+  </SuomifiThemeConsumer>
+);
+
+Link.displayName = 'Link';
+export { Link };

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -92,10 +92,13 @@ const StyledRouterLink = styled(PolymorphicLink)`
   ${({ theme }) => RouterLinkStyles(theme)}
 `;
 
-export const RouterLink = <C extends React.ElementType = 'a'>(
+const RouterLink = <C extends React.ElementType = 'a'>(
   props: RouterLinkProps<C>,
 ) => (
   <SuomifiThemeConsumer>
     {({ suomifiTheme }) => <StyledRouterLink theme={suomifiTheme} {...props} />}
   </SuomifiThemeConsumer>
 );
+
+RouterLink.displayName = 'RouterLink';
+export { RouterLink };

--- a/src/core/Link/SkipLink/SkipLink.tsx
+++ b/src/core/Link/SkipLink/SkipLink.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { Link } from '../Link/Link';
@@ -21,19 +21,20 @@ const StyledSkipLink = styled((props: SkipLinkProps & SuomifiThemeProp) => {
  * <i class="semantics" />
  * Used for adding skip link for keyboard and screenreader users
  */
-export class SkipLink extends Component<SkipLinkProps> {
-  render() {
-    const { className, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledSkipLink
-            theme={suomifiTheme}
-            {...passProps}
-            className={classnames(className, skipClassName)}
-          />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const SkipLink = (props: SkipLinkProps) => {
+  const { className, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledSkipLink
+          theme={suomifiTheme}
+          {...passProps}
+          className={classnames(className, skipClassName)}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+SkipLink.displayName = 'SkipLink';
+export { SkipLink };

--- a/src/core/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.tsx
@@ -108,7 +108,7 @@ const StyledLoadingSpinner = styled(
 )`
   ${({ theme }) => baseStyles(theme)};
 `;
-export const LoadingSpinner = forwardRef(
+const LoadingSpinner = forwardRef(
   (props: LoadingSpinnerProps, ref: React.RefObject<HTMLDivElement>) => {
     const { ...passProps } = props;
     return (
@@ -124,3 +124,6 @@ export const LoadingSpinner = forwardRef(
     );
   },
 );
+
+LoadingSpinner.displayName = 'LoadingSpinner';
+export { LoadingSpinner };

--- a/src/core/LogoIcon/LogoIcon.tsx
+++ b/src/core/LogoIcon/LogoIcon.tsx
@@ -1,13 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { ariaLabelOrHidden, ariaFocusableNoLabel } from '../../utils/aria';
 import { SuomifiLogoIcon, SuomifiLogoIconInterface } from 'suomifi-icons';
-import {
-  iconLogger,
-  cursorPointerClassName,
-  baseClassName,
-} from '../Icon/Icon';
+import { cursorPointerClassName, baseClassName } from '../Icon/Icon';
 import { logoIconBaseStyles } from './LogoIcon.baseStyles';
 
 export { LogoIconKeys } from 'suomifi-icons';
@@ -38,30 +34,18 @@ const StyledSuomifiLogoIcon = styled(
 /**
  * Logo icon-component
  */
-export class LogoIcon extends Component<LogoIconProps> {
-  render() {
-    const { icon, className, mousePointer, ...passProps } = this.props;
-    const { ariaLabel } = this.props;
+const LogoIcon = (props: LogoIconProps) => {
+  const { className, mousePointer, ...passProps } = props;
 
-    if (icon !== undefined) {
-      return (
-        <StyledSuomifiLogoIcon
-          {...passProps}
-          icon={icon}
-          className={classnames(
-            baseClassName,
-            logoIconBaseClassName,
-            className,
-            {
-              [cursorPointerClassName]: !!mousePointer,
-            },
-          )}
-        />
-      );
-    }
+  return (
+    <StyledSuomifiLogoIcon
+      {...passProps}
+      className={classnames(baseClassName, logoIconBaseClassName, className, {
+        [cursorPointerClassName]: !!mousePointer,
+      })}
+    />
+  );
+};
 
-    iconLogger(ariaLabel, className);
-
-    return;
-  }
-}
+LogoIcon.displayName = 'LogoIcon';
+export { LogoIcon };

--- a/src/core/Modal/Modal/Modal.tsx
+++ b/src/core/Modal/Modal/Modal.tsx
@@ -1,11 +1,12 @@
-import React, { Component, ReactNode, createRef } from 'react';
+import React, { Component, ReactNode, createRef, ReactElement } from 'react';
 import { default as styled } from 'styled-components';
 import { getLogger } from '../../../utils/log';
 import { default as ReactModal } from 'react-modal';
 import classnames from 'classnames';
-import { ModalContent, ModalFooter } from '../';
 import { baseStyles } from './Modal.baseStyles';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import { ModalFooterProps } from '../ModalFooter/ModalFooter';
+import { ModalContentProps } from '../ModalContent/ModalContent';
 
 export type ModalVariant = 'smallScreen' | 'default';
 
@@ -19,7 +20,7 @@ export interface ModalProps {
   /** Modal content wrapper styles */
   style?: React.CSSProperties;
   /** Children */
-  children: ModalContent | ModalFooter | ReactNode;
+  children: ReactElement<ModalContentProps | ModalFooterProps> | ReactNode;
   /**
    * Variant. Use smallScreen for mobile and small displays
    * @default 'default'
@@ -200,21 +201,21 @@ const StyledModal = styled(BaseModal)`
  * Use for showing modal content.
  * NOTE: Modal hides the application root node from screen readers using the provided appElementId.
  */
-export class Modal extends Component<ModalProps> {
-  render() {
-    const { className: propClassName, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledModal
-            theme={suomifiTheme}
-            propClassName={propClassName}
-            {...passProps}
-          />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const Modal = (props: ModalProps) => {
+  const { className: propClassName, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledModal
+          theme={suomifiTheme}
+          propClassName={propClassName}
+          {...passProps}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
 
-export { ModalProvider, ModalConsumer };
+Modal.displayName = 'Modal';
+
+export { Modal, ModalProvider, ModalConsumer };

--- a/src/core/Modal/ModalContent/ModalContent.tsx
+++ b/src/core/Modal/ModalContent/ModalContent.tsx
@@ -64,23 +64,22 @@ const StyledModalContent = styled(BaseModalContent)`
  * Use for showing modal content.
  * Props other than specified explicitly are passed on to outermost content div.
  */
-export class ModalContent extends Component<ModalContentProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <ModalConsumer>
-            {({ variant, scrollable }) => (
-              <StyledModalContent
-                theme={suomifiTheme}
-                modalVariant={variant}
-                scrollable={scrollable}
-                {...this.props}
-              />
-            )}
-          </ModalConsumer>
+const ModalContent = (props: ModalContentProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <ModalConsumer>
+        {({ variant, scrollable }) => (
+          <StyledModalContent
+            theme={suomifiTheme}
+            modalVariant={variant}
+            scrollable={scrollable}
+            {...props}
+          />
         )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+      </ModalConsumer>
+    )}
+  </SuomifiThemeConsumer>
+);
+
+ModalContent.displayName = 'ModalContent';
+export { ModalContent };

--- a/src/core/Modal/ModalFooter/ModalFooter.tsx
+++ b/src/core/Modal/ModalFooter/ModalFooter.tsx
@@ -67,25 +67,26 @@ const StyledModalFooter = styled(BaseModalFooter)`
  * Applies variant specific spacings to immediate children.
  * Props other than specified explicitly are passed on to the content wrapping div.
  */
-export class ModalFooter extends Component<ModalFooterProps> {
-  render() {
-    const { className, ...passProps } = this.props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <ModalConsumer>
-            {({ variant, scrollable }) => (
-              <StyledModalFooter
-                modalVariant={variant}
-                scrollable={scrollable}
-                propClassName={className}
-                theme={suomifiTheme}
-                {...passProps}
-              />
-            )}
-          </ModalConsumer>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const ModalFooter = (props: ModalFooterProps) => {
+  const { className, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <ModalConsumer>
+          {({ variant, scrollable }) => (
+            <StyledModalFooter
+              modalVariant={variant}
+              scrollable={scrollable}
+              propClassName={className}
+              theme={suomifiTheme}
+              {...passProps}
+            />
+          )}
+        </ModalConsumer>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+ModalFooter.displayName = 'ModalFooter';
+export { ModalFooter };

--- a/src/core/Modal/ModalTitle/ModalTitle.tsx
+++ b/src/core/Modal/ModalTitle/ModalTitle.tsx
@@ -85,25 +85,24 @@ const StyledModalTitle = styled(BaseModalTitle)`
  * Id and smallScreen variant are provided by Modal context and cannot be given as props.
  * Children are wrapped in h2 heading and styled as h3 by default.
  */
-export class ModalTitle extends Component<ModalTitleProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <ModalConsumer>
-            {({ focusTitleOnOpen, titleRef, variant, scrollable }) => (
-              <StyledModalTitle
-                focusTitleOnOpen={focusTitleOnOpen}
-                {...(titleRef ? { titleRef } : {})}
-                modalVariant={variant}
-                scrollable={scrollable}
-                theme={suomifiTheme}
-                {...this.props}
-              />
-            )}
-          </ModalConsumer>
+const ModalTitle = (props: ModalTitleProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <ModalConsumer>
+        {({ focusTitleOnOpen, titleRef, variant, scrollable }) => (
+          <StyledModalTitle
+            focusTitleOnOpen={focusTitleOnOpen}
+            {...(titleRef ? { titleRef } : {})}
+            modalVariant={variant}
+            scrollable={scrollable}
+            theme={suomifiTheme}
+            {...props}
+          />
         )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+      </ModalConsumer>
+    )}
+  </SuomifiThemeConsumer>
+);
+
+ModalTitle.displayName = 'ModalTitle';
+export { ModalTitle };

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -166,7 +166,7 @@ const StyledNotification = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-export const Notification = forwardRef(
+const Notification = forwardRef(
   (props: NotificationProps, ref: React.RefObject<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
@@ -187,3 +187,6 @@ export const Notification = forwardRef(
     );
   },
 );
+
+Notification.displayName = 'Notification';
+export { Notification };

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SpacingWithoutInsetProp } from '../theme/utils/spacing';
@@ -35,16 +35,13 @@ const StyledParagraph = styled(
 `;
 
 /**
- * Used displaying Paragraph with correct styles
+ * Used for displaying a <p> element with correct styles
  */
-export class Paragraph extends Component<ParagraphProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledParagraph theme={suomifiTheme} {...this.props} />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const Paragraph = (props: ParagraphProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => <StyledParagraph theme={suomifiTheme} {...props} />}
+  </SuomifiThemeConsumer>
+);
+
+Paragraph.displayName = 'Paragraph';
+export { Paragraph };

--- a/src/core/StaticIcon/StaticIcon.tsx
+++ b/src/core/StaticIcon/StaticIcon.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { ariaLabelOrHidden, ariaFocusableNoLabel } from '../../utils/aria';
@@ -10,7 +10,6 @@ import {
 } from 'suomifi-icons';
 import {
   IconBaseProps,
-  iconLogger,
   cursorPointerClassName,
   baseClassName,
 } from '../Icon/Icon';
@@ -56,33 +55,20 @@ const StyledSuomifiStaticIcon = styled(
 /**
  * Static icon-component
  */
-export class StaticIcon extends Component<StaticIconProps> {
-  render() {
-    const { icon, className, mousePointer, ...passProps } = this.props;
-    const { ariaLabel } = this.props;
+const StaticIcon = (props: StaticIconProps) => {
+  const { className, mousePointer, ...passProps } = props;
 
-    if (icon !== undefined) {
-      return (
-        <StyledSuomifiStaticIcon
-          {...passProps}
-          icon={icon}
-          className={classnames(
-            baseClassName,
-            staticIconBaseClassName,
-            className,
-            {
-              [cursorPointerClassName]: !!mousePointer,
-            },
-          )}
-        />
-      );
-    }
+  return (
+    <StyledSuomifiStaticIcon
+      {...passProps}
+      className={classnames(baseClassName, staticIconBaseClassName, className, {
+        [cursorPointerClassName]: !!mousePointer,
+      })}
+    />
+  );
+};
 
-    iconLogger(ariaLabel, className);
-
-    return;
-  }
-}
+StaticIcon.displayName = 'StaticIcon';
 
 export interface ComponentIconProps
   extends IconBaseProps,
@@ -100,22 +86,17 @@ const StyledSuomifiComponentIcon = styled(
   ${staticIconBaseStyles}
 `;
 
-export class ComponentIcon extends Component<ComponentIconProps> {
-  render() {
-    const { icon, className, ariaLabel, ...passProps } = this.props;
-    if (icon !== undefined) {
-      return (
-        <StyledSuomifiComponentIcon
-          {...passProps}
-          ariaLabel={ariaLabel}
-          className={className}
-          icon={icon}
-        />
-      );
-    }
+const ComponentIcon = (props: ComponentIconProps) => {
+  const { className, ariaLabel, ...passProps } = props;
 
-    iconLogger(ariaLabel, className);
+  return (
+    <StyledSuomifiComponentIcon
+      {...passProps}
+      ariaLabel={ariaLabel}
+      className={className}
+    />
+  );
+};
 
-    return;
-  }
-}
+ComponentIcon.displayName = 'ComponentIcon';
+export { ComponentIcon, StaticIcon };

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { ColorProp, SuomifiThemeConsumer, SuomifiThemeProp } from '../theme';
@@ -46,16 +46,13 @@ const StyledText = styled(
 `;
 
 /**
- * Used displaying text with correct fonts
+ * Used for displaying text with correct fonts
  */
-export class Text extends Component<TextProps> {
-  render() {
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledText theme={suomifiTheme} {...this.props} />
-        )}
-      </SuomifiThemeConsumer>
-    );
-  }
-}
+const Text = (props: TextProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => <StyledText theme={suomifiTheme} {...props} />}
+  </SuomifiThemeConsumer>
+);
+
+Text.displayName = 'Text';
+export { Text };

--- a/src/core/Toast/Toast.tsx
+++ b/src/core/Toast/Toast.tsx
@@ -87,7 +87,8 @@ const StyledToast = styled(
 )`
   ${({ theme }) => baseStyles(theme)};
 `;
-export const Toast = forwardRef(
+
+const Toast = forwardRef(
   (props: ToastProps, ref: React.RefObject<HTMLDivElement>) => {
     const { ...passProps } = props;
     return (
@@ -99,3 +100,6 @@ export const Toast = forwardRef(
     );
   },
 );
+
+Toast.displayName = 'Toast';
+export { Toast };

--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -183,9 +183,12 @@ class BaseTooltip extends Component<
   }
 }
 
-export const Tooltip = forwardRef(
+const Tooltip = forwardRef(
   (props: TooltipProps, ref: React.RefObject<HTMLButtonElement>) => {
     const { ...passProps } = props;
     return <BaseTooltip forwardedRef={ref} {...passProps} />;
   },
 );
+
+Tooltip.displayName = 'Tooltip';
+export { Tooltip };

--- a/src/core/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/core/VisuallyHidden/VisuallyHidden.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlSpan, HtmlSpanProps } from '../../reset/HtmlSpan/HtmlSpan';
@@ -22,14 +22,15 @@ const StyledVisuallyHidden = styled((props: VisuallyHiddenProps) => (
   overflow: hidden;
 `;
 
-export class VisuallyHidden extends Component<VisuallyHiddenProps> {
-  render() {
-    const { className, ...passProps } = this.props;
-    return (
-      <StyledVisuallyHidden
-        {...passProps}
-        className={classnames(baseClassName, className)}
-      />
-    );
-  }
-}
+const VisuallyHidden = (props: VisuallyHiddenProps) => {
+  const { className, ...passProps } = props;
+  return (
+    <StyledVisuallyHidden
+      {...passProps}
+      className={classnames(baseClassName, className)}
+    />
+  );
+};
+
+VisuallyHidden.displayName = 'VisuallyHidden';
+export { VisuallyHidden };


### PR DESCRIPTION
## Description

This PR adds the `displayName` property to all exported components of the library.
Also convert all outer components to function components (in favor of class components) for a more unified codebase.

## Motivation and Context

This came up when creating a demo for a refurbished DS-site (https://github.com/riitasointi/ds-site-poc). When crafting component showcases, it became apparent the displayNames are missing from our components. 

## How Has This Been Tested?

In a CRA app and the DS-site demo NextJS project. 

## Release notes

* Add the `displayName` property to all components
