### PR TITLE
[Feature] Add all around margin & padding props to Block

### DIFF
--- a/src/core/Block/Block.baseStyles.ts
+++ b/src/core/Block/Block.baseStyles.ts
@@ -7,5 +7,13 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   ${spacingModifiers(theme)('margin')('&.fi-block--margin')}
+  ${spacingModifiers(theme)('margin-top')('&.fi-block--margin-top')}
+  ${spacingModifiers(theme)('margin-right')('&.fi-block--margin-right')}
+  ${spacingModifiers(theme)('margin-bottom')('&.fi-block--margin-bottom')}
+  ${spacingModifiers(theme)('margin-left')('&.fi-block--margin-left')}
   ${spacingModifiers(theme)('padding')('&.fi-block--padding')}
+  ${spacingModifiers(theme)('padding-top')('&.fi-block--padding-top')}
+  ${spacingModifiers(theme)('padding-right')('&.fi-block--padding-right')}
+  ${spacingModifiers(theme)('padding-bottom')('&.fi-block--padding-bottom')}
+  ${spacingModifiers(theme)('padding-left')('&.fi-block--padding-left')}
 `;

--- a/src/core/Block/Block.md
+++ b/src/core/Block/Block.md
@@ -7,13 +7,21 @@ import { Block } from 'suomifi-ui-components';
 ```js
 import { Block } from 'suomifi-ui-components';
 
-<Block padding="xxxl">Block with xl-padding</Block>;
+<Block padding="xxxl" style={{ border: '1px solid red' }}>
+  Block with xl-padding
+</Block>;
 ```
 
 ```js
 import { Block } from 'suomifi-ui-components';
 
-<Block pt="m" pr="l" pb="xl" pl="xxl">
+<Block
+  pt="s"
+  pr="l"
+  pb="xxl"
+  pl="xxxl"
+  style={{ border: '1px solid red' }}
+>
   Block with indepedent paddings on each side
 </Block>;
 ```

--- a/src/core/Block/Block.md
+++ b/src/core/Block/Block.md
@@ -13,5 +13,13 @@ import { Block } from 'suomifi-ui-components';
 ```js
 import { Block } from 'suomifi-ui-components';
 
+<Block pt="m" pr="l" pb="xl" pl="xxl">
+  Block with indepedent paddings on each side
+</Block>;
+```
+
+```js
+import { Block } from 'suomifi-ui-components';
+
 <Block variant="section">I'm semantically a section</Block>;
 ```

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -11,8 +11,32 @@ const baseClassName = 'fi-block';
 export interface BlockProps extends HtmlDivProps {
   /** Padding from theme */
   padding?: SpacingWithoutInsetProp;
+  /** Padding-top from theme */
+  pt?: SpacingWithoutInsetProp;
+  /** Padding-right from theme */
+  pr?: SpacingWithoutInsetProp;
+  /** Padding-bottom from theme */
+  pb?: SpacingWithoutInsetProp;
+  /** Padding-left from theme */
+  pl?: SpacingWithoutInsetProp;
+  /** Padding on the x-axis (left & right) from theme */
+  px?: SpacingWithoutInsetProp;
+  /** Padding on the y-axis (top & bottom) from theme */
+  py?: SpacingWithoutInsetProp;
   /** Margin from theme */
   margin?: SpacingWithoutInsetProp;
+  /** Margin-top from theme */
+  mt?: SpacingWithoutInsetProp;
+  /** Margin-right from theme */
+  mr?: SpacingWithoutInsetProp;
+  /** Margin-bottom from theme */
+  mb?: SpacingWithoutInsetProp;
+  /** Margin-left from theme */
+  ml?: SpacingWithoutInsetProp;
+  /** Margin on the x-axis (left & right) from theme */
+  mx?: SpacingWithoutInsetProp;
+  /** Margin on the y-axis (top & bottom) from theme */
+  my?: SpacingWithoutInsetProp;
   /**
    * Change block semantics
    * @default default
@@ -22,7 +46,25 @@ export interface BlockProps extends HtmlDivProps {
 
 class SemanticBlock extends Component<BlockProps> {
   render() {
-    const { className, variant, padding, margin, ...passProps } = this.props;
+    const {
+      className,
+      variant,
+      padding,
+      margin,
+      mt,
+      mr,
+      mb,
+      ml,
+      mx,
+      my,
+      pt,
+      pr,
+      pb,
+      pl,
+      px,
+      py,
+      ...passProps
+    } = this.props;
     const ComponentVariant =
       !variant || variant === 'default' ? HtmlDiv : variant;
     return (
@@ -32,6 +74,22 @@ class SemanticBlock extends Component<BlockProps> {
           [`${baseClassName}--padding-${padding}`]: !!padding,
           [`${baseClassName}--margin-${margin}`]: !!margin,
           [`${baseClassName}--${variant}`]: !!variant,
+          [`${baseClassName}--margin-top-${mt}`]: !!mt,
+          [`${baseClassName}--margin-right-${mr}`]: !!mr,
+          [`${baseClassName}--margin-bottom-${mb}`]: !!mb,
+          [`${baseClassName}--margin-left-${ml}`]: !!ml,
+          [`${baseClassName}--margin-left-${mx}`]: !!mx,
+          [`${baseClassName}--margin-right-${mx}`]: !!mx,
+          [`${baseClassName}--margin-top-${my}`]: !!my,
+          [`${baseClassName}--margin-bottom-${my}`]: !!my,
+          [`${baseClassName}--padding-top-${pt}`]: !!pt,
+          [`${baseClassName}--padding-right-${pr}`]: !!pr,
+          [`${baseClassName}--padding-bottop-${pb}`]: !!pb,
+          [`${baseClassName}--padding-left-${pl}`]: !!pl,
+          [`${baseClassName}--padding-left-${px}`]: !!px,
+          [`${baseClassName}--padding-right-${px}`]: !!px,
+          [`${baseClassName}--padding-top-${py}`]: !!py,
+          [`${baseClassName}--padding-bottom-${py}`]: !!py,
         })}
       />
     );

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -104,7 +104,7 @@ const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
 `;
 
 /**
- * Used in displaying a generic piece of HTML e.g. a <div>
+ * Used in displaying a generic piece of HTML e.g. a div
  */
 const Block = (props: BlockProps) => (
   <SuomifiThemeConsumer>

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -84,7 +84,7 @@ class SemanticBlock extends Component<BlockProps> {
           [`${baseClassName}--margin-bottom-${my}`]: !!my,
           [`${baseClassName}--padding-top-${pt}`]: !!pt,
           [`${baseClassName}--padding-right-${pr}`]: !!pr,
-          [`${baseClassName}--padding-bottop-${pb}`]: !!pb,
+          [`${baseClassName}--padding-bottom-${pb}`]: !!pb,
           [`${baseClassName}--padding-left-${pl}`]: !!pl,
           [`${baseClassName}--padding-left-${px}`]: !!px,
           [`${baseClassName}--padding-right-${px}`]: !!px,

--- a/src/core/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/core/Block/__snapshots__/Block.test.tsx.snap
@@ -111,6 +111,262 @@ exports[`calling render with the same component on the same container does not r
   margin: 20px;
 }
 
+.c1.fi-block--margin-top-xxs {
+  margin-top: 5px;
+}
+
+.c1.fi-block--margin-top-xs {
+  margin-top: 10px;
+}
+
+.c1.fi-block--margin-top-s {
+  margin-top: 15px;
+}
+
+.c1.fi-block--margin-top-m {
+  margin-top: 20px;
+}
+
+.c1.fi-block--margin-top-l {
+  margin-top: 25px;
+}
+
+.c1.fi-block--margin-top-xl {
+  margin-top: 30px;
+}
+
+.c1.fi-block--margin-top-xxl {
+  margin-top: 40px;
+}
+
+.c1.fi-block--margin-top-xxxl {
+  margin-top: 60px;
+}
+
+.c1.fi-block--margin-top-xxxxl {
+  margin-top: 80px;
+}
+
+.c1.fi-block--margin-top-insetXxs {
+  margin-top: 2px;
+}
+
+.c1.fi-block--margin-top-insetXs {
+  margin-top: 4px;
+}
+
+.c1.fi-block--margin-top-insetS {
+  margin-top: 6px;
+}
+
+.c1.fi-block--margin-top-insetM {
+  margin-top: 8px;
+}
+
+.c1.fi-block--margin-top-insetL {
+  margin-top: 10px;
+}
+
+.c1.fi-block--margin-top-insetXl {
+  margin-top: 16px;
+}
+
+.c1.fi-block--margin-top-insetXxl {
+  margin-top: 20px;
+}
+
+.c1.fi-block--margin-right-xxs {
+  margin-right: 5px;
+}
+
+.c1.fi-block--margin-right-xs {
+  margin-right: 10px;
+}
+
+.c1.fi-block--margin-right-s {
+  margin-right: 15px;
+}
+
+.c1.fi-block--margin-right-m {
+  margin-right: 20px;
+}
+
+.c1.fi-block--margin-right-l {
+  margin-right: 25px;
+}
+
+.c1.fi-block--margin-right-xl {
+  margin-right: 30px;
+}
+
+.c1.fi-block--margin-right-xxl {
+  margin-right: 40px;
+}
+
+.c1.fi-block--margin-right-xxxl {
+  margin-right: 60px;
+}
+
+.c1.fi-block--margin-right-xxxxl {
+  margin-right: 80px;
+}
+
+.c1.fi-block--margin-right-insetXxs {
+  margin-right: 2px;
+}
+
+.c1.fi-block--margin-right-insetXs {
+  margin-right: 4px;
+}
+
+.c1.fi-block--margin-right-insetS {
+  margin-right: 6px;
+}
+
+.c1.fi-block--margin-right-insetM {
+  margin-right: 8px;
+}
+
+.c1.fi-block--margin-right-insetL {
+  margin-right: 10px;
+}
+
+.c1.fi-block--margin-right-insetXl {
+  margin-right: 16px;
+}
+
+.c1.fi-block--margin-right-insetXxl {
+  margin-right: 20px;
+}
+
+.c1.fi-block--margin-bottom-xxs {
+  margin-bottom: 5px;
+}
+
+.c1.fi-block--margin-bottom-xs {
+  margin-bottom: 10px;
+}
+
+.c1.fi-block--margin-bottom-s {
+  margin-bottom: 15px;
+}
+
+.c1.fi-block--margin-bottom-m {
+  margin-bottom: 20px;
+}
+
+.c1.fi-block--margin-bottom-l {
+  margin-bottom: 25px;
+}
+
+.c1.fi-block--margin-bottom-xl {
+  margin-bottom: 30px;
+}
+
+.c1.fi-block--margin-bottom-xxl {
+  margin-bottom: 40px;
+}
+
+.c1.fi-block--margin-bottom-xxxl {
+  margin-bottom: 60px;
+}
+
+.c1.fi-block--margin-bottom-xxxxl {
+  margin-bottom: 80px;
+}
+
+.c1.fi-block--margin-bottom-insetXxs {
+  margin-bottom: 2px;
+}
+
+.c1.fi-block--margin-bottom-insetXs {
+  margin-bottom: 4px;
+}
+
+.c1.fi-block--margin-bottom-insetS {
+  margin-bottom: 6px;
+}
+
+.c1.fi-block--margin-bottom-insetM {
+  margin-bottom: 8px;
+}
+
+.c1.fi-block--margin-bottom-insetL {
+  margin-bottom: 10px;
+}
+
+.c1.fi-block--margin-bottom-insetXl {
+  margin-bottom: 16px;
+}
+
+.c1.fi-block--margin-bottom-insetXxl {
+  margin-bottom: 20px;
+}
+
+.c1.fi-block--margin-left-xxs {
+  margin-left: 5px;
+}
+
+.c1.fi-block--margin-left-xs {
+  margin-left: 10px;
+}
+
+.c1.fi-block--margin-left-s {
+  margin-left: 15px;
+}
+
+.c1.fi-block--margin-left-m {
+  margin-left: 20px;
+}
+
+.c1.fi-block--margin-left-l {
+  margin-left: 25px;
+}
+
+.c1.fi-block--margin-left-xl {
+  margin-left: 30px;
+}
+
+.c1.fi-block--margin-left-xxl {
+  margin-left: 40px;
+}
+
+.c1.fi-block--margin-left-xxxl {
+  margin-left: 60px;
+}
+
+.c1.fi-block--margin-left-xxxxl {
+  margin-left: 80px;
+}
+
+.c1.fi-block--margin-left-insetXxs {
+  margin-left: 2px;
+}
+
+.c1.fi-block--margin-left-insetXs {
+  margin-left: 4px;
+}
+
+.c1.fi-block--margin-left-insetS {
+  margin-left: 6px;
+}
+
+.c1.fi-block--margin-left-insetM {
+  margin-left: 8px;
+}
+
+.c1.fi-block--margin-left-insetL {
+  margin-left: 10px;
+}
+
+.c1.fi-block--margin-left-insetXl {
+  margin-left: 16px;
+}
+
+.c1.fi-block--margin-left-insetXxl {
+  margin-left: 20px;
+}
+
 .c1.fi-block--padding-xxs {
   padding: 5px;
 }
@@ -173,6 +429,262 @@ exports[`calling render with the same component on the same container does not r
 
 .c1.fi-block--padding-insetXxl {
   padding: 20px;
+}
+
+.c1.fi-block--padding-top-xxs {
+  padding-top: 5px;
+}
+
+.c1.fi-block--padding-top-xs {
+  padding-top: 10px;
+}
+
+.c1.fi-block--padding-top-s {
+  padding-top: 15px;
+}
+
+.c1.fi-block--padding-top-m {
+  padding-top: 20px;
+}
+
+.c1.fi-block--padding-top-l {
+  padding-top: 25px;
+}
+
+.c1.fi-block--padding-top-xl {
+  padding-top: 30px;
+}
+
+.c1.fi-block--padding-top-xxl {
+  padding-top: 40px;
+}
+
+.c1.fi-block--padding-top-xxxl {
+  padding-top: 60px;
+}
+
+.c1.fi-block--padding-top-xxxxl {
+  padding-top: 80px;
+}
+
+.c1.fi-block--padding-top-insetXxs {
+  padding-top: 2px;
+}
+
+.c1.fi-block--padding-top-insetXs {
+  padding-top: 4px;
+}
+
+.c1.fi-block--padding-top-insetS {
+  padding-top: 6px;
+}
+
+.c1.fi-block--padding-top-insetM {
+  padding-top: 8px;
+}
+
+.c1.fi-block--padding-top-insetL {
+  padding-top: 10px;
+}
+
+.c1.fi-block--padding-top-insetXl {
+  padding-top: 16px;
+}
+
+.c1.fi-block--padding-top-insetXxl {
+  padding-top: 20px;
+}
+
+.c1.fi-block--padding-right-xxs {
+  padding-right: 5px;
+}
+
+.c1.fi-block--padding-right-xs {
+  padding-right: 10px;
+}
+
+.c1.fi-block--padding-right-s {
+  padding-right: 15px;
+}
+
+.c1.fi-block--padding-right-m {
+  padding-right: 20px;
+}
+
+.c1.fi-block--padding-right-l {
+  padding-right: 25px;
+}
+
+.c1.fi-block--padding-right-xl {
+  padding-right: 30px;
+}
+
+.c1.fi-block--padding-right-xxl {
+  padding-right: 40px;
+}
+
+.c1.fi-block--padding-right-xxxl {
+  padding-right: 60px;
+}
+
+.c1.fi-block--padding-right-xxxxl {
+  padding-right: 80px;
+}
+
+.c1.fi-block--padding-right-insetXxs {
+  padding-right: 2px;
+}
+
+.c1.fi-block--padding-right-insetXs {
+  padding-right: 4px;
+}
+
+.c1.fi-block--padding-right-insetS {
+  padding-right: 6px;
+}
+
+.c1.fi-block--padding-right-insetM {
+  padding-right: 8px;
+}
+
+.c1.fi-block--padding-right-insetL {
+  padding-right: 10px;
+}
+
+.c1.fi-block--padding-right-insetXl {
+  padding-right: 16px;
+}
+
+.c1.fi-block--padding-right-insetXxl {
+  padding-right: 20px;
+}
+
+.c1.fi-block--padding-bottom-xxs {
+  padding-bottom: 5px;
+}
+
+.c1.fi-block--padding-bottom-xs {
+  padding-bottom: 10px;
+}
+
+.c1.fi-block--padding-bottom-s {
+  padding-bottom: 15px;
+}
+
+.c1.fi-block--padding-bottom-m {
+  padding-bottom: 20px;
+}
+
+.c1.fi-block--padding-bottom-l {
+  padding-bottom: 25px;
+}
+
+.c1.fi-block--padding-bottom-xl {
+  padding-bottom: 30px;
+}
+
+.c1.fi-block--padding-bottom-xxl {
+  padding-bottom: 40px;
+}
+
+.c1.fi-block--padding-bottom-xxxl {
+  padding-bottom: 60px;
+}
+
+.c1.fi-block--padding-bottom-xxxxl {
+  padding-bottom: 80px;
+}
+
+.c1.fi-block--padding-bottom-insetXxs {
+  padding-bottom: 2px;
+}
+
+.c1.fi-block--padding-bottom-insetXs {
+  padding-bottom: 4px;
+}
+
+.c1.fi-block--padding-bottom-insetS {
+  padding-bottom: 6px;
+}
+
+.c1.fi-block--padding-bottom-insetM {
+  padding-bottom: 8px;
+}
+
+.c1.fi-block--padding-bottom-insetL {
+  padding-bottom: 10px;
+}
+
+.c1.fi-block--padding-bottom-insetXl {
+  padding-bottom: 16px;
+}
+
+.c1.fi-block--padding-bottom-insetXxl {
+  padding-bottom: 20px;
+}
+
+.c1.fi-block--padding-left-xxs {
+  padding-left: 5px;
+}
+
+.c1.fi-block--padding-left-xs {
+  padding-left: 10px;
+}
+
+.c1.fi-block--padding-left-s {
+  padding-left: 15px;
+}
+
+.c1.fi-block--padding-left-m {
+  padding-left: 20px;
+}
+
+.c1.fi-block--padding-left-l {
+  padding-left: 25px;
+}
+
+.c1.fi-block--padding-left-xl {
+  padding-left: 30px;
+}
+
+.c1.fi-block--padding-left-xxl {
+  padding-left: 40px;
+}
+
+.c1.fi-block--padding-left-xxxl {
+  padding-left: 60px;
+}
+
+.c1.fi-block--padding-left-xxxxl {
+  padding-left: 80px;
+}
+
+.c1.fi-block--padding-left-insetXxs {
+  padding-left: 2px;
+}
+
+.c1.fi-block--padding-left-insetXs {
+  padding-left: 4px;
+}
+
+.c1.fi-block--padding-left-insetS {
+  padding-left: 6px;
+}
+
+.c1.fi-block--padding-left-insetM {
+  padding-left: 8px;
+}
+
+.c1.fi-block--padding-left-insetL {
+  padding-left: 10px;
+}
+
+.c1.fi-block--padding-left-insetXl {
+  padding-left: 16px;
+}
+
+.c1.fi-block--padding-left-insetXxl {
+  padding-left: 20px;
 }
 
 <div

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -76,7 +76,19 @@ export const padding = (theme: SuomifiTheme) => space(theme)('padding');
  */
 export const spacingModifiers =
   (theme: SuomifiTheme) =>
-  (spacing: 'padding' | 'margin' | 'margin-bottom') =>
+  (
+    spacing:
+      | 'padding'
+      | 'padding-top'
+      | 'padding-right'
+      | 'padding-bottom'
+      | 'padding-left'
+      | 'margin'
+      | 'margin-top'
+      | 'margin-right'
+      | 'margin-bottom'
+      | 'margin-left',
+  ) =>
   (selector: string) =>
     spacingTokensKeys.reduce(
       (ret, k) =>


### PR DESCRIPTION
## Description

This PR introduces new props to the `<Block>` component. Margins and paddings can now be added separately to all sides of the component as well as to the x-axis and y-axis.

## Motivation and Context

Make the `<Block>` component more usable as a wrapper

## How Has This Been Tested?

Styleguidist

## Release notes

### Block
* Add separate props for margin & padding to each side. The props accept suomifi-design-token spacing values.
  - mt (margin-top)
  - mr (margin-right)
  - mb (margin-bottom)
  - ml (margin-left)
  - mx (margin-left & margin-right)
  - my (margin-top & margin-bottom)
  - pt (padding-top)
  - pr (padding-right)
  - pb (padding-bottom)
  - pl (padding-left)
  - px (padding-left & padding-right)
  - py (padding-top & padding-bottom)
