### PR TITLE
[Feature] ServiceNavigation

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -207,7 +207,14 @@ module.exports = {
             'WizardNavigation/WizardNavigation',
             'WizardNavigationItem/WizardNavigationItem',
           ]),
-        }
+        },
+        {
+          name: 'ServiceNavigation',
+          components: getComponentWithVariants('Navigation/ServiceNavigation')([
+            'ServiceNavigation/ServiceNavigation',
+            'ServiceNavigationItem/ServiceNavigationItem',
+          ]),
+        },
       ],
       sectionDepth: 1,
       expand: true,

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -1,0 +1,14 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodyText')}
+  &.fi-service-navigation {
+    & .fi-service-navigation_list {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+    }
+  }
+`;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -5,7 +5,24 @@ import { SuomifiTheme } from '../../../theme';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')}
   &.fi-service-navigation {
-    & .fi-service-navigation_list {
+    &--small-screen {
+      background: ${theme.colors.highlightLight3};
+      .fi-service-navigation_expand-button {
+        ${font(theme)('heading4')}
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: ${theme.spacing.m};
+        border: 1px solid ${theme.colors.highlightLight2};
+
+        .fi-icon {
+          height: 25px;
+          width: 25px;
+        }
+      }
+    }
+    .fi-service-navigation_list {
       list-style-type: none;
       margin: 0;
       padding: 0;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -7,6 +7,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-service-navigation {
     &--small-screen {
       background: ${theme.colors.highlightLight3};
+      .fi-service-navigation-item,
+      .fi-service-navigation-item--selected {
+        border-bottom: 1px solid ${theme.colors.whiteBase};
+      }
       .fi-service-navigation_expand-button {
         ${font(theme)('heading4')}
         position: relative;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -9,12 +9,20 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       background: ${theme.colors.highlightLight3};
       .fi-service-navigation_expand-button {
         ${font(theme)('heading4')}
+        position: relative;
         width: 100%;
         display: flex;
         justify-content: space-between;
         align-items: center;
         padding: ${theme.spacing.m};
         border: 1px solid ${theme.colors.highlightLight2};
+
+        &:focus {
+          outline: 0;
+          &:after {
+            ${theme.focus.absoluteFocus}
+          }
+        }
 
         .fi-icon {
           height: 25px;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -21,6 +21,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         padding: ${theme.spacing.m};
         border: 1px solid ${theme.colors.highlightLight2};
 
+        .fi-service-navigation_expand-button_text-wrapper {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
         &:focus {
           outline: 0;
           &:after {

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
@@ -63,7 +63,9 @@ const CustomButton = (props) => {
       </RouterLink>
     </ServiceNavigationItem>
     <ServiceNavigationItem disabled>
-      <RouterLink href="https://www.suomi.fi">Devices</RouterLink>
+      <RouterLink role="link" aria-disabled tabIndex={-1}>
+        Devices
+      </RouterLink>
     </ServiceNavigationItem>
   </ServiceNavigation>
 </div>;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
@@ -1,0 +1,67 @@
+```js
+import {
+  ServiceNavigation,
+  ServiceNavigationItem,
+  RouterLink,
+  ExternalLink,
+  StaticChip
+} from 'suomifi-ui-components';
+
+const Comp = (props) => {
+  const { children, ...passProps } = props;
+  return <div {...passProps}>{props.children}</div>;
+};
+
+<div style={{ width: '300px' }}>
+  <ServiceNavigation>
+    <ServiceNavigationItem aria-label="16 unread messages">
+      <RouterLink href="/">
+        Inbox
+        <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
+          16
+        </StaticChip>
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://suomi.fi"
+        hideIcon
+      >
+        Sent
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem selected ariaCurrent="page">
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        New Message
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        Drafts
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={Comp}
+        onClick={() => console.log('Nav item clicked')}
+        role="button"
+        tabIndex="0"
+      >
+        Settings
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem disabled>
+      <RouterLink>Devices</RouterLink>
+    </ServiceNavigationItem>
+  </ServiceNavigation>
+</div>;
+```

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
@@ -35,11 +35,12 @@ const CustomButton = (props) => {
         Sent
       </RouterLink>
     </ServiceNavigationItem>
-    <ServiceNavigationItem selected ariaCurrent="page">
+    <ServiceNavigationItem selected>
       <RouterLink
         asComponent={ExternalLink}
         href="https://www.suomi.fi"
         hideIcon
+        aria-current="page"
       >
         New Message
       </RouterLink>
@@ -130,15 +131,12 @@ const expandButtonContent = (
         New Message
       </RouterLink>
     </ServiceNavigationItem>
-    <ServiceNavigationItem
-      selected
-      ariaCurrent="page"
-      aria-label="3 draft messages"
-    >
+    <ServiceNavigationItem selected aria-label="3 draft messages">
       <RouterLink
         asComponent={ExternalLink}
         href="https://www.suomi.fi"
         hideIcon
+        aria-current="page"
       >
         Drafts
         <StaticChip style={{ marginLeft: '15px' }} aria-hidden>

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
@@ -63,7 +63,7 @@ const CustomButton = (props) => {
       </RouterLink>
     </ServiceNavigationItem>
     <ServiceNavigationItem disabled>
-      <RouterLink role="link" aria-disabled tabIndex={-1}>
+      <RouterLink role="link" aria-disabled>
         Devices
       </RouterLink>
     </ServiceNavigationItem>
@@ -150,7 +150,9 @@ const Comp = (props) => {
       </RouterLink>
     </ServiceNavigationItem>
     <ServiceNavigationItem disabled>
-      <RouterLink href="https://www.suomi.fi">Devices</RouterLink>
+      <RouterLink role="link" aria-disabled>
+        Devices
+      </RouterLink>
     </ServiceNavigationItem>
   </ServiceNavigation>
 </div>;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
@@ -63,7 +63,7 @@ const CustomButton = (props) => {
       </RouterLink>
     </ServiceNavigationItem>
     <ServiceNavigationItem disabled>
-      <RouterLink>Devices</RouterLink>
+      <RouterLink href="https://www.suomi.fi">Devices</RouterLink>
     </ServiceNavigationItem>
   </ServiceNavigation>
 </div>;
@@ -95,19 +95,10 @@ const Comp = (props) => {
   return <div {...passProps}>{props.children}</div>;
 };
 
-const expandButtonContent = (
-  <>
-    <span>DRAFTS</span>
-    <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
-      3
-    </StaticChip>
-  </>
-);
-
 <div style={{ width: '300px' }}>
   <ServiceNavigation
     variant="smallScreen"
-    smallScreenExpandButtonText={expandButtonContent}
+    smallScreenExpandButtonText="Menu"
     initiallyExpanded={false}
   >
     <ServiceNavigationItem>
@@ -156,7 +147,7 @@ const expandButtonContent = (
       </RouterLink>
     </ServiceNavigationItem>
     <ServiceNavigationItem disabled>
-      <RouterLink>Devices</RouterLink>
+      <RouterLink href="https://www.suomi.fi">Devices</RouterLink>
     </ServiceNavigationItem>
   </ServiceNavigation>
 </div>;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
@@ -17,7 +17,7 @@ const CustomButton = (props) => {
 };
 
 <div style={{ width: '300px' }}>
-  <ServiceNavigation>
+  <ServiceNavigation aria-label="Main">
     <ServiceNavigationItem>
       <RouterLink href="/" aria-label="Inbox. 16 unread messages.">
         Inbox
@@ -102,6 +102,7 @@ const Comp = (props) => {
     variant="smallScreen"
     smallScreenExpandButtonText="Menu"
     initiallyExpanded={false}
+    aria-label="Main"
   >
     <ServiceNavigationItem>
       <RouterLink href="/">Inbox</RouterLink>

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
@@ -1,3 +1,7 @@
+### Basic usage
+
+Please use `<RouterLink>` as the child of `<ServiceNavigationItem>` to get inteded CSS styles. `<RouterLink>` is polymorphic, and can be rendered as any component of your choice, for example React Router Link.
+
 ```js
 import {
   ServiceNavigation,
@@ -7,9 +11,9 @@ import {
   StaticChip
 } from 'suomifi-ui-components';
 
-const Comp = (props) => {
+const CustomButton = (props) => {
   const { children, ...passProps } = props;
-  return <div {...passProps}>{props.children}</div>;
+  return <button {...passProps}>{props.children}</button>;
 };
 
 <div style={{ width: '300px' }}>
@@ -47,6 +51,99 @@ const Comp = (props) => {
         hideIcon
       >
         Drafts
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={CustomButton}
+        onClick={() => console.log('Nav item clicked')}
+      >
+        Settings
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem disabled>
+      <RouterLink>Devices</RouterLink>
+    </ServiceNavigationItem>
+  </ServiceNavigation>
+</div>;
+```
+
+For frameworks where its internal link component is used as a wrapper for the actual link, for example NextJS, the following approach can be used:
+
+```jsx static
+<ServiceNavigationItem>
+  <NextJSLink href="/some-route" passHref>
+    <RouterLink>Inbox</RouterLink>
+  </NextJSLink>
+</ServiceNavigationItem>
+```
+
+### Small screen variant
+
+```js
+import {
+  ServiceNavigation,
+  ServiceNavigationItem,
+  RouterLink,
+  ExternalLink,
+  StaticChip
+} from 'suomifi-ui-components';
+
+const Comp = (props) => {
+  const { children, ...passProps } = props;
+  return <div {...passProps}>{props.children}</div>;
+};
+
+const expandButtonContent = (
+  <>
+    <span>DRAFTS</span>
+    <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
+      3
+    </StaticChip>
+  </>
+);
+
+<div style={{ width: '300px' }}>
+  <ServiceNavigation
+    variant="smallScreen"
+    smallScreenExpandButtonText={expandButtonContent}
+    initiallyExpanded={false}
+  >
+    <ServiceNavigationItem>
+      <RouterLink href="/">Inbox</RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://suomi.fi"
+        hideIcon
+      >
+        Sent
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        New Message
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem
+      selected
+      ariaCurrent="page"
+      aria-label="3 draft messages"
+    >
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        Drafts
+        <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
+          3
+        </StaticChip>
       </RouterLink>
     </ServiceNavigationItem>
     <ServiceNavigationItem>

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
@@ -18,8 +18,8 @@ const CustomButton = (props) => {
 
 <div style={{ width: '300px' }}>
   <ServiceNavigation>
-    <ServiceNavigationItem aria-label="16 unread messages">
-      <RouterLink href="/">
+    <ServiceNavigationItem>
+      <RouterLink href="/" aria-label="Inbox. 16 unread messages.">
         Inbox
         <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
           16
@@ -131,12 +131,13 @@ const expandButtonContent = (
         New Message
       </RouterLink>
     </ServiceNavigationItem>
-    <ServiceNavigationItem selected aria-label="3 draft messages">
+    <ServiceNavigationItem selected>
       <RouterLink
         asComponent={ExternalLink}
         href="https://www.suomi.fi"
         hideIcon
         aria-current="page"
+        aria-label="Drafts. 3 drafts waiting."
       >
         Drafts
         <StaticChip style={{ marginLeft: '15px' }} aria-hidden>

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
@@ -21,14 +21,11 @@ const Comp = ({ children, ...passProps }: TestProps) => (
 const TestServiceNavigation = (
   <ServiceNavigation>
     <ServiceNavigationItem aria-label="16 unread messages">
-      <RouterLink
-        asComponent={Comp}
-        onClick={() => console.log('Nav item clicked')}
-        role="button"
-        tabIndex={0}
-      >
+      <RouterLink href="/">
         Inbox
-        <StaticChip style={{ marginLeft: '15px' }}>16</StaticChip>
+        <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
+          16
+        </StaticChip>
       </RouterLink>
     </ServiceNavigationItem>
     <ServiceNavigationItem>
@@ -36,11 +33,12 @@ const TestServiceNavigation = (
         Sent
       </RouterLink>
     </ServiceNavigationItem>
-    <ServiceNavigationItem selected ariaCurrent="page">
+    <ServiceNavigationItem selected>
       <RouterLink
         asComponent={ExternalLink}
         href="https://www.suomi.fi"
         hideIcon
+        aria-current="page"
       >
         New Message
       </RouterLink>
@@ -56,20 +54,19 @@ const TestServiceNavigation = (
     </ServiceNavigationItem>
     <ServiceNavigationItem>
       <RouterLink
-        asComponent={ExternalLink}
-        href="https://www.suomi.fi"
-        hideIcon
+        asComponent={Comp}
+        onClick={() => console.log('Nav item clicked')}
       >
         Settings
       </RouterLink>
     </ServiceNavigationItem>
-    <ServiceNavigationItem>
+    <ServiceNavigationItem disabled>
       <RouterLink>Devices</RouterLink>
     </ServiceNavigationItem>
   </ServiceNavigation>
 );
 
-test('calling render with the same component on the same container does not remount', () => {
+it('should match snapshot', () => {
   const NavRendered = render(TestServiceNavigation);
   const { container } = NavRendered;
   expect(container.firstChild).toMatchSnapshot();

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
@@ -19,56 +19,54 @@ const Comp = ({ children, ...passProps }: TestProps) => (
 );
 
 const TestServiceNavigation = (
-  <div data-testid="test-paragraph">
-    <ServiceNavigation>
-      <ServiceNavigationItem aria-label="16 unread messages">
-        <RouterLink
-          asComponent={Comp}
-          onClick={() => console.log('Nav item clicked')}
-          role="button"
-          tabIndex={0}
-        >
-          Inbox
-          <StaticChip style={{ marginLeft: '15px' }}>16</StaticChip>
-        </RouterLink>
-      </ServiceNavigationItem>
-      <ServiceNavigationItem>
-        <RouterLink asComponent={ExternalLink} href="https://suomi.fi" hideIcon>
-          Sent
-        </RouterLink>
-      </ServiceNavigationItem>
-      <ServiceNavigationItem selected ariaCurrent="page">
-        <RouterLink
-          asComponent={ExternalLink}
-          href="https://www.suomi.fi"
-          hideIcon
-        >
-          New Message
-        </RouterLink>
-      </ServiceNavigationItem>
-      <ServiceNavigationItem>
-        <RouterLink
-          asComponent={ExternalLink}
-          href="https://www.suomi.fi"
-          hideIcon
-        >
-          Drafts
-        </RouterLink>
-      </ServiceNavigationItem>
-      <ServiceNavigationItem>
-        <RouterLink
-          asComponent={ExternalLink}
-          href="https://www.suomi.fi"
-          hideIcon
-        >
-          Settings
-        </RouterLink>
-      </ServiceNavigationItem>
-      <ServiceNavigationItem>
-        <RouterLink>Devices</RouterLink>
-      </ServiceNavigationItem>
-    </ServiceNavigation>
-  </div>
+  <ServiceNavigation>
+    <ServiceNavigationItem aria-label="16 unread messages">
+      <RouterLink
+        asComponent={Comp}
+        onClick={() => console.log('Nav item clicked')}
+        role="button"
+        tabIndex={0}
+      >
+        Inbox
+        <StaticChip style={{ marginLeft: '15px' }}>16</StaticChip>
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink asComponent={ExternalLink} href="https://suomi.fi" hideIcon>
+        Sent
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem selected ariaCurrent="page">
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        New Message
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        Drafts
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        Settings
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink>Devices</RouterLink>
+    </ServiceNavigationItem>
+  </ServiceNavigation>
 );
 
 test('calling render with the same component on the same container does not remount', () => {

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axeTest } from '../../../../utils/test';
+
+import { ServiceNavigation } from './ServiceNavigation';
+import { ServiceNavigationItem } from '../ServiceNavigationItem/ServiceNavigationItem';
+import { ExternalLink, RouterLink } from '../../../Link';
+import { StaticChip } from '../../../Chip';
+
+interface TestProps {
+  children: string;
+  onClick?: () => void;
+  role?: string;
+  tabIndex?: number;
+}
+
+const Comp = ({ children, ...passProps }: TestProps) => (
+  <div {...passProps}>{children}</div>
+);
+
+const TestServiceNavigation = (
+  <div data-testid="test-paragraph">
+    <ServiceNavigation>
+      <ServiceNavigationItem aria-label="16 unread messages">
+        <RouterLink
+          asComponent={Comp}
+          onClick={() => console.log('Nav item clicked')}
+          role="button"
+          tabIndex={0}
+        >
+          Inbox
+          <StaticChip style={{ marginLeft: '15px' }}>16</StaticChip>
+        </RouterLink>
+      </ServiceNavigationItem>
+      <ServiceNavigationItem>
+        <RouterLink asComponent={ExternalLink} href="https://suomi.fi" hideIcon>
+          Sent
+        </RouterLink>
+      </ServiceNavigationItem>
+      <ServiceNavigationItem selected ariaCurrent="page">
+        <RouterLink
+          asComponent={ExternalLink}
+          href="https://www.suomi.fi"
+          hideIcon
+        >
+          New Message
+        </RouterLink>
+      </ServiceNavigationItem>
+      <ServiceNavigationItem>
+        <RouterLink
+          asComponent={ExternalLink}
+          href="https://www.suomi.fi"
+          hideIcon
+        >
+          Drafts
+        </RouterLink>
+      </ServiceNavigationItem>
+      <ServiceNavigationItem>
+        <RouterLink
+          asComponent={ExternalLink}
+          href="https://www.suomi.fi"
+          hideIcon
+        >
+          Settings
+        </RouterLink>
+      </ServiceNavigationItem>
+      <ServiceNavigationItem>
+        <RouterLink>Devices</RouterLink>
+      </ServiceNavigationItem>
+    </ServiceNavigation>
+  </div>
+);
+
+test('calling render with the same component on the same container does not remount', () => {
+  const ParagraphRendered = render(TestServiceNavigation);
+  const { container } = ParagraphRendered;
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test(
+  'should not have basic accessibility issues',
+  axeTest(TestServiceNavigation),
+);

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
@@ -70,8 +70,8 @@ const TestServiceNavigation = (
 );
 
 test('calling render with the same component on the same container does not remount', () => {
-  const ParagraphRendered = render(TestServiceNavigation);
-  const { container } = ParagraphRendered;
+  const NavRendered = render(TestServiceNavigation);
+  const { container } = NavRendered;
   expect(container.firstChild).toMatchSnapshot();
 });
 

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
@@ -20,8 +20,8 @@ const Comp = ({ children, ...passProps }: TestProps) => (
 
 const TestServiceNavigation = (
   <ServiceNavigation>
-    <ServiceNavigationItem aria-label="16 unread messages">
-      <RouterLink href="/">
+    <ServiceNavigationItem>
+      <RouterLink href="/" aria-label="Inbox. 16 unread messages.">
         Inbox
         <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
           16

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
@@ -19,7 +19,7 @@ const Comp = ({ children, ...passProps }: TestProps) => (
 );
 
 const TestServiceNavigation = (
-  <ServiceNavigation>
+  <ServiceNavigation aria-label="Test">
     <ServiceNavigationItem>
       <RouterLink href="/" aria-label="Inbox. 16 unread messages.">
         Inbox

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -25,8 +25,7 @@ export interface ServiceNavigationProps {
    * @default true
    */
   initiallyExpanded?: boolean;
-  /** When using smallScreen variant, this is the text showed in the expander button.
-   * Intended to be the same text as the currently selected nav item.  */
+  /** When using smallScreen variant, this is the text showed in the expander button */
   smallScreenExpandButtonText?: string | ReactNode;
   /** Custom classname to extend or customize */
   className?: string;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -11,7 +11,7 @@ export interface ServiceNavigationProps {
    * Normal or small screen variant
    * @default normal
    */
-  variant: 'normal' | 'smallScreen';
+  variant?: 'normal' | 'smallScreen';
   /** Custom classname to extend or customize */
   className?: string;
 }

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -1,9 +1,16 @@
-import React, { ReactNode } from 'react';
-import { HtmlNav, HtmlUl } from '../../../../reset';
+import React, { ReactNode, useState } from 'react';
+import {
+  HtmlButton,
+  HtmlDiv,
+  HtmlNav,
+  HtmlSpan,
+  HtmlUl,
+} from '../../../../reset';
 import styled from 'styled-components';
 import { SuomifiThemeConsumer } from '../../../theme';
 import { baseStyles } from './ServiceNavigation.baseStyles';
 import classnames from 'classnames';
+import { Icon } from '../../../Icon/Icon';
 
 export interface ServiceNavigationProps {
   children: ReactNode | ReactNode[];
@@ -11,31 +18,69 @@ export interface ServiceNavigationProps {
    * Normal or small screen variant
    * @default normal
    */
-  variant?: 'normal' | 'smallScreen';
+  variant?: 'default' | 'smallScreen';
+  /**
+   * Whether the menu is initially expanded. Only applies to smallScreen variant.
+   * @default true
+   */
+  initiallyExpanded?: boolean;
+  /** When using smallScreen variant, this is the text showed in the expander button.
+   * Intended to be the same text as the currently selected nav item.  */
+  smallScreenExpandButtonText?: string | ReactNode;
   /** Custom classname to extend or customize */
   className?: string;
 }
 
 const baseClassName = 'fi-service-navigation';
+const smallScreenClassName = `${baseClassName}--small-screen`;
 const listClassName = `${baseClassName}_list`;
+const smallScreenExpandButtonClassName = `${baseClassName}_expand-button`;
 
 const BaseServiceNavigation = ({
   children,
   variant,
+  initiallyExpanded,
+  smallScreenExpandButtonText,
   className,
-}: ServiceNavigationProps) => (
-  // Throws TS error without fragments
-  /* eslint-disable react/jsx-no-useless-fragment */
-  <>
-    {variant === 'smallScreen' ? (
-      <div>Nope</div>
-    ) : (
-      <HtmlNav className={classnames(baseClassName, className)}>
-        <HtmlUl className={listClassName}>{children}</HtmlUl>
-      </HtmlNav>
-    )}
-  </>
-);
+}: ServiceNavigationProps) => {
+  const initiallyExpandedValue =
+    initiallyExpanded !== undefined ? initiallyExpanded : true;
+  const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
+    initiallyExpandedValue,
+  );
+  return (
+    <HtmlDiv
+      className={classnames(baseClassName, className, {
+        [smallScreenClassName]: variant === 'smallScreen',
+      })}
+    >
+      {variant === 'smallScreen' && (
+        <HtmlButton
+          className={smallScreenExpandButtonClassName}
+          onClick={() => setSmallScreenNavOpen(!smallScreenNavOpen)}
+          aria-expanded={smallScreenNavOpen}
+        >
+          <HtmlSpan
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            {smallScreenExpandButtonText}
+          </HtmlSpan>
+          <Icon icon={smallScreenNavOpen ? 'chevronDown' : 'chevronRight'} />
+        </HtmlButton>
+      )}
+      {((variant === 'smallScreen' && smallScreenNavOpen) ||
+        variant !== 'smallScreen') && (
+        <HtmlNav>
+          <HtmlUl className={listClassName}>{children}</HtmlUl>
+        </HtmlNav>
+      )}
+    </HtmlDiv>
+  );
+};
 
 const StyledServiceNavigation = styled(BaseServiceNavigation)`
   ${({ theme }) => baseStyles(theme)}

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -42,6 +42,7 @@ const baseClassName = 'fi-service-navigation';
 const smallScreenClassName = `${baseClassName}--small-screen`;
 const listClassName = `${baseClassName}_list`;
 const smallScreenExpandButtonClassName = `${baseClassName}_expand-button`;
+const buttonTextClassName = `${baseClassName}_expand-button_text-wrapper`;
 
 const BaseServiceNavigation = ({
   children,
@@ -71,13 +72,7 @@ const BaseServiceNavigation = ({
           onClick={() => setSmallScreenNavOpen(!smallScreenNavOpen)}
           aria-expanded={smallScreenNavOpen}
         >
-          <HtmlSpan
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-            }}
-          >
+          <HtmlSpan className={buttonTextClassName}>
             {smallScreenExpandButtonText}
           </HtmlSpan>
           <Icon icon={smallScreenNavOpen ? 'chevronDown' : 'chevronRight'} />

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -90,7 +90,9 @@ const BaseServiceNavigation = ({
           id={id}
           {...getConditionalAriaProp('aria-label', [ariaLabel])}
         >
-          <HtmlUl className={listClassName}>{children}</HtmlUl>
+          <HtmlUl className={listClassName} role="list">
+            {children}
+          </HtmlUl>
         </HtmlNav>
       )}
     </HtmlDiv>

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -16,14 +16,14 @@ import { getConditionalAriaProp } from '../../../../utils/aria';
 export interface ServiceNavigationProps {
   /** Use the `<ServiceNavigationItem>` components as children */
   children: ReactNode;
-  /**
-   * Normal or small screen variant
-   * @default normal
-   */
   /** Name for the navigation element. Don't use the word "navigation" since it will be read by screen reader regardless. */
   'aria-label': string;
   /** HTML nav element will receive this id */
   id?: string;
+  /**
+   * Normal or small screen variant
+   * @default normal
+   */
   variant?: 'default' | 'smallScreen';
   /**
    * Whether the menu is initially expanded. Only applies to smallScreen variant.

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -1,0 +1,53 @@
+import React, { ReactNode } from 'react';
+import { HtmlNav, HtmlUl } from '../../../../reset';
+import styled from 'styled-components';
+import { SuomifiThemeConsumer } from '../../../theme';
+import { baseStyles } from './ServiceNavigation.baseStyles';
+import classnames from 'classnames';
+
+export interface ServiceNavigationProps {
+  children: ReactNode | ReactNode[];
+  /**
+   * Normal or small screen variant
+   * @default normal
+   */
+  variant: 'normal' | 'smallScreen';
+  /** Custom classname to extend or customize */
+  className?: string;
+}
+
+const baseClassName = 'fi-service-navigation';
+const listClassName = `${baseClassName}_list`;
+
+const BaseServiceNavigation = ({
+  children,
+  variant,
+  className,
+}: ServiceNavigationProps) => (
+  // Throws TS error without fragments
+  /* eslint-disable react/jsx-no-useless-fragment */
+  <>
+    {variant === 'smallScreen' ? (
+      <div>Nope</div>
+    ) : (
+      <HtmlNav className={classnames(baseClassName, className)}>
+        <HtmlUl className={listClassName}>{children}</HtmlUl>
+      </HtmlNav>
+    )}
+  </>
+);
+
+const StyledServiceNavigation = styled(BaseServiceNavigation)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const ServiceNavigation = (props: ServiceNavigationProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledServiceNavigation theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+ServiceNavigation.displayName = 'ServiceNavigation';
+export { ServiceNavigation };

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -15,7 +15,7 @@ import { getConditionalAriaProp } from '../../../../utils/aria';
 
 export interface ServiceNavigationProps {
   /** Use the `<ServiceNavigationItem>` components as children */
-  children: ReactNode | ReactNode[];
+  children: ReactNode;
   /**
    * Normal or small screen variant
    * @default normal

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { forwardRef, ReactNode, useState } from 'react';
 import {
   HtmlButton,
   HtmlDiv,
@@ -7,12 +7,13 @@ import {
   HtmlUl,
 } from '../../../../reset';
 import styled from 'styled-components';
-import { SuomifiThemeConsumer } from '../../../theme';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
 import { baseStyles } from './ServiceNavigation.baseStyles';
 import classnames from 'classnames';
 import { Icon } from '../../../Icon/Icon';
 
 export interface ServiceNavigationProps {
+  /** Use the `<ServiceNavigationItem>` components as children */
   children: ReactNode | ReactNode[];
   /**
    * Normal or small screen variant
@@ -31,6 +32,10 @@ export interface ServiceNavigationProps {
   className?: string;
 }
 
+interface InnerRef {
+  forwardedRef: React.RefObject<HTMLDivElement>;
+}
+
 const baseClassName = 'fi-service-navigation';
 const smallScreenClassName = `${baseClassName}--small-screen`;
 const listClassName = `${baseClassName}_list`;
@@ -42,12 +47,14 @@ const BaseServiceNavigation = ({
   initiallyExpanded,
   smallScreenExpandButtonText,
   className,
-}: ServiceNavigationProps) => {
+  forwardedRef,
+}: ServiceNavigationProps & InnerRef) => {
   const initiallyExpandedValue =
     initiallyExpanded !== undefined ? initiallyExpanded : true;
   const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
     initiallyExpandedValue,
   );
+
   return (
     <HtmlDiv
       className={classnames(baseClassName, className, {
@@ -74,7 +81,7 @@ const BaseServiceNavigation = ({
       )}
       {((variant === 'smallScreen' && smallScreenNavOpen) ||
         variant !== 'smallScreen') && (
-        <HtmlNav>
+        <HtmlNav forwardedRef={forwardedRef}>
           <HtmlUl className={listClassName}>{children}</HtmlUl>
         </HtmlNav>
       )}
@@ -82,16 +89,27 @@ const BaseServiceNavigation = ({
   );
 };
 
-const StyledServiceNavigation = styled(BaseServiceNavigation)`
+const StyledServiceNavigation = styled(
+  (props: ServiceNavigationProps & InnerRef & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseServiceNavigation {...passProps} />;
+  },
+)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const ServiceNavigation = (props: ServiceNavigationProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledServiceNavigation theme={suomifiTheme} {...props} />
-    )}
-  </SuomifiThemeConsumer>
+const ServiceNavigation = forwardRef(
+  (props: ServiceNavigationProps, ref: React.RefObject<HTMLDivElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledServiceNavigation
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 ServiceNavigation.displayName = 'ServiceNavigation';

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -11,6 +11,7 @@ import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
 import { baseStyles } from './ServiceNavigation.baseStyles';
 import classnames from 'classnames';
 import { Icon } from '../../../Icon/Icon';
+import { getConditionalAriaProp } from '../../../../utils/aria';
 
 export interface ServiceNavigationProps {
   /** Use the `<ServiceNavigationItem>` components as children */
@@ -19,6 +20,10 @@ export interface ServiceNavigationProps {
    * Normal or small screen variant
    * @default normal
    */
+  /** Name for the navigation element. Don't use the word "navigation" since it will be read by screen reader regardless. */
+  'aria-label': string;
+  /** HTML nav element will receive this id */
+  id?: string;
   variant?: 'default' | 'smallScreen';
   /**
    * Whether the menu is initially expanded. Only applies to smallScreen variant.
@@ -29,10 +34,8 @@ export interface ServiceNavigationProps {
   smallScreenExpandButtonText?: string | ReactNode;
   /** Custom classname to extend or customize */
   className?: string;
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
+  /** Ref is forwarded to nav element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
 const baseClassName = 'fi-service-navigation';
@@ -42,12 +45,14 @@ const smallScreenExpandButtonClassName = `${baseClassName}_expand-button`;
 
 const BaseServiceNavigation = ({
   children,
+  'aria-label': ariaLabel,
+  id,
   variant,
   initiallyExpanded,
   smallScreenExpandButtonText,
   className,
   forwardedRef,
-}: ServiceNavigationProps & InnerRef) => {
+}: ServiceNavigationProps) => {
   const initiallyExpandedValue =
     initiallyExpanded !== undefined ? initiallyExpanded : true;
   const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
@@ -80,7 +85,11 @@ const BaseServiceNavigation = ({
       )}
       {((variant === 'smallScreen' && smallScreenNavOpen) ||
         variant !== 'smallScreen') && (
-        <HtmlNav forwardedRef={forwardedRef}>
+        <HtmlNav
+          forwardedRef={forwardedRef}
+          id={id}
+          {...getConditionalAriaProp('aria-label', [ariaLabel])}
+        >
           <HtmlUl className={listClassName}>{children}</HtmlUl>
         </HtmlNav>
       )}
@@ -89,7 +98,7 @@ const BaseServiceNavigation = ({
 };
 
 const StyledServiceNavigation = styled(
-  (props: ServiceNavigationProps & InnerRef & SuomifiThemeProp) => {
+  (props: ServiceNavigationProps & SuomifiThemeProp) => {
     const { theme, ...passProps } = props;
     return <BaseServiceNavigation {...passProps} />;
   },

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -35,7 +35,7 @@ export interface ServiceNavigationProps {
   /** Custom classname to extend or customize */
   className?: string;
   /** Ref is forwarded to nav element. Alternative for React `ref` attribute. */
-  forwardedRef?: React.RefObject<HTMLDivElement>;
+  forwardedRef?: React.Ref<HTMLElement>;
 }
 
 const baseClassName = 'fi-service-navigation';
@@ -107,7 +107,7 @@ const StyledServiceNavigation = styled(
 `;
 
 const ServiceNavigation = forwardRef(
-  (props: ServiceNavigationProps, ref: React.RefObject<HTMLDivElement>) => (
+  (props: ServiceNavigationProps, ref: React.Ref<HTMLElement>) => (
     <SuomifiThemeConsumer>
       {({ suomifiTheme }) => (
         <StyledServiceNavigation

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -18,7 +18,7 @@ export interface ServiceNavigationProps {
   children: ReactNode;
   /** Name for the navigation element. Don't use the word "navigation" since it will be read by screen reader regardless. */
   'aria-label': string;
-  /** HTML nav element will receive this id */
+  /** ID for the HTML nav element */
   id?: string;
   /**
    * Normal or small screen variant
@@ -26,7 +26,7 @@ export interface ServiceNavigationProps {
    */
   variant?: 'default' | 'smallScreen';
   /**
-   * Whether the menu is initially expanded. Only applies to smallScreen variant.
+   * Initial expand status for the menu. Only applies to smallScreen variant
    * @default true
    */
   initiallyExpanded?: boolean;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -565,10 +565,10 @@ exports[`should match snapshot 1`] = `
       class="c3 fi-service-navigation_list"
     >
       <li
-        aria-label="16 unread messages"
         class="c4 c5 fi-service-navigation-item"
       >
         <a
+          aria-label="Inbox. 16 unread messages."
           class="c6 fi-link--router c7"
           href="/"
         >

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -349,9 +349,22 @@ exports[`should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
+.c5.fi-service-navigation-item--disabled:hover,
+.c5.fi-service-navigation-item--disabled:active {
+  background: transparent;
+  cursor: not-allowed;
+  border-left: none;
+}
+
+.c5.fi-service-navigation-item--disabled:hover .fi-link--router,
+.c5.fi-service-navigation-item--disabled:active .fi-link--router {
+  padding-left: 20px;
+}
+
 .c5.fi-service-navigation-item--disabled .fi-link--router {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
+  pointer-events: none;
 }
 
 .c5.fi-service-navigation-item--disabled .fi-link--router:hover,

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -617,7 +617,9 @@ exports[`should match snapshot 1`] = `
   class="c0 fi-service-navigation c1"
 >
   <nav
+    aria-label="Test"
     class="c2"
+    id="Heppis"
   >
     <ul
       class="c3 fi-service-navigation_list"

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -199,6 +199,11 @@ exports[`should match snapshot 1`] = `
   background: hsl(212,63%,95%);
 }
 
+.c1.fi-service-navigation--small-screen .fi-service-navigation-item,
+.c1.fi-service-navigation--small-screen .fi-service-navigation-item--selected {
+  border-bottom: 1px solid hsl(0,0%,100%);
+}
+
 .c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -287,12 +292,35 @@ exports[`should match snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  position: relative;
 }
 
 .c5.fi-service-navigation-item:hover,
 .c5.fi-service-navigation-item:active {
-  background: hsl(215,100%,97%);
+  background: hsl(212,63%,95%);
   cursor: pointer;
+  border-left: 4px solid hsl(212,63%,45%);
+}
+
+.c5.fi-service-navigation-item:hover .fi-link--router,
+.c5.fi-service-navigation-item:active .fi-link--router {
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-service-navigation-item:focus {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c5.fi-service-navigation-item .fi-link--router {
@@ -341,8 +369,25 @@ exports[`should match snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: hsl(215,100%,97%);
+  background: hsl(212,63%,95%);
   border-left: 4px solid hsl(212,63%,45%);
+  position: relative;
+}
+
+.c5.fi-service-navigation-item--selected:focus {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c5.fi-service-navigation-item--selected .fi-link--router {

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -1,0 +1,569 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calling render with the same component on the same container does not remount 1`] = `
+.c8 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c8::before,
+.c8::after {
+  box-sizing: border-box;
+}
+
+.c8:hover,
+.c8:active,
+.c8:focus,
+.c8:focus-within {
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c1 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c1.fi-service-navigation .fi-service-navigation_list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c4 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.c4.fi-service-navigation-item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4.fi-service-navigation-item:hover,
+.c4.fi-service-navigation-item:active {
+  background: hsl(215,100%,97%);
+  cursor: pointer;
+}
+
+.c4.fi-service-navigation-item .fi-link--router {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 10px 25px;
+  text-transform: uppercase;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c4.fi-service-navigation-item .fi-link--router:hover,
+.c4.fi-service-navigation-item .fi-link--router:active,
+.c4.fi-service-navigation-item .fi-link--router:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c4.fi-service-navigation-item--disabled .fi-link--router {
+  color: hsl(202,7%,67%);
+  cursor: not-allowed;
+}
+
+.c4.fi-service-navigation-item--disabled .fi-link--router:hover,
+.c4.fi-service-navigation-item--disabled .fi-link--router:active,
+.c4.fi-service-navigation-item--disabled .fi-link--router:visited {
+  color: hsl(202,7%,67%);
+}
+
+.c4.fi-service-navigation-item--selected {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: hsl(215,100%,97%);
+  border-left: 4px solid hsl(212,63%,45%);
+}
+
+.c4.fi-service-navigation-item--selected .fi-link--router {
+  font-weight: bold;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 10px 25px;
+  padding-left: calc(25px - 4px);
+  text-transform: uppercase;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c4.fi-service-navigation-item--selected .fi-link--router:hover,
+.c4.fi-service-navigation-item--selected .fi-link--router:active,
+.c4.fi-service-navigation-item--selected .fi-link--router:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c10 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c9 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c9.fi-link {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c9.fi-link:hover,
+.c9.fi-link:active,
+.c9.fi-link:focus,
+.c9.fi-link:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c9.fi-link:focus,
+.c9.fi-link:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c9.fi-link:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c9.fi-link:hover,
+.c9.fi-link:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c9.fi-link:visited {
+  color: hsl(284,36%,45%);
+}
+
+.c9 .fi-link_icon {
+  padding-left: 4px;
+  font-size: 16px;
+  box-sizing: content-box;
+}
+
+.c5 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c5.fi-link--router {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5.fi-link--router:hover,
+.c5.fi-link--router:active,
+.c5.fi-link--router:focus,
+.c5.fi-link--router:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c5.fi-link--router:focus,
+.c5.fi-link--router:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5.fi-link--router:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c5.fi-link--router:hover,
+.c5.fi-link--router:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5.fi-link--router:visited {
+  color: hsl(284,36%,45%);
+}
+
+.c7 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.c7.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
+  display: inline-block;
+}
+
+.c7.fi-chip:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c7.fi-chip:focus::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+  border-radius: 16px;
+}
+
+.c7.fi-chip .fi-chip--content {
+  display: block;
+  word-break: break-word;
+  overflow: hidden;
+  line-height: 1.5em;
+}
+
+.c7.fi-chip--disabled.fi-chip {
+  cursor: not-allowed;
+  background: hsl(202,7%,67%);
+}
+
+.c7.fi-chip--disabled.fi-chip:hover,
+.c7.fi-chip--disabled.fi-chip:active {
+  background: hsl(202,7%,67%);
+}
+
+<div
+  data-testid="test-paragraph"
+>
+  <nav
+    class="c0 fi-service-navigation c1"
+  >
+    <ul
+      class="c2 fi-service-navigation_list"
+    >
+      <li
+        aria-label="16 unread messages"
+        class="c3 c4 fi-service-navigation-item"
+      >
+        <div
+          class="fi-link--router c5"
+          role="button"
+          tabindex="0"
+        >
+          Inbox
+          <span
+            class="c6 fi-chip c7"
+            style="margin-left: 15px;"
+          >
+            <span
+              class="c6 fi-chip--content"
+            >
+              16
+            </span>
+          </span>
+        </div>
+      </li>
+      <li
+        class="c3 c4 fi-service-navigation-item"
+      >
+        <a
+          class="c8 fi-link c9 fi-link--router c5 fi-link--external"
+          href="https://suomi.fi"
+          rel="noopener"
+          target="_blank"
+        >
+          Sent
+          <span
+            class="c6 c10 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        aria-current="page"
+        class="c3 c4 fi-service-navigation-item--selected"
+      >
+        <a
+          class="c8 fi-link c9 fi-link--router c5 fi-link--external"
+          href="https://www.suomi.fi"
+          rel="noopener"
+          target="_blank"
+        >
+          New Message
+          <span
+            class="c6 c10 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        class="c3 c4 fi-service-navigation-item"
+      >
+        <a
+          class="c8 fi-link c9 fi-link--router c5 fi-link--external"
+          href="https://www.suomi.fi"
+          rel="noopener"
+          target="_blank"
+        >
+          Drafts
+          <span
+            class="c6 c10 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        class="c3 c4 fi-service-navigation-item"
+      >
+        <a
+          class="c8 fi-link c9 fi-link--router c5 fi-link--external"
+          href="https://www.suomi.fi"
+          rel="noopener"
+          target="_blank"
+        >
+          Settings
+          <span
+            class="c6 c10 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        class="c3 c4 fi-service-navigation-item"
+      >
+        <a
+          class="c8 fi-link--router c5"
+        >
+          Devices
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>
+`;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -619,7 +619,6 @@ exports[`should match snapshot 1`] = `
   <nav
     aria-label="Test"
     class="c2"
-    id="Heppis"
   >
     <ul
       class="c3 fi-service-navigation_list"

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -535,111 +535,107 @@ exports[`calling render with the same component on the same container does not r
 }
 
 <div
-  data-testid="test-paragraph"
+  class="c0 fi-service-navigation c1"
 >
-  <div
-    class="c0 fi-service-navigation c1"
+  <nav
+    class="c2"
   >
-    <nav
-      class="c2"
+    <ul
+      class="c3 fi-service-navigation_list"
     >
-      <ul
-        class="c3 fi-service-navigation_list"
+      <li
+        aria-label="16 unread messages"
+        class="c4 c5 fi-service-navigation-item"
       >
-        <li
-          aria-label="16 unread messages"
-          class="c4 c5 fi-service-navigation-item"
+        <div
+          class="fi-link--router c6"
+          role="button"
+          tabindex="0"
         >
-          <div
-            class="fi-link--router c6"
-            role="button"
-            tabindex="0"
+          Inbox
+          <span
+            class="c7 fi-chip c8"
+            style="margin-left: 15px;"
           >
-            Inbox
             <span
-              class="c7 fi-chip c8"
-              style="margin-left: 15px;"
+              class="c7 fi-chip--content"
             >
-              <span
-                class="c7 fi-chip--content"
-              >
-                16
-              </span>
+              16
             </span>
-          </div>
-        </li>
-        <li
-          class="c4 c5 fi-service-navigation-item"
+          </span>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-service-navigation-item"
+      >
+        <a
+          class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+          href="https://suomi.fi"
+          rel="noopener"
+          target="_blank"
         >
-          <a
-            class="c9 fi-link c10 fi-link--router c6 fi-link--external"
-            href="https://suomi.fi"
-            rel="noopener"
-            target="_blank"
-          >
-            Sent
-            <span
-              class="c7 c11 fi-visually-hidden"
-            />
-          </a>
-        </li>
-        <li
-          aria-current="page"
-          class="c4 c5 fi-service-navigation-item--selected"
+          Sent
+          <span
+            class="c7 c11 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        aria-current="page"
+        class="c4 c5 fi-service-navigation-item--selected"
+      >
+        <a
+          class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+          href="https://www.suomi.fi"
+          rel="noopener"
+          target="_blank"
         >
-          <a
-            class="c9 fi-link c10 fi-link--router c6 fi-link--external"
-            href="https://www.suomi.fi"
-            rel="noopener"
-            target="_blank"
-          >
-            New Message
-            <span
-              class="c7 c11 fi-visually-hidden"
-            />
-          </a>
-        </li>
-        <li
-          class="c4 c5 fi-service-navigation-item"
+          New Message
+          <span
+            class="c7 c11 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        class="c4 c5 fi-service-navigation-item"
+      >
+        <a
+          class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+          href="https://www.suomi.fi"
+          rel="noopener"
+          target="_blank"
         >
-          <a
-            class="c9 fi-link c10 fi-link--router c6 fi-link--external"
-            href="https://www.suomi.fi"
-            rel="noopener"
-            target="_blank"
-          >
-            Drafts
-            <span
-              class="c7 c11 fi-visually-hidden"
-            />
-          </a>
-        </li>
-        <li
-          class="c4 c5 fi-service-navigation-item"
+          Drafts
+          <span
+            class="c7 c11 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        class="c4 c5 fi-service-navigation-item"
+      >
+        <a
+          class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+          href="https://www.suomi.fi"
+          rel="noopener"
+          target="_blank"
         >
-          <a
-            class="c9 fi-link c10 fi-link--router c6 fi-link--external"
-            href="https://www.suomi.fi"
-            rel="noopener"
-            target="_blank"
-          >
-            Settings
-            <span
-              class="c7 c11 fi-visually-hidden"
-            />
-          </a>
-        </li>
-        <li
-          class="c4 c5 fi-service-navigation-item"
+          Settings
+          <span
+            class="c7 c11 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        class="c4 c5 fi-service-navigation-item"
+      >
+        <a
+          class="c9 fi-link--router c6"
         >
-          <a
-            class="c9 fi-link--router c6"
-          >
-            Devices
-          </a>
-        </li>
-      </ul>
-    </nav>
-  </div>
+          Devices
+        </a>
+      </li>
+    </ul>
+  </nav>
 </div>
 `;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calling render with the same component on the same container does not remount 1`] = `
-.c9 {
+exports[`should match snapshot 1`] = `
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -24,15 +24,15 @@ exports[`calling render with the same component on the same container does not r
   text-decoration: underline;
 }
 
-.c9::before,
-.c9::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c9:hover,
-.c9:active,
-.c9:focus,
-.c9:focus-within {
+.c6:hover,
+.c6:active,
+.c6:focus,
+.c6:focus-within {
   color: inherit;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -119,7 +119,7 @@ exports[`calling render with the same component on the same container does not r
   box-sizing: border-box;
 }
 
-.c7 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -143,8 +143,8 @@ exports[`calling render with the same component on the same container does not r
   white-space: normal;
 }
 
-.c7::before,
-.c7::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
@@ -213,6 +213,7 @@ exports[`calling render with the same component on the same container does not r
   font-size: 18px;
   line-height: 24px;
   font-weight: 600;
+  position: relative;
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -228,6 +229,26 @@ exports[`calling render with the same component on the same container does not r
   align-items: center;
   padding: 20px;
   border: 1px solid hsl(212,63%,90%);
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button:focus {
+  outline: 0;
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button .fi-icon {
@@ -418,7 +439,7 @@ exports[`calling render with the same component on the same container does not r
   box-sizing: content-box;
 }
 
-.c6 {
+.c7 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -434,42 +455,42 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
-.c6.fi-link--router {
+.c7.fi-link--router {
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c6.fi-link--router:hover,
-.c6.fi-link--router:active,
-.c6.fi-link--router:focus,
-.c6.fi-link--router:focus-within {
+.c7.fi-link--router:hover,
+.c7.fi-link--router:active,
+.c7.fi-link--router:focus,
+.c7.fi-link--router:focus-within {
   color: hsl(212,63%,45%);
 }
 
-.c6.fi-link--router:focus,
-.c6.fi-link--router:focus-within {
+.c7.fi-link--router:focus,
+.c7.fi-link--router:focus-within {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c6.fi-link--router:focus {
+.c7.fi-link--router:focus {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
 }
 
-.c6.fi-link--router:hover,
-.c6.fi-link--router:active {
+.c7.fi-link--router:hover,
+.c7.fi-link--router:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c6.fi-link--router:visited {
+.c7.fi-link--router:visited {
   color: hsl(284,36%,45%);
 }
 
-.c8 {
+.c9 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -486,7 +507,7 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 600;
 }
 
-.c8.fi-chip {
+.c9.fi-chip {
   border-radius: 14px;
   padding: 2px 10px;
   color: hsl(0,0%,100%);
@@ -495,12 +516,12 @@ exports[`calling render with the same component on the same container does not r
   display: inline-block;
 }
 
-.c8.fi-chip:focus {
+.c9.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c8.fi-chip:focus::after {
+.c9.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -517,20 +538,20 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 16px;
 }
 
-.c8.fi-chip .fi-chip--content {
+.c9.fi-chip .fi-chip--content {
   display: block;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;
 }
 
-.c8.fi-chip--disabled.fi-chip {
+.c9.fi-chip--disabled.fi-chip {
   cursor: not-allowed;
   background: hsl(202,7%,67%);
 }
 
-.c8.fi-chip--disabled.fi-chip:hover,
-.c8.fi-chip--disabled.fi-chip:active {
+.c9.fi-chip--disabled.fi-chip:hover,
+.c9.fi-chip--disabled.fi-chip:active {
   background: hsl(202,7%,67%);
 }
 
@@ -547,52 +568,52 @@ exports[`calling render with the same component on the same container does not r
         aria-label="16 unread messages"
         class="c4 c5 fi-service-navigation-item"
       >
-        <div
-          class="fi-link--router c6"
-          role="button"
-          tabindex="0"
+        <a
+          class="c6 fi-link--router c7"
+          href="/"
         >
           Inbox
           <span
-            class="c7 fi-chip c8"
+            aria-hidden="true"
+            class="c8 fi-chip c9"
             style="margin-left: 15px;"
           >
             <span
-              class="c7 fi-chip--content"
+              class="c8 fi-chip--content"
             >
               16
             </span>
           </span>
-        </div>
+        </a>
       </li>
       <li
         class="c4 c5 fi-service-navigation-item"
       >
         <a
-          class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+          class="c6 fi-link c10 fi-link--router c7 fi-link--external"
           href="https://suomi.fi"
           rel="noopener"
           target="_blank"
         >
           Sent
           <span
-            class="c7 c11 fi-visually-hidden"
+            class="c8 c11 fi-visually-hidden"
           />
         </a>
       </li>
       <li
-        aria-current="page"
         class="c4 c5 fi-service-navigation-item--selected"
       >
         <a
-          class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+          aria-current="page"
+          class="c6 fi-link c10 fi-link--router c7 fi-link--external"
           href="https://www.suomi.fi"
           rel="noopener"
           target="_blank"
         >
           New Message
           <span
-            class="c7 c11 fi-visually-hidden"
+            class="c8 c11 fi-visually-hidden"
           />
         </a>
       </li>
@@ -600,37 +621,32 @@ exports[`calling render with the same component on the same container does not r
         class="c4 c5 fi-service-navigation-item"
       >
         <a
-          class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+          class="c6 fi-link c10 fi-link--router c7 fi-link--external"
           href="https://www.suomi.fi"
           rel="noopener"
           target="_blank"
         >
           Drafts
           <span
-            class="c7 c11 fi-visually-hidden"
+            class="c8 c11 fi-visually-hidden"
           />
         </a>
       </li>
       <li
         class="c4 c5 fi-service-navigation-item"
       >
-        <a
-          class="c9 fi-link c10 fi-link--router c6 fi-link--external"
-          href="https://www.suomi.fi"
-          rel="noopener"
-          target="_blank"
+        <div
+          class="fi-link--router c7"
         >
           Settings
-          <span
-            class="c7 c11 fi-visually-hidden"
-          />
-        </a>
+        </div>
       </li>
       <li
-        class="c4 c5 fi-service-navigation-item"
+        aria-disabled="true"
+        class="c4 c5 fi-service-navigation-item fi-service-navigation-item--disabled"
       >
         <a
-          class="c9 fi-link--router c6"
+          class="c6 fi-link--router c7"
         >
           Devices
         </a>

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -619,6 +619,7 @@ exports[`should match snapshot 1`] = `
   >
     <ul
       class="c3 fi-service-navigation_list"
+      role="list"
     >
       <li
         class="c4 c5 fi-service-navigation-item"

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -307,18 +307,9 @@ exports[`should match snapshot 1`] = `
   padding-left: calc(20px - 4px);
 }
 
-.c5.fi-service-navigation-item:focus {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
+.c5.fi-service-navigation-item:focus-within {
+  outline: 0;
   border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
 }
@@ -339,6 +330,12 @@ exports[`should match snapshot 1`] = `
   cursor: pointer;
   background: inherit;
   border: none;
+}
+
+.c5.fi-service-navigation-item .fi-link--router:focus {
+  outline: 0;
+  border: none;
+  box-shadow: none;
 }
 
 .c5.fi-service-navigation-item .fi-link--router:hover,

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -236,6 +236,21 @@ exports[`should match snapshot 1`] = `
   border: 1px solid hsl(212,63%,90%);
 }
 
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button .fi-service-navigation_expand-button_text-wrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 .c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button:focus {
   outline: 0;
 }

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`calling render with the same component on the same container does not remount 1`] = `
-.c8 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -24,44 +24,19 @@ exports[`calling render with the same component on the same container does not r
   text-decoration: underline;
 }
 
-.c8::before,
-.c8::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
-.c8:hover,
-.c8:active,
-.c8:focus,
-.c8:focus-within {
+.c9:hover,
+.c9:active,
+.c9:focus,
+.c9:focus-within {
   color: inherit;
   -webkit-text-decoration: underline;
   text-decoration: underline;
   cursor: pointer;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: list-item;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
 }
 
 .c0 {
@@ -83,6 +58,9 @@ exports[`calling render with the same component on the same container does not r
   cursor: inherit;
   display: block;
   max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
 }
 
 .c0::before,
@@ -90,7 +68,58 @@ exports[`calling render with the same component on the same container does not r
   box-sizing: border-box;
 }
 
-.c6 {
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -114,12 +143,12 @@ exports[`calling render with the same component on the same container does not r
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c2 {
+.c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -145,8 +174,8 @@ exports[`calling render with the same component on the same container does not r
   padding-left: 40px;
 }
 
-.c2::before,
-.c2::after {
+.c3::before,
+.c3::after {
   box-sizing: border-box;
 }
 
@@ -166,184 +195,50 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
+.c1.fi-service-navigation--small-screen {
+  background: hsl(212,63%,95%);
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 20px;
+  border: 1px solid hsl(212,63%,90%);
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button .fi-icon {
+  height: 25px;
+  width: 25px;
+}
+
 .c1.fi-service-navigation .fi-service-navigation_list {
   list-style-type: none;
   margin: 0;
   padding: 0;
-}
-
-.c4 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 600;
-}
-
-.c4.fi-service-navigation-item {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c4.fi-service-navigation-item:hover,
-.c4.fi-service-navigation-item:active {
-  background: hsl(215,100%,97%);
-  cursor: pointer;
-}
-
-.c4.fi-service-navigation-item .fi-link--router {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: hsl(0,0%,16%);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 10px 25px;
-  text-transform: uppercase;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c4.fi-service-navigation-item .fi-link--router:hover,
-.c4.fi-service-navigation-item .fi-link--router:active,
-.c4.fi-service-navigation-item .fi-link--router:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: hsl(0,0%,16%);
-}
-
-.c4.fi-service-navigation-item--disabled .fi-link--router {
-  color: hsl(202,7%,67%);
-  cursor: not-allowed;
-}
-
-.c4.fi-service-navigation-item--disabled .fi-link--router:hover,
-.c4.fi-service-navigation-item--disabled .fi-link--router:active,
-.c4.fi-service-navigation-item--disabled .fi-link--router:visited {
-  color: hsl(202,7%,67%);
-}
-
-.c4.fi-service-navigation-item--selected {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: hsl(215,100%,97%);
-  border-left: 4px solid hsl(212,63%,45%);
-}
-
-.c4.fi-service-navigation-item--selected .fi-link--router {
-  font-weight: bold;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: hsl(0,0%,16%);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 10px 25px;
-  padding-left: calc(25px - 4px);
-  text-transform: uppercase;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c4.fi-service-navigation-item--selected .fi-link--router:hover,
-.c4.fi-service-navigation-item--selected .fi-link--router:active,
-.c4.fi-service-navigation-item--selected .fi-link--router:visited {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: hsl(0,0%,16%);
-}
-
-.c10 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-}
-
-.c9 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c9.fi-link {
-  color: hsl(212,63%,45%);
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c9.fi-link:hover,
-.c9.fi-link:active,
-.c9.fi-link:focus,
-.c9.fi-link:focus-within {
-  color: hsl(212,63%,45%);
-}
-
-.c9.fi-link:focus,
-.c9.fi-link:focus-within {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c9.fi-link:focus {
-  outline: 0;
-  border-radius: 2px;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-}
-
-.c9.fi-link:hover,
-.c9.fi-link:active {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c9.fi-link:visited {
-  color: hsl(284,36%,45%);
-}
-
-.c9 .fi-link_icon {
-  padding-left: 4px;
-  font-size: 16px;
-  box-sizing: content-box;
 }
 
 .c5 {
@@ -359,45 +254,222 @@ exports[`calling render with the same component on the same container does not r
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 18px;
   line-height: 1.5;
+  font-weight: 600;
+}
+
+.c5.fi-service-navigation-item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5.fi-service-navigation-item:hover,
+.c5.fi-service-navigation-item:active {
+  background: hsl(215,100%,97%);
+  cursor: pointer;
+}
+
+.c5.fi-service-navigation-item .fi-link--router {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 10px 20px;
+  text-transform: uppercase;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+  background: inherit;
+  border: none;
+}
+
+.c5.fi-service-navigation-item .fi-link--router:hover,
+.c5.fi-service-navigation-item .fi-link--router:active,
+.c5.fi-service-navigation-item .fi-link--router:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-service-navigation-item--disabled .fi-link--router {
+  color: hsl(202,7%,67%);
+  cursor: not-allowed;
+}
+
+.c5.fi-service-navigation-item--disabled .fi-link--router:hover,
+.c5.fi-service-navigation-item--disabled .fi-link--router:active,
+.c5.fi-service-navigation-item--disabled .fi-link--router:visited {
+  color: hsl(202,7%,67%);
+}
+
+.c5.fi-service-navigation-item--selected {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: hsl(215,100%,97%);
+  border-left: 4px solid hsl(212,63%,45%);
+}
+
+.c5.fi-service-navigation-item--selected .fi-link--router {
+  font-weight: bold;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 10px 25px;
+  padding-left: calc(20px - 4px);
+  text-transform: uppercase;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c5.fi-service-navigation-item--selected .fi-link--router:hover,
+.c5.fi-service-navigation-item--selected .fi-link--router:active,
+.c5.fi-service-navigation-item--selected .fi-link--router:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c11 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c10 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-link--router {
+.c10.fi-link {
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c5.fi-link--router:hover,
-.c5.fi-link--router:active,
-.c5.fi-link--router:focus,
-.c5.fi-link--router:focus-within {
+.c10.fi-link:hover,
+.c10.fi-link:active,
+.c10.fi-link:focus,
+.c10.fi-link:focus-within {
   color: hsl(212,63%,45%);
 }
 
-.c5.fi-link--router:focus,
-.c5.fi-link--router:focus-within {
+.c10.fi-link:focus,
+.c10.fi-link:focus-within {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c5.fi-link--router:focus {
+.c10.fi-link:focus {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
 }
 
-.c5.fi-link--router:hover,
-.c5.fi-link--router:active {
+.c10.fi-link:hover,
+.c10.fi-link:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c5.fi-link--router:visited {
+.c10.fi-link:visited {
   color: hsl(284,36%,45%);
 }
 
-.c7 {
+.c10 .fi-link_icon {
+  padding-left: 4px;
+  font-size: 16px;
+  box-sizing: content-box;
+}
+
+.c6 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c6.fi-link--router {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6.fi-link--router:hover,
+.c6.fi-link--router:active,
+.c6.fi-link--router:focus,
+.c6.fi-link--router:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c6.fi-link--router:focus,
+.c6.fi-link--router:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6.fi-link--router:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c6.fi-link--router:hover,
+.c6.fi-link--router:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c6.fi-link--router:visited {
+  color: hsl(284,36%,45%);
+}
+
+.c8 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -414,7 +486,7 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 600;
 }
 
-.c7.fi-chip {
+.c8.fi-chip {
   border-radius: 14px;
   padding: 2px 10px;
   color: hsl(0,0%,100%);
@@ -423,12 +495,12 @@ exports[`calling render with the same component on the same container does not r
   display: inline-block;
 }
 
-.c7.fi-chip:focus {
+.c8.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c7.fi-chip:focus::after {
+.c8.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -445,125 +517,129 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 16px;
 }
 
-.c7.fi-chip .fi-chip--content {
+.c8.fi-chip .fi-chip--content {
   display: block;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;
 }
 
-.c7.fi-chip--disabled.fi-chip {
+.c8.fi-chip--disabled.fi-chip {
   cursor: not-allowed;
   background: hsl(202,7%,67%);
 }
 
-.c7.fi-chip--disabled.fi-chip:hover,
-.c7.fi-chip--disabled.fi-chip:active {
+.c8.fi-chip--disabled.fi-chip:hover,
+.c8.fi-chip--disabled.fi-chip:active {
   background: hsl(202,7%,67%);
 }
 
 <div
   data-testid="test-paragraph"
 >
-  <nav
+  <div
     class="c0 fi-service-navigation c1"
   >
-    <ul
-      class="c2 fi-service-navigation_list"
+    <nav
+      class="c2"
     >
-      <li
-        aria-label="16 unread messages"
-        class="c3 c4 fi-service-navigation-item"
+      <ul
+        class="c3 fi-service-navigation_list"
       >
-        <div
-          class="fi-link--router c5"
-          role="button"
-          tabindex="0"
+        <li
+          aria-label="16 unread messages"
+          class="c4 c5 fi-service-navigation-item"
         >
-          Inbox
-          <span
-            class="c6 fi-chip c7"
-            style="margin-left: 15px;"
+          <div
+            class="fi-link--router c6"
+            role="button"
+            tabindex="0"
           >
+            Inbox
             <span
-              class="c6 fi-chip--content"
+              class="c7 fi-chip c8"
+              style="margin-left: 15px;"
             >
-              16
+              <span
+                class="c7 fi-chip--content"
+              >
+                16
+              </span>
             </span>
-          </span>
-        </div>
-      </li>
-      <li
-        class="c3 c4 fi-service-navigation-item"
-      >
-        <a
-          class="c8 fi-link c9 fi-link--router c5 fi-link--external"
-          href="https://suomi.fi"
-          rel="noopener"
-          target="_blank"
+          </div>
+        </li>
+        <li
+          class="c4 c5 fi-service-navigation-item"
         >
-          Sent
-          <span
-            class="c6 c10 fi-visually-hidden"
-          />
-        </a>
-      </li>
-      <li
-        aria-current="page"
-        class="c3 c4 fi-service-navigation-item--selected"
-      >
-        <a
-          class="c8 fi-link c9 fi-link--router c5 fi-link--external"
-          href="https://www.suomi.fi"
-          rel="noopener"
-          target="_blank"
+          <a
+            class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+            href="https://suomi.fi"
+            rel="noopener"
+            target="_blank"
+          >
+            Sent
+            <span
+              class="c7 c11 fi-visually-hidden"
+            />
+          </a>
+        </li>
+        <li
+          aria-current="page"
+          class="c4 c5 fi-service-navigation-item--selected"
         >
-          New Message
-          <span
-            class="c6 c10 fi-visually-hidden"
-          />
-        </a>
-      </li>
-      <li
-        class="c3 c4 fi-service-navigation-item"
-      >
-        <a
-          class="c8 fi-link c9 fi-link--router c5 fi-link--external"
-          href="https://www.suomi.fi"
-          rel="noopener"
-          target="_blank"
+          <a
+            class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+            href="https://www.suomi.fi"
+            rel="noopener"
+            target="_blank"
+          >
+            New Message
+            <span
+              class="c7 c11 fi-visually-hidden"
+            />
+          </a>
+        </li>
+        <li
+          class="c4 c5 fi-service-navigation-item"
         >
-          Drafts
-          <span
-            class="c6 c10 fi-visually-hidden"
-          />
-        </a>
-      </li>
-      <li
-        class="c3 c4 fi-service-navigation-item"
-      >
-        <a
-          class="c8 fi-link c9 fi-link--router c5 fi-link--external"
-          href="https://www.suomi.fi"
-          rel="noopener"
-          target="_blank"
+          <a
+            class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+            href="https://www.suomi.fi"
+            rel="noopener"
+            target="_blank"
+          >
+            Drafts
+            <span
+              class="c7 c11 fi-visually-hidden"
+            />
+          </a>
+        </li>
+        <li
+          class="c4 c5 fi-service-navigation-item"
         >
-          Settings
-          <span
-            class="c6 c10 fi-visually-hidden"
-          />
-        </a>
-      </li>
-      <li
-        class="c3 c4 fi-service-navigation-item"
-      >
-        <a
-          class="c8 fi-link--router c5"
+          <a
+            class="c9 fi-link c10 fi-link--router c6 fi-link--external"
+            href="https://www.suomi.fi"
+            rel="noopener"
+            target="_blank"
+          >
+            Settings
+            <span
+              class="c7 c11 fi-visually-hidden"
+            />
+          </a>
+        </li>
+        <li
+          class="c4 c5 fi-service-navigation-item"
         >
-          Devices
-        </a>
-      </li>
-    </ul>
-  </nav>
+          <a
+            class="c9 fi-link--router c6"
+          >
+            Devices
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </div>
 `;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -1,0 +1,76 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodySemiBold')};
+
+  /* stylelint-disable no-descending-specificity */
+  /* Nested :hover etc selectors do not work well with this rule. */
+  &.fi-service-navigation-item {
+    display: flex;
+    align-items: center;
+
+    &:hover,
+    &:active {
+      background: ${theme.colors.depthSecondary};
+      cursor: pointer;
+    }
+
+    .fi-link--router {
+      text-decoration: none;
+      color: ${theme.colors.blackBase};
+      display: flex;
+      padding: ${theme.spacing.xs} ${theme.spacing.l};
+      text-transform: uppercase;
+      flex: 1;
+
+      &:hover,
+      &:active,
+      &:visited {
+        text-decoration: none;
+        color: ${theme.colors.blackBase};
+      }
+    }
+
+    &--disabled {
+      .fi-link--router {
+        color: ${theme.colors.depthBase};
+        cursor: not-allowed;
+
+        &:hover,
+        &:active,
+        &:visited {
+          color: ${theme.colors.depthBase};
+        }
+      }
+    }
+
+    &--selected {
+      display: flex;
+      align-items: center;
+      background: ${theme.colors.depthSecondary};
+      border-left: 4px solid ${theme.colors.highlightBase};
+
+      .fi-link--router {
+        font-weight: bold;
+        text-decoration: none;
+        color: ${theme.colors.blackBase};
+        display: flex;
+        padding: ${theme.spacing.xs} ${theme.spacing.l};
+        padding-left: calc(${theme.spacing.l} - 4px);
+        text-transform: uppercase;
+        flex: 1;
+
+        &:hover,
+        &:active,
+        &:visited {
+          text-decoration: none;
+          color: ${theme.colors.blackBase};
+        }
+      }
+    }
+  }
+`;
+
+/* stylelint-enable no-descending-specificity */

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -10,11 +10,20 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-service-navigation-item {
     display: flex;
     align-items: center;
+    position: relative;
 
     &:hover,
     &:active {
-      background: ${theme.colors.depthSecondary};
+      background: ${theme.colors.highlightLight3};
       cursor: pointer;
+      border-left: 4px solid ${theme.colors.highlightBase};
+      .fi-link--router {
+        padding-left: calc(${theme.spacing.m} - 4px);
+      }
+    }
+
+    &:focus {
+      ${theme.focus.absoluteFocus};
     }
 
     .fi-link--router {
@@ -52,8 +61,13 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &--selected {
       display: flex;
       align-items: center;
-      background: ${theme.colors.depthSecondary};
+      background: ${theme.colors.highlightLight3};
       border-left: 4px solid ${theme.colors.highlightBase};
+      position: relative;
+
+      &:focus {
+        ${theme.focus.absoluteFocus};
+      }
 
       .fi-link--router {
         font-weight: bold;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -22,8 +22,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
 
-    &:focus {
-      ${theme.focus.absoluteFocus};
+    &:focus-within {
+      ${theme.focus.boxShadowFocus};
+      z-index: ${theme.zindexes.focus};
     }
 
     .fi-link--router {
@@ -36,6 +37,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       cursor: pointer;
       background: inherit;
       border: none;
+
+      &:focus {
+        outline: 0;
+        border: none;
+        box-shadow: none;
+      }
 
       &:hover,
       &:active,

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -46,9 +46,19 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     &--disabled {
+      &:hover,
+      &:active {
+        background: transparent;
+        cursor: not-allowed;
+        border-left: none;
+        .fi-link--router {
+          padding-left: ${theme.spacing.m};
+        }
+      }
       .fi-link--router {
         color: ${theme.colors.depthBase};
         cursor: not-allowed;
+        pointer-events: none;
 
         &:hover,
         &:active,

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -99,5 +99,3 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
   }
 `;
-
-/* stylelint-enable no-descending-specificity */

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -21,9 +21,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       text-decoration: none;
       color: ${theme.colors.blackBase};
       display: flex;
-      padding: ${theme.spacing.xs} ${theme.spacing.l};
+      padding: ${theme.spacing.xs} ${theme.spacing.m};
       text-transform: uppercase;
       flex: 1;
+      cursor: pointer;
+      background: inherit;
+      border: none;
 
       &:hover,
       &:active,
@@ -58,7 +61,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         color: ${theme.colors.blackBase};
         display: flex;
         padding: ${theme.spacing.xs} ${theme.spacing.l};
-        padding-left: calc(${theme.spacing.l} - 4px);
+        padding-left: calc(${theme.spacing.m} - 4px);
         text-transform: uppercase;
         flex: 1;
 

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
@@ -10,9 +10,9 @@ export interface ServiceNavigationItemProps {
   className?: string;
   /** Use the polymorphic `<RouterLink>` component as child to get intended CSS styling */
   children: ReactNode;
-  /** Show item as the selected one */
+  /** Toggle to show item as the selected one */
   selected?: boolean;
-  /** Disable the item */
+  /** Disables the item */
   disabled?: boolean;
 }
 

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
@@ -34,7 +34,6 @@ const BaseServiceNavigationItem = ({
       [disabledClassName]: disabled,
     })}
     aria-disabled={disabled}
-    role="option"
     {...passProps}
   >
     {children}

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
@@ -8,13 +8,13 @@ import styled from 'styled-components';
 interface BasicServiceNavigationItemProps {
   /** Custom class */
   className?: string;
-  /** Use the polymorphic RouterLink component as child to get intended CSS styling */
+  /** Use the polymorphic `<RouterLink>` component as child to get intended CSS styling */
   children: ReactNode;
   /** Disable the item */
   disabled?: boolean;
 }
 
-type SeletedProps =
+type SelectedProps =
   | {
       /** Show item as the selected one */
       selected: boolean;
@@ -27,7 +27,7 @@ type SeletedProps =
     };
 
 export type ServiceNavigationItemProps = BasicServiceNavigationItemProps &
-  SeletedProps;
+  SelectedProps;
 
 const baseClassName = 'fi-service-navigation-item';
 const selectedClassName = `${baseClassName}--selected`;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
@@ -1,0 +1,76 @@
+import React, { ReactNode } from 'react';
+import classnames from 'classnames';
+import { HtmlLi } from '../../../../reset';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import { baseStyles } from './ServiceNavigationItem.baseStyles';
+import styled from 'styled-components';
+
+interface BasicServiceNavigationItemProps {
+  /** Custom class */
+  className?: string;
+  /** Use the polymorphic RouterLink component as child to get intended CSS styling */
+  children: ReactNode;
+  /** Disable the item */
+  disabled?: boolean;
+}
+
+type SeletedProps =
+  | {
+      /** Show item as the selected one */
+      selected: boolean;
+      /** Selected item information for screen reader. Required when `selected` is true */
+      ariaCurrent: 'step' | 'page' | 'location';
+    }
+  | {
+      selected?: never;
+      ariaCurrent?: never;
+    };
+
+export type ServiceNavigationItemProps = BasicServiceNavigationItemProps &
+  SeletedProps;
+
+const baseClassName = 'fi-service-navigation-item';
+const selectedClassName = `${baseClassName}--selected`;
+const disabledClassName = `${baseClassName}--disabled`;
+
+const BaseServiceNavigationItem = ({
+  selected,
+  ariaCurrent,
+  className,
+  children,
+  disabled,
+  ...passProps
+}: ServiceNavigationItemProps) => (
+  <HtmlLi
+    className={classnames(className, {
+      [baseClassName]: !selected,
+      [selectedClassName]: selected,
+      [disabledClassName]: disabled,
+    })}
+    aria-current={!!ariaCurrent ? ariaCurrent : undefined}
+    aria-disabled={disabled}
+    {...passProps}
+  >
+    {children}
+  </HtmlLi>
+);
+
+const StyledServiceNavigationItem = styled(
+  (props: ServiceNavigationItemProps & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseServiceNavigationItem {...passProps} />;
+  },
+)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const ServiceNavigationItem = (props: ServiceNavigationItemProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledServiceNavigationItem theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+ServiceNavigationItem.displayName = 'ServiceNavigationItem';
+export { ServiceNavigationItem };

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
@@ -5,29 +5,16 @@ import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
 import { baseStyles } from './ServiceNavigationItem.baseStyles';
 import styled from 'styled-components';
 
-interface BasicServiceNavigationItemProps {
+export interface ServiceNavigationItemProps {
   /** Custom class */
   className?: string;
   /** Use the polymorphic `<RouterLink>` component as child to get intended CSS styling */
   children: ReactNode;
+  /** Show item as the selected one */
+  selected?: boolean;
   /** Disable the item */
   disabled?: boolean;
 }
-
-type SelectedProps =
-  | {
-      /** Show item as the selected one */
-      selected: boolean;
-      /** Selected item information for screen reader. Required when `selected` is true */
-      ariaCurrent: 'step' | 'page' | 'location';
-    }
-  | {
-      selected?: never;
-      ariaCurrent?: never;
-    };
-
-export type ServiceNavigationItemProps = BasicServiceNavigationItemProps &
-  SelectedProps;
 
 const baseClassName = 'fi-service-navigation-item';
 const selectedClassName = `${baseClassName}--selected`;
@@ -35,7 +22,6 @@ const disabledClassName = `${baseClassName}--disabled`;
 
 const BaseServiceNavigationItem = ({
   selected,
-  ariaCurrent,
   className,
   children,
   disabled,
@@ -47,7 +33,6 @@ const BaseServiceNavigationItem = ({
       [selectedClassName]: selected,
       [disabledClassName]: disabled,
     })}
-    aria-current={!!ariaCurrent ? ariaCurrent : undefined}
     aria-disabled={disabled}
     {...passProps}
   >

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
@@ -34,6 +34,7 @@ const BaseServiceNavigationItem = ({
       [disabledClassName]: disabled,
     })}
     aria-disabled={disabled}
+    role="option"
     {...passProps}
   >
     {children}

--- a/src/core/Navigation/ServiceNavigation/index.ts
+++ b/src/core/Navigation/ServiceNavigation/index.ts
@@ -1,0 +1,8 @@
+export {
+  ServiceNavigation,
+  ServiceNavigationProps,
+} from './ServiceNavigation/ServiceNavigation';
+export {
+  ServiceNavigationItem,
+  ServiceNavigationItemProps,
+} from './ServiceNavigationItem/ServiceNavigationItem';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -102,6 +102,12 @@ export {
   WizardNavigationItemProps,
 } from './core/Navigation/WizardNavigation';
 export {
+  ServiceNavigation,
+  ServiceNavigationProps,
+  ServiceNavigationItem,
+  ServiceNavigationItemProps,
+} from './core/Navigation/ServiceNavigation';
+export {
   Expander,
   ExpanderProps,
   ExpanderGroup,


### PR DESCRIPTION
## Description

This PR introduces the `<ServiceNavigation>` component. As children, it takes `<ServiceNavigationItem>` components which in turn takes a ReactNode as child. In practice, the child of a `<ServiceNavigationItem>` is supposed to be a `<RouterLink>` which is polymorphic and can thus be rendered as any semantic HTML element as well as third party library elements such as React Router Link, Gatsby Link etc. 

## Motivation and Context

We want to have ready-made navigation components available in the library. Having the polymorphic `<RouterLink>` component available was the key to implementing this component in a way which allows a wide range of usecases. 

## How Has This Been Tested?

Styleguidist, CRA app, NextJS app

## Screenshots
![image](https://user-images.githubusercontent.com/17459942/185923410-43fb0e0f-cc03-4a3f-95b5-5bf6b395ce0d.png)

## Release notes

### ServiceNavigation
* Introduce `<ServiceNavigation>` component
