### PR TITLE
[Fix] Label content types

### DIFF
--- a/src/core/Alert/InlineAlert/InlineAlert.tsx
+++ b/src/core/Alert/InlineAlert/InlineAlert.tsx
@@ -27,7 +27,7 @@ export interface InlineAlertProps extends HtmlDivWithRefProps {
   /** Use small screen styling */
   smallScreen?: boolean;
   /** Label for the alert */
-  labelText?: string;
+  labelText?: ReactNode;
   /** Set aria-live mode for the alert text content and label.
    * @default 'assertive'
    */

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -56,7 +56,7 @@ interface InternalDropdownProps {
   /** Controlled selected value, overrides defaultValue if provided. */
   value?: string;
   /** Label for the Dropdown component. */
-  labelText: string;
+  labelText: ReactNode;
   /** Visual hint to show if nothing is selected and no value or defaultValue is provided */
   visualPlaceholder?: ReactNode;
   /** Show the visual placeholder instead of selected value and act as an action menu */

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -31,7 +31,7 @@ export interface CheckboxGroupProps {
   /** Hint text to be displayed under the label. */
   groupHintText?: string;
   /** Label for the group */
-  labelText: string;
+  labelText: ReactNode;
   /** Hide or show label. Label element is always present, but can be visually hidden.
    * @default visible
    */

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -46,7 +46,7 @@ interface InternalFilterInputProps<T>
   /** Placeholder text for input. Use only as visual aid, not for instructions. */
   visualPlaceholder?: string;
   /** Label */
-  labelText: string;
+  labelText: ReactNode;
   /** Hide or show label. Label element is always present, but can be visually hidden.
    * @default visible
    */

--- a/src/core/Form/RadioButton/RadioButtonGroup.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.tsx
@@ -23,7 +23,7 @@ export interface RadioButtonGroupProps {
   /** Hint text to be displayed under the label. */
   groupHintText?: string;
   /** Label for the group */
-  labelText: string;
+  labelText: ReactNode;
   /** Hide or show label. Label element is always present, but can be visually hidden.
    * @default visible
    */

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, Component, createRef, FocusEvent } from 'react';
+import React, {
+  ChangeEvent,
+  Component,
+  createRef,
+  FocusEvent,
+  ReactNode,
+} from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../utils/AutoId/AutoId';
@@ -43,7 +49,7 @@ export interface SearchInputProps
   /** SearchInput wrapping div element props */
   wrapperProps?: Omit<HtmlDivProps, 'className'>;
   /** Label text */
-  labelText: string;
+  labelText: ReactNode;
   /** Hide or show label. Label element is always present, but can be visually hidden.
    * @default visible
    */

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../../theme';
@@ -106,7 +106,7 @@ interface InternalMultiSelectProps<T extends MultiSelectData> {
    */
   id?: string;
   /** Label */
-  labelText: string;
+  labelText: ReactNode;
   /** Text to mark a field optional. Wrapped in parentheses and shown after labelText. */
   optionalText?: string;
   /** Hint text to be shown below the label */

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv } from '../../../../reset';
@@ -48,7 +48,7 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
    */
   id?: string;
   /** Label */
-  labelText: string;
+  labelText: ReactNode;
   /** Text to mark a field optional. Wrapped in parentheses and shown after labelText. */
   optionalText?: string;
   /** Hint text to be shown below the label */

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, Component, ChangeEvent, FocusEvent } from 'react';
+import React, {
+  forwardRef,
+  Component,
+  ChangeEvent,
+  FocusEvent,
+  ReactNode,
+} from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../utils/AutoId/AutoId';
@@ -52,7 +58,7 @@ interface InternalTextInputProps
   /** To execute on input text onBlur */
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
   /** Label */
-  labelText: string;
+  labelText: ReactNode;
   /** Hide or show label. Label element is always present, but can be visually hidden.
    * @default visible
    */

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -1,4 +1,10 @@
-import React, { Component, ChangeEvent, FocusEvent, forwardRef } from 'react';
+import React, {
+  Component,
+  ChangeEvent,
+  FocusEvent,
+  forwardRef,
+  ReactNode,
+} from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
@@ -45,7 +51,7 @@ interface InternalTextareaProps
   /** To execute on textarea text onBlur */
   onBlur?: (event: FocusEvent<HTMLTextAreaElement>) => void;
   /** Label */
-  labelText: string;
+  labelText: ReactNode;
   /** Hide or show label. Label element is always present, but can be visually hidden.
    * @default visible
    */


### PR DESCRIPTION
## Description
This PR changes the prop type of label content from `string` to `ReactNode` in all applicable components. This allows the labels to contain other elements than just text, such as tooltip icons etc. 

The Label component itself that's used by many of the components already supports ReactNode as content, but the APIs of the components were dragging behind.

## Motivation and Context
There is current and future need for more varied content in the labels.

## How Has This Been Tested?
Tested by running styleguidist locally on Chrome and adding different kinds of content to labels. Also checked that screen readers behave predictably. Optional text works as before in most cases as well.

## Screenshots (if appropriate):

## Release notes
### Dropdown, CheckboxGroup, RadiobuttonGroup, FilterInput, SearchInput, MultiSelect, SingleSelect, TextInput, TextArea
* **Breaking change:** Change label content type from `string` to `ReactNode` (#652)
