### PR TITLE
[Feature] Hide / show ExpanderGroup toggle all button

### DIFF
--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -64,6 +64,36 @@ import {
 </ExpanderGroup>;
 ```
 
+```jsx
+import {
+  Expander,
+  ExpanderGroup,
+  ExpanderTitleButton,
+  ExpanderContent
+} from 'suomifi-ui-components';
+
+<ExpanderGroup
+  openAllText="Open all"
+  ariaOpenAllText="Open all expanders"
+  closeAllText="Close all"
+  ariaCloseAllText="Close all expanders"
+  showToggleAllButton={false}
+>
+  <Expander>
+    <ExpanderTitleButton>Test expander 1</ExpanderTitleButton>
+    <ExpanderContent>Test expander content 1</ExpanderContent>
+  </Expander>
+  <Expander>
+    <ExpanderTitleButton>Test expander 2</ExpanderTitleButton>
+    <ExpanderContent>Test expander content 2</ExpanderContent>
+  </Expander>
+  <Expander>
+    <ExpanderTitleButton>Test expander 3</ExpanderTitleButton>
+    <ExpanderContent>Test expander content 3</ExpanderContent>
+  </Expander>
+</ExpanderGroup>;
+```
+
 ## Controlled
 
 - State for the individual Expanders are stored outside of the component and user has full control.

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
@@ -159,6 +159,47 @@ describe('default behaviour', () => {
   });
 });
 
+describe('Toggle all button', () => {
+  it('should be hidden when showToggleAllButton is false', () => {
+    const { queryByTestId } = render(
+      TestExpanderGroup(
+        [
+          {
+            expanderProps: {
+              id: 'id-first',
+            },
+            titleProps: {
+              'data-testid': 'expander-title-1',
+              children: 'First',
+            },
+            content: 'First content',
+          },
+          {
+            expanderProps: {
+              id: 'id-second',
+
+              defaultOpen: true,
+            },
+            titleProps: {
+              'data-testid': 'expander-title-2',
+              children: 'Second',
+            },
+            content: 'Second content',
+          },
+        ],
+        {
+          toggleAllButtonProps: {
+            'data-testid': 'toggle-all-button',
+          },
+          showToggleAllButton: false,
+        },
+      ),
+    );
+    const toggleAllButton = queryByTestId('toggle-all-button');
+    expect(toggleAllButton).toBeNull();
+  });
+});
+
 describe('defaultOpen', () => {
   it('gives the classname to expander title and icon', () => {
     const { getByTestId } = render(

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -23,6 +23,11 @@ export interface ExpanderGroupProps {
   ariaCloseAllText?: string;
   /** Custom classname to extend or customize */
   className?: string;
+  /**
+   * Show Open/Close all button
+   * @default true
+   */
+  showToggleAllButton?: boolean;
   /** Open/Close all button props */
   toggleAllButtonProps?: Omit<
     HtmlButtonProps,
@@ -138,6 +143,7 @@ class BaseExpanderGroup extends Component<
       ariaOpenAllText,
       closeAllText,
       ariaCloseAllText,
+      showToggleAllButton = true,
       toggleAllButtonProps,
       ...passProps
     } = this.props;
@@ -149,24 +155,26 @@ class BaseExpanderGroup extends Component<
           [openClassName]: this.openExpanderCount > 0,
         })}
       >
-        <HtmlButton
-          {...toggleAllButtonProps}
-          onClick={this.handleAllToggleClick}
-          className={classnames(
-            toggleAllButtonProps?.className,
-            openAllButtonClassName,
-          )}
-          aria-expanded={allOpen}
-        >
-          <HtmlSpan aria-hidden={true}>
-            {allOpen ? closeAllText : openAllText}
-          </HtmlSpan>
-          <VisuallyHidden>
-            {allOpen
-              ? ariaCloseAllText || closeAllText
-              : ariaOpenAllText || openAllText}
-          </VisuallyHidden>
-        </HtmlButton>
+        {!!showToggleAllButton && (
+          <HtmlButton
+            {...toggleAllButtonProps}
+            onClick={this.handleAllToggleClick}
+            className={classnames(
+              toggleAllButtonProps?.className,
+              openAllButtonClassName,
+            )}
+            aria-expanded={allOpen}
+          >
+            <HtmlSpan aria-hidden={true}>
+              {allOpen ? closeAllText : openAllText}
+            </HtmlSpan>
+            <VisuallyHidden>
+              {allOpen
+                ? ariaCloseAllText || closeAllText
+                : ariaOpenAllText || openAllText}
+            </VisuallyHidden>
+          </HtmlButton>
+        )}
         <HtmlDiv className={expandersContainerClassName}>
           <Provider
             value={{


### PR DESCRIPTION
## Description
This PR adds support for hiding the ExpanderGroup open / close all button.

## Motivation and Context
In cases where there are only a couple of expanders, there is no need to show the toggle all button. Yet using a group over individual expanders is often required.

## How Has This Been Tested?
Tested using Chrome on MacOS with VoiceOver.

## Screenshots (if appropriate):
![Screenshot 2022-09-05 at 10 07 11](https://user-images.githubusercontent.com/53744258/188385708-e0074ced-592b-4360-8f36-2a48c8858039.png)

## Release notes
### ExpanderGroup
  - Add `showToggleAllButton` prop with a default value of true