### PR TITLE
[Feature] WizardNavigation

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -201,6 +201,13 @@ module.exports = {
           name: 'Toast',
           components: getComponents(['Toast']),
         },
+        {
+          name: 'WizardNavigation',
+          components: getComponentWithVariants('Navigation/WizardNavigation')([
+            'WizardNavigation/WizardNavigation',
+            'WizardNavigationItem/WizardNavigationItem',
+          ]),
+        }
       ],
       sectionDepth: 1,
       expand: true,

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
@@ -1,0 +1,34 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  &.fi-wizard-navigation {
+    padding: ${theme.spacing.s};
+    .fi-wizard-navigation_heading {
+      ${font(theme)('heading4')}
+
+      &--small-screen {
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        ${font(theme)('heading4')}
+
+        .fi-icon {
+          color: ${theme.colors.highlightBase};
+          width: 20px;
+          height: 20px;
+        }
+      }
+    }
+    .fi-wizard-navigation_list {
+      border-top: 1px solid ${theme.colors.depthBase};
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+      padding-top: ${theme.spacing.s};
+      margin-top: ${theme.spacing.s};
+    }
+  }
+`;

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
@@ -4,7 +4,24 @@ import { SuomifiTheme } from '../../../theme';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-wizard-navigation {
-    padding: ${theme.spacing.s};
+    .fi-wizard-navigation_heading {
+      margin-left: ${theme.spacing.m};
+      ${font(theme)('heading4')}
+    }
+    .fi-wizard-navigation_divider {
+      height: 1px;
+      background: ${theme.colors.depthLight1};
+      margin-top: ${theme.spacing.m};
+      margin-left: ${theme.spacing.m};
+      margin-right: ${theme.spacing.m};
+    }
+    .fi-wizard-navigation_list {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+      margin-top: ${theme.spacing.s};
+      position: relative;
+    }
 
     &--small-screen {
       background: ${theme.colors.highlightLight3};
@@ -13,26 +30,29 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         display: flex;
         justify-content: space-between;
         align-items: center;
+        padding: ${theme.spacing.s};
+        margin-left: 0;
+        position: relative;
         ${font(theme)('heading4')}
+        &:focus {
+          outline: 0;
+          &:before {
+            ${theme.focus.absoluteFocus}
+          }
+        }
 
         .fi-icon {
           color: ${theme.colors.highlightBase};
-          width: 20px;
-          height: 20px;
+          width: 24px;
+          height: 24px;
         }
       }
-    }
 
-    .fi-wizard-navigation_heading {
-      ${font(theme)('heading4')}
-    }
-    .fi-wizard-navigation_list {
-      border-top: 1px solid ${theme.colors.depthBase};
-      list-style-type: none;
-      margin: 0;
-      padding: 0;
-      padding-top: ${theme.spacing.s};
-      margin-top: ${theme.spacing.s};
+      .fi-wizard-navigation_divider {
+        margin-top: ${theme.spacing.xxs};
+        margin-left: ${theme.spacing.s};
+        margin-right: ${theme.spacing.s};
+      }
     }
   }
 `;

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
@@ -5,10 +5,10 @@ import { SuomifiTheme } from '../../../theme';
 export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-wizard-navigation {
     padding: ${theme.spacing.s};
-    .fi-wizard-navigation_heading {
-      ${font(theme)('heading4')}
 
-      &--small-screen {
+    &--small-screen {
+      background: ${theme.colors.highlightLight3};
+      .fi-wizard-navigation_heading {
         width: 100%;
         display: flex;
         justify-content: space-between;
@@ -21,6 +21,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
           height: 20px;
         }
       }
+    }
+
+    .fi-wizard-navigation_heading {
+      ${font(theme)('heading4')}
     }
     .fi-wizard-navigation_list {
       border-top: 1px solid ${theme.colors.depthBase};

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
@@ -1,6 +1,6 @@
 ### Basic usage
 
-A `<WizardNavigationItem>` can have one of these 5 statuses:
+A `<WizardNavigationItem>` can have one of these 6 statuses:
 
 - default: reachable & incomplete step
 - current: currently active step

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
@@ -24,17 +24,17 @@ const Comp = (props) => {
 };
 
 <div style={{ width: '350px' }}>
-  <WizardNavigation heading="Steps">
+  <WizardNavigation heading="Steps" aria-label="Main">
     <WizardNavigationItem status="completed">
-      <RouterLink href="https://suomi.fi">Step 1</RouterLink>
+      <RouterLink
+        href="https://suomi.fi"
+        aria-label="Step 1. This step is completed"
+      >
+        Step 1
+      </RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="default">
-      <RouterLink
-        href="#"
-        aria-label="Step 2. This step is completed"
-      >
-        Step 2
-      </RouterLink>
+      <RouterLink href="#">Step 2</RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="current">
       <RouterLink aria-current="step" href="#">
@@ -42,28 +42,23 @@ const Comp = (props) => {
       </RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="coming">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
+      <RouterLink aria-disabled role="link">
         Step 4 with a long text that wraps to the second line like
         this
       </RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="coming">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
+      <RouterLink aria-disabled role="link">
         Step 5
       </RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="disabled">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
+      <RouterLink aria-disabled role="link">
         Step 6
       </RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="coming">
-      <RouterLink
-        asComponent={Comp}
-        role="button"
-        aria-disabled
-        tabIndex={-1}
-      >
+      <RouterLink asComponent={Comp} role="button" aria-disabled>
         Step 7
       </RouterLink>
     </WizardNavigationItem>
@@ -100,6 +95,7 @@ const Comp = (props) => {
     variant="smallScreen"
     heading="Steps"
     initiallyExpanded={false}
+    aria-label="Main"
   >
     <WizardNavigationItem status="default">
       <RouterLink href="https://suomi.fi">Step 1</RouterLink>
@@ -118,27 +114,22 @@ const Comp = (props) => {
       </RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="coming">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
+      <RouterLink aria-disabled role="link">
         Step 4
       </RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="coming">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
+      <RouterLink aria-disabled role="link">
         Step 5
       </RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="disabled">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
+      <RouterLink aria-disabled role="link">
         Step 6
       </RouterLink>
     </WizardNavigationItem>
     <WizardNavigationItem status="coming">
-      <RouterLink
-        asComponent={Comp}
-        role="button"
-        aria-disabled
-        tabIndex={-1}
-      >
+      <RouterLink asComponent={Comp} role="button" aria-disabled>
         Step 7
       </RouterLink>
     </WizardNavigationItem>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
@@ -1,0 +1,123 @@
+### Basic usage
+
+A `<WizardNavigationItem>` can have one of these 5 statuses:
+
+- visited: the user has already visited this step and can go back to it
+- current: currently active step
+- proceed: the step directly following the current step. Is reachable
+- not-visited: a step which follows the current step but is not directly after it, not reachable
+- disabled: disabled step, not reachable
+
+Please use `<RouterLink>` as the child of `<WizardNavigationItem>` to get inteded CSS styles. `<RouterLink>` is polymorphic, and can be rendered as any component of your choice, for example React Router Link.
+
+```js
+import {
+  WizardNavigation,
+  WizardNavigationItem,
+  RouterLink
+} from 'suomifi-ui-components';
+
+const Comp = (props) => {
+  const { children, ...passProps } = props;
+  return <div {...passProps}>{props.children}</div>;
+};
+
+<div style={{ width: '300px' }}>
+  <WizardNavigation heading="Steps">
+    <WizardNavigationItem stepNumber={1} status="visited">
+      <RouterLink href="https://suomi.fi">
+        Step 1 (visited)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={2} status="current">
+      <RouterLink aria-current="step" aria-disabled href="#">
+        Step 2 (current)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={3} status="proceed">
+      <RouterLink
+        asComponent={Comp}
+        onClick={() => console.log('Step 3 clicked!')}
+        role="button"
+        tabIndex={0}
+      >
+        Step 3 (proceed)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={4} status="not-visited">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 4 (not visited)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={5} status="disabled">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 5 (disabled)
+      </RouterLink>
+    </WizardNavigationItem>
+  </WizardNavigation>
+</div>;
+```
+
+For frameworks where its internal link component is used as a wrapper for the actual link, for example NextJS, the following approach can be used:
+
+```jsx static
+<WizardNavigationItem stepNumber={1} status="current">
+  <NextJSLink href="/some-route" passHref>
+    <RouterLink>Step 1</RouterLink>
+  </NextJSLink>
+</WizardNavigationItem>
+```
+
+### Small screen version
+
+```js
+import {
+  WizardNavigation,
+  WizardNavigationItem,
+  RouterLink
+} from 'suomifi-ui-components';
+
+const Comp = (props) => {
+  const { children, ...passProps } = props;
+  return <div {...passProps}>{props.children}</div>;
+};
+
+<div style={{ width: '300px' }}>
+  <WizardNavigation
+    heading="Steps"
+    variant="smallScreen"
+    initiallyExpanded={false}
+  >
+    <WizardNavigationItem stepNumber={1} status="visited">
+      <RouterLink href="https://suomi.fi">
+        Step 1 (visited)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={2} status="current">
+      <RouterLink aria-current="step" aria-disabled href="#">
+        Step 2 (current)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={3} status="proceed">
+      <RouterLink
+        asComponent={Comp}
+        onClick={() => console.log('Step 3 clicked!')}
+        role="button"
+        tabIndex={0}
+      >
+        Step 3 (proceed)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={4} status="not-visited">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 4 (not visited)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={5} status="disabled">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 5 (disabled)
+      </RouterLink>
+    </WizardNavigationItem>
+  </WizardNavigation>
+</div>;
+```

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
@@ -2,11 +2,12 @@
 
 A `<WizardNavigationItem>` can have one of these 5 statuses:
 
-- visited: the user has already visited this step and can go back to it
+- default: reachable & incomplete step
 - current: currently active step
-- proceed: the step directly following the current step. Is reachable
-- not-visited: a step which follows the current step but is not directly after it, not reachable
-- disabled: disabled step, not reachable
+- completed: a step where the user has filled all necessary information
+- current-completed: a combination of current and completed statuses
+- coming: a step which is unreachable at the moment (but will become available when e.g. the previous steps have been completed)
+- disabled: disabled step, not reachable. We do not recommend the use of this status unless absolutely necessary
 
 Please use `<RouterLink>` as the child of `<WizardNavigationItem>` to get inteded CSS styles. `<RouterLink>` is polymorphic, and can be rendered as any component of your choice, for example React Router Link.
 
@@ -22,36 +23,48 @@ const Comp = (props) => {
   return <div {...passProps}>{props.children}</div>;
 };
 
-<div style={{ width: '300px' }}>
+<div style={{ width: '350px' }}>
   <WizardNavigation heading="Steps">
-    <WizardNavigationItem stepNumber={1} status="visited">
-      <RouterLink href="https://suomi.fi">
-        Step 1 (visited)
+    <WizardNavigationItem status="completed">
+      <RouterLink href="https://suomi.fi">Step 1</RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="default">
+      <RouterLink
+        href="#"
+        aria-label="Step 2. This step is completed"
+      >
+        Step 2
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={2} status="current">
-      <RouterLink aria-current="step" aria-disabled href="#">
-        Step 2 (current)
+    <WizardNavigationItem status="current">
+      <RouterLink aria-current="step" href="#">
+        Step 3
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={3} status="proceed">
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 4 with a long text that wraps to the second line like
+        this
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 5
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="disabled">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 6
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
       <RouterLink
         asComponent={Comp}
-        onClick={() => console.log('Step 3 clicked!')}
         role="button"
-        tabIndex={0}
+        aria-disabled
+        tabIndex={-1}
       >
-        Step 3 (proceed)
-      </RouterLink>
-    </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={4} status="not-visited">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
-        Step 4 (not visited)
-      </RouterLink>
-    </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={5} status="disabled">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
-        Step 5 (disabled)
+        Step 7
       </RouterLink>
     </WizardNavigationItem>
   </WizardNavigation>
@@ -61,7 +74,7 @@ const Comp = (props) => {
 For frameworks where its internal link component is used as a wrapper for the actual link, for example NextJS, the following approach can be used:
 
 ```jsx static
-<WizardNavigationItem stepNumber={1} status="current">
+<WizardNavigationItem status="default">
   <NextJSLink href="/some-route" passHref>
     <RouterLink>Step 1</RouterLink>
   </NextJSLink>
@@ -84,38 +97,49 @@ const Comp = (props) => {
 
 <div style={{ width: '300px' }}>
   <WizardNavigation
-    heading="Steps"
     variant="smallScreen"
+    heading="Steps"
     initiallyExpanded={false}
   >
-    <WizardNavigationItem stepNumber={1} status="visited">
-      <RouterLink href="https://suomi.fi">
-        Step 1 (visited)
+    <WizardNavigationItem status="default">
+      <RouterLink href="https://suomi.fi">Step 1</RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="completed">
+      <RouterLink
+        href="#"
+        aria-label="Step 2. This step is completed"
+      >
+        Step 2
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={2} status="current">
-      <RouterLink aria-current="step" aria-disabled href="#">
-        Step 2 (current)
+    <WizardNavigationItem status="current">
+      <RouterLink aria-current="step" href="#">
+        Step 3
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={3} status="proceed">
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 4
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 5
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="disabled">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 6
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
       <RouterLink
         asComponent={Comp}
-        onClick={() => console.log('Step 3 clicked!')}
         role="button"
-        tabIndex={0}
+        aria-disabled
+        tabIndex={-1}
       >
-        Step 3 (proceed)
-      </RouterLink>
-    </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={4} status="not-visited">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
-        Step 4 (not visited)
-      </RouterLink>
-    </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={5} status="disabled">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
-        Step 5 (disabled)
+        Step 7
       </RouterLink>
     </WizardNavigationItem>
   </WizardNavigation>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axeTest } from '../../../../utils/test';
+
+import { WizardNavigation } from './WizardNavigation';
+import { WizardNavigationItem } from '../WizardNavigationItem/WizardNavigationItem';
+import { RouterLink } from '../../../Link';
+
+const TestWizardNavigation = (
+  <WizardNavigation heading="Steps">
+    <WizardNavigationItem stepNumber={1} status="visited">
+      <RouterLink href="https://suomi.fi">Step 1 (visited)</RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={2} status="current">
+      <RouterLink aria-current="step" aria-disabled href="#">
+        Step 2 (current)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={3} status="proceed">
+      <RouterLink
+        asComponent="button"
+        onClick={() => console.log('Step 3 clicked!')}
+      >
+        Step 3 (proceed)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={4} status="not-visited">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 4 (not visited)
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem stepNumber={5} status="disabled">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        Step 5 (disabled)
+      </RouterLink>
+    </WizardNavigationItem>
+  </WizardNavigation>
+);
+
+test('calling render with the same component on the same container does not remount', () => {
+  const WizardNavRendered = render(TestWizardNavigation);
+  const { container } = WizardNavRendered;
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test(
+  'should not have basic accessibility issues',
+  axeTest(TestWizardNavigation),
+);

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
@@ -8,30 +8,37 @@ import { RouterLink } from '../../../Link';
 
 const TestWizardNavigation = (
   <WizardNavigation heading="Steps">
-    <WizardNavigationItem stepNumber={1} status="visited">
-      <RouterLink href="https://suomi.fi">Step 1 (visited)</RouterLink>
+    <WizardNavigationItem status="default">
+      <RouterLink href="https://suomi.fi">1. Step</RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={2} status="current">
-      <RouterLink aria-current="step" aria-disabled href="#">
-        Step 2 (current)
+    <WizardNavigationItem status="completed">
+      <RouterLink href="#" aria-label="Step 2. This step is completed">
+        2. Step
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={3} status="proceed">
-      <RouterLink
-        asComponent="button"
-        onClick={() => console.log('Step 3 clicked!')}
-      >
-        Step 3 (proceed)
+    <WizardNavigationItem status="current">
+      <RouterLink aria-current="step" href="#">
+        3. Step
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={4} status="not-visited">
+    <WizardNavigationItem status="coming">
       <RouterLink aria-disabled tabIndex={-1} href="#">
-        Step 4 (not visited)
+        4. Step
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem stepNumber={5} status="disabled">
+    <WizardNavigationItem status="coming">
       <RouterLink aria-disabled tabIndex={-1} href="#">
-        Step 5 (disabled)
+        5. Step
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="disabled">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        6. Step
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink asComponent="button" aria-disabled tabIndex={-1}>
+        7. Step
       </RouterLink>
     </WizardNavigationItem>
   </WizardNavigation>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
@@ -7,7 +7,7 @@ import { WizardNavigationItem } from '../WizardNavigationItem/WizardNavigationIt
 import { RouterLink } from '../../../Link';
 
 const TestWizardNavigation = (
-  <WizardNavigation heading="Steps">
+  <WizardNavigation heading="Steps" aria-label="Test">
     <WizardNavigationItem status="default">
       <RouterLink href="https://suomi.fi">1. Step</RouterLink>
     </WizardNavigationItem>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -26,6 +26,7 @@ export interface WizardNavigationProps {
 
 const baseClassName = 'fi-wizard-navigation';
 const smallScreenClassName = `${baseClassName}--small-screen`;
+const dividerClassName = `${baseClassName}_divider`;
 const listClassName = `${baseClassName}_list`;
 const headingClassName = `${baseClassName}_heading`;
 
@@ -62,6 +63,7 @@ const BaseWizardNavigation = ({
       {((variant === 'smallScreen' && smallScreenNavOpen) ||
         variant !== 'smallScreen') && (
         <HtmlNav>
+          <HtmlDiv className={dividerClassName} />
           <HtmlUl className={listClassName}>{children}</HtmlUl>
         </HtmlNav>
       )}

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -25,9 +25,9 @@ export interface WizardNavigationProps {
 }
 
 const baseClassName = 'fi-wizard-navigation';
+const smallScreenClassName = `${baseClassName}--small-screen`;
 const listClassName = `${baseClassName}_list`;
 const headingClassName = `${baseClassName}_heading`;
-const headingSmallScreenClassName = `${baseClassName}_heading--small-screen`;
 
 const BaseWizardNavigation = ({
   children,
@@ -42,10 +42,14 @@ const BaseWizardNavigation = ({
     initiallyExpandedValue,
   );
   return (
-    <HtmlDiv className={classnames(baseClassName, className)}>
+    <HtmlDiv
+      className={classnames(baseClassName, className, {
+        [smallScreenClassName]: variant === 'smallScreen',
+      })}
+    >
       {variant === 'smallScreen' ? (
         <HtmlButton
-          className={headingSmallScreenClassName}
+          className={headingClassName}
           onClick={() => setSmallScreenNavOpen(!smallScreenNavOpen)}
           aria-expanded={smallScreenNavOpen}
         >

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -80,7 +80,9 @@ const BaseWizardNavigation = ({
           {...getConditionalAriaProp('aria-label', [ariaLabel])}
         >
           <HtmlDiv className={dividerClassName} />
-          <HtmlUl className={listClassName}>{children}</HtmlUl>
+          <HtmlUl className={listClassName} role="list">
+            {children}
+          </HtmlUl>
         </HtmlNav>
       )}
     </HtmlDiv>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -29,7 +29,7 @@ export interface WizardNavigationProps {
   /** Custom classname to extend or customize */
   className?: string;
   /** Ref is forwarded to nav element. Alternative for React `ref` attribute. */
-  forwardedRef?: React.RefObject<HTMLDivElement>;
+  forwardedRef?: React.Ref<HTMLElement>;
 }
 
 const baseClassName = 'fi-wizard-navigation';
@@ -97,7 +97,7 @@ const StyledWizardNavigation = styled(
 `;
 
 const WizardNavigation = forwardRef(
-  (props: WizardNavigationProps, ref: React.RefObject<HTMLDivElement>) => (
+  (props: WizardNavigationProps, ref: React.Ref<HTMLElement>) => (
     <SuomifiThemeConsumer>
       {({ suomifiTheme }) => (
         <StyledWizardNavigation

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -12,7 +12,7 @@ export interface WizardNavigationProps {
   children: ReactNode;
   /** Name for the navigation element. Don't use the word "navigation" since it will be read by screen reader regardless. */
   'aria-label': string;
-  /** HTML nav element will receive this id */
+  /** ID for the HTML nav element */
   id?: string;
   /**
    * Normal or small screen variant
@@ -20,7 +20,7 @@ export interface WizardNavigationProps {
    */
   variant?: 'default' | 'smallScreen';
   /**
-   * Whether the menu is initially expanded. Only applies to smallScreen variant.
+   * Initial expand status for the menu. Only applies to smallScreen variant
    * @default true
    */
   initiallyExpanded?: boolean;

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -1,0 +1,81 @@
+import React, { ReactNode, useState } from 'react';
+import { HtmlButton, HtmlDiv, HtmlNav, HtmlUl } from '../../../../reset';
+import styled from 'styled-components';
+import { SuomifiThemeConsumer } from '../../../theme';
+import { baseStyles } from './WizardNavigation.baseStyles';
+import classnames from 'classnames';
+import { Icon } from '../../../Icon/Icon';
+
+export interface WizardNavigationProps {
+  children: ReactNode | ReactNode[];
+  /**
+   * Normal or small screen variant
+   * @default normal
+   */
+  variant?: 'default' | 'smallScreen';
+  /**
+   * Whether the menu is initially expanded. Only applies to smallScreen variant.
+   * @default true
+   */
+  initiallyExpanded?: boolean;
+  /** Navigation component heading text */
+  heading: string;
+  /** Custom classname to extend or customize */
+  className?: string;
+}
+
+const baseClassName = 'fi-wizard-navigation';
+const listClassName = `${baseClassName}_list`;
+const headingClassName = `${baseClassName}_heading`;
+const headingSmallScreenClassName = `${baseClassName}_heading--small-screen`;
+
+const BaseWizardNavigation = ({
+  children,
+  variant,
+  initiallyExpanded,
+  heading,
+  className,
+}: WizardNavigationProps) => {
+  const initiallyExpandedValue =
+    initiallyExpanded !== undefined ? initiallyExpanded : true;
+  const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
+    initiallyExpandedValue,
+  );
+  return (
+    <HtmlDiv className={classnames(baseClassName, className)}>
+      {variant === 'smallScreen' ? (
+        <HtmlButton
+          className={headingSmallScreenClassName}
+          onClick={() => setSmallScreenNavOpen(!smallScreenNavOpen)}
+          aria-expanded={smallScreenNavOpen}
+        >
+          {heading}
+          <Icon icon={smallScreenNavOpen ? 'chevronDown' : 'chevronRight'} />
+        </HtmlButton>
+      ) : (
+        <HtmlDiv className={headingClassName}>{heading}</HtmlDiv>
+      )}
+      {((variant === 'smallScreen' && smallScreenNavOpen) ||
+        variant !== 'smallScreen') && (
+        <HtmlNav>
+          <HtmlUl className={listClassName}>{children}</HtmlUl>
+        </HtmlNav>
+      )}
+    </HtmlDiv>
+  );
+};
+
+const StyledWizardNavigation = styled(BaseWizardNavigation)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const WizardNavigation = (props: WizardNavigationProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledWizardNavigation theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+WizardNavigation.displayName = 'WizardNavigation';
+export { WizardNavigation };

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -1,13 +1,19 @@
-import React, { ReactNode, useState } from 'react';
+import React, { forwardRef, ReactNode, useState } from 'react';
 import { HtmlButton, HtmlDiv, HtmlNav, HtmlUl } from '../../../../reset';
 import styled from 'styled-components';
-import { SuomifiThemeConsumer } from '../../../theme';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
 import { baseStyles } from './WizardNavigation.baseStyles';
 import classnames from 'classnames';
 import { Icon } from '../../../Icon/Icon';
+import { getConditionalAriaProp } from '../../../../utils/aria';
 
 export interface WizardNavigationProps {
-  children: ReactNode | ReactNode[];
+  /** Use the `<WizardNavigationItem>` components as children */
+  children: ReactNode;
+  /** Name for the navigation element. Don't use the word "navigation" since it will be read by screen reader regardless. */
+  'aria-label': string;
+  /** HTML nav element will receive this id */
+  id?: string;
   /**
    * Normal or small screen variant
    * @default normal
@@ -22,6 +28,8 @@ export interface WizardNavigationProps {
   heading: string;
   /** Custom classname to extend or customize */
   className?: string;
+  /** Ref is forwarded to nav element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
 const baseClassName = 'fi-wizard-navigation';
@@ -32,16 +40,20 @@ const headingClassName = `${baseClassName}_heading`;
 
 const BaseWizardNavigation = ({
   children,
+  'aria-label': ariaLabel,
+  id,
   variant,
   initiallyExpanded,
   heading,
   className,
+  forwardedRef,
 }: WizardNavigationProps) => {
   const initiallyExpandedValue =
     initiallyExpanded !== undefined ? initiallyExpanded : true;
   const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
     initiallyExpandedValue,
   );
+
   return (
     <HtmlDiv
       className={classnames(baseClassName, className, {
@@ -62,7 +74,11 @@ const BaseWizardNavigation = ({
       )}
       {((variant === 'smallScreen' && smallScreenNavOpen) ||
         variant !== 'smallScreen') && (
-        <HtmlNav>
+        <HtmlNav
+          forwardedRef={forwardedRef}
+          id={id}
+          {...getConditionalAriaProp('aria-label', [ariaLabel])}
+        >
           <HtmlDiv className={dividerClassName} />
           <HtmlUl className={listClassName}>{children}</HtmlUl>
         </HtmlNav>
@@ -71,16 +87,27 @@ const BaseWizardNavigation = ({
   );
 };
 
-const StyledWizardNavigation = styled(BaseWizardNavigation)`
+const StyledWizardNavigation = styled(
+  (props: WizardNavigationProps & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseWizardNavigation {...passProps} />;
+  },
+)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const WizardNavigation = (props: WizardNavigationProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledWizardNavigation theme={suomifiTheme} {...props} />
-    )}
-  </SuomifiThemeConsumer>
+const WizardNavigation = forwardRef(
+  (props: WizardNavigationProps, ref: React.RefObject<HTMLDivElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledWizardNavigation
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 WizardNavigation.displayName = 'WizardNavigation';

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -297,7 +297,6 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 50%;
   width: 25px;
   height: 25px;
-  margin-right: 10px;
   font-weight: 600;
   line-height: 27px;
   font-size: 18px;

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -1,0 +1,640 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calling render with the same component on the same container does not remount 1`] = `
+.c7 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7::before,
+.c7::after {
+  box-sizing: border-box;
+}
+
+.c7:hover,
+.c7:active,
+.c7:focus,
+.c7:focus-within {
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c1.fi-wizard-navigation {
+  padding: 15px;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_heading {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_heading--small-screen {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_heading--small-screen .fi-icon {
+  color: hsl(212,63%,45%);
+  width: 20px;
+  height: 20px;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_list {
+  border-top: 1px solid hsl(202,7%,67%);
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  padding-top: 15px;
+  margin-top: 15px;
+}
+
+.c5.fi-wizard-navigation-item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+}
+
+.c5.fi-wizard-navigation-item:not(:last-child) {
+  margin-bottom: 22px;
+}
+
+.c5.fi-wizard-navigation-item:not(:last-child):after {
+  content: '';
+  height: 10px;
+  width: 2px;
+  background: hsl(202,7%,67%);
+  position: absolute;
+  bottom: -16px;
+  left: 12px;
+}
+
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
+  border: 1px solid hsl(202,7%,40%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  width: 25px;
+  height: 25px;
+  margin-right: 10px;
+  font-weight: 600;
+  line-height: 27px;
+  font-size: 18px;
+  margin-right: 10px;
+}
+
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  margin-bottom: 1px;
+}
+
+.c5.fi-wizard-navigation-item--visited .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
+  background: hsl(165,90%,27%);
+  color: hsl(0,0%,100%);
+}
+
+.c5.fi-wizard-navigation-item--visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.c5.fi-wizard-navigation-item--visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5.fi-wizard-navigation-item--visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(212,63%,45%);
+}
+
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
+  background: hsl(165,90%,27%);
+  color: hsl(0,0%,100%);
+}
+
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  margin-bottom: 1px;
+}
+
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-wizard-navigation-item--proceed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
+  background: hsl(0,0%,100%);
+  color: hsl(202,7%,40%);
+  border: 1px solid hsl(166,90%,34%);
+}
+
+.c5.fi-wizard-navigation-item--proceed .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.c5.fi-wizard-navigation-item--proceed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5.fi-wizard-navigation-item--proceed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(212,63%,45%);
+}
+
+.c5.fi-wizard-navigation-item--not-visited .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
+  background: hsl(0,0%,100%);
+  color: hsl(0,0%,16%);
+  border: 1px solid hsl(0,0%,16%);
+}
+
+.c5.fi-wizard-navigation-item--not-visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c5.fi-wizard-navigation-item--not-visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5.fi-wizard-navigation-item--not-visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
+  background: hsl(0,0%,100%);
+  color: hsl(202,7%,40%);
+  border: 1px solid hsl(202,7%,80%);
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(202,7%,67%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(202,7%,67%);
+}
+
+.c8 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c8.fi-link--router {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c8.fi-link--router:hover,
+.c8.fi-link--router:active,
+.c8.fi-link--router:focus,
+.c8.fi-link--router:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c8.fi-link--router:focus,
+.c8.fi-link--router:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c8.fi-link--router:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c8.fi-link--router:hover,
+.c8.fi-link--router:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c8.fi-link--router:visited {
+  color: hsl(284,36%,45%);
+}
+
+<div
+  class="c0 fi-wizard-navigation c1"
+>
+  <div
+    class="c0 fi-wizard-navigation_heading"
+  >
+    Steps
+  </div>
+  <nav
+    class="c2"
+  >
+    <ul
+      class="c3 fi-wizard-navigation_list"
+    >
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--visited"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_step-number"
+          >
+            1
+          </span>
+          <a
+            class="c7 fi-link--router c8"
+            href="https://suomi.fi"
+          >
+            Step 1 (visited)
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--current"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_step-number"
+          >
+            2
+          </span>
+          <a
+            aria-current="step"
+            aria-disabled="true"
+            class="c7 fi-link--router c8"
+            href="#"
+          >
+            Step 2 (current)
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--proceed"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_step-number"
+          >
+            3
+          </span>
+          <button
+            class="fi-link--router c8"
+          >
+            Step 3 (proceed)
+          </button>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--not-visited"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_step-number"
+          >
+            4
+          </span>
+          <a
+            aria-disabled="true"
+            class="c7 fi-link--router c8"
+            href="#"
+            tabindex="-1"
+          >
+            Step 4 (not visited)
+          </a>
+        </div>
+      </li>
+      <li
+        aria-disabled="true"
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--disabled"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_step-number"
+          >
+            5
+          </span>
+          <a
+            aria-disabled="true"
+            class="c7 fi-link--router c8"
+            href="#"
+            tabindex="-1"
+          >
+            Step 5 (disabled)
+          </a>
+        </div>
+      </li>
+    </ul>
+  </nav>
+</div>
+`;

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -816,6 +816,7 @@ exports[`calling render with the same component on the same container does not r
     />
     <ul
       class="c3 fi-wizard-navigation_list"
+      role="list"
     >
       <li
         class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--default"

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -308,6 +308,10 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
   margin-bottom: 1px;
 }
 

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -179,8 +179,61 @@ exports[`calling render with the same component on the same container does not r
   box-sizing: border-box;
 }
 
-.c1.fi-wizard-navigation {
-  padding: 15px;
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-icon {
+  display: inline-block;
+}
+
+.c9 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c9 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_heading {
+  margin-left: 20px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_divider {
+  height: 1px;
+  background: hsl(202,7%,80%);
+  margin-top: 20px;
+  margin-left: 20px;
+  margin-right: 20px;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  margin-top: 15px;
+  position: relative;
 }
 
 .c1.fi-wizard-navigation--small-screen {
@@ -201,6 +254,9 @@ exports[`calling render with the same component on the same container does not r
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  padding: 15px;
+  margin-left: 0;
+  position: relative;
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -214,37 +270,38 @@ exports[`calling render with the same component on the same container does not r
   font-size: 18px;
   line-height: 24px;
   font-weight: 600;
+}
+
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_heading:focus {
+  outline: 0;
+}
+
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_heading:focus:before {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_heading .fi-icon {
   color: hsl(212,63%,45%);
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
 }
 
-.c1.fi-wizard-navigation .fi-wizard-navigation_heading {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: 600;
-}
-
-.c1.fi-wizard-navigation .fi-wizard-navigation_list {
-  border-top: 1px solid hsl(202,7%,67%);
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  padding-top: 15px;
-  margin-top: 15px;
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_divider {
+  margin-top: 5px;
+  margin-left: 15px;
+  margin-right: 15px;
 }
 
 .c5.fi-wizard-navigation-item {
@@ -257,20 +314,41 @@ exports[`calling render with the same component on the same container does not r
   -ms-flex-align: center;
   align-items: center;
   position: relative;
+  padding: 5px 20px;
 }
 
 .c5.fi-wizard-navigation-item:not(:last-child) {
-  margin-bottom: 22px;
+  margin-bottom: 10px;
 }
 
-.c5.fi-wizard-navigation-item:not(:last-child):after {
+.c5.fi-wizard-navigation-item:after {
   content: '';
-  height: 10px;
-  width: 2px;
-  background: hsl(202,7%,67%);
+  height: calc(100% - 26px);
+  width: 1px;
+  background: hsl(0,0%,58%);
   position: absolute;
-  bottom: -16px;
-  left: 12px;
+  bottom: -10px;
+  left: 33px;
+}
+
+.c5.fi-wizard-navigation-item:last-child:after {
+  display: none;
+}
+
+.c5.fi-wizard-navigation-item:focus-within:before {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper {
@@ -278,14 +356,42 @@ exports[`calling render with the same component on the same container does not r
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
-.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
-  border: 1px solid hsl(202,7%,40%);
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  margin-bottom: 1px;
+}
+
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
+  outline: 0;
+  border: none;
+  box-shadow: none;
+}
+
+.c5.fi-wizard-navigation-item--default:hover {
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--default:hover:after {
+  left: 29px;
+}
+
+.c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -299,28 +405,16 @@ exports[`calling render with the same component on the same container does not r
   -ms-flex-align: center;
   align-items: center;
   border-radius: 50%;
-  width: 25px;
-  height: 25px;
-  font-weight: 600;
-  line-height: 27px;
+  border: 1px solid hsl(0,0%,58%);
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
   font-size: 18px;
   margin-right: 10px;
+  background: hsl(0,0%,100%);
 }
 
-.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
-  background: transparent;
-  border: none;
-  padding: 0;
-  margin: 0;
-  margin-bottom: 1px;
-}
-
-.c5.fi-wizard-navigation-item--visited .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
-  background: hsl(165,90%,27%);
-  color: hsl(0,0%,100%);
-}
-
-.c5.fi-wizard-navigation-item--visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+.c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -337,18 +431,52 @@ exports[`calling render with the same component on the same container does not r
   cursor: pointer;
 }
 
-.c5.fi-wizard-navigation-item--visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+.c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c5.fi-wizard-navigation-item--visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+.c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
   color: hsl(212,63%,45%);
 }
 
-.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
-  background: hsl(165,90%,27%);
-  color: hsl(0,0%,100%);
+.c5.fi-wizard-navigation-item--current {
+  background: hsl(212,63%,95%);
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--current:hover {
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--current:after {
+  left: 29px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  border: 1px solid hsl(0,0%,58%);
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+  background: hsl(0,0%,100%);
 }
 
 .c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
@@ -377,13 +505,116 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-wizard-navigation-item--proceed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
-  background: hsl(0,0%,100%);
-  color: hsl(202,7%,40%);
-  border: 1px solid hsl(166,90%,34%);
+.c5.fi-wizard-navigation-item--current-completed {
+  background: hsl(212,63%,95%);
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
 }
 
-.c5.fi-wizard-navigation-item--proceed .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+.c5.fi-wizard-navigation-item--current-completed:hover {
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--current-completed:after {
+  left: 29px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  border: 1px solid hsl(165,90%,27%);
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+  background: hsl(165,90%,27%);
+  color: hsl(0,0%,100%);
+}
+
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon .fi-icon {
+  width: 10px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  margin-bottom: 1px;
+}
+
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-wizard-navigation-item--completed:hover {
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--completed:hover:after {
+  left: 29px;
+}
+
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  border: 1px solid hsl(165,90%,27%);
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+  background: hsl(165,90%,27%);
+  color: hsl(0,0%,100%);
+}
+
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon .fi-icon {
+  width: 10px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -400,24 +631,51 @@ exports[`calling render with the same component on the same container does not r
   cursor: pointer;
 }
 
-.c5.fi-wizard-navigation-item--proceed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c5.fi-wizard-navigation-item--proceed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
   color: hsl(212,63%,45%);
 }
 
-.c5.fi-wizard-navigation-item--not-visited .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
-  background: hsl(0,0%,100%);
-  color: hsl(0,0%,16%);
-  border: 1px solid hsl(0,0%,16%);
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  position: relative;
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
 }
 
-.c5.fi-wizard-navigation-item--not-visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon:after {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  content: '';
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  border: 1px solid hsl(201,7%,58%);
+  width: 5px;
+  height: 5px;
+  background: hsl(201,7%,58%);
+}
+
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
   pointer-events: none;
-  color: hsl(0,0%,16%);
+  color: hsl(201,7%,58%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -433,24 +691,49 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
-.c5.fi-wizard-navigation-item--not-visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c5.fi-wizard-navigation-item--not-visited .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
-  color: hsl(0,0%,16%);
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(201,7%,58%);
 }
 
-.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_step-number {
-  background: hsl(0,0%,100%);
-  color: hsl(202,7%,40%);
-  border: 1px solid hsl(202,7%,80%);
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  position: relative;
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon:after {
+  position: absolute;
+  top: -5px;
+  right: 12px;
+  content: '';
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 1px;
+  height: 36px;
+  background: hsl(201,7%,58%);
 }
 
 .c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
   pointer-events: none;
-  color: hsl(202,7%,67%);
+  color: hsl(201,7%,58%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -472,7 +755,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
-  color: hsl(202,7%,67%);
+  color: hsl(201,7%,58%);
 }
 
 .c8 {
@@ -537,25 +820,61 @@ exports[`calling render with the same component on the same container does not r
   <nav
     class="c2"
   >
+    <div
+      class="c0 fi-wizard-navigation_divider"
+    />
     <ul
       class="c3 fi-wizard-navigation_list"
     >
       <li
-        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--visited"
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--default"
       >
         <div
           class="c0 fi-wizard-navigation-item_inner-wrapper"
         >
           <span
-            class="c6 fi-wizard-navigation-item_step-number"
-          >
-            1
-          </span>
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
           <a
             class="c7 fi-link--router c8"
             href="https://suomi.fi"
           >
-            Step 1 (visited)
+            1. Step
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--completed"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="fi-icon c9"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 20 20"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="fi-icon-base-fill"
+                d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
+                fill="#222"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <a
+            aria-label="Step 2. This step is completed"
+            class="c7 fi-link--router c8"
+            href="#"
+          >
+            2. Step
           </a>
         </div>
       </li>
@@ -566,56 +885,52 @@ exports[`calling render with the same component on the same container does not r
           class="c0 fi-wizard-navigation-item_inner-wrapper"
         >
           <span
-            class="c6 fi-wizard-navigation-item_step-number"
-          >
-            2
-          </span>
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
           <a
             aria-current="step"
-            aria-disabled="true"
             class="c7 fi-link--router c8"
             href="#"
           >
-            Step 2 (current)
+            3. Step
           </a>
         </div>
       </li>
       <li
-        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--proceed"
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--coming"
       >
         <div
           class="c0 fi-wizard-navigation-item_inner-wrapper"
         >
           <span
-            class="c6 fi-wizard-navigation-item_step-number"
-          >
-            3
-          </span>
-          <button
-            class="fi-link--router c8"
-          >
-            Step 3 (proceed)
-          </button>
-        </div>
-      </li>
-      <li
-        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--not-visited"
-      >
-        <div
-          class="c0 fi-wizard-navigation-item_inner-wrapper"
-        >
-          <span
-            class="c6 fi-wizard-navigation-item_step-number"
-          >
-            4
-          </span>
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
           <a
             aria-disabled="true"
             class="c7 fi-link--router c8"
             href="#"
             tabindex="-1"
           >
-            Step 4 (not visited)
+            4. Step
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--coming"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
+          <a
+            aria-disabled="true"
+            class="c7 fi-link--router c8"
+            href="#"
+            tabindex="-1"
+          >
+            5. Step
           </a>
         </div>
       </li>
@@ -627,18 +942,34 @@ exports[`calling render with the same component on the same container does not r
           class="c0 fi-wizard-navigation-item_inner-wrapper"
         >
           <span
-            class="c6 fi-wizard-navigation-item_step-number"
-          >
-            5
-          </span>
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
           <a
             aria-disabled="true"
             class="c7 fi-link--router c8"
             href="#"
             tabindex="-1"
           >
-            Step 5 (disabled)
+            6. Step
           </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--coming"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
+          <button
+            aria-disabled="true"
+            class="fi-link--router c8"
+            tabindex="-1"
+          >
+            7. Step
+          </button>
         </div>
       </li>
     </ul>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -335,20 +335,10 @@ exports[`calling render with the same component on the same container does not r
   display: none;
 }
 
-.c5.fi-wizard-navigation-item:focus-within:before {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
+.c5.fi-wizard-navigation-item:focus-within {
+  outline: 0;
   border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper {

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -818,6 +818,7 @@ exports[`calling render with the same component on the same container does not r
     Steps
   </div>
   <nav
+    aria-label="Test"
     class="c2"
   >
     <div

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -183,23 +183,11 @@ exports[`calling render with the same component on the same container does not r
   padding: 15px;
 }
 
-.c1.fi-wizard-navigation .fi-wizard-navigation_heading {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: 600;
+.c1.fi-wizard-navigation--small-screen {
+  background: hsl(212,63%,95%);
 }
 
-.c1.fi-wizard-navigation .fi-wizard-navigation_heading--small-screen {
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_heading {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -228,10 +216,26 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 600;
 }
 
-.c1.fi-wizard-navigation .fi-wizard-navigation_heading--small-screen .fi-icon {
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_heading .fi-icon {
   color: hsl(212,63%,45%);
   width: 20px;
   height: 20px;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_heading {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
 }
 
 .c1.fi-wizard-navigation .fi-wizard-navigation_list {

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -41,6 +41,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
 
       .fi-link--router {
+        background: transparent;
+        border: none;
+        padding: 0;
+        margin: 0;
         margin-bottom: 1px; /* Compensate font size difference */
       }
     }

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -9,35 +9,38 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     display: flex;
     align-items: center;
     position: relative;
+    padding: ${theme.spacing.xxs} ${theme.spacing.m};
+
     &:not(:last-child) {
-      margin-bottom: 22px;
+      margin-bottom: 10px;
+    }
+    &:after {
+      content: '';
+      height: calc(100% - 26px);
+      width: 1px;
+      background: ${theme.colors.blackLight1};
+      position: absolute;
+      bottom: -10px;
+      left: 33px;
+    }
+    &:last-child {
       &:after {
-        content: '';
-        height: 10px;
-        width: 2px;
-        background: ${theme.colors.depthBase};
-        position: absolute;
-        bottom: -16px;
-        left: 12px;
+        display: none;
+      }
+    }
+
+    &:focus-within {
+      &:before {
+        ${theme.focus.absoluteFocus}
       }
     }
 
     .fi-wizard-navigation-item_inner-wrapper {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
 
-      .fi-wizard-navigation-item_step-number {
-        border: 1px solid ${theme.colors.depthDark1};
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        border-radius: 50%;
-        width: 25px;
-        height: 25px;
-        font-weight: 600;
-        line-height: 27px;
-        font-size: 18px;
-        margin-right: ${theme.spacing.xs};
+      .fi-wizard-navigation-item_left-icon {
+        flex-shrink: 0;
       }
 
       .fi-link--router {
@@ -46,14 +49,36 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         padding: 0;
         margin: 0;
         margin-bottom: 1px; /* Compensate font size difference */
+        &:focus {
+          outline: 0;
+          border: none;
+          box-shadow: none;
+        }
       }
     }
 
-    &--visited {
+    &--default {
+      &:hover {
+        border-left: 4px solid ${theme.colors.highlightBase};
+        padding-left: calc(${theme.spacing.m} - 4px);
+
+        &:after {
+          left: 29px;
+        }
+      }
       .fi-wizard-navigation-item_inner-wrapper {
-        .fi-wizard-navigation-item_step-number {
-          background: ${theme.colors.successDark1};
-          color: ${theme.colors.whiteBase};
+        .fi-wizard-navigation-item_left-icon {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: 50%;
+          border: 1px solid ${theme.colors.blackLight1};
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          background: ${theme.colors.whiteBase};
         }
         .fi-link--router {
           ${font(theme)('actionElementInnerText')}
@@ -69,10 +94,32 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     &--current {
+      &:hover {
+        border-left: 4px solid ${theme.colors.highlightBase};
+        padding-left: calc(${theme.spacing.m} - 4px);
+      }
+      background: ${theme.colors.highlightLight3};
+      border-left: 4px solid ${theme.colors.highlightBase};
+      padding-left: calc(${theme.spacing.m} - 4px);
+
+      &:after {
+        left: 29px;
+        height: 10px;
+      }
+
       .fi-wizard-navigation-item_inner-wrapper {
-        .fi-wizard-navigation-item_step-number {
-          background: ${theme.colors.successDark1};
-          color: ${theme.colors.whiteBase};
+        .fi-wizard-navigation-item_left-icon {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: 50%;
+          border: 1px solid ${theme.colors.blackLight1};
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          background: ${theme.colors.whiteBase};
         }
         .fi-link--router {
           pointer-events: none;
@@ -88,12 +135,83 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
 
-    &--proceed {
+    &--current-completed {
+      &:hover {
+        border-left: 4px solid ${theme.colors.highlightBase};
+        padding-left: calc(${theme.spacing.m} - 4px);
+      }
+
+      background: ${theme.colors.highlightLight3};
+      border-left: 4px solid ${theme.colors.highlightBase};
+      padding-left: calc(${theme.spacing.m} - 4px);
+
+      &:after {
+        left: 29px;
+        height: 10px;
+      }
+
       .fi-wizard-navigation-item_inner-wrapper {
-        .fi-wizard-navigation-item_step-number {
-          background: ${theme.colors.whiteBase};
-          color: ${theme.colors.depthDark1};
-          border: 1px solid ${theme.colors.successBase};
+        .fi-wizard-navigation-item_left-icon {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: 50%;
+          border: 1px solid ${theme.colors.successDark1};
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          background: ${theme.colors.successDark1};
+          color: ${theme.colors.whiteBase};
+
+          .fi-icon {
+            width: 10px;
+            height: 10px;
+          }
+        }
+        .fi-link--router {
+          pointer-events: none;
+          color: ${theme.colors.blackBase};
+          ${font(theme)('actionElementInnerTextBold')}
+          &:hover,
+          &:focus {
+            text-decoration: none;
+            color: ${theme.colors.blackBase};
+          }
+          margin-bottom: 1px; /* Compensate font size difference */
+        }
+      }
+    }
+
+    &--completed {
+      &:hover {
+        border-left: 4px solid ${theme.colors.highlightBase};
+        padding-left: calc(${theme.spacing.m} - 4px);
+
+        &:after {
+          left: 29px;
+        }
+      }
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_left-icon {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: 50%;
+          border: 1px solid ${theme.colors.successDark1};
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          background: ${theme.colors.successDark1};
+          color: ${theme.colors.whiteBase};
+
+          .fi-icon {
+            width: 10px;
+            height: 10px;
+          }
         }
         .fi-link--router {
           ${font(theme)('actionElementInnerText')}
@@ -108,22 +226,39 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
 
-    &--not-visited {
+    &--coming {
       .fi-wizard-navigation-item_inner-wrapper {
-        .fi-wizard-navigation-item_step-number {
-          background: ${theme.colors.whiteBase};
-          color: ${theme.colors.blackBase};
-          border: 1px solid ${theme.colors.blackBase};
+        .fi-wizard-navigation-item_left-icon {
+          position: relative;
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          &:after {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            content: '';
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            border-radius: 50%;
+            border: 1px solid ${theme.colors.depthDark3};
+            width: 5px;
+            height: 5px;
+            background: ${theme.colors.depthDark3};
+          }
         }
         .fi-link--router {
           pointer-events: none;
-          color: ${theme.colors.blackBase};
+          color: ${theme.colors.depthDark3};
           ${font(theme)('actionElementInnerText')}
           &:hover {
             text-decoration: none;
           }
           &:visited {
-            color: ${theme.colors.blackBase};
+            color: ${theme.colors.depthDark3};
           }
         }
       }
@@ -131,20 +266,35 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &--disabled {
       .fi-wizard-navigation-item_inner-wrapper {
-        .fi-wizard-navigation-item_step-number {
-          background: ${theme.colors.whiteBase};
-          color: ${theme.colors.depthDark1};
-          border: 1px solid ${theme.colors.depthLight1};
+        .fi-wizard-navigation-item_left-icon {
+          position: relative;
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          &:after {
+            position: absolute;
+            top: -5px;
+            right: 12px;
+            content: '';
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            width: 1px;
+            height: 36px;
+            background: ${theme.colors.depthDark3};
+          }
         }
         .fi-link--router {
           pointer-events: none;
-          color: ${theme.colors.depthBase};
+          color: ${theme.colors.depthDark3};
           ${font(theme)('actionElementInnerText')}
           &:hover {
             text-decoration: none;
           }
           &:visited {
-            color: ${theme.colors.depthBase};
+            color: ${theme.colors.depthDark3};
           }
         }
       }

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -30,9 +30,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     &:focus-within {
-      &:before {
-        ${theme.focus.absoluteFocus}
-      }
+      ${theme.focus.boxShadowFocus}
     }
 
     .fi-wizard-navigation-item_inner-wrapper {

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -1,0 +1,149 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  /* stylelint-disable no-descending-specificity */
+  /* Nested :hover etc selectors do not work well with this rule. */
+  &.fi-wizard-navigation-item {
+    display: flex;
+    align-items: center;
+    position: relative;
+    &:not(:last-child) {
+      margin-bottom: 22px;
+      &:after {
+        content: '';
+        height: 10px;
+        width: 2px;
+        background: ${theme.colors.depthBase};
+        position: absolute;
+        bottom: -16px;
+        left: 12px;
+      }
+    }
+
+    .fi-wizard-navigation-item_inner-wrapper {
+      display: flex;
+      align-items: center;
+
+      .fi-wizard-navigation-item_step-number {
+        border: 1px solid ${theme.colors.depthDark1};
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        border-radius: 50%;
+        width: 25px;
+        height: 25px;
+        font-weight: 600;
+        line-height: 27px;
+        font-size: 18px;
+        margin-right: ${theme.spacing.xs};
+      }
+
+      .fi-link--router {
+        margin-bottom: 1px; /* Compensate font size difference */
+      }
+    }
+
+    &--visited {
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_step-number {
+          background: ${theme.colors.successDark1};
+          color: ${theme.colors.whiteBase};
+        }
+        .fi-link--router {
+          ${font(theme)('actionElementInnerText')}
+          cursor: pointer;
+          &:hover {
+            text-decoration: underline;
+          }
+          &:visited {
+            color: ${theme.colors.highlightBase};
+          }
+        }
+      }
+    }
+
+    &--current {
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_step-number {
+          background: ${theme.colors.successDark1};
+          color: ${theme.colors.whiteBase};
+        }
+        .fi-link--router {
+          pointer-events: none;
+          color: ${theme.colors.blackBase};
+          ${font(theme)('actionElementInnerTextBold')}
+          &:hover,
+          &:focus {
+            text-decoration: none;
+            color: ${theme.colors.blackBase};
+          }
+          margin-bottom: 1px; /* Compensate font size difference */
+        }
+      }
+    }
+
+    &--proceed {
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_step-number {
+          background: ${theme.colors.whiteBase};
+          color: ${theme.colors.depthDark1};
+          border: 1px solid ${theme.colors.successBase};
+        }
+        .fi-link--router {
+          ${font(theme)('actionElementInnerText')}
+          cursor: pointer;
+          &:hover {
+            text-decoration: underline;
+          }
+          &:visited {
+            color: ${theme.colors.highlightBase};
+          }
+        }
+      }
+    }
+
+    &--not-visited {
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_step-number {
+          background: ${theme.colors.whiteBase};
+          color: ${theme.colors.blackBase};
+          border: 1px solid ${theme.colors.blackBase};
+        }
+        .fi-link--router {
+          pointer-events: none;
+          color: ${theme.colors.blackBase};
+          ${font(theme)('actionElementInnerText')}
+          &:hover {
+            text-decoration: none;
+          }
+          &:visited {
+            color: ${theme.colors.blackBase};
+          }
+        }
+      }
+    }
+
+    &--disabled {
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_step-number {
+          background: ${theme.colors.whiteBase};
+          color: ${theme.colors.depthDark1};
+          border: 1px solid ${theme.colors.depthLight1};
+        }
+        .fi-link--router {
+          pointer-events: none;
+          color: ${theme.colors.depthBase};
+          ${font(theme)('actionElementInnerText')}
+          &:hover {
+            text-decoration: none;
+          }
+          &:visited {
+            color: ${theme.colors.depthBase};
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
@@ -11,7 +11,7 @@ export interface WizardNavigationItemProps {
   className?: string;
   /** Use the polymorphic RouterLink component as child to get intended CSS styling */
   children: ReactNode;
-  /** Status of the item. Changes styling and availability */
+  /** Status of the item. Affects styling and element reachability */
   status:
     | 'default'
     | 'current'

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
@@ -4,48 +4,58 @@ import { HtmlDiv, HtmlLi, HtmlSpan } from '../../../../reset';
 import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
 import { baseStyles } from './WizardNavigationItem.baseStyles';
 import styled from 'styled-components';
+import { Icon } from '../../../Icon/Icon';
 
 export interface WizardNavigationItemProps {
   /** Custom class */
   className?: string;
   /** Use the polymorphic RouterLink component as child to get intended CSS styling */
   children: ReactNode;
-  /** Indicates the step's number */
-  stepNumber: Number;
   /** Status of the item. Changes styling and availability */
-  status: 'visited' | 'current' | 'proceed' | 'not-visited' | 'disabled';
+  status:
+    | 'default'
+    | 'current'
+    | 'current-completed'
+    | 'completed'
+    | 'coming'
+    | 'disabled';
 }
 
 const baseClassName = 'fi-wizard-navigation-item';
-const visitedClassName = `${baseClassName}--visited`;
+const defaultClassName = `${baseClassName}--default`;
 const currentClassName = `${baseClassName}--current`;
-const proceedClassName = `${baseClassName}--proceed`;
-const notVisitedClassName = `${baseClassName}--not-visited`;
+const currentCompletedClassName = `${baseClassName}--current-completed`;
+const completedClassName = `${baseClassName}--completed`;
+const comingClassName = `${baseClassName}--coming`;
 const disabledClassName = `${baseClassName}--disabled`;
 
 const innerWrapperClassName = `${baseClassName}_inner-wrapper`;
-const stepNumberClassName = `${baseClassName}_step-number`;
+const leftIconClassName = `${baseClassName}_left-icon`;
 
 const BaseWizardNavigationItem = ({
   className,
   children,
   status,
-  stepNumber,
   ...passProps
 }: WizardNavigationItemProps) => (
   <HtmlLi
     className={classnames(className, baseClassName, {
-      [visitedClassName]: status === 'visited',
+      [defaultClassName]: status === 'default',
       [currentClassName]: status === 'current',
-      [proceedClassName]: status === 'proceed',
-      [notVisitedClassName]: status === 'not-visited',
+      [currentCompletedClassName]: status === 'current-completed',
+      [completedClassName]: status === 'completed',
+      [comingClassName]: status === 'coming',
       [disabledClassName]: status === 'disabled',
     })}
     aria-disabled={status === 'disabled' ? true : undefined}
     {...passProps}
   >
     <HtmlDiv className={innerWrapperClassName}>
-      <HtmlSpan className={stepNumberClassName}>{stepNumber}</HtmlSpan>
+      <HtmlSpan className={leftIconClassName}>
+        {(status === 'completed' || status === 'current-completed') && (
+          <Icon icon="check" />
+        )}
+      </HtmlSpan>
       {children}
     </HtmlDiv>
   </HtmlLi>

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
@@ -1,0 +1,72 @@
+import React, { ReactNode } from 'react';
+import classnames from 'classnames';
+import { HtmlDiv, HtmlLi, HtmlSpan } from '../../../../reset';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import { baseStyles } from './WizardNavigationItem.baseStyles';
+import styled from 'styled-components';
+
+export interface WizardNavigationItemProps {
+  /** Custom class */
+  className?: string;
+  /** Use the polymorphic RouterLink component as child to get intended CSS styling */
+  children: ReactNode;
+  /** Indicates the step's number */
+  stepNumber: Number;
+  /** Status of the item. Changes styling and availability */
+  status: 'visited' | 'current' | 'proceed' | 'not-visited' | 'disabled';
+}
+
+const baseClassName = 'fi-wizard-navigation-item';
+const visitedClassName = `${baseClassName}--visited`;
+const currentClassName = `${baseClassName}--current`;
+const proceedClassName = `${baseClassName}--proceed`;
+const notVisitedClassName = `${baseClassName}--not-visited`;
+const disabledClassName = `${baseClassName}--disabled`;
+
+const innerWrapperClassName = `${baseClassName}_inner-wrapper`;
+const stepNumberClassName = `${baseClassName}_step-number`;
+
+const BaseWizardNavigationItem = ({
+  className,
+  children,
+  status,
+  stepNumber,
+  ...passProps
+}: WizardNavigationItemProps) => (
+  <HtmlLi
+    className={classnames(className, baseClassName, {
+      [visitedClassName]: status === 'visited',
+      [currentClassName]: status === 'current',
+      [proceedClassName]: status === 'proceed',
+      [notVisitedClassName]: status === 'not-visited',
+      [disabledClassName]: status === 'disabled',
+    })}
+    aria-disabled={status === 'disabled' ? true : undefined}
+    {...passProps}
+  >
+    <HtmlDiv className={innerWrapperClassName}>
+      <HtmlSpan className={stepNumberClassName}>{stepNumber}</HtmlSpan>
+      {children}
+    </HtmlDiv>
+  </HtmlLi>
+);
+
+const StyledWizardNavigationItem = styled(
+  (props: WizardNavigationItemProps & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseWizardNavigationItem {...passProps} />;
+  },
+)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const WizardNavigationItem = (props: WizardNavigationItemProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledWizardNavigationItem theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+WizardNavigationItem.displayName = 'WizardNavigationItem';
+export { WizardNavigationItem };

--- a/src/core/Navigation/WizardNavigation/index.ts
+++ b/src/core/Navigation/WizardNavigation/index.ts
@@ -1,0 +1,8 @@
+export {
+  WizardNavigation,
+  WizardNavigationProps,
+} from './WizardNavigation/WizardNavigation';
+export {
+  WizardNavigationItem,
+  WizardNavigationItemProps,
+} from './WizardNavigationItem/WizardNavigationItem';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,6 +96,12 @@ export {
   ModalFooterProps,
 } from './core/Modal/';
 export {
+  WizardNavigation,
+  WizardNavigationProps,
+  WizardNavigationItem,
+  WizardNavigationItemProps,
+} from './core/Navigation/WizardNavigation';
+export {
   Expander,
   ExpanderProps,
   ExpanderGroup,

--- a/src/reset/HtmlNav/HtmlNav.tsx
+++ b/src/reset/HtmlNav/HtmlNav.tsx
@@ -6,7 +6,7 @@ import { asPropType } from '../../utils/typescript';
 export interface HtmlNavProps
   extends Omit<HTMLProps<HTMLElement>, 'ref' | 'as'> {
   as?: asPropType;
-  forwardedRef?: React.RefObject<HTMLDivElement>;
+  forwardedRef?: React.Ref<HTMLElement>;
 }
 
 const aResets = css`

--- a/src/reset/HtmlNav/HtmlNav.tsx
+++ b/src/reset/HtmlNav/HtmlNav.tsx
@@ -6,6 +6,7 @@ import { asPropType } from '../../utils/typescript';
 export interface HtmlNavProps
   extends Omit<HTMLProps<HTMLElement>, 'ref' | 'as'> {
   as?: asPropType;
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
 const aResets = css`
@@ -15,7 +16,9 @@ const aResets = css`
   max-width: 100%;
 `;
 
-const Nav = (props: HtmlNavProps) => <nav {...props} />;
+const Nav = ({ forwardedRef, ...passProps }: HtmlNavProps) => (
+  <nav ref={forwardedRef} {...passProps} />
+);
 
 export const HtmlNav = styled(Nav)`
   ${aResets}


### PR DESCRIPTION
## Description

This PR introduces the `<WizardNavigation>` component. As children, it takes `<WizardNavigationItem>` components which in turn takes a ReactNode as child. In practice, the child of a `<WizardNavigationItem>` is supposed to be a `<RouterLink>` which is polymorphic and can thus be rendered as any semantic HTML element as well as third party library elements such as React Router Link, Gatsby Link etc. 

A `<WizardNavigationItem>` can have one of these 5 statuses (affects styling and link availability):

- default: reachable & incomplete step
- current: currently active step
- completed: a step where the user has filled all necessary information
- current-completed: a combination of current and completed statuses
- coming: a step which is unreachable at the moment (but will become available when e.g. the previous steps have been completed)
- disabled: disabled step, not reachable. We do not recommend the use of this status unless absolutely necessary

## Motivation and Context

We want to have ready-made navigation components available in the library. Having the polymorphic `<RouterLink>` component available was the key to implementing this component in a way which allows a wide range of usecases. 

## How Has This Been Tested?

Styleguidist, CRA app

## Screenshots
![image](https://user-images.githubusercontent.com/17459942/189882541-68dfca8d-11ec-4be6-bf92-26cfe720bb70.png)


## Release notes

### WizardNavigation
* Introduce `<WizardNavigation>` component