### PR TITLE
[Feature] Add plain div and span as variants for Block

### DIFF
--- a/src/core/Block/Block.baseStyles.ts
+++ b/src/core/Block/Block.baseStyles.ts
@@ -2,8 +2,9 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
 import { spacingModifiers } from '../theme/utils';
+import { BlockVariant } from './Block';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, variant?: BlockVariant) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   ${spacingModifiers(theme)('margin')('&.fi-block--margin')}
@@ -16,4 +17,5 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${spacingModifiers(theme)('padding-right')('&.fi-block--padding-right')}
   ${spacingModifiers(theme)('padding-bottom')('&.fi-block--padding-bottom')}
   ${spacingModifiers(theme)('padding-left')('&.fi-block--padding-left')}
+  ${!!variant && variant === 'span' ? 'display: inline-block' : ''}
 `;

--- a/src/core/Block/Block.md
+++ b/src/core/Block/Block.md
@@ -38,5 +38,10 @@ import { Block } from 'suomifi-ui-components';
 ```js
 import { Block } from 'suomifi-ui-components';
 
-<Block variant="section">I'm semantically a section</Block>;
+<>
+  <Block variant="section">I'm semantically a section</Block>
+  <Block variant="span">
+    Block component rendered as an inline-block span
+  </Block>
+</>;
 ```

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -53,6 +53,8 @@ export interface BlockProps extends HtmlDivProps {
    * @default default
    */
   variant?: BlockVariant;
+  /** Ref is forwarded to the block element. All variants are supported. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<any>;
 }
 
 class SemanticBlock extends Component<BlockProps> {
@@ -121,7 +123,7 @@ const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
 /**
  * Used in displaying a generic piece of HTML e.g. a div
  */
-const Block = forwardRef((props: BlockProps, ref: React.Ref<HTMLElement>) => (
+const Block = forwardRef((props: BlockProps, ref: React.RefObject<any>) => (
   <SuomifiThemeConsumer>
     {({ suomifiTheme }) => (
       <StyledBlock theme={suomifiTheme} forwardedRef={ref} {...props} />

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -8,6 +8,16 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
 
 const baseClassName = 'fi-block';
 
+export type BlockVariant =
+  | 'default'
+  | 'div'
+  | 'span'
+  | 'section'
+  | 'header'
+  | 'nav'
+  | 'main'
+  | 'footer';
+
 export interface BlockProps extends HtmlDivProps {
   /** Padding from theme */
   padding?: SpacingWithoutInsetProp;
@@ -39,17 +49,10 @@ export interface BlockProps extends HtmlDivProps {
   my?: SpacingWithoutInsetProp;
   /**
    * Change block semantics. "Default" renders a div with SuomifiTheme reset styles applied,
-   * whereas "div" renders a plain HTML div
+   * whereas "div" renders a plain HTML div. "Span" gets rendered with display: inline-block style
    * @default default
    */
-  variant?:
-    | 'default'
-    | 'div'
-    | 'section'
-    | 'header'
-    | 'nav'
-    | 'main'
-    | 'footer';
+  variant?: BlockVariant;
 }
 
 class SemanticBlock extends Component<BlockProps> {
@@ -108,11 +111,11 @@ class SemanticBlock extends Component<BlockProps> {
   }
 }
 
-const StyledBlock = styled((props: SuomifiThemeProp) => {
-  const { theme, ...passProps } = props;
-  return <SemanticBlock {...passProps} />;
+const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
+  const { theme, variant, ...passProps } = props;
+  return <SemanticBlock variant={variant} {...passProps} />;
 })`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, variant }) => baseStyles(theme, variant)}
 `;
 
 /**

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -54,7 +54,7 @@ export interface BlockProps extends HtmlDivProps {
    */
   variant?: BlockVariant;
   /** Ref is forwarded to the block element. All variants are supported. Alternative for React `ref` attribute. */
-  forwardedRef?: React.RefObject<any>;
+  forwardedRef?: React.Ref<any>;
 }
 
 class SemanticBlock extends Component<BlockProps> {
@@ -123,7 +123,7 @@ const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
 /**
  * Used in displaying a generic piece of HTML e.g. a div
  */
-const Block = forwardRef((props: BlockProps, ref: React.RefObject<any>) => (
+const Block = forwardRef((props: BlockProps, ref: React.Ref<any>) => (
   <SuomifiThemeConsumer>
     {({ suomifiTheme }) => (
       <StyledBlock theme={suomifiTheme} forwardedRef={ref} {...props} />

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -38,12 +38,18 @@ export interface BlockProps extends HtmlDivProps {
   /** Margin on the y-axis (top & bottom) from theme */
   my?: SpacingWithoutInsetProp;
   /**
-   * Change block semantics
+   * Change block semantics. "Default" renders a div with SuomifiTheme reset styles applied,
+   * whereas "div" renders a plain HTML div
    * @default default
    */
-  variant?: 'default' | 'section' | 'header' | 'nav' | 'main' | 'footer';
-  /** Ref is forwarded to the block element. All variants are supported. Alternative for React `ref` attribute. */
-  forwardedRef?: React.Ref<HTMLElement>;
+  variant?:
+    | 'default'
+    | 'div'
+    | 'section'
+    | 'header'
+    | 'nav'
+    | 'main'
+    | 'footer';
 }
 
 class SemanticBlock extends Component<BlockProps> {


### PR DESCRIPTION
## Description

This PR adds two new variant options for the `<Block>` component:
- div
- span

## Motivation and Context
The existing `default` variant renders the component as a `<div>`, but it applies the reset styles from the suomifiTheme (including margin: 0 and padding: 0). This has been deemed cumbersome by our users. Now the `<Block>` component can be rendered as a plain div without the reset styles. 

In addition, there was a request to add `span` as one of the available variants. Span renders as an inline-block without reset styles

## How Has This Been Tested?
Styleguidist

## Release notes

### Block
* Add `div` and `span` as a possible variants. "Div" renders as a plain HTML div without suomifiTheme div reset styles. "Span" renders as an inline-block without suomifiTheme reset styles
