### PR TITLE
[Feature] SideNavigation

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -201,6 +201,13 @@ module.exports = {
           name: 'Toast',
           components: getComponents(['Toast']),
         },
+        {
+          name: 'WizardNavigation',
+          components: getComponentWithVariants('Navigation/WizardNavigation')([
+            'WizardNavigation/WizardNavigation',
+            'WizardNavigationItem/WizardNavigationItem',
+          ]),
+        }
       ],
       sectionDepth: 1,
       expand: true,

--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -215,6 +215,13 @@ module.exports = {
             'ServiceNavigationItem/ServiceNavigationItem',
           ]),
         },
+        {
+          name: 'SideNavigation',
+          components: getComponentWithVariants('Navigation/SideNavigation')([
+            'SideNavigation/SideNavigation',
+            'SideNavigationItem/SideNavigationItem',
+          ]),
+        },
       ],
       sectionDepth: 1,
       expand: true,

--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -207,7 +207,14 @@ module.exports = {
             'WizardNavigation/WizardNavigation',
             'WizardNavigationItem/WizardNavigationItem',
           ]),
-        }
+        },
+        {
+          name: 'ServiceNavigation',
+          components: getComponentWithVariants('Navigation/ServiceNavigation')([
+            'ServiceNavigation/ServiceNavigation',
+            'ServiceNavigationItem/ServiceNavigationItem',
+          ]),
+        },
       ],
       sectionDepth: 1,
       expand: true,

--- a/.styleguidist/webpack.config.js
+++ b/.styleguidist/webpack.config.js
@@ -3,6 +3,9 @@ const path = require('path');
 module.exports = (env) => ({
   mode: env.production ? 'production' : 'development',
   devtool: env.production ? 'inline-source-map' : 'eval',
+  devServer: {
+    injectClient: true,
+  },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx'],
     fallback: {

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ After cloning suomifi-ui-components, run `yarn` to fetch its dependencies. Then,
 
 2. `yarn test` runs written tests.
 
-3. `yarn test:lint` checks TypeScript code for readability, maintainability, and functionality errors.
+3. `yarn lint` checks TypeScript code for readability, maintainability, and functionality errors.
 
 4. `yarn prettier:check` checks the code style.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "9.0.0",
+  "version": "9.1.0-beta.0",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "9.0.0-beta.3",
+  "version": "9.0.0",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "9.1.0-beta.0",
+  "version": "9.1.0-beta.1",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/core/Alert/Alert/Alert.md
+++ b/src/core/Alert/Alert/Alert.md
@@ -1,8 +1,11 @@
 ```js
 import { Alert } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
 
 <>
-  <Alert closeText="Close" smallScreen>
+  <Alert closeText="Close" smallScreen ref={exampleRef}>
     The service will be temporarily unavailable on 5.6.2021 at 21.00 –
     23.59 due to maintenance.
   </Alert>

--- a/src/core/Alert/Alert/Alert.tsx
+++ b/src/core/Alert/Alert/Alert.tsx
@@ -39,13 +39,11 @@ export interface AlertProps extends HtmlDivWithRefProps {
   onCloseButtonClick?: () => void;
   /** Custom props passed to the close button */
   closeButtonProps?: Omit<HtmlButtonProps, 'onClick' | 'aria-label'>;
+  /** Ref is passed to the root div element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
-}
-
-class BaseAlert extends Component<AlertProps & InnerRef> {
+class BaseAlert extends Component<AlertProps> {
   render() {
     const {
       className,
@@ -112,12 +110,10 @@ class BaseAlert extends Component<AlertProps & InnerRef> {
   }
 }
 
-const StyledAlert = styled(
-  (props: AlertProps & InnerRef & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
-    return <BaseAlert {...passProps} />;
-  },
-)`
+const StyledAlert = styled((props: AlertProps & SuomifiThemeProp) => {
+  const { theme, ...passProps } = props;
+  return <BaseAlert {...passProps} />;
+})`
   ${({ theme }) => baseStyles(theme)}
 `;
 

--- a/src/core/Alert/InlineAlert/InlineAlert.md
+++ b/src/core/Alert/InlineAlert/InlineAlert.md
@@ -1,8 +1,11 @@
 ```js
 import { InlineAlert } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
 
 <>
-  <InlineAlert labelText="Info">
+  <InlineAlert labelText="Info" ref={exampleRef}>
     Make sure that your name is typed exactly as it appears in your
     identification.
   </InlineAlert>

--- a/src/core/Block/Block.baseStyles.ts
+++ b/src/core/Block/Block.baseStyles.ts
@@ -2,8 +2,9 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
 import { spacingModifiers } from '../theme/utils';
+import { BlockVariant } from './Block';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, variant?: BlockVariant) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   ${spacingModifiers(theme)('margin')('&.fi-block--margin')}
@@ -16,4 +17,5 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${spacingModifiers(theme)('padding-right')('&.fi-block--padding-right')}
   ${spacingModifiers(theme)('padding-bottom')('&.fi-block--padding-bottom')}
   ${spacingModifiers(theme)('padding-left')('&.fi-block--padding-left')}
+  ${!!variant && variant === 'span' ? 'display: inline-block' : ''}
 `;

--- a/src/core/Block/Block.md
+++ b/src/core/Block/Block.md
@@ -6,6 +6,15 @@ import { Block } from 'suomifi-ui-components';
 
 ```js
 import { Block } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
+
+<Block ref={exampleRef}>Block with ref</Block>;
+```
+
+```js
+import { Block } from 'suomifi-ui-components';
 
 <Block padding="xxxl" style={{ border: '1px solid red' }}>
   Block with xl-padding

--- a/src/core/Block/Block.md
+++ b/src/core/Block/Block.md
@@ -38,5 +38,10 @@ import { Block } from 'suomifi-ui-components';
 ```js
 import { Block } from 'suomifi-ui-components';
 
-<Block variant="section">I'm semantically a section</Block>;
+<>
+  <Block variant="section">I'm semantically a section</Block>
+  <Block variant="span">
+    Block component rendered as an inline-block span
+  </Block>
+</>;
 ```

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -8,6 +8,16 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
 
 const baseClassName = 'fi-block';
 
+export type BlockVariant =
+  | 'default'
+  | 'div'
+  | 'span'
+  | 'section'
+  | 'header'
+  | 'nav'
+  | 'main'
+  | 'footer';
+
 export interface BlockProps extends HtmlDivProps {
   /** Padding from theme */
   padding?: SpacingWithoutInsetProp;
@@ -38,12 +48,13 @@ export interface BlockProps extends HtmlDivProps {
   /** Margin on the y-axis (top & bottom) from theme */
   my?: SpacingWithoutInsetProp;
   /**
-   * Change block semantics
+   * Change block semantics. "Default" renders a div with SuomifiTheme reset styles applied,
+   * whereas "div" renders a plain HTML div. "Span" gets rendered with display: inline-block style
    * @default default
    */
-  variant?: 'default' | 'section' | 'header' | 'nav' | 'main' | 'footer';
+  variant?: BlockVariant;
   /** Ref is forwarded to the block element. All variants are supported. Alternative for React `ref` attribute. */
-  forwardedRef?: React.Ref<HTMLElement>;
+  forwardedRef?: React.Ref<any>;
 }
 
 class SemanticBlock extends Component<BlockProps> {
@@ -102,17 +113,17 @@ class SemanticBlock extends Component<BlockProps> {
   }
 }
 
-const StyledBlock = styled((props: SuomifiThemeProp) => {
-  const { theme, ...passProps } = props;
-  return <SemanticBlock {...passProps} />;
+const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
+  const { theme, variant, ...passProps } = props;
+  return <SemanticBlock variant={variant} {...passProps} />;
 })`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, variant }) => baseStyles(theme, variant)}
 `;
 
 /**
  * Used in displaying a generic piece of HTML e.g. a div
  */
-const Block = forwardRef((props: BlockProps, ref: React.Ref<HTMLElement>) => (
+const Block = forwardRef((props: BlockProps, ref: React.Ref<any>) => (
   <SuomifiThemeConsumer>
     {({ suomifiTheme }) => (
       <StyledBlock theme={suomifiTheme} forwardedRef={ref} {...props} />

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React, { Component, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SpacingWithoutInsetProp } from '../theme/utils/spacing';
 import { baseStyles } from './Block.baseStyles';
-import { HtmlDiv, HtmlDivProps } from '../../reset';
+import { HtmlDivWithNativeRef, HtmlDivProps } from '../../reset';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
 
 const baseClassName = 'fi-block';
@@ -42,6 +42,8 @@ export interface BlockProps extends HtmlDivProps {
    * @default default
    */
   variant?: 'default' | 'section' | 'header' | 'nav' | 'main' | 'footer';
+  /** Ref is forwarded to the block element. All variants are supported. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLElement>;
 }
 
 class SemanticBlock extends Component<BlockProps> {
@@ -63,12 +65,16 @@ class SemanticBlock extends Component<BlockProps> {
       pl,
       px,
       py,
+      forwardedRef,
       ...passProps
     } = this.props;
+
     const ComponentVariant =
-      !variant || variant === 'default' ? HtmlDiv : variant;
+      !variant || variant === 'default' ? HtmlDivWithNativeRef : variant;
+
     return (
       <ComponentVariant
+        ref={forwardedRef}
         {...passProps}
         className={classnames(baseClassName, className, {
           [`${baseClassName}--padding-${padding}`]: !!padding,
@@ -96,7 +102,7 @@ class SemanticBlock extends Component<BlockProps> {
   }
 }
 
-const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
+const StyledBlock = styled((props: SuomifiThemeProp) => {
   const { theme, ...passProps } = props;
   return <SemanticBlock {...passProps} />;
 })`
@@ -106,11 +112,13 @@ const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
 /**
  * Used in displaying a generic piece of HTML e.g. a div
  */
-const Block = (props: BlockProps) => (
+const Block = forwardRef((props: BlockProps, ref: React.Ref<HTMLElement>) => (
   <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledBlock theme={suomifiTheme} {...props} />}
+    {({ suomifiTheme }) => (
+      <StyledBlock theme={suomifiTheme} forwardedRef={ref} {...props} />
+    )}
   </SuomifiThemeConsumer>
-);
+));
 
 Block.displayName = 'Block';
 export { Block };

--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -233,6 +233,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c7.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7.fi-link--initial-underline:focus,
+.c7.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7.fi-link--initial-underline:hover,
+.c7.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c8 {
   vertical-align: baseline;
 }

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -13,7 +13,7 @@ type ButtonVariant =
   | 'secondaryNoBorder'
   | 'link';
 
-interface InternalButtonProps
+export interface ButtonProps
   extends Omit<HtmlButtonProps, 'aria-disabled' | 'onClick'> {
   /**
    * 'default' | 'inverted' | 'secondary' | 'secondaryNoBorder' | 'link'
@@ -55,15 +55,8 @@ interface InternalButtonProps
    *  @default void
    */
   onClick?: (event: React.MouseEvent) => void;
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLButtonElement>;
-}
-
-export interface ButtonProps extends InternalButtonProps {
-  /** Ref object to be passed to the input element */
-  ref?: React.RefObject<HTMLButtonElement>;
+  /** Ref object is passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
 
 const baseClassName = 'fi-button';
@@ -72,7 +65,7 @@ const iconClassName = `${baseClassName}_icon`;
 const iconRightClassName = `${baseClassName}_icon--right`;
 const fullWidthClassName = `${baseClassName}--fullwidth`;
 
-class BaseButton extends Component<ButtonProps & InnerRef> {
+class BaseButton extends Component<ButtonProps> {
   render() {
     const {
       fullWidth,
@@ -138,10 +131,7 @@ class BaseButton extends Component<ButtonProps & InnerRef> {
 }
 
 const StyledButton = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalButtonProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: ButtonProps & SuomifiThemeProp) => (
     <BaseButton {...passProps} />
   ),
 )`

--- a/src/core/Chip/Chip/Chip.tsx
+++ b/src/core/Chip/Chip/Chip.tsx
@@ -19,7 +19,7 @@ const chipButtonClassNames = {
   icon: `${baseClassName}--icon`,
 };
 
-interface InternalChipProps
+export interface ChipProps
   extends BaseChipProps,
     Omit<
       HtmlButtonProps,
@@ -38,18 +38,10 @@ interface InternalChipProps
   actionLabel?: string;
   /** Soft disable the chip to allow tab-focus, but disable onClick functionality */
   'aria-disabled'?: boolean;
+  /** Ref is passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLButtonElement>;
-}
-
-export interface ChipProps extends InternalChipProps {
-  /** Ref object to be passed to the button element */
-  ref?: React.RefObject<HTMLButtonElement>;
-}
-
-class DefaultChip extends Component<ChipProps & InnerRef> {
+class DefaultChip extends Component<ChipProps> {
   render() {
     const {
       className,
@@ -106,10 +98,7 @@ class DefaultChip extends Component<ChipProps & InnerRef> {
 }
 
 const StyledChip = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalChipProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: ChipProps & SuomifiThemeProp) => (
     <DefaultChip {...passProps} />
   ),
 )`

--- a/src/core/Chip/StaticChip/StaticChip.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, forwardRef } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
@@ -12,7 +12,10 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 
 export interface StaticChipProps
   extends BaseChipProps,
-    Omit<HtmlSpanProps, 'children'> {}
+    Omit<HtmlSpanProps, 'children'> {
+  /** Ref is forwarded to the span element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
+}
 
 class BaseChip extends Component<StaticChipProps> {
   render() {
@@ -39,10 +42,14 @@ const StyledChip = styled(
   ${({ theme }) => staticChipBaseStyles(theme)}
 `;
 
-const StaticChip = (props: StaticChipProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledChip theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
+const StaticChip = forwardRef(
+  (props: StaticChipProps, ref: React.Ref<HTMLSpanElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledChip theme={suomifiTheme} forwardedRef={ref} {...props} />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 StaticChip.displayName = 'StaticChip';

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -43,7 +43,7 @@ interface DropdownState {
   selectedValue: string | undefined;
 }
 
-interface InternalDropdownProps {
+export interface DropdownProps {
   /**
    * Unique id
    * If no id is specified, one will be generated automatically
@@ -86,15 +86,8 @@ interface InternalDropdownProps {
     | ReactElement<DropdownItemProps>;
   /** Callback that fires when the dropdown value changes. */
   onChange?(newValue: string): void;
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
-}
-
-export interface DropdownProps extends InternalDropdownProps {
-  /** Ref object to be passed to the input element */
-  ref?: React.RefObject<HTMLDivElement>;
+  /** Ref object to be passed to the input element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
 const ListBoxContextWrapper = (props: {
@@ -159,7 +152,7 @@ const ListBoxContextWrapper = (props: {
   );
 };
 
-class BaseDropdown extends Component<DropdownProps & InnerRef> {
+class BaseDropdown extends Component<DropdownProps> {
   state: DropdownState = {
     selectedValue:
       'value' in this.props
@@ -173,7 +166,7 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
 
   popoverRef: React.RefObject<HTMLDivElement>;
 
-  constructor(props: DropdownProps & InnerRef) {
+  constructor(props: DropdownProps) {
     super(props);
     this.buttonRef = React.createRef();
     this.popoverRef = React.createRef();
@@ -314,10 +307,7 @@ class BaseDropdown extends Component<DropdownProps & InnerRef> {
 }
 
 const StyledDropdown = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalDropdownProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: DropdownProps & SuomifiThemeProp) => (
     <BaseDropdown {...passProps} />
   ),
 )`

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1522,6 +1522,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
       >
         <label
           class="c5 fi-visually-hidden"
+          id="test-id-label"
         >
           Dropdown test
         </label>

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1520,11 +1520,11 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
       <div
         class="c3 c4 fi-label"
       >
-        <span
-          class="c0 c5 fi-visually-hidden"
+        <label
+          class="c5 fi-visually-hidden"
         >
           Dropdown test
-        </span>
+        </label>
       </div>
       <div
         data-reach-listbox-input=""

--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -64,6 +64,36 @@ import {
 </ExpanderGroup>;
 ```
 
+```jsx
+import {
+  Expander,
+  ExpanderGroup,
+  ExpanderTitleButton,
+  ExpanderContent
+} from 'suomifi-ui-components';
+
+<ExpanderGroup
+  openAllText="Open all"
+  ariaOpenAllText="Open all expanders"
+  closeAllText="Close all"
+  ariaCloseAllText="Close all expanders"
+  showToggleAllButton={false}
+>
+  <Expander>
+    <ExpanderTitleButton>Test expander 1</ExpanderTitleButton>
+    <ExpanderContent>Test expander content 1</ExpanderContent>
+  </Expander>
+  <Expander>
+    <ExpanderTitleButton>Test expander 2</ExpanderTitleButton>
+    <ExpanderContent>Test expander content 2</ExpanderContent>
+  </Expander>
+  <Expander>
+    <ExpanderTitleButton>Test expander 3</ExpanderTitleButton>
+    <ExpanderContent>Test expander content 3</ExpanderContent>
+  </Expander>
+</ExpanderGroup>;
+```
+
 ## Controlled
 
 - State for the individual Expanders are stored outside of the component and user has full control.

--- a/src/core/Expander/Expander/Expander.tsx
+++ b/src/core/Expander/Expander/Expander.tsx
@@ -1,8 +1,8 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { HtmlDiv } from '../../../reset';
+import { HtmlDivWithRef } from '../../../reset';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import {
   ExpanderGroupConsumer,
@@ -55,6 +55,8 @@ export interface ExpanderProps {
   open?: boolean;
   /** Event handler to execute when clicked */
   onOpenChange?: (open: boolean) => void;
+  /** Ref is forwarded to wrapping div element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLDivElement>;
 }
 
 export interface ExpanderTitleBaseProps {
@@ -158,7 +160,7 @@ class BaseExpander extends Component<BaseExpanderProps & SuomifiThemeProp> {
     const openState = open !== undefined ? !!open : this.state.openState;
 
     return (
-      <HtmlDiv
+      <HtmlDivWithRef
         id={id}
         {...passProps}
         className={classnames(className, baseClassName, {
@@ -175,7 +177,7 @@ class BaseExpander extends Component<BaseExpanderProps & SuomifiThemeProp> {
         >
           {children}
         </ExpanderProvider>
-      </HtmlDiv>
+      </HtmlDivWithRef>
     );
   }
 }
@@ -192,29 +194,32 @@ interface ExpanderState {
  * <i class="semantics" />
  * Hide or show content with always visible title
  */
-const Expander = (props: ExpanderProps) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <ExpanderGroupConsumer>
-              {(consumer) => (
-                <StyledExpander
-                  theme={suomifiTheme}
-                  id={id}
-                  {...passProps}
-                  consumer={consumer}
-                />
-              )}
-            </ExpanderGroupConsumer>
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const Expander = forwardRef(
+  (props: ExpanderProps, ref: React.Ref<HTMLDivElement>) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <ExpanderGroupConsumer>
+                {(consumer) => (
+                  <StyledExpander
+                    theme={suomifiTheme}
+                    id={id}
+                    forwardedRef={ref}
+                    {...passProps}
+                    consumer={consumer}
+                  />
+                )}
+              </ExpanderGroupConsumer>
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 Expander.displayName = 'Expander';
 export { Expander, ExpanderConsumer, ExpanderProvider };

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Basic expander shoud match snapshot 1`] = `
-.c4 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -27,30 +27,59 @@ exports[`Basic expander shoud match snapshot 1`] = `
   cursor: pointer;
 }
 
-.c4:-moz-focusring {
+.c5:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
-.c4::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
 
-.c4::-webkit-file-upload-button {
+.c5::-webkit-file-upload-button {
   -webkit-appearance: button;
   font: inherit;
 }
 
-.c4::-webkit-inner-spin-button {
+.c5::-webkit-inner-spin-button {
   height: auto;
 }
 
-.c4::-webkit-outer-spin-button {
+.c5::-webkit-outer-spin-button {
   height: auto;
 }
 
-.c4::before,
-.c4::after {
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -83,7 +112,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -107,8 +136,8 @@ exports[`Basic expander shoud match snapshot 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
@@ -145,7 +174,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   opacity: 0;
 }
 
-.c6 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -178,15 +207,15 @@ exports[`Basic expander shoud match snapshot 1`] = `
   will-change: transition,height;
 }
 
-.c6.fi-expander {
+.c7.fi-expander {
   display: block;
 }
 
-.c6:not(.fi-expander_content--no-padding) {
+.c7:not(.fi-expander_content--no-padding) {
   padding: 0 16px;
 }
 
-.c6.fi-expander_content--open {
+.c7.fi-expander_content--open {
   visibility: visible;
   height: auto;
   border-top-left-radius: 0;
@@ -195,38 +224,38 @@ exports[`Basic expander shoud match snapshot 1`] = `
   animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
 }
 
-.c6.fi-expander_content--open:not(.fi-expander_content--no-padding) {
+.c7.fi-expander_content--open:not(.fi-expander_content--no-padding) {
   padding-top: 0;
   padding-right: 20px;
   padding-bottom: 20px;
   padding-left: 20px;
 }
 
-.c5 {
+.c6 {
   vertical-align: baseline;
 }
 
-.c5.fi-icon {
+.c6.fi-icon {
   display: inline-block;
 }
 
-.c5 .fi-icon-base-fill {
+.c6 .fi-icon-base-fill {
   fill: currentColor;
 }
 
-.c5 .fi-icon-base-stroke {
+.c6 .fi-icon-base-stroke {
   stroke: currentColor;
 }
 
-.c5.fi-icon--cursor-pointer {
+.c6.fi-icon--cursor-pointer {
   cursor: pointer;
 }
 
-.c5.fi-icon--cursor-pointer * {
+.c6.fi-icon--cursor-pointer * {
   cursor: inherit;
 }
 
-.c2 {
+.c3 {
   color: hsl(0,0%,16%);
   position: relative;
   width: 100%;
@@ -236,17 +265,17 @@ exports[`Basic expander shoud match snapshot 1`] = `
   border-radius: inherit;
 }
 
-.c2.fi-expander_title-button {
+.c3.fi-expander_title-button {
   display: block;
 }
 
-.c2.fi-expander_title-button--open {
+.c3.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.c2 .fi-expander_title-button_button {
+.c3 .fi-expander_title-button_button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -284,15 +313,15 @@ exports[`Basic expander shoud match snapshot 1`] = `
   padding: 17px 60px 16px 20px;
 }
 
-.c2 .fi-expander_title-button_button:focus {
+.c3 .fi-expander_title-button_button:focus {
   outline: 0;
 }
 
-.c2 .fi-expander_title-button_button:focus-within {
+.c3 .fi-expander_title-button_button:focus-within {
   outline: 0;
 }
 
-.c2 .fi-expander_title-button_button:focus-within:after {
+.c3 .fi-expander_title-button_button:focus-within:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -308,26 +337,26 @@ exports[`Basic expander shoud match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c2 .fi-expander_title-button_button:not(:focus-visible) {
+.c3 .fi-expander_title-button_button:not(:focus-visible) {
   outline: 0;
 }
 
-.c2 .fi-expander_title-button_button:not(:focus-visible):after {
+.c3 .fi-expander_title-button_button:not(:focus-visible):after {
   content: none;
 }
 
-.c2 .fi-expander_title-button_button * {
+.c3 .fi-expander_title-button_button * {
   cursor: pointer;
 }
 
-.c2 .fi-expander_title-button_button:hover,
-.c2 .fi-expander_title-button_button:active,
-.c2 .fi-expander_title-button_button:focus,
-.c2 .fi-expander_title-button_button:focus-within {
+.c3 .fi-expander_title-button_button:hover,
+.c3 .fi-expander_title-button_button:active,
+.c3 .fi-expander_title-button_button:focus,
+.c3 .fi-expander_title-button_button:focus-within {
   cursor: pointer;
 }
 
-.c2 .fi-expander_title-button-icon {
+.c3 .fi-expander_title-button-icon {
   position: absolute;
   top: 0;
   right: 0;
@@ -336,8 +365,8 @@ exports[`Basic expander shoud match snapshot 1`] = `
   margin: 20px;
 }
 
-.c2 .fi-expander_title-button--open .fi-expander_title-button-icon,
-.c2 .fi-expander_title-button-icon--open {
+.c3 .fi-expander_title-button--open .fi-expander_title-button-icon,
+.c3 .fi-expander_title-button-icon--open {
   -webkit-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
   transform: rotate(-180deg);
@@ -348,27 +377,27 @@ exports[`Basic expander shoud match snapshot 1`] = `
   id="4"
 >
   <div
-    class="c0 c2 fi-expander_title-button"
+    class="c2 c3 fi-expander_title-button"
     data-testid="expander-title"
   >
     <span
-      class="c3"
+      class="c4"
     >
       <button
         aria-controls="4_content"
         aria-expanded="false"
-        class="c4 fi-expander_title-button_button"
+        class="c5 fi-expander_title-button_button"
         type="button"
       >
         <span
-          class="c3"
+          class="c4"
           id="4_title"
         >
           Test expander
         </span>
         <svg
           aria-hidden="true"
-          class="fi-icon c5 fi-expander_title-button-icon"
+          class="fi-icon c6 fi-expander_title-button-icon"
           focusable="false"
           height="1em"
           viewBox="0 0 24 24"
@@ -388,7 +417,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="4_title"
-    class="c0 c6 fi-expander_content"
+    class="c2 c7 fi-expander_content"
     id="4_content"
     role="region"
   >

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
@@ -159,6 +159,47 @@ describe('default behaviour', () => {
   });
 });
 
+describe('Toggle all button', () => {
+  it('should be hidden when showToggleAllButton is false', () => {
+    const { queryByTestId } = render(
+      TestExpanderGroup(
+        [
+          {
+            expanderProps: {
+              id: 'id-first',
+            },
+            titleProps: {
+              'data-testid': 'expander-title-1',
+              children: 'First',
+            },
+            content: 'First content',
+          },
+          {
+            expanderProps: {
+              id: 'id-second',
+
+              defaultOpen: true,
+            },
+            titleProps: {
+              'data-testid': 'expander-title-2',
+              children: 'Second',
+            },
+            content: 'Second content',
+          },
+        ],
+        {
+          toggleAllButtonProps: {
+            'data-testid': 'toggle-all-button',
+          },
+          showToggleAllButton: false,
+        },
+      ),
+    );
+    const toggleAllButton = queryByTestId('toggle-all-button');
+    expect(toggleAllButton).toBeNull();
+  });
+});
+
 describe('defaultOpen', () => {
   it('gives the classname to expander title and icon', () => {
     const { getByTestId } = render(

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -23,6 +23,11 @@ export interface ExpanderGroupProps {
   ariaCloseAllText?: string;
   /** Custom classname to extend or customize */
   className?: string;
+  /**
+   * Show Open/Close all button
+   * @default true
+   */
+  showToggleAllButton?: boolean;
   /** Open/Close all button props */
   toggleAllButtonProps?: Omit<
     HtmlButtonProps,
@@ -138,6 +143,7 @@ class BaseExpanderGroup extends Component<
       ariaOpenAllText,
       closeAllText,
       ariaCloseAllText,
+      showToggleAllButton = true,
       toggleAllButtonProps,
       ...passProps
     } = this.props;
@@ -149,24 +155,26 @@ class BaseExpanderGroup extends Component<
           [openClassName]: this.openExpanderCount > 0,
         })}
       >
-        <HtmlButton
-          {...toggleAllButtonProps}
-          onClick={this.handleAllToggleClick}
-          className={classnames(
-            toggleAllButtonProps?.className,
-            openAllButtonClassName,
-          )}
-          aria-expanded={allOpen}
-        >
-          <HtmlSpan aria-hidden={true}>
-            {allOpen ? closeAllText : openAllText}
-          </HtmlSpan>
-          <VisuallyHidden>
-            {allOpen
-              ? ariaCloseAllText || closeAllText
-              : ariaOpenAllText || openAllText}
-          </VisuallyHidden>
-        </HtmlButton>
+        {!!showToggleAllButton && (
+          <HtmlButton
+            {...toggleAllButtonProps}
+            onClick={this.handleAllToggleClick}
+            className={classnames(
+              toggleAllButtonProps?.className,
+              openAllButtonClassName,
+            )}
+            aria-expanded={allOpen}
+          >
+            <HtmlSpan aria-hidden={true}>
+              {allOpen ? closeAllText : openAllText}
+            </HtmlSpan>
+            <VisuallyHidden>
+              {allOpen
+                ? ariaCloseAllText || closeAllText
+                : ariaOpenAllText || openAllText}
+            </VisuallyHidden>
+          </HtmlButton>
+        )}
         <HtmlDiv className={expandersContainerClassName}>
           <Provider
             value={{

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv, HtmlButton, HtmlButtonProps, HtmlSpan } from '../../../reset';
@@ -38,6 +38,8 @@ export interface ExpanderGroupProps {
     | 'onKeyUp'
     | 'onKeyDown'
   >;
+  /** Ref is forwarded to button element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLButtonElement>;
 }
 
 interface ExpanderOpenStates {
@@ -145,6 +147,7 @@ class BaseExpanderGroup extends Component<
       ariaCloseAllText,
       showToggleAllButton = true,
       toggleAllButtonProps,
+      forwardedRef,
       ...passProps
     } = this.props;
     const { expanderGroupOpenState, allOpen } = this.state;
@@ -164,6 +167,7 @@ class BaseExpanderGroup extends Component<
               openAllButtonClassName,
             )}
             aria-expanded={allOpen}
+            forwardedRef={forwardedRef}
           >
             <HtmlSpan aria-hidden={true}>
               {allOpen ? closeAllText : openAllText}
@@ -198,12 +202,19 @@ const StyledExpanderGroup = styled(BaseExpanderGroup)`
  * <i class="semantics" />
  * Wrapper for multiple expanders with Open/Close All button
  */
-const ExpanderGroup = (props: ExpanderGroupProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledExpanderGroup theme={suomifiTheme} {...props} />
-    )}
-  </SuomifiThemeConsumer>
+
+const ExpanderGroup = forwardRef(
+  (props: ExpanderGroupProps, ref: React.Ref<HTMLButtonElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledExpanderGroup
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 ExpanderGroup.displayName = 'ExpanderGroup';

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -83,6 +83,35 @@ exports[`Basic expander group should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
 .c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -243,7 +272,7 @@ exports[`Basic expander group should match snapshot 1`] = `
   content: none;
 }
 
-.c5 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -267,16 +296,16 @@ exports[`Basic expander group should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c5.fi-expander {
+.c6.fi-expander {
   display: block;
 }
 
-.c5:before {
+.c6:before {
   background-color: hsl(212,63%,98%);
   opacity: 0;
 }
 
-.c8 {
+.c9 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -309,15 +338,15 @@ exports[`Basic expander group should match snapshot 1`] = `
   will-change: transition,height;
 }
 
-.c8.fi-expander {
+.c9.fi-expander {
   display: block;
 }
 
-.c8:not(.fi-expander_content--no-padding) {
+.c9:not(.fi-expander_content--no-padding) {
   padding: 0 16px;
 }
 
-.c8.fi-expander_content--open {
+.c9.fi-expander_content--open {
   visibility: visible;
   height: auto;
   border-top-left-radius: 0;
@@ -326,38 +355,38 @@ exports[`Basic expander group should match snapshot 1`] = `
   animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;
 }
 
-.c8.fi-expander_content--open:not(.fi-expander_content--no-padding) {
+.c9.fi-expander_content--open:not(.fi-expander_content--no-padding) {
   padding-top: 0;
   padding-right: 20px;
   padding-bottom: 20px;
   padding-left: 20px;
 }
 
-.c7 {
+.c8 {
   vertical-align: baseline;
 }
 
-.c7.fi-icon {
+.c8.fi-icon {
   display: inline-block;
 }
 
-.c7 .fi-icon-base-fill {
+.c8 .fi-icon-base-fill {
   fill: currentColor;
 }
 
-.c7 .fi-icon-base-stroke {
+.c8 .fi-icon-base-stroke {
   stroke: currentColor;
 }
 
-.c7.fi-icon--cursor-pointer {
+.c8.fi-icon--cursor-pointer {
   cursor: pointer;
 }
 
-.c7.fi-icon--cursor-pointer * {
+.c8.fi-icon--cursor-pointer * {
   cursor: inherit;
 }
 
-.c6 {
+.c7 {
   color: hsl(0,0%,16%);
   position: relative;
   width: 100%;
@@ -367,17 +396,17 @@ exports[`Basic expander group should match snapshot 1`] = `
   border-radius: inherit;
 }
 
-.c6.fi-expander_title-button {
+.c7.fi-expander_title-button {
   display: block;
 }
 
-.c6.fi-expander_title-button--open {
+.c7.fi-expander_title-button--open {
   background-color: hsl(0,0%,100%);
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.c6 .fi-expander_title-button_button {
+.c7 .fi-expander_title-button_button {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -415,15 +444,15 @@ exports[`Basic expander group should match snapshot 1`] = `
   padding: 17px 60px 16px 20px;
 }
 
-.c6 .fi-expander_title-button_button:focus {
+.c7 .fi-expander_title-button_button:focus {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button_button:focus-within {
+.c7 .fi-expander_title-button_button:focus-within {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button_button:focus-within:after {
+.c7 .fi-expander_title-button_button:focus-within:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -439,26 +468,26 @@ exports[`Basic expander group should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c6 .fi-expander_title-button_button:not(:focus-visible) {
+.c7 .fi-expander_title-button_button:not(:focus-visible) {
   outline: 0;
 }
 
-.c6 .fi-expander_title-button_button:not(:focus-visible):after {
+.c7 .fi-expander_title-button_button:not(:focus-visible):after {
   content: none;
 }
 
-.c6 .fi-expander_title-button_button * {
+.c7 .fi-expander_title-button_button * {
   cursor: pointer;
 }
 
-.c6 .fi-expander_title-button_button:hover,
-.c6 .fi-expander_title-button_button:active,
-.c6 .fi-expander_title-button_button:focus,
-.c6 .fi-expander_title-button_button:focus-within {
+.c7 .fi-expander_title-button_button:hover,
+.c7 .fi-expander_title-button_button:active,
+.c7 .fi-expander_title-button_button:focus,
+.c7 .fi-expander_title-button_button:focus-within {
   cursor: pointer;
 }
 
-.c6 .fi-expander_title-button-icon {
+.c7 .fi-expander_title-button-icon {
   position: absolute;
   top: 0;
   right: 0;
@@ -467,8 +496,8 @@ exports[`Basic expander group should match snapshot 1`] = `
   margin: 20px;
 }
 
-.c6 .fi-expander_title-button--open .fi-expander_title-button-icon,
-.c6 .fi-expander_title-button-icon--open {
+.c7 .fi-expander_title-button--open .fi-expander_title-button-icon,
+.c7 .fi-expander_title-button-icon--open {
   -webkit-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
   transform: rotate(-180deg);
@@ -498,11 +527,11 @@ exports[`Basic expander group should match snapshot 1`] = `
     class="c0 fi-expander-group_expanders"
   >
     <div
-      class="c0 c5 fi-expander"
+      class="c5 c6 fi-expander"
       id="id-first"
     >
       <div
-        class="c0 c6 fi-expander_title-button"
+        class="c0 c7 fi-expander_title-button"
         data-testid="expander-title-1"
       >
         <span
@@ -522,7 +551,7 @@ exports[`Basic expander group should match snapshot 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="fi-icon c7 fi-expander_title-button-icon"
+              class="fi-icon c8 fi-expander_title-button-icon"
               focusable="false"
               height="1em"
               viewBox="0 0 24 24"
@@ -542,7 +571,7 @@ exports[`Basic expander group should match snapshot 1`] = `
       <div
         aria-hidden="true"
         aria-labelledby="id-first_title"
-        class="c0 c8 fi-expander_content"
+        class="c0 c9 fi-expander_content"
         id="id-first_content"
         role="region"
       >
@@ -550,11 +579,11 @@ exports[`Basic expander group should match snapshot 1`] = `
       </div>
     </div>
     <div
-      class="c0 c5 fi-expander"
+      class="c5 c6 fi-expander"
       id="id-second"
     >
       <div
-        class="c0 c6 fi-expander_title-button"
+        class="c0 c7 fi-expander_title-button"
         data-testid="expander-title-2"
       >
         <span
@@ -574,7 +603,7 @@ exports[`Basic expander group should match snapshot 1`] = `
             </span>
             <svg
               aria-hidden="true"
-              class="fi-icon c7 fi-expander_title-button-icon"
+              class="fi-icon c8 fi-expander_title-button-icon"
               focusable="false"
               height="1em"
               viewBox="0 0 24 24"
@@ -594,7 +623,7 @@ exports[`Basic expander group should match snapshot 1`] = `
       <div
         aria-hidden="true"
         aria-labelledby="id-second_title"
-        class="c0 c8 fi-expander_content"
+        class="c0 c9 fi-expander_content"
         id="id-second_content"
         role="region"
       >

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv, HtmlButton, HtmlButtonProps, HtmlSpan } from '../../../reset';
@@ -30,6 +30,8 @@ export interface ExpanderTitleButtonProps {
     | 'onKeyUp'
     | 'onKeyDown'
   >;
+  /** Ref is forwarded to the button element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
 
 interface InternalExpanderTitleButtonProps
@@ -46,6 +48,7 @@ class BaseExpanderTitleButton extends Component<InternalExpanderTitleButtonProps
       theme,
       toggleButtonProps,
       consumer,
+      forwardedRef,
       ...passProps
     } = this.props;
 
@@ -58,6 +61,7 @@ class BaseExpanderTitleButton extends Component<InternalExpanderTitleButtonProps
       >
         <HtmlSpan {...(!!asHeading ? { as: asHeading } : {})}>
           <HtmlButton
+            forwardedRef={forwardedRef}
             {...toggleButtonProps}
             onClick={consumer.onToggleExpander}
             aria-expanded={!!consumer.open}
@@ -86,20 +90,26 @@ const StyledExpanderTitle = styled(BaseExpanderTitleButton)`
  * <i class="semantics" />
  * Expander title button for static title content and toggle for content visiblity
  */
-const ExpanderTitleButton = (props: ExpanderTitleButtonProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <ExpanderConsumer>
-        {(consumer) => (
-          <StyledExpanderTitle
-            theme={suomifiTheme}
-            consumer={consumer}
-            {...props}
-          />
-        )}
-      </ExpanderConsumer>
-    )}
-  </SuomifiThemeConsumer>
+const ExpanderTitleButton = forwardRef(
+  (
+    props: ExpanderTitleButtonProps,
+    ref: React.RefObject<HTMLButtonElement>,
+  ) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <ExpanderConsumer>
+          {(consumer) => (
+            <StyledExpanderTitle
+              theme={suomifiTheme}
+              consumer={consumer}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </ExpanderConsumer>
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 ExpanderTitleButton.displayName = 'ExpanderTitleButton';

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -91,10 +91,8 @@ interface InternalCheckboxProps extends StatusTextCommonProps {
   name?: string;
   /** Value */
   value?: string;
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLInputElement>;
+  /** Ref object to be passed to the input element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
 export interface CheckboxProps extends InternalCheckboxProps {
@@ -102,7 +100,7 @@ export interface CheckboxProps extends InternalCheckboxProps {
   ref?: React.RefObject<HTMLInputElement>;
 }
 
-class BaseCheckbox extends Component<CheckboxProps & InnerRef> {
+class BaseCheckbox extends Component<CheckboxProps> {
   state = {
     checkedState: !!this.props.checked || !!this.props.defaultChecked,
   };
@@ -241,10 +239,7 @@ class BaseCheckbox extends Component<CheckboxProps & InnerRef> {
 }
 
 const StyledCheckbox = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalCheckboxProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: InternalCheckboxProps & SuomifiThemeProp) => (
     <BaseCheckbox {...passProps} />
   ),
 )`

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -1,9 +1,14 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
-import { HtmlDiv, HtmlFieldSet, HtmlLegend } from '../../../reset';
+import {
+  HtmlDiv,
+  HtmlDivWithRef,
+  HtmlFieldSet,
+  HtmlLegend,
+} from '../../../reset';
 import { InputStatus } from '../types';
 import { Label } from '../Label/Label';
 import { HintText } from '../HintText/HintText';
@@ -51,6 +56,8 @@ export interface CheckboxGroupProps {
   groupStatus?: CheckboxGroupStatus;
   /** Status text to be shown below the component. Use e.g. for validation error */
   groupStatusText?: string;
+  /** Ref is forwarded to the root div element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLDivElement>;
 }
 
 export interface CheckboxGroupProviderState {
@@ -83,7 +90,7 @@ class BaseCheckboxGroup extends Component<
     const statusTextId = !!groupStatusText ? `${id}-statusText` : undefined;
 
     return (
-      <HtmlDiv
+      <HtmlDivWithRef
         className={classnames(baseClassName, className)}
         id={id}
         {...passProps}
@@ -127,7 +134,7 @@ class BaseCheckboxGroup extends Component<
         >
           {groupStatusText}
         </StatusText>
-      </HtmlDiv>
+      </HtmlDivWithRef>
     );
   }
 }
@@ -139,20 +146,27 @@ const StyledCheckboxGroup = styled(BaseCheckboxGroup)`
 /**
  * Use for grouping Checkboxes.
  */
-const CheckboxGroup = (props: CheckboxGroupProps) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledCheckboxGroup theme={suomifiTheme} id={id} {...passProps} />
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const CheckboxGroup = forwardRef(
+  (props: CheckboxGroupProps, ref: React.Ref<HTMLDivElement>) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <StyledCheckboxGroup
+                theme={suomifiTheme}
+                id={id}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 CheckboxGroup.displayName = 'CheckboxGroup';
 

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -1,6 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`default, with only required props should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -27,35 +56,6 @@ exports[`default, with only required props should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -167,7 +167,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -191,8 +191,8 @@ exports[`default, with only required props should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -223,7 +223,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(3,59%,48%);
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -242,14 +242,14 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -425,10 +425,10 @@ exports[`default, with only required props should match snapshot 1`] = `
         class="c3 fi-checkbox-group_legend"
       >
         <div
-          class="c4 c5 fi-checkbox-group_label--visible fi-label"
+          class="c0 c4 fi-checkbox-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="1"
           >
             Label
@@ -436,10 +436,10 @@ exports[`default, with only required props should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-checkbox-group_container"
+        class="c6 fi-checkbox-group_container"
       >
         <div
-          class="c0 fi-checkbox_container c7 fi-checkbox"
+          class="c6 fi-checkbox_container c7 fi-checkbox"
         >
           <input
             aria-invalid="false"
@@ -456,11 +456,11 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c6 c10 fi-status-text"
+            class="c5 c10 fi-status-text"
           />
         </div>
         <div
-          class="c0 fi-checkbox_container c7 fi-checkbox"
+          class="c6 fi-checkbox_container c7 fi-checkbox"
         >
           <input
             aria-invalid="false"
@@ -477,11 +477,11 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c6 c10 fi-status-text"
+            class="c5 c10 fi-status-text"
           />
         </div>
         <div
-          class="c0 fi-checkbox_container c7 fi-checkbox"
+          class="c6 fi-checkbox_container c7 fi-checkbox"
         >
           <input
             aria-invalid="false"
@@ -498,7 +498,7 @@ exports[`default, with only required props should match snapshot 1`] = `
           <span
             aria-atomic="true"
             aria-live="assertive"
-            class="c6 c10 fi-status-text"
+            class="c5 c10 fi-status-text"
           />
         </div>
       </div>
@@ -506,7 +506,7 @@ exports[`default, with only required props should match snapshot 1`] = `
     <span
       aria-atomic="true"
       aria-live="polite"
-      class="c6 c10 fi-status-text"
+      class="c5 c10 fi-status-text"
     />
   </div>
 </div>

--- a/src/core/Form/HintText/HintText.tsx
+++ b/src/core/Form/HintText/HintText.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
@@ -14,6 +14,9 @@ export interface HintTextProps extends HtmlSpanProps {
   children?: ReactNode;
   /** Custom class name for styling and customizing  */
   className?: string;
+
+  /** Ref is forwarded to the span element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
 const StyledHintText = styled(
@@ -34,21 +37,27 @@ const StyledHintText = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const HintText = (props: HintTextProps) => {
-  const { children, ...passProps } = props;
-  if (!children) {
-    return null;
-  }
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledHintText theme={suomifiTheme} {...passProps}>
-          {children}
-        </StyledHintText>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const HintText = forwardRef(
+  (props: HintTextProps, ref: React.Ref<HTMLSpanElement>) => {
+    const { children, ...passProps } = props;
+    if (!children) {
+      return null;
+    }
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledHintText
+            forwardedRef={ref}
+            theme={suomifiTheme}
+            {...passProps}
+          >
+            {children}
+          </StyledHintText>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 HintText.displayName = 'HintText';
 export { HintText };

--- a/src/core/Form/Label/Label.tsx
+++ b/src/core/Form/Label/Label.tsx
@@ -94,7 +94,7 @@ const StyledLabel = styled(
         }
       >
         {labelMode === 'hidden' ? (
-          <VisuallyHidden>
+          <VisuallyHidden as={asProp}>
             {children}
             {optionalText && `(${optionalText})`}
           </VisuallyHidden>

--- a/src/core/Form/Label/Label.tsx
+++ b/src/core/Form/Label/Label.tsx
@@ -94,7 +94,7 @@ const StyledLabel = styled(
         }
       >
         {labelMode === 'hidden' ? (
-          <VisuallyHidden as={asProp}>
+          <VisuallyHidden as={asProp} {...passProps}>
             {children}
             {optionalText && `(${optionalText})`}
           </VisuallyHidden>

--- a/src/core/Form/RadioButton/RadioButton.tsx
+++ b/src/core/Form/RadioButton/RadioButton.tsx
@@ -24,7 +24,7 @@ const radioButtonClassNames = {
   checked: `${baseClassName}--checked`,
 };
 
-interface InternalRadioButtonProps {
+export interface RadioButtonProps {
   /** Custom classname to extend or customize */
   className?: string;
   /** Label for element content */
@@ -57,22 +57,16 @@ interface InternalRadioButtonProps {
    * Screen readers will ignore children as label if id is provided.
    */
   'aria-labelledby'?: string;
+
+  /** Ref object to be passed to the input element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
 interface RadioButtonState {
   checkedState: boolean;
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLInputElement>;
-}
-
-export interface RadioButtonProps extends InternalRadioButtonProps {
-  /** Ref object to be passed to the input element */
-  ref?: React.RefObject<HTMLInputElement>;
-}
-
-class BaseRadioButton extends Component<RadioButtonProps & InnerRef> {
+class BaseRadioButton extends Component<RadioButtonProps> {
   state = {
     checkedState: !!this.props.checked,
   };
@@ -164,10 +158,7 @@ class BaseRadioButton extends Component<RadioButtonProps & InnerRef> {
 }
 
 const StyledRadioButton = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalRadioButtonProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: RadioButtonProps & SuomifiThemeProp) => (
     <BaseRadioButton {...passProps} />
   ),
 )`

--- a/src/core/Form/RadioButton/RadioButtonGroup.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.tsx
@@ -1,7 +1,12 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
-import { HtmlDiv, HtmlFieldSet, HtmlLegend } from '../../../reset';
+import {
+  HtmlDiv,
+  HtmlDivWithRef,
+  HtmlFieldSet,
+  HtmlLegend,
+} from '../../../reset';
 import { Label } from '../Label/Label';
 import { HintText } from '../HintText/HintText';
 import { RadioButtonProps } from './RadioButton';
@@ -43,6 +48,8 @@ export interface RadioButtonGroupProps {
   defaultValue?: string;
   /** Callback for RadioButtonGroup selected changes. */
   onChange?: (value: string) => void;
+  /** Ref is forwarded to the root div element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
 export interface RadioButtonGroupProviderState {
@@ -104,7 +111,7 @@ class BaseRadioButtonGroup extends Component<
     } = this.props;
 
     return (
-      <HtmlDiv
+      <HtmlDivWithRef
         className={classnames(baseClassName, className)}
         id={id}
         {...passProps}
@@ -137,7 +144,7 @@ class BaseRadioButtonGroup extends Component<
             </Provider>
           </HtmlDiv>
         </HtmlFieldSet>
-      </HtmlDiv>
+      </HtmlDivWithRef>
     );
   }
 }
@@ -151,24 +158,27 @@ const StyledRadioButtonGroup = styled(BaseRadioButtonGroup)`
  * Always overrides nested RadioButtons' name, checked and defaultChecked props.
  * Use RadioButtonGroup's name, value and defaultValue instead.
  */
-const RadioButtonGroup = (props: RadioButtonGroupProps) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledRadioButtonGroup
-              theme={suomifiTheme}
-              id={id}
-              {...passProps}
-            />
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const RadioButtonGroup = forwardRef(
+  (props: RadioButtonGroupProps, ref: React.RefObject<HTMLDivElement>) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <StyledRadioButtonGroup
+                theme={suomifiTheme}
+                id={id}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 RadioButtonGroup.displayName = 'RadioButtonGroup';
 

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -3652,7 +3652,7 @@ exports[`props label should match snapshot 1`] = `
 `;
 
 exports[`props labelMode should match snapshot 1`] = `
-.c7 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3676,8 +3676,8 @@ exports[`props labelMode should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c7::before,
-.c7::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
@@ -3735,7 +3735,7 @@ exports[`props labelMode should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3758,13 +3758,13 @@ exports[`props labelMode should match snapshot 1`] = `
   max-width: 100%;
 }
 
-.c9::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c9::before,
-.c9::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
@@ -3818,7 +3818,7 @@ exports[`props labelMode should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3842,8 +3842,8 @@ exports[`props labelMode should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c5::before,
-.c5::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -3863,7 +3863,7 @@ exports[`props labelMode should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -3962,7 +3962,7 @@ exports[`props labelMode should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c8 {
+.c7 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -3980,7 +3980,7 @@ exports[`props labelMode should match snapshot 1`] = `
   position: relative;
 }
 
-.c8.fi-radio-button .fi-radio-button_hintText {
+.c7.fi-radio-button .fi-radio-button_hintText {
   display: block;
   padding-left: 26px;
   color: hsl(202,7%,40%);
@@ -3990,7 +3990,7 @@ exports[`props labelMode should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c8.fi-radio-button .fi-radio-button_label {
+.c7.fi-radio-button .fi-radio-button_label {
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -3998,7 +3998,7 @@ exports[`props labelMode should match snapshot 1`] = `
   padding-left: 26px;
 }
 
-.c8.fi-radio-button .fi-radio-button_input {
+.c7.fi-radio-button .fi-radio-button_input {
   opacity: 0;
   position: absolute;
   z-index: -9999;
@@ -4008,7 +4008,7 @@ exports[`props labelMode should match snapshot 1`] = `
   left: 2px;
 }
 
-.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 3px;
   left: 0;
   margin: 2px;
@@ -4017,77 +4017,77 @@ exports[`props labelMode should match snapshot 1`] = `
   position: absolute;
 }
 
-.c8.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(201,7%,58%);
   fill: hsl(0,0%,100%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(212,63%,45%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   stroke: hsl(212,63%,45%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus {
+.c7.fi-radio-button .fi-radio-button_input:focus {
   outline: 0;
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   border-radius: 50%;
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
   box-shadow: none;
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_label {
   cursor: not-allowed;
   color: hsl(202,7%,67%);
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_hintText {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-icon-radio-base {
   fill: hsl(202,7%,97%);
   stroke: hsl(202,7%,80%);
 }
 
-.c8.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
+.c7.fi-radio-button.fi-radio-button--disabled .fi-radio-button_input:checked + .fi-radio-button_icon_wrapper .fi-icon-radio-checked {
   fill: hsl(202,7%,67%);
 }
 
-.c8.fi-radio-button--large .fi-radio-button_hintText {
+.c7.fi-radio-button--large .fi-radio-button_hintText {
   padding-left: 40px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_input {
+.c7.fi-radio-button--large .fi-radio-button_input {
   top: 2px;
   left: 2px;
   height: 30px;
   width: 30px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper {
   top: 0;
   left: 0;
   height: 30px;
   width: 30px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
+.c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
 }
 
-.c8.fi-radio-button--large .fi-radio-button_label {
+.c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
 }
@@ -4106,28 +4106,28 @@ exports[`props labelMode should match snapshot 1`] = `
         <div
           class="c0 c4 fi-label"
         >
-          <span
-            class="c5 c6 fi-visually-hidden"
+          <label
+            class="c5 fi-visually-hidden"
           >
             Label here
-          </span>
+          </label>
         </div>
       </legend>
       <div
-        class="c7 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c7 fi-radio-button fi-radio-button_container c8"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c9 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-1"
             name="name"
             type="radio"
             value="1"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c9 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4165,17 +4165,17 @@ exports[`props labelMode should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c7 fi-radio-button fi-radio-button_container c8"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c9 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-2"
             name="name"
             type="radio"
             value="2"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c9 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4213,17 +4213,17 @@ exports[`props labelMode should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c7 fi-radio-button fi-radio-button_container c8"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
-            class="c9 fi-radio-button_input"
+            class="c8 fi-radio-button_input"
             id="test-id-3"
             name="name"
             type="radio"
             value="3"
           />
           <span
-            class="c5 fi-radio-button_icon_wrapper"
+            class="c9 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -4108,6 +4108,7 @@ exports[`props labelMode should match snapshot 1`] = `
         >
           <label
             class="c5 fi-visually-hidden"
+            for="test-id"
           >
             Label here
           </label>

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -1,6 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`default, with only required props should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -27,35 +56,6 @@ exports[`default, with only required props should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -167,7 +167,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -191,8 +191,8 @@ exports[`default, with only required props should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -212,7 +212,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -231,14 +231,14 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -441,10 +441,10 @@ exports[`default, with only required props should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -452,10 +452,10 @@ exports[`default, with only required props should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -465,7 +465,7 @@ exports[`default, with only required props should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -503,7 +503,7 @@ exports[`default, with only required props should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -513,7 +513,7 @@ exports[`default, with only required props should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -551,7 +551,7 @@ exports[`default, with only required props should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -561,7 +561,7 @@ exports[`default, with only required props should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -605,6 +605,35 @@ exports[`default, with only required props should match snapshot 1`] = `
 `;
 
 exports[`props className should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -631,35 +660,6 @@ exports[`props className should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -771,7 +771,7 @@ exports[`props className should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -795,8 +795,8 @@ exports[`props className should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -816,7 +816,7 @@ exports[`props className should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -835,14 +835,14 @@ exports[`props className should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -1045,10 +1045,10 @@ exports[`props className should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -1056,10 +1056,10 @@ exports[`props className should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1069,7 +1069,7 @@ exports[`props className should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1107,7 +1107,7 @@ exports[`props className should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1117,7 +1117,7 @@ exports[`props className should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1155,7 +1155,7 @@ exports[`props className should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1165,7 +1165,7 @@ exports[`props className should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1209,6 +1209,35 @@ exports[`props className should match snapshot 1`] = `
 `;
 
 exports[`props defaultValue should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1235,35 +1264,6 @@ exports[`props defaultValue should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -1375,7 +1375,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1399,8 +1399,8 @@ exports[`props defaultValue should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -1420,7 +1420,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1439,14 +1439,14 @@ exports[`props defaultValue should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -1649,10 +1649,10 @@ exports[`props defaultValue should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -1660,10 +1660,10 @@ exports[`props defaultValue should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1673,7 +1673,7 @@ exports[`props defaultValue should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1711,7 +1711,7 @@ exports[`props defaultValue should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -1721,7 +1721,7 @@ exports[`props defaultValue should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1759,7 +1759,7 @@ exports[`props defaultValue should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
+          class="c6 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
         >
           <input
             checked=""
@@ -1770,7 +1770,7 @@ exports[`props defaultValue should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -1814,6 +1814,35 @@ exports[`props defaultValue should match snapshot 1`] = `
 `;
 
 exports[`props hintText should match snapshot 1`] = `
+.c7 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c7::before,
+.c7::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1840,35 +1869,6 @@ exports[`props hintText should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -1980,7 +1980,7 @@ exports[`props hintText should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2004,12 +2004,12 @@ exports[`props hintText should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c7 {
+.c6 {
   color: hsl(0,0%,16%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -2026,7 +2026,7 @@ exports[`props hintText should match snapshot 1`] = `
   font-weight: 400;
 }
 
-.c7.fi-hint-text {
+.c6.fi-hint-text {
   display: block;
 }
 
@@ -2046,7 +2046,7 @@ exports[`props hintText should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2065,14 +2065,14 @@ exports[`props hintText should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -2275,26 +2275,26 @@ exports[`props hintText should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
           </label>
         </div>
         <span
-          class="c6 c7 fi-hint-text"
+          class="c5 c6 fi-hint-text"
         >
           Example hint text
         </span>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c7 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -2304,7 +2304,7 @@ exports[`props hintText should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2342,7 +2342,7 @@ exports[`props hintText should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -2352,7 +2352,7 @@ exports[`props hintText should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2390,7 +2390,7 @@ exports[`props hintText should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -2400,7 +2400,7 @@ exports[`props hintText should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2444,6 +2444,35 @@ exports[`props hintText should match snapshot 1`] = `
 `;
 
 exports[`props id should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2470,35 +2499,6 @@ exports[`props id should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -2610,7 +2610,7 @@ exports[`props id should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2634,8 +2634,8 @@ exports[`props id should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -2655,7 +2655,7 @@ exports[`props id should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2674,14 +2674,14 @@ exports[`props id should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -2884,10 +2884,10 @@ exports[`props id should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="good-id"
           >
             Label
@@ -2895,10 +2895,10 @@ exports[`props id should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -2908,7 +2908,7 @@ exports[`props id should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2946,7 +2946,7 @@ exports[`props id should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -2956,7 +2956,7 @@ exports[`props id should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -2994,7 +2994,7 @@ exports[`props id should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -3004,7 +3004,7 @@ exports[`props id should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3048,6 +3048,35 @@ exports[`props id should match snapshot 1`] = `
 `;
 
 exports[`props label should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -3074,35 +3103,6 @@ exports[`props label should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -3214,7 +3214,7 @@ exports[`props label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3238,8 +3238,8 @@ exports[`props label should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -3259,7 +3259,7 @@ exports[`props label should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3278,14 +3278,14 @@ exports[`props label should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -3488,10 +3488,10 @@ exports[`props label should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label here
@@ -3499,10 +3499,10 @@ exports[`props label should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -3512,7 +3512,7 @@ exports[`props label should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3550,7 +3550,7 @@ exports[`props label should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -3560,7 +3560,7 @@ exports[`props label should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3598,7 +3598,7 @@ exports[`props label should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -3608,7 +3608,7 @@ exports[`props label should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -3652,6 +3652,35 @@ exports[`props label should match snapshot 1`] = `
 `;
 
 exports[`props labelMode should match snapshot 1`] = `
+.c7 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c7::before,
+.c7::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -3678,35 +3707,6 @@ exports[`props labelMode should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -3818,7 +3818,7 @@ exports[`props labelMode should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -3842,8 +3842,8 @@ exports[`props labelMode should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -3863,7 +3863,7 @@ exports[`props labelMode should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c7 {
+.c6 {
   position: absolute;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -3875,7 +3875,7 @@ exports[`props labelMode should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3894,14 +3894,14 @@ exports[`props labelMode should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -4104,20 +4104,20 @@ exports[`props labelMode should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-label"
+          class="c0 c4 fi-label"
         >
           <span
-            class="c6 c7 fi-visually-hidden"
+            class="c5 c6 fi-visually-hidden"
           >
             Label here
           </span>
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c7 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -4127,7 +4127,7 @@ exports[`props labelMode should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4165,7 +4165,7 @@ exports[`props labelMode should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -4175,7 +4175,7 @@ exports[`props labelMode should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4213,7 +4213,7 @@ exports[`props labelMode should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c8"
+          class="c7 fi-radio-button fi-radio-button_container c8"
         >
           <input
             class="c9 fi-radio-button_input"
@@ -4223,7 +4223,7 @@ exports[`props labelMode should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4267,6 +4267,35 @@ exports[`props labelMode should match snapshot 1`] = `
 `;
 
 exports[`props name should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -4293,35 +4322,6 @@ exports[`props name should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -4433,7 +4433,7 @@ exports[`props name should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -4457,8 +4457,8 @@ exports[`props name should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -4478,7 +4478,7 @@ exports[`props name should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -4497,14 +4497,14 @@ exports[`props name should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -4707,10 +4707,10 @@ exports[`props name should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -4718,10 +4718,10 @@ exports[`props name should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -4731,7 +4731,7 @@ exports[`props name should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4769,7 +4769,7 @@ exports[`props name should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -4779,7 +4779,7 @@ exports[`props name should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4817,7 +4817,7 @@ exports[`props name should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -4827,7 +4827,7 @@ exports[`props name should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -4871,6 +4871,35 @@ exports[`props name should match snapshot 1`] = `
 `;
 
 exports[`props value should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -4897,35 +4926,6 @@ exports[`props value should match snapshot 1`] = `
 
 .c0::before,
 .c0::after {
-  box-sizing: border-box;
-}
-
-.c4 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c4::before,
-.c4::after {
   box-sizing: border-box;
 }
 
@@ -5037,7 +5037,7 @@ exports[`props value should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -5061,8 +5061,8 @@ exports[`props value should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
@@ -5082,7 +5082,7 @@ exports[`props value should match snapshot 1`] = `
   cursor: inherit;
 }
 
-.c5.fi-label .fi-label_label-span {
+.c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -5101,14 +5101,14 @@ exports[`props value should match snapshot 1`] = `
   color: hsl(0,0%,16%);
 }
 
-.c5.fi-label .fi-label_label-span .fi-label_optional-text {
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c5.fi-label .fi-label_label-span .fi-tooltip {
+.c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -5312,10 +5312,10 @@ exports[`props value should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c4 c5 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--visible fi-label"
         >
           <label
-            class="c6 fi-label_label-span"
+            class="c5 fi-label_label-span"
             for="test-id"
           >
             Label
@@ -5323,10 +5323,10 @@ exports[`props value should match snapshot 1`] = `
         </div>
       </legend>
       <div
-        class="c0 fi-radio-button-group_container"
+        class="c6 fi-radio-button-group_container"
       >
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -5336,7 +5336,7 @@ exports[`props value should match snapshot 1`] = `
             value="1"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -5374,7 +5374,7 @@ exports[`props value should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
+          class="c6 fi-radio-button fi-radio-button_container c7 fi-radio-button--checked"
         >
           <input
             checked=""
@@ -5385,7 +5385,7 @@ exports[`props value should match snapshot 1`] = `
             value="2"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"
@@ -5423,7 +5423,7 @@ exports[`props value should match snapshot 1`] = `
           </label>
         </div>
         <div
-          class="c0 fi-radio-button fi-radio-button_container c7"
+          class="c6 fi-radio-button fi-radio-button_container c7"
         >
           <input
             class="c8 fi-radio-button_input"
@@ -5433,7 +5433,7 @@ exports[`props value should match snapshot 1`] = `
             value="3"
           />
           <span
-            class="c6 fi-radio-button_icon_wrapper"
+            class="c5 fi-radio-button_icon_wrapper"
           >
             <svg
               aria-hidden="true"

--- a/src/core/Form/SearchInput/SearchInput.test.tsx
+++ b/src/core/Form/SearchInput/SearchInput.test.tsx
@@ -214,6 +214,23 @@ describe('props', () => {
       expect(inputElement.value).toBe('new value');
     });
   });
+
+  describe('ref', () => {
+    it('ref is forwarded to input', () => {
+      const ref = React.createRef<HTMLInputElement>();
+
+      render(
+        <SearchInput
+          labelText="Debounced search"
+          clearButtonLabel="clear"
+          searchButtonLabel="search"
+          ref={ref}
+        />,
+      );
+
+      expect(ref.current?.tagName).toBe('INPUT');
+    });
+  });
 });
 
 describe('states', () => {

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -4,6 +4,7 @@ import React, {
   createRef,
   FocusEvent,
   ReactNode,
+  forwardRef,
 } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
@@ -83,6 +84,8 @@ export interface SearchInputProps
   onSearch?: (value: SearchInputValue) => void;
   /** Debounce time in milliseconds for onChange function. No debounce is applied if no value is given. */
   debounce?: number;
+  /** Ref is forwarded to input element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
 const baseClassName = 'fi-search-input';
@@ -112,7 +115,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
     value: this.props.value || this.props.defaultValue || '',
   };
 
-  private inputRef = createRef<HTMLInputElement>();
+  private inputRef = this.props.forwardedRef || createRef<HTMLInputElement>();
 
   static getDerivedStateFromProps(
     nextProps: SearchInputProps,
@@ -146,6 +149,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
       fullWidth,
       debounce,
       theme,
+      forwardedRef, // Taking this out so it's not passed "twice" to HtmlInput
       'aria-describedby': ariaDescribedBy,
       statusTextAriaLiveMode = 'assertive',
       ...passProps
@@ -304,20 +308,27 @@ const StyledSearchInput = styled(BaseSearchInput)`
  * Use for user inputting search text.
  * Props other than specified explicitly are passed on to underlying input element.
  */
-const SearchInput = (props: SearchInputProps) => {
-  const { id: propId, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledSearchInput theme={suomifiTheme} id={id} {...passProps} />
-          )}
-        </AutoId>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const SearchInput = forwardRef(
+  (props: SearchInputProps, ref: React.RefObject<HTMLInputElement>) => {
+    const { id: propId, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <AutoId id={propId}>
+            {(id) => (
+              <StyledSearchInput
+                theme={suomifiTheme}
+                id={id}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </AutoId>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 SearchInput.displayName = 'SearchInput';
 export { SearchInput };

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -735,3 +735,25 @@ describe('custom item addition mode', () => {
     }
   });
 });
+
+describe('forward ref', () => {
+  it('ref is forwarded to input', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(
+      <MultiSelect
+        id="123"
+        labelText="MultiSelect"
+        items={[]}
+        noItemsText="No items"
+        visualPlaceholder="Select item(s)"
+        status="error"
+        ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
+        ref={ref}
+      />,
+    );
+
+    expect(ref.current?.tagName).toBe('INPUT');
+  });
+});

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -463,6 +463,61 @@ describe('custom item addition mode', () => {
   });
 });
 
+describe('ariaOptionsAvailable', () => {
+  const planets: SingleSelectData[] = [
+    { labelText: 'Mercury', uniqueItemId: 'Me' },
+    { labelText: 'Venus', uniqueItemId: 'Ve' },
+    { labelText: 'Earth', uniqueItemId: 'Ea' },
+    { labelText: 'Mars', uniqueItemId: 'Ma' },
+  ];
+
+  it('should include ariaOptionsAvailableText', async () => {
+    const { getByRole, getByText } = render(
+      <SingleSelect
+        labelText="SingleSelect"
+        clearButtonLabel="Clear"
+        items={planets}
+        visualPlaceholder="Choose your planet"
+        noItemsText="No items"
+        ariaOptionsAvailableText="Options available"
+      />,
+    );
+    const input = getByRole('textbox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'M' } });
+    });
+    const ariaText = getByText(`2 Options available`);
+    expect(ariaText).toBeInTheDocument();
+  });
+
+  it('should include text from ariaOptionsAvailableTextFunction', async () => {
+    const { getByRole, getByText } = render(
+      <SingleSelect
+        labelText="SingleSelect"
+        clearButtonLabel="Clear"
+        items={planets}
+        visualPlaceholder="Choose your planet"
+        noItemsText="No items"
+        ariaOptionsAvailableTextFunction={(length) =>
+          length === 1
+            ? `There is ${length} option available`
+            : `There are ${length} options available`
+        }
+      />,
+    );
+    const input = getByRole('textbox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'V' } });
+    });
+    const ariaText = getByText(`There is 1 option available`);
+    expect(ariaText).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'M' } });
+    });
+    expect(ariaText).toHaveTextContent('There are 2 options available');
+  });
+});
+
 describe('forward ref', () => {
   it('ref is forwarded to input', () => {
     const ref = React.createRef<HTMLInputElement>();

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -462,3 +462,25 @@ describe('custom item addition mode', () => {
     }
   });
 });
+
+describe('forward ref', () => {
+  it('ref is forwarded to input', () => {
+    const ref = React.createRef<HTMLInputElement>();
+
+    render(
+      <SingleSelect
+        labelText="SingleSelect"
+        clearButtonLabel="Clear selection"
+        items={tools}
+        defaultSelectedItem={defaultSelectedTool}
+        noItemsText="No items"
+        visualPlaceholder="Select item"
+        ariaOptionsAvailableText="Options available"
+        ref={ref}
+      />,
+    );
+
+    expect(ref.current?.tagName).toBe('INPUT');
+    expect(ref.current?.value).toBe('Hammer');
+  });
+});

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -37,6 +37,23 @@ export interface SingleSelectData {
 
 export type SingleSelectStatus = FilterInputStatus & {};
 
+type AriaOptionsAvailableProps =
+  | {
+      ariaOptionsAvailableText?: never;
+      ariaOptionsAvailableTextFunction: (length: number) => string;
+    }
+  | {
+      /** Text for screen reader indicating the amount of available options after filtering by typing. Will be read after the amount.
+       * E.g 'options available' as prop value would result in '{amount} options available' being read by screen reader upon removal.
+       */
+      ariaOptionsAvailableText: string;
+
+      /** Function to provide text for screen reader indicating the amount of available options after filtering by typing. Overrides
+       * `ariaOptionsAvailableText` if both are provided.
+       */
+      ariaOptionsAvailableTextFunction?: never;
+    };
+
 export interface InternalSingleSelectProps<T extends SingleSelectData> {
   /** SingleSelect container div class name for custom styling. */
   className?: string;
@@ -59,11 +76,6 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
   onItemSelectionChange?: (selectedItem: (T & SingleSelectData) | null) => void;
   /** Placeholder text for input. Use only as visual aid, not for instructions. */
   visualPlaceholder?: string;
-  /**
-   * Text for screen reader indicating the amount of available options after filtering by typing. Will be read after the amount.
-   * E.g 'options available' as prop value would result in '{amount} options available' being read by screen reader upon removal.
-   */
-  ariaOptionsAvailableText: string;
   /** Default selected items */
   defaultSelectedItem?: T & SingleSelectData;
   /** Event sent when filter changes */
@@ -111,7 +123,8 @@ type AllowItemAdditionProps =
 export type SingleSelectProps<T> = InternalSingleSelectProps<
   T & SingleSelectData
 > &
-  AllowItemAdditionProps;
+  AllowItemAdditionProps &
+  AriaOptionsAvailableProps;
 
 interface SingleSelectState<T extends SingleSelectData> {
   filterInputValue: string;
@@ -460,6 +473,7 @@ class BaseSingleSelect<T> extends Component<
       selectedItem: controlledItem,
       clearButtonLabel,
       ariaOptionsAvailableText,
+      ariaOptionsAvailableTextFunction,
       onItemSelect,
       disabled,
       allowItemAddition,
@@ -655,7 +669,9 @@ class BaseSingleSelect<T> extends Component<
         )}
         {this.state.filterMode && (
           <VisuallyHidden aria-live="polite" aria-atomic="true">
-            {`${popoverItems.length} ${ariaOptionsAvailableText}`}
+            {ariaOptionsAvailableTextFunction
+              ? ariaOptionsAvailableTextFunction(popoverItems.length)
+              : `${popoverItems.length} ${ariaOptionsAvailableText}`}
           </VisuallyHidden>
         )}
       </HtmlDiv>

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
@@ -27,6 +27,8 @@ export interface StatusTextProps extends HtmlSpanProps {
    * @default polite
    */
   ariaLiveMode?: AriaLiveMode;
+  /** Ref is forwarded to the span element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
 const StyledStatusText = styled(
@@ -60,18 +62,24 @@ const StyledStatusText = styled(
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const StatusText = (props: StatusTextProps) => {
-  const { children, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledStatusText theme={suomifiTheme} {...passProps}>
-          {children}
-        </StyledStatusText>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const StatusText = forwardRef<HTMLSpanElement, StatusTextProps>(
+  (props: StatusTextProps, ref: React.Ref<HTMLSpanElement>) => {
+    const { children, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledStatusText
+            forwardedRef={ref}
+            theme={suomifiTheme}
+            {...passProps}
+          >
+            {children}
+          </StyledStatusText>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 StatusText.displayName = 'StatusText';
 export { StatusText };

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -764,11 +764,11 @@ exports[`snapshots match hidden label with placeholder 1`] = `
     <div
       class="c3 c4 fi-label"
     >
-      <span
-        class="c2 c5 fi-visually-hidden"
+      <label
+        class="c5 fi-visually-hidden"
       >
         Test input
-      </span>
+      </label>
     </div>
     <div
       class="c0 fi-text-input_input-element-container"

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -766,6 +766,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
     >
       <label
         class="c5 fi-visually-hidden"
+        for="test-id1"
       >
         Test input
       </label>

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -37,7 +37,7 @@ const textareaClassNames = {
 
 type TextareaStatus = Exclude<InputStatus, 'success'>;
 
-interface InternalTextareaProps
+export interface TextareaProps
   extends StatusTextCommonProps,
     Omit<HtmlTextareaProps, 'placeholder'> {
   /** Custom classname to extend or customize */
@@ -85,18 +85,11 @@ interface InternalTextareaProps
   fullWidth?: boolean;
   /** Textarea container div props */
   containerProps?: Omit<HtmlDivProps, 'className'>;
+  /** Ref is passed to the textarea element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLTextAreaElement>;
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLTextAreaElement>;
-}
-
-export interface TextareaProps extends InternalTextareaProps {
-  /** Ref object to be passed to the textarea element */
-  ref?: React.RefObject<HTMLTextAreaElement>;
-}
-
-class BaseTextarea extends Component<TextareaProps & InnerRef> {
+class BaseTextarea extends Component<TextareaProps> {
   render() {
     const {
       id,
@@ -176,10 +169,7 @@ class BaseTextarea extends Component<TextareaProps & InnerRef> {
 }
 
 const StyledTextarea = styled(
-  ({
-    theme,
-    ...passProps
-  }: InternalTextareaProps & InnerRef & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: TextareaProps & SuomifiThemeProp) => (
     <BaseTextarea {...passProps} />
   ),
 )`

--- a/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
@@ -22,19 +22,14 @@ export interface ToggleButtonProps
     Omit<HtmlButtonProps, 'onClick' | 'type'> {
   /** Event handler to execute when clicked */
   onClick?: (checked: boolean) => void;
-  /** Ref object to be passed to the button element */
-  ref?: React.RefObject<HTMLButtonElement>;
+  /** Ref object to be passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLButtonElement>;
-}
-
 interface ToggleState {
   toggleState: boolean;
 }
 
-class BaseToggleButton extends Component<ToggleButtonProps & InnerRef> {
+class BaseToggleButton extends Component<ToggleButtonProps> {
   state: ToggleState = {
     toggleState: !!this.props.checked || !!this.props.defaultChecked,
   };
@@ -112,7 +107,7 @@ class BaseToggleButton extends Component<ToggleButtonProps & InnerRef> {
 }
 
 const StyledToggleButton = styled(
-  (props: ToggleBaseProps & InnerRef & SuomifiThemeProp) => {
+  (props: ToggleBaseProps & SuomifiThemeProp) => {
     const { theme, ...passProps } = props;
     return <BaseToggleButton {...passProps} />;
   },

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
@@ -34,15 +34,11 @@ export interface ToggleInputProps
   name?: string;
   /** Event handler to execute when clicked */
   onChange?: (checked: boolean) => void;
-  /** Ref object to be passed to the input element */
-  ref?: React.RefObject<HTMLInputElement>;
+  /** Ref object is passed to the input element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLInputElement>;
-}
-
-class BaseToggleInput extends Component<ToggleInputProps & InnerRef> {
+class BaseToggleInput extends Component<ToggleInputProps> {
   state: ToggleState = {
     toggleState: !!this.props.checked || !!this.props.defaultChecked,
   };
@@ -123,7 +119,7 @@ class BaseToggleInput extends Component<ToggleInputProps & InnerRef> {
 }
 
 const StyledToggleInput = styled(
-  (props: ToggleBaseProps & InnerRef & SuomifiThemeProp) => {
+  (props: ToggleBaseProps & SuomifiThemeProp) => {
     const { theme, ...passProps } = props;
     return <BaseToggleInput {...passProps} />;
   },

--- a/src/core/Heading/Heading.md
+++ b/src/core/Heading/Heading.md
@@ -1,8 +1,13 @@
 ```js
 import { Heading } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
 
 <>
-  <Heading variant="h1">h1 text</Heading>
+  <Heading variant="h1" ref={exampleRef}>
+    h1 text
+  </Heading>
   <Heading variant="h2">h2 text</Heading>
   <Heading variant="h3" as="h2">
     h3 as h2 text

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -25,10 +25,11 @@ export interface HeadingProps extends HtmlHProps {
   className?: string;
   /** Render the heading as another element e.g. h3 as h2. Will override semantics derived from variant prop but keep the variant styles. */
   as?: asPropType;
+  /** Ref object is passed to the heading element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLHeadingElement>;
 }
 
 interface InternalHeadingProps extends HeadingProps, SuomifiThemeProp {
-  forwardedRef?: React.RefObject<HTMLHeadingElement>;
   asProp?: asPropType;
 }
 

--- a/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu/LanguageMenu.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode, Fragment } from 'react';
+import React, { Component, ReactNode, Fragment, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import {
@@ -49,6 +49,8 @@ export interface LanguageMenuProps {
     | Array<React.ReactElement<LanguageMenuPopoverItemsProps>>
     | null
     | undefined;
+  /** Ref is passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLButtonElement>;
 }
 
 class BaseLanguageMenu extends Component<LanguageMenuProps & SuomifiThemeProp> {
@@ -58,6 +60,7 @@ class BaseLanguageMenu extends Component<LanguageMenuProps & SuomifiThemeProp> {
       name,
       className,
       theme,
+      forwardedRef,
       languageMenuButtonClassName: menuButtonClassName,
       languageMenuOpenButtonClassName: menuButtonOpenClassName,
       ...passProps
@@ -73,6 +76,7 @@ class BaseLanguageMenu extends Component<LanguageMenuProps & SuomifiThemeProp> {
           {({ isOpen }: { isOpen: boolean }) => (
             <Fragment>
               <MenuButton
+                ref={forwardedRef}
                 {...passProps}
                 className={classnames(
                   menuButtonClassName,
@@ -164,33 +168,37 @@ const StyledMenuPopover = styled(
  * <i class="semantics" />
  * Use for dropdown menu.
  */
-const LanguageMenu = (props: LanguageMenuProps) => {
-  const { children, name, className, ...passProps } = props;
-  const languageMenuButtonClassName = classnames(
-    languageMenuClassNames.button,
-    languageMenuClassNames.buttonLang,
-    className,
-  );
 
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledLanguageMenu
-          theme={suomifiTheme}
-          {...passProps}
-          name={languageName(name)}
-          languageMenuButtonClassName={languageMenuButtonClassName}
-          languageMenuOpenButtonClassName={languageMenuClassNames.buttonOpen}
-        >
-          {LanguageMenuPopoverWithProps(
-            children,
-            languageMenuClassNames.itemLang,
-          )}
-        </StyledLanguageMenu>
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const LanguageMenu = forwardRef(
+  (props: LanguageMenuProps, ref: React.Ref<HTMLButtonElement>) => {
+    const { children, name, className, ...passProps } = props;
+    const languageMenuButtonClassName = classnames(
+      languageMenuClassNames.button,
+      languageMenuClassNames.buttonLang,
+      className,
+    );
+
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledLanguageMenu
+            theme={suomifiTheme}
+            forwardedRef={ref}
+            {...passProps}
+            name={languageName(name)}
+            languageMenuButtonClassName={languageMenuButtonClassName}
+            languageMenuOpenButtonClassName={languageMenuClassNames.buttonOpen}
+          >
+            {LanguageMenuPopoverWithProps(
+              children,
+              languageMenuClassNames.itemLang,
+            )}
+          </StyledLanguageMenu>
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 LanguageMenu.displayName = 'LanguageMenu';
 export { LanguageMenu };

--- a/src/core/Link/BaseLink/BaseLink.baseStyles.ts
+++ b/src/core/Link/BaseLink/BaseLink.baseStyles.ts
@@ -27,5 +27,19 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &:visited {
       color: ${theme.colors.accentTertiaryDark1};
     }
+
+    &--initial-underline {
+      text-decoration: underline;
+
+      &:focus,
+      &:focus-within {
+        text-decoration: underline;
+      }
+
+      &:hover,
+      &:active {
+        text-decoration: none;
+      }
+    }
   }
 `;

--- a/src/core/Link/BaseLink/BaseLink.tsx
+++ b/src/core/Link/BaseLink/BaseLink.tsx
@@ -4,6 +4,11 @@ import { asPropType } from '../../../utils/typescript';
 
 export const baseClassName = 'fi-link';
 
+export const linkClassNames = {
+  linkUnderline: `${baseClassName}--initial-underline`,
+};
+
+export type UnderlineVariant = 'initial' | 'hover';
 export interface BaseLinkProps extends HtmlAProps {
   /** Link url. Link is not focusable without the href */
   href: string;
@@ -13,5 +18,16 @@ export interface BaseLinkProps extends HtmlAProps {
    * Link element displayed content
    */
   children: ReactNode;
+  /**
+   * 'initial' | 'hover'
+   *
+   * Option 'initial' shows underline in link's normal state, and no underline on hover.
+   * Option 'hover' shows underline on hover, and no underline in link's normal state.
+   *
+   * Note: default will be changed from 'hover' to 'initial', so set 'hover' explicitly when necessary.
+   *
+   * @default hover
+   */
+  underline?: UnderlineVariant;
   asProp?: asPropType;
 }

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -6,7 +6,11 @@ import { Icon } from '../../Icon/Icon';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import { ExternalLinkStyles } from './ExternalLink.baseStyles';
 import { HtmlA } from '../../../reset';
-import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
+import {
+  BaseLinkProps,
+  baseClassName,
+  linkClassNames,
+} from '../BaseLink/BaseLink';
 
 const iconClassName = 'fi-link_icon';
 const externalClassName = 'fi-link--external';
@@ -43,12 +47,15 @@ class BaseExternalLink extends Component<ExternalLinkProps> {
       toNewWindow = true,
       labelNewWindow,
       hideIcon,
+      underline = 'hover',
       ...passProps
     } = this.props;
     return (
       <HtmlA
         {...passProps}
-        className={classnames(baseClassName, className, externalClassName)}
+        className={classnames(baseClassName, className, externalClassName, {
+          [linkClassNames.linkUnderline]: underline === 'initial',
+        })}
         target={!!toNewWindow ? '_blank' : undefined}
         rel={!!toNewWindow ? 'noopener' : undefined}
         as={asProp}

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
@@ -28,6 +28,8 @@ interface InternalExternalLinkProps extends BaseLinkProps {
   toNewWindow?: boolean;
   /** Translated explanation of 'opens to a new window' */
   labelNewWindow?: string;
+  /** Ref is passed to the anchor element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLAnchorElement>;
 }
 
 export type ExternalLinkProps = newWindowProps & InternalExternalLinkProps;
@@ -78,13 +80,18 @@ const StyledExternalLink = styled(
  * <i class="semantics" />
  * Used for adding a external site link
  */
-
-const ExternalLink = (props: ExternalLinkProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledExternalLink theme={suomifiTheme} {...props} />
-    )}
-  </SuomifiThemeConsumer>
+const ExternalLink = forwardRef(
+  (props: ExternalLinkProps, ref: React.Ref<HTMLAnchorElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledExternalLink
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 ExternalLink.displayName = 'ExternalLink';

--- a/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
+++ b/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
@@ -155,6 +155,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c1.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:focus,
+.c1.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:hover,
+.c1.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c1 .fi-link_icon {
   padding-left: 4px;
   font-size: 16px;

--- a/src/core/Link/Link/Link.md
+++ b/src/core/Link/Link/Link.md
@@ -5,11 +5,19 @@ import { Link, Paragraph } from 'suomifi-ui-components';
   <Link
     className="test-classname"
     href="https://www.notvisitedlink.com/"
+    underline="initial"
   >
     Not visited link
   </Link>{' '}
-  <Link className="test-classname" href="#">
+  <Link className="test-classname" href="#" underline="initial">
     Visited link
+  </Link>{' '}
+  <Link
+    className="test-classname"
+    href="https://www.notvisitedlink.com/"
+    underline="hover"
+  >
+    Link without underline
   </Link>
 </Paragraph>;
 ```

--- a/src/core/Link/Link/Link.md
+++ b/src/core/Link/Link/Link.md
@@ -71,16 +71,28 @@ This component is mainly intended to be used with external libraries/frameworks.
 
 ```js
 import { RouterLink } from 'suomifi-ui-components';
+import { forwardRef, useRef } from 'react';
 
-const Component = ({ children, ...passProps }) => (
-  <a {...passProps}>Some component - {children}</a>
-);
+const Component = forwardRef((props, ref) => {
+  const { children, ...passProps } = props;
+  return (
+    <a {...passProps} ref={ref}>
+      Some component - {children}
+    </a>
+  );
+});
+
+const r = useRef();
 
 <>
+  <button onClick={() => console.log(r.current)}>
+    Log ref to console
+  </button>
   <RouterLink
-    asComponent={Component}
     href="https://suomi.fi"
     target="_blank"
+    asComponent={Component}
+    ref={r}
   >
     Testing
   </RouterLink>

--- a/src/core/Link/Link/Link.test.tsx
+++ b/src/core/Link/Link/Link.test.tsx
@@ -10,11 +10,27 @@ const TestLink = (
   </Link>
 );
 
+const LinkVariant = (
+  <Link href="/" underline="initial">
+    Link variant
+  </Link>
+);
+
 test('calling render with the same component on the same container does not remount', () => {
   const LinkRendered = render(TestLink);
   const { getByTestId, container } = LinkRendered;
   expect(container.firstChild).toMatchSnapshot();
   expect(getByTestId('test-link').textContent).toBe('Hey this is test');
+});
+
+test('should not have underline class by default', () => {
+  const { container } = render(TestLink);
+  expect(container.firstChild).not.toHaveClass('fi-link--initial-underline');
+});
+
+test('should have option with underline', () => {
+  const { container } = render(LinkVariant);
+  expect(container.firstChild).toHaveClass('fi-link--initial-underline');
 });
 
 test('should not have basic accessibility issues', axeTest(TestLink));

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { LinkStyles } from '../Link/Link.baseStyles';
@@ -6,7 +6,10 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlA } from '../../../reset';
 import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
 
-export interface LinkProps extends BaseLinkProps {}
+export interface LinkProps extends BaseLinkProps {
+  /** Ref  is passed to the anchor element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLAnchorElement>;
+}
 
 const StyledLink = styled(
   ({
@@ -29,10 +32,14 @@ const StyledLink = styled(
  * <i class="semantics" />
  * Used for adding a link
  */
-const Link = (props: LinkProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledLink theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
+const Link = forwardRef(
+  (props: LinkProps, ref: React.Ref<HTMLAnchorElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledLink theme={suomifiTheme} forwardedRef={ref} {...props} />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 Link.displayName = 'Link';

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -4,7 +4,11 @@ import classnames from 'classnames';
 import { LinkStyles } from '../Link/Link.baseStyles';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlA } from '../../../reset';
-import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
+import {
+  BaseLinkProps,
+  baseClassName,
+  linkClassNames,
+} from '../BaseLink/BaseLink';
 
 export interface LinkProps extends BaseLinkProps {
   /** Ref  is passed to the anchor element. Alternative to React `ref` attribute. */
@@ -16,11 +20,14 @@ const StyledLink = styled(
     asProp,
     className,
     theme,
+    underline = 'hover',
     ...passProps
   }: LinkProps & SuomifiThemeProp) => (
     <HtmlA
       {...passProps}
-      className={classnames(baseClassName, className)}
+      className={classnames(baseClassName, className, {
+        [linkClassNames.linkUnderline]: underline === 'initial',
+      })}
       as={asProp}
     />
   ),

--- a/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
@@ -90,6 +90,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c1.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:focus,
+.c1.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:hover,
+.c1.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <a
   class="c0 fi-link c1"
   data-testid="test-link"

--- a/src/core/Link/RouterLink/RouterLink.baseStyles.ts
+++ b/src/core/Link/RouterLink/RouterLink.baseStyles.ts
@@ -28,4 +28,18 @@ export const RouterLinkStyles = (theme: SuomifiTheme) => css`
       color: ${theme.colors.accentTertiaryDark1};
     }
   }
+
+  &.fi-link--initial-underline {
+    text-decoration: underline;
+
+    &:focus,
+    &:focus-within {
+      text-decoration: underline;
+    }
+
+    &:hover,
+    &:active {
+      text-decoration: none;
+    }
+  }
 `;

--- a/src/core/Link/RouterLink/RouterLink.test.tsx
+++ b/src/core/Link/RouterLink/RouterLink.test.tsx
@@ -14,6 +14,16 @@ const RouterLinkAsButton = (
   <RouterLink asComponent="button">Router link as a button</RouterLink>
 );
 
+const RouterLinkVariant = (
+  <RouterLink underline="initial">RouterLink variant</RouterLink>
+);
+
+const RouterLinkButtonVariant = (
+  <RouterLink asComponent="button" underline="initial">
+    Router link as button variant
+  </RouterLink>
+);
+
 test('calling render with the same component on the same container does not remount', () => {
   const { getByTestId, container } = render(TestRouterLink);
   expect(container.firstChild).toMatchSnapshot();
@@ -23,6 +33,26 @@ test('calling render with the same component on the same container does not remo
 it('should still have the correct styles applied when rendered as something other than <a> ', () => {
   const { container } = render(RouterLinkAsButton);
   expect(container.firstChild).toHaveClass('fi-link--router');
+});
+
+test('should not have underline by default', () => {
+  const { container } = render(TestRouterLink);
+  expect(container.firstChild).not.toHaveClass('fi-link--initial-underline');
+});
+
+test('should not have underline be default when rendered as something other than <a>', () => {
+  const { container } = render(RouterLinkAsButton);
+  expect(container.firstChild).not.toHaveClass('fi-link--initial-underline');
+});
+
+test('should have option for underline', () => {
+  const { container } = render(RouterLinkVariant);
+  expect(container.firstChild).toHaveClass('fi-link--initial-underline');
+});
+
+test('should have option for underline when rendered as something other than <a>', () => {
+  const { container } = render(RouterLinkButtonVariant);
+  expect(container.firstChild).toHaveClass('fi-link--initial-underline');
 });
 
 test('should not have basic accessibility issues', axeTest(TestRouterLink));

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -3,7 +3,11 @@ import React, { forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import { RouterLinkStyles } from './RouterLink.baseStyles';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
-import { baseClassName } from '../BaseLink/BaseLink';
+import {
+  baseClassName,
+  linkClassNames,
+  UnderlineVariant,
+} from '../BaseLink/BaseLink';
 import classnames from 'classnames';
 import { HtmlA } from '../../../reset';
 
@@ -85,6 +89,17 @@ interface Props {
    * Link element displayed content
    */
   children: ReactNode;
+  /**
+   * 'initial' | 'hover'
+   *
+   * Option 'initial' shows underline in link's normal state, and no underline on hover.
+   * Option 'hover' shows underline on hover, and no underline in link's normal state.
+   *
+   * Note: default will be changed from 'hover' to 'initial', so set 'hover' explicitly when necessary.
+   *
+   * @default hover
+   */
+  underline?: UnderlineVariant;
 }
 
 export type RouterLinkProps<C extends React.ElementType> =
@@ -98,19 +113,20 @@ const PolymorphicLink = <C extends React.ElementType>(
     children,
     className,
     theme,
+    underline = 'hover',
     forwardedRef,
     ...passProps
   } = props;
   const Component = asComponent || HtmlA;
 
+  const classNames = classnames(routerLinkClassName, className, {
+    [linkClassNames.linkUnderline]: underline === 'initial',
+  });
+
   // If asComponent is included, we assume it can take a normal ref-prop
   if (!!asComponent) {
     return (
-      <Component
-        className={classnames(routerLinkClassName, className)}
-        ref={forwardedRef}
-        {...passProps}
-      >
+      <Component className={classNames} ref={forwardedRef} {...passProps}>
         {children}
       </Component>
     );
@@ -119,7 +135,7 @@ const PolymorphicLink = <C extends React.ElementType>(
   // HtmlA (which is rendered by default) exposes a prop called forwardedRef instead
   return (
     <Component
-      className={classnames(routerLinkClassName, className)}
+      className={classNames}
       forwardedRef={forwardedRef}
       {...passProps}
     >

--- a/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
+++ b/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
@@ -90,6 +90,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c1.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:focus,
+.c1.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:hover,
+.c1.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <a
   class="c0 fi-link--router c1"
   data-testid="test-link"

--- a/src/core/Link/SkipLink/SkipLink.baseStyles.ts
+++ b/src/core/Link/SkipLink/SkipLink.baseStyles.ts
@@ -13,7 +13,6 @@ export const SkipLinkStyles = (theme: SuomifiTheme) => css`
     background: ${theme.colors.highlightLight3};
     border: 1px solid ${theme.colors.depthLight1};
     color: ${theme.colors.blackBase};
-    text-decoration: none;
   }
 
   &.fi-link--skip:focus {

--- a/src/core/Link/SkipLink/SkipLink.tsx
+++ b/src/core/Link/SkipLink/SkipLink.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { Link } from '../Link/Link';
@@ -8,7 +8,10 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 
 const skipClassName = 'fi-link--skip';
 
-export interface SkipLinkProps extends BaseLinkProps {}
+export interface SkipLinkProps extends BaseLinkProps {
+  /** Ref  is passed to the anchor element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLAnchorElement>;
+}
 
 const StyledSkipLink = styled((props: SkipLinkProps & SuomifiThemeProp) => {
   const { theme, ...passProps } = props;
@@ -21,20 +24,23 @@ const StyledSkipLink = styled((props: SkipLinkProps & SuomifiThemeProp) => {
  * <i class="semantics" />
  * Used for adding skip link for keyboard and screenreader users
  */
-const SkipLink = (props: SkipLinkProps) => {
-  const { className, ...passProps } = props;
-  return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledSkipLink
-          theme={suomifiTheme}
-          {...passProps}
-          className={classnames(className, skipClassName)}
-        />
-      )}
-    </SuomifiThemeConsumer>
-  );
-};
+const SkipLink = forwardRef(
+  (props: SkipLinkProps, ref: React.Ref<HTMLAnchorElement>) => {
+    const { className, ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledSkipLink
+            theme={suomifiTheme}
+            forwardedRef={ref}
+            {...passProps}
+            className={classnames(className, skipClassName)}
+          />
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
+);
 
 SkipLink.displayName = 'SkipLink';
 export { SkipLink };

--- a/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
+++ b/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
@@ -90,6 +90,23 @@ exports[`should match snapshot 1`] = `
   color: hsl(284,36%,45%);
 }
 
+.c1.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:focus,
+.c1.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:hover,
+.c1.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c2 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -141,6 +158,23 @@ exports[`should match snapshot 1`] = `
   color: hsl(284,36%,45%);
 }
 
+.c2.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2.fi-link--initial-underline:focus,
+.c2.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2.fi-link--initial-underline:hover,
+.c2.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c2.fi-link--skip {
   position: absolute;
   z-index: 10000;
@@ -150,8 +184,6 @@ exports[`should match snapshot 1`] = `
   background: hsl(212,63%,95%);
   border: 1px solid hsl(202,7%,80%);
   color: hsl(0,0%,16%);
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c2.fi-link--skip:focus {

--- a/src/core/LoadingSpinner/LoadingSpinner.md
+++ b/src/core/LoadingSpinner/LoadingSpinner.md
@@ -1,5 +1,8 @@
 ```js
 import { LoadingSpinner } from 'suomifi-ui-components';
+import { createRef } from 'react';
+
+const exampleRef = createRef();
 
 <>
   <div>
@@ -8,6 +11,7 @@ import { LoadingSpinner } from 'suomifi-ui-components';
       variant="normal"
       textAlign="right"
       text="Loading"
+      ref={exampleRef}
     />
     <br />
     <LoadingSpinner status="success" text="Loading finished" />

--- a/src/core/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.tsx
@@ -32,10 +32,10 @@ export interface LoadingSpinnerProps {
    * @default 'normal'
    */
   variant?: 'normal' | 'small';
+  /** Ref to be passed to the root div element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLDivElement>;
 }
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
-}
+
 const baseClassName = 'fi-loadingSpinner';
 
 export const loadingSpinnerClassNames = {
@@ -49,7 +49,7 @@ export const loadingSpinnerClassNames = {
   icon: `${baseClassName}_icon`,
 };
 
-class BaseLoadingSpinner extends Component<LoadingSpinnerProps & InnerRef> {
+class BaseLoadingSpinner extends Component<LoadingSpinnerProps> {
   render() {
     const {
       className,
@@ -101,7 +101,7 @@ class BaseLoadingSpinner extends Component<LoadingSpinnerProps & InnerRef> {
   }
 }
 const StyledLoadingSpinner = styled(
-  (props: LoadingSpinnerProps & InnerRef & SuomifiThemeProp) => {
+  (props: LoadingSpinnerProps & SuomifiThemeProp) => {
     const { theme, ...passProps } = props;
     return <BaseLoadingSpinner {...passProps} />;
   },
@@ -109,7 +109,7 @@ const StyledLoadingSpinner = styled(
   ${({ theme }) => baseStyles(theme)};
 `;
 const LoadingSpinner = forwardRef(
-  (props: LoadingSpinnerProps, ref: React.RefObject<HTMLDivElement>) => {
+  (props: LoadingSpinnerProps, ref: React.Ref<HTMLDivElement>) => {
     const { ...passProps } = props;
     return (
       <SuomifiThemeConsumer>

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -1,0 +1,49 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodyText')}
+  &.fi-service-navigation {
+    &--small-screen {
+      background: ${theme.colors.highlightLight3};
+      .fi-service-navigation-item,
+      .fi-service-navigation-item--selected {
+        border-bottom: 1px solid ${theme.colors.whiteBase};
+      }
+      .fi-service-navigation_expand-button {
+        ${font(theme)('heading4')}
+        position: relative;
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: ${theme.spacing.m};
+        border: 1px solid ${theme.colors.highlightLight2};
+
+        .fi-service-navigation_expand-button_text-wrapper {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        &:focus {
+          outline: 0;
+          &:after {
+            ${theme.focus.absoluteFocus}
+          }
+        }
+
+        .fi-icon {
+          height: 25px;
+          width: 25px;
+        }
+      }
+    }
+    .fi-service-navigation_list {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+    }
+  }
+`;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.md
@@ -1,0 +1,159 @@
+### Basic usage
+
+Please use `<RouterLink>` as the child of `<ServiceNavigationItem>` to get inteded CSS styles. `<RouterLink>` is polymorphic, and can be rendered as any component of your choice, for example React Router Link.
+
+```js
+import {
+  ServiceNavigation,
+  ServiceNavigationItem,
+  RouterLink,
+  ExternalLink,
+  StaticChip
+} from 'suomifi-ui-components';
+
+const CustomButton = (props) => {
+  const { children, ...passProps } = props;
+  return <button {...passProps}>{props.children}</button>;
+};
+
+<div style={{ width: '300px' }}>
+  <ServiceNavigation aria-label="Main">
+    <ServiceNavigationItem>
+      <RouterLink href="/" aria-label="Inbox. 16 unread messages.">
+        Inbox
+        <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
+          16
+        </StaticChip>
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://suomi.fi"
+        hideIcon
+      >
+        Sent
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem selected>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+        aria-current="page"
+      >
+        New Message
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        Drafts
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={CustomButton}
+        onClick={() => console.log('Nav item clicked')}
+      >
+        Settings
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem disabled>
+      <RouterLink role="link" aria-disabled>
+        Devices
+      </RouterLink>
+    </ServiceNavigationItem>
+  </ServiceNavigation>
+</div>;
+```
+
+For frameworks where its internal link component is used as a wrapper for the actual link, for example NextJS, the following approach can be used:
+
+```jsx static
+<ServiceNavigationItem>
+  <NextJSLink href="/some-route" passHref>
+    <RouterLink>Inbox</RouterLink>
+  </NextJSLink>
+</ServiceNavigationItem>
+```
+
+### Small screen variant
+
+```js
+import {
+  ServiceNavigation,
+  ServiceNavigationItem,
+  RouterLink,
+  ExternalLink,
+  StaticChip
+} from 'suomifi-ui-components';
+
+const Comp = (props) => {
+  const { children, ...passProps } = props;
+  return <div {...passProps}>{props.children}</div>;
+};
+
+<div style={{ width: '300px' }}>
+  <ServiceNavigation
+    variant="smallScreen"
+    smallScreenExpandButtonText="Menu"
+    initiallyExpanded={false}
+    aria-label="Main"
+  >
+    <ServiceNavigationItem>
+      <RouterLink href="/">Inbox</RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://suomi.fi"
+        hideIcon
+      >
+        Sent
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        New Message
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem selected>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+        aria-current="page"
+        aria-label="Drafts. 3 drafts waiting."
+      >
+        Drafts
+        <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
+          3
+        </StaticChip>
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={Comp}
+        onClick={() => console.log('Nav item clicked')}
+        role="button"
+        tabIndex="0"
+      >
+        Settings
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem disabled>
+      <RouterLink role="link" aria-disabled>
+        Devices
+      </RouterLink>
+    </ServiceNavigationItem>
+  </ServiceNavigation>
+</div>;
+```

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axeTest } from '../../../../utils/test';
+
+import { ServiceNavigation } from './ServiceNavigation';
+import { ServiceNavigationItem } from '../ServiceNavigationItem/ServiceNavigationItem';
+import { ExternalLink, RouterLink } from '../../../Link';
+import { StaticChip } from '../../../Chip';
+
+interface TestProps {
+  children: string;
+  onClick?: () => void;
+  role?: string;
+  tabIndex?: number;
+}
+
+const Comp = ({ children, ...passProps }: TestProps) => (
+  <div {...passProps}>{children}</div>
+);
+
+const TestServiceNavigation = (
+  <ServiceNavigation aria-label="Test">
+    <ServiceNavigationItem>
+      <RouterLink href="/" aria-label="Inbox. 16 unread messages.">
+        Inbox
+        <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
+          16
+        </StaticChip>
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink asComponent={ExternalLink} href="https://suomi.fi" hideIcon>
+        Sent
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem selected>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+        aria-current="page"
+      >
+        New Message
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={ExternalLink}
+        href="https://www.suomi.fi"
+        hideIcon
+      >
+        Drafts
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem>
+      <RouterLink
+        asComponent={Comp}
+        onClick={() => console.log('Nav item clicked')}
+      >
+        Settings
+      </RouterLink>
+    </ServiceNavigationItem>
+    <ServiceNavigationItem disabled>
+      <RouterLink>Devices</RouterLink>
+    </ServiceNavigationItem>
+  </ServiceNavigation>
+);
+
+it('should match snapshot', () => {
+  const NavRendered = render(TestServiceNavigation);
+  const { container } = NavRendered;
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test(
+  'should not have basic accessibility issues',
+  axeTest(TestServiceNavigation),
+);

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -1,0 +1,121 @@
+import React, { forwardRef, ReactNode, useState } from 'react';
+import {
+  HtmlButton,
+  HtmlDiv,
+  HtmlNav,
+  HtmlSpan,
+  HtmlUl,
+} from '../../../../reset';
+import styled from 'styled-components';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import { baseStyles } from './ServiceNavigation.baseStyles';
+import classnames from 'classnames';
+import { Icon } from '../../../Icon/Icon';
+import { getConditionalAriaProp } from '../../../../utils/aria';
+
+export interface ServiceNavigationProps {
+  /** Use the `<ServiceNavigationItem>` components as children */
+  children: ReactNode;
+  /** Name for the navigation element. Don't use the word "navigation" since it will be read by screen reader regardless. */
+  'aria-label': string;
+  /** ID for the HTML nav element */
+  id?: string;
+  /**
+   * Normal or small screen variant
+   * @default normal
+   */
+  variant?: 'default' | 'smallScreen';
+  /**
+   * Initial expand status for the menu. Only applies to smallScreen variant
+   * @default true
+   */
+  initiallyExpanded?: boolean;
+  /** When using smallScreen variant, this is the text showed in the expander button */
+  smallScreenExpandButtonText?: string | ReactNode;
+  /** Custom classname to extend or customize */
+  className?: string;
+  /** Ref is forwarded to nav element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLElement>;
+}
+
+const baseClassName = 'fi-service-navigation';
+const smallScreenClassName = `${baseClassName}--small-screen`;
+const listClassName = `${baseClassName}_list`;
+const smallScreenExpandButtonClassName = `${baseClassName}_expand-button`;
+const buttonTextClassName = `${baseClassName}_expand-button_text-wrapper`;
+
+const BaseServiceNavigation = ({
+  children,
+  'aria-label': ariaLabel,
+  id,
+  variant,
+  initiallyExpanded,
+  smallScreenExpandButtonText,
+  className,
+  forwardedRef,
+}: ServiceNavigationProps) => {
+  const initiallyExpandedValue =
+    initiallyExpanded !== undefined ? initiallyExpanded : true;
+  const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
+    initiallyExpandedValue,
+  );
+
+  return (
+    <HtmlDiv
+      className={classnames(baseClassName, className, {
+        [smallScreenClassName]: variant === 'smallScreen',
+      })}
+    >
+      {variant === 'smallScreen' && (
+        <HtmlButton
+          className={smallScreenExpandButtonClassName}
+          onClick={() => setSmallScreenNavOpen(!smallScreenNavOpen)}
+          aria-expanded={smallScreenNavOpen}
+        >
+          <HtmlSpan className={buttonTextClassName}>
+            {smallScreenExpandButtonText}
+          </HtmlSpan>
+          <Icon icon={smallScreenNavOpen ? 'chevronDown' : 'chevronRight'} />
+        </HtmlButton>
+      )}
+      {((variant === 'smallScreen' && smallScreenNavOpen) ||
+        variant !== 'smallScreen') && (
+        <HtmlNav
+          forwardedRef={forwardedRef}
+          id={id}
+          {...getConditionalAriaProp('aria-label', [ariaLabel])}
+        >
+          <HtmlUl className={listClassName} role="list">
+            {children}
+          </HtmlUl>
+        </HtmlNav>
+      )}
+    </HtmlDiv>
+  );
+};
+
+const StyledServiceNavigation = styled(
+  (props: ServiceNavigationProps & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseServiceNavigation {...passProps} />;
+  },
+)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const ServiceNavigation = forwardRef(
+  (props: ServiceNavigationProps, ref: React.Ref<HTMLElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledServiceNavigation
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
+);
+
+ServiceNavigation.displayName = 'ServiceNavigation';
+export { ServiceNavigation };

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -1,0 +1,729 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c6:hover,
+.c6:active,
+.c6:focus,
+.c6:focus-within {
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c8 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c8::before,
+.c8::after {
+  box-sizing: border-box;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c1 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c1.fi-service-navigation--small-screen {
+  background: hsl(212,63%,95%);
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation-item,
+.c1.fi-service-navigation--small-screen .fi-service-navigation-item--selected {
+  border-bottom: 1px solid hsl(0,0%,100%);
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+  position: relative;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 20px;
+  border: 1px solid hsl(212,63%,90%);
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button .fi-service-navigation_expand-button_text-wrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button:focus {
+  outline: 0;
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+.c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button .fi-icon {
+  height: 25px;
+  width: 25px;
+}
+
+.c1.fi-service-navigation .fi-service-navigation_list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c5 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.c5.fi-service-navigation-item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+}
+
+.c5.fi-service-navigation-item:hover,
+.c5.fi-service-navigation-item:active {
+  background: hsl(212,63%,95%);
+  cursor: pointer;
+  border-left: 4px solid hsl(212,63%,45%);
+}
+
+.c5.fi-service-navigation-item:hover .fi-link--router,
+.c5.fi-service-navigation-item:active .fi-link--router {
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-service-navigation-item:focus-within {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+.c5.fi-service-navigation-item .fi-link--router {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 10px 20px;
+  text-transform: uppercase;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+  background: inherit;
+  border: none;
+}
+
+.c5.fi-service-navigation-item .fi-link--router:focus {
+  outline: 0;
+  border: none;
+  box-shadow: none;
+}
+
+.c5.fi-service-navigation-item .fi-link--router:hover,
+.c5.fi-service-navigation-item .fi-link--router:active,
+.c5.fi-service-navigation-item .fi-link--router:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-service-navigation-item--disabled:hover,
+.c5.fi-service-navigation-item--disabled:active {
+  background: transparent;
+  cursor: not-allowed;
+  border-left: none;
+}
+
+.c5.fi-service-navigation-item--disabled:hover .fi-link--router,
+.c5.fi-service-navigation-item--disabled:active .fi-link--router {
+  padding-left: 20px;
+}
+
+.c5.fi-service-navigation-item--disabled .fi-link--router {
+  color: hsl(202,7%,67%);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.c5.fi-service-navigation-item--disabled .fi-link--router:hover,
+.c5.fi-service-navigation-item--disabled .fi-link--router:active,
+.c5.fi-service-navigation-item--disabled .fi-link--router:visited {
+  color: hsl(202,7%,67%);
+}
+
+.c5.fi-service-navigation-item--selected {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: hsl(212,63%,95%);
+  border-left: 4px solid hsl(212,63%,45%);
+  position: relative;
+}
+
+.c5.fi-service-navigation-item--selected:focus {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+.c5.fi-service-navigation-item--selected .fi-link--router {
+  font-weight: bold;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 10px 25px;
+  padding-left: calc(20px - 4px);
+  text-transform: uppercase;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.c5.fi-service-navigation-item--selected .fi-link--router:hover,
+.c5.fi-service-navigation-item--selected .fi-link--router:active,
+.c5.fi-service-navigation-item--selected .fi-link--router:visited {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c11 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c10 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c10.fi-link {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c10.fi-link:hover,
+.c10.fi-link:active,
+.c10.fi-link:focus,
+.c10.fi-link:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c10.fi-link:focus,
+.c10.fi-link:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c10.fi-link:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c10.fi-link:hover,
+.c10.fi-link:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c10.fi-link:visited {
+  color: hsl(284,36%,45%);
+}
+
+.c10 .fi-link_icon {
+  padding-left: 4px;
+  font-size: 16px;
+  box-sizing: content-box;
+}
+
+.c7 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c7.fi-link--router {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c7.fi-link--router:hover,
+.c7.fi-link--router:active,
+.c7.fi-link--router:focus,
+.c7.fi-link--router:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c7.fi-link--router:focus,
+.c7.fi-link--router:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c7.fi-link--router:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c7.fi-link--router:hover,
+.c7.fi-link--router:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7.fi-link--router:visited {
+  color: hsl(284,36%,45%);
+}
+
+.c9 {
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.c9.fi-chip {
+  border-radius: 14px;
+  padding: 2px 10px;
+  color: hsl(0,0%,100%);
+  background: hsl(212,63%,45%);
+  max-height: 100%;
+  display: inline-block;
+}
+
+.c9.fi-chip:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c9.fi-chip:focus::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+  border-radius: 16px;
+}
+
+.c9.fi-chip .fi-chip--content {
+  display: block;
+  word-break: break-word;
+  overflow: hidden;
+  line-height: 1.5em;
+}
+
+.c9.fi-chip--disabled.fi-chip {
+  cursor: not-allowed;
+  background: hsl(202,7%,67%);
+}
+
+.c9.fi-chip--disabled.fi-chip:hover,
+.c9.fi-chip--disabled.fi-chip:active {
+  background: hsl(202,7%,67%);
+}
+
+<div
+  class="c0 fi-service-navigation c1"
+>
+  <nav
+    aria-label="Test"
+    class="c2"
+  >
+    <ul
+      class="c3 fi-service-navigation_list"
+      role="list"
+    >
+      <li
+        class="c4 c5 fi-service-navigation-item"
+      >
+        <a
+          aria-label="Inbox. 16 unread messages."
+          class="c6 fi-link--router c7"
+          href="/"
+        >
+          Inbox
+          <span
+            aria-hidden="true"
+            class="c8 fi-chip c9"
+            style="margin-left: 15px;"
+          >
+            <span
+              class="c8 fi-chip--content"
+            >
+              16
+            </span>
+          </span>
+        </a>
+      </li>
+      <li
+        class="c4 c5 fi-service-navigation-item"
+      >
+        <a
+          class="c6 fi-link c10 fi-link--router c7 fi-link--external"
+          href="https://suomi.fi"
+          rel="noopener"
+          target="_blank"
+        >
+          Sent
+          <span
+            class="c8 c11 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        class="c4 c5 fi-service-navigation-item--selected"
+      >
+        <a
+          aria-current="page"
+          class="c6 fi-link c10 fi-link--router c7 fi-link--external"
+          href="https://www.suomi.fi"
+          rel="noopener"
+          target="_blank"
+        >
+          New Message
+          <span
+            class="c8 c11 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        class="c4 c5 fi-service-navigation-item"
+      >
+        <a
+          class="c6 fi-link c10 fi-link--router c7 fi-link--external"
+          href="https://www.suomi.fi"
+          rel="noopener"
+          target="_blank"
+        >
+          Drafts
+          <span
+            class="c8 c11 fi-visually-hidden"
+          />
+        </a>
+      </li>
+      <li
+        class="c4 c5 fi-service-navigation-item"
+      >
+        <div
+          class="fi-link--router c7"
+        >
+          Settings
+        </div>
+      </li>
+      <li
+        aria-disabled="true"
+        class="c4 c5 fi-service-navigation-item fi-service-navigation-item--disabled"
+      >
+        <a
+          class="c6 fi-link--router c7"
+        >
+          Devices
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>
+`;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -503,6 +503,23 @@ exports[`should match snapshot 1`] = `
   color: hsl(284,36%,45%);
 }
 
+.c10.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c10.fi-link--initial-underline:focus,
+.c10.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c10.fi-link--initial-underline:hover,
+.c10.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c10 .fi-link_icon {
   padding-left: 4px;
   font-size: 16px;
@@ -558,6 +575,23 @@ exports[`should match snapshot 1`] = `
 
 .c7.fi-link--router:visited {
   color: hsl(284,36%,45%);
+}
+
+.c7.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7.fi-link--initial-underline:focus,
+.c7.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7.fi-link--initial-underline:hover,
+.c7.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c9 {

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -1,0 +1,108 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodySemiBold')};
+
+  /* stylelint-disable no-descending-specificity */
+  /* Nested :hover etc selectors do not work well with this rule. */
+  &.fi-service-navigation-item {
+    display: flex;
+    align-items: center;
+    position: relative;
+
+    &:hover,
+    &:active {
+      background: ${theme.colors.highlightLight3};
+      cursor: pointer;
+      border-left: 4px solid ${theme.colors.highlightBase};
+      .fi-link--router {
+        padding-left: calc(${theme.spacing.m} - 4px);
+      }
+    }
+
+    &:focus-within {
+      ${theme.focus.boxShadowFocus};
+      z-index: ${theme.zindexes.focus};
+    }
+
+    .fi-link--router {
+      text-decoration: none;
+      color: ${theme.colors.blackBase};
+      display: flex;
+      padding: ${theme.spacing.xs} ${theme.spacing.m};
+      text-transform: uppercase;
+      flex: 1;
+      cursor: pointer;
+      background: inherit;
+      border: none;
+
+      &:focus {
+        outline: 0;
+        border: none;
+        box-shadow: none;
+      }
+
+      &:hover,
+      &:active,
+      &:visited {
+        text-decoration: none;
+        color: ${theme.colors.blackBase};
+      }
+    }
+
+    &--disabled {
+      &:hover,
+      &:active {
+        background: transparent;
+        cursor: not-allowed;
+        border-left: none;
+        .fi-link--router {
+          padding-left: ${theme.spacing.m};
+        }
+      }
+      .fi-link--router {
+        color: ${theme.colors.depthBase};
+        cursor: not-allowed;
+        pointer-events: none;
+
+        &:hover,
+        &:active,
+        &:visited {
+          color: ${theme.colors.depthBase};
+        }
+      }
+    }
+
+    &--selected {
+      display: flex;
+      align-items: center;
+      background: ${theme.colors.highlightLight3};
+      border-left: 4px solid ${theme.colors.highlightBase};
+      position: relative;
+
+      &:focus {
+        ${theme.focus.absoluteFocus};
+      }
+
+      .fi-link--router {
+        font-weight: bold;
+        text-decoration: none;
+        color: ${theme.colors.blackBase};
+        display: flex;
+        padding: ${theme.spacing.xs} ${theme.spacing.l};
+        padding-left: calc(${theme.spacing.m} - 4px);
+        text-transform: uppercase;
+        flex: 1;
+
+        &:hover,
+        &:active,
+        &:visited {
+          text-decoration: none;
+          color: ${theme.colors.blackBase};
+        }
+      }
+    }
+  }
+`;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.tsx
@@ -1,0 +1,61 @@
+import React, { ReactNode } from 'react';
+import classnames from 'classnames';
+import { HtmlLi } from '../../../../reset';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import { baseStyles } from './ServiceNavigationItem.baseStyles';
+import styled from 'styled-components';
+
+export interface ServiceNavigationItemProps {
+  /** Custom class */
+  className?: string;
+  /** Use the polymorphic `<RouterLink>` component as child to get intended CSS styling */
+  children: ReactNode;
+  /** Toggle to show item as the selected one */
+  selected?: boolean;
+  /** Disables the item */
+  disabled?: boolean;
+}
+
+const baseClassName = 'fi-service-navigation-item';
+const selectedClassName = `${baseClassName}--selected`;
+const disabledClassName = `${baseClassName}--disabled`;
+
+const BaseServiceNavigationItem = ({
+  selected,
+  className,
+  children,
+  disabled,
+  ...passProps
+}: ServiceNavigationItemProps) => (
+  <HtmlLi
+    className={classnames(className, {
+      [baseClassName]: !selected,
+      [selectedClassName]: selected,
+      [disabledClassName]: disabled,
+    })}
+    aria-disabled={disabled}
+    {...passProps}
+  >
+    {children}
+  </HtmlLi>
+);
+
+const StyledServiceNavigationItem = styled(
+  (props: ServiceNavigationItemProps & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseServiceNavigationItem {...passProps} />;
+  },
+)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const ServiceNavigationItem = (props: ServiceNavigationItemProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledServiceNavigationItem theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+ServiceNavigationItem.displayName = 'ServiceNavigationItem';
+export { ServiceNavigationItem };

--- a/src/core/Navigation/ServiceNavigation/index.ts
+++ b/src/core/Navigation/ServiceNavigation/index.ts
@@ -1,0 +1,8 @@
+export {
+  ServiceNavigation,
+  ServiceNavigationProps,
+} from './ServiceNavigation/ServiceNavigation';
+export {
+  ServiceNavigationItem,
+  ServiceNavigationItemProps,
+} from './ServiceNavigationItem/ServiceNavigationItem';

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
@@ -5,35 +5,10 @@ import { SuomifiTheme } from '../../../theme';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')}
   &.fi-side-navigation {
-    &--small-screen {
-      border: 1px solid ${theme.colors.depthLight1};
-      .fi-side-navigation_heading {
-        ${font(theme)('heading4')}
-        width: 100%;
-        padding: ${theme.spacing.m};
-
-        &:focus {
-          position: relative;
-          outline: 0;
-
-          &:after {
-            ${theme.focus.absoluteFocus}
-          }
-        }
-
-        .fi-icon {
-          height: 25px;
-          width: 25px;
-        }
-      }
-
-      .fi-side-navigation-item {
-        &:last-child {
-          &:after {
-            display: none;
-          }
-        }
-      }
+    .fi-side-navigation_divider {
+      height: 1px;
+      background: ${theme.colors.highlightLight2};
+      margin: ${theme.spacing.s} ${theme.spacing.m} ${theme.spacing.s} 0;
     }
 
     .fi-side-navigation_heading {
@@ -41,7 +16,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: ${theme.spacing.xs} ${theme.spacing.s};
+      padding: ${theme.spacing.xs} ${theme.spacing.s} 0 0;
 
       .fi-side-navigation_heading_inner {
         display: flex;
@@ -59,6 +34,36 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       list-style-type: none;
       margin: 0;
       padding: 0;
+    }
+
+    &--small-screen {
+      border: 1px solid ${theme.colors.depthLight1};
+      nav {
+        padding: 0 ${theme.spacing.xxs};
+      }
+      .fi-side-navigation_divider {
+        margin: ${theme.spacing.xxs} ${theme.spacing.s} 0 ${theme.spacing.s};
+      }
+
+      .fi-side-navigation_heading {
+        ${font(theme)('heading4')}
+        width: 100%;
+        padding: ${theme.spacing.s};
+
+        &:focus {
+          position: relative;
+          outline: 0;
+
+          &:after {
+            ${theme.focus.absoluteFocus}
+          }
+        }
+
+        .fi-icon {
+          height: 25px;
+          width: 25px;
+        }
+      }
     }
   }
 `;

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
@@ -1,0 +1,48 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodyText')}
+  &.fi-side-navigation {
+    &--small-screen {
+      background: ${theme.colors.highlightLight3};
+      .fi-side-navigation_heading {
+        ${font(theme)('heading4')}
+        width: 100%;
+        padding: ${theme.spacing.m};
+        border: 1px solid ${theme.colors.highlightLight2};
+
+        .fi-icon {
+          height: 25px;
+          width: 25px;
+        }
+      }
+    }
+
+    .fi-side-navigation_heading {
+      ${font(theme)('heading4')}
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: ${theme.spacing.s};
+
+      .fi-side-navigation_heading_inner {
+        display: flex;
+        align-items: center;
+      }
+
+      .fi-static-icon {
+        height: 50px;
+        width: 50px;
+        margin-right: ${theme.spacing.s};
+      }
+    }
+
+    .fi-side-navigation_list {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+    }
+  }
+`;

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
@@ -7,8 +7,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-side-navigation {
     .fi-side-navigation_divider {
       height: 1px;
-      background: ${theme.colors.highlightLight2};
-      margin: ${theme.spacing.s} ${theme.spacing.m} ${theme.spacing.s} 0;
+      background: ${theme.colors.depthSecondary};
+      margin: ${theme.spacing.s};
     }
 
     .fi-side-navigation_heading {
@@ -16,7 +16,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: ${theme.spacing.xs} ${theme.spacing.s} 0 0;
+      padding: ${theme.spacing.xs} ${theme.spacing.s} 0 ${theme.spacing.s};
 
       .fi-side-navigation_heading_inner {
         display: flex;
@@ -62,6 +62,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         .fi-icon {
           height: 25px;
           width: 25px;
+          color: ${theme.colors.highlightBase};
         }
       }
     }

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
@@ -6,16 +6,32 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')}
   &.fi-side-navigation {
     &--small-screen {
-      background: ${theme.colors.highlightLight3};
+      border: 1px solid ${theme.colors.depthLight1};
       .fi-side-navigation_heading {
         ${font(theme)('heading4')}
         width: 100%;
         padding: ${theme.spacing.m};
-        border: 1px solid ${theme.colors.highlightLight2};
+
+        &:focus {
+          position: relative;
+          outline: 0;
+
+          &:after {
+            ${theme.focus.absoluteFocus}
+          }
+        }
 
         .fi-icon {
           height: 25px;
           width: 25px;
+        }
+      }
+
+      .fi-side-navigation-item {
+        &:last-child {
+          &:after {
+            display: none;
+          }
         }
       }
     }
@@ -25,7 +41,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: ${theme.spacing.s};
+      padding: ${theme.spacing.xs} ${theme.spacing.s};
 
       .fi-side-navigation_heading_inner {
         display: flex;
@@ -33,8 +49,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
 
       .fi-static-icon {
-        height: 50px;
-        width: 50px;
+        height: 45px;
+        width: 45px;
         margin-right: ${theme.spacing.s};
       }
     }

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
@@ -101,3 +101,96 @@ For frameworks where its internal link component is used as a wrapper for the ac
 ```
 
 ### Small screen variant
+
+```js
+import {
+  SideNavigation,
+  SideNavigationItem,
+  RouterLink,
+  ExternalLink
+} from 'suomifi-ui-components';
+
+const CustomButton = (props) => {
+  const { children, ...passProps } = props;
+  return <button {...passProps}>{props.children}</button>;
+};
+
+<div style={{ width: '350px' }}>
+  <SideNavigation
+    variant="smallScreen"
+    heading="Economy"
+    icon="piggyBank"
+    initiallyExpanded={false}
+  >
+    <SideNavigationItem
+      subLevel={1}
+      content={
+        <RouterLink href="/" aria-current="location">
+          Personal economy
+        </RouterLink>
+      }
+    >
+      <SideNavigationItem
+        subLevel={2}
+        content={
+          <RouterLink href="/" aria-current="location">
+            Crisis situations in personal finances
+          </RouterLink>
+        }
+      >
+        <SideNavigationItem
+          subLevel={3}
+          content={
+            <RouterLink href="/">
+              If you are unable to pay your debts
+            </RouterLink>
+          }
+        />
+        <SideNavigationItem
+          subLevel={3}
+          selected
+          content={
+            <RouterLink href="/" aria-current="page">
+              Advice on banking and insurance matters
+            </RouterLink>
+          }
+        />
+      </SideNavigationItem>
+      <SideNavigationItem
+        subLevel={2}
+        content={
+          <RouterLink href="/">Last will and testament</RouterLink>
+        }
+      />
+    </SideNavigationItem>
+    <SideNavigationItem
+      subLevel={1}
+      content={
+        <RouterLink
+          asComponent={ExternalLink}
+          href="https://suomi.fi"
+          hideIcon
+        >
+          Taxation and public economy
+        </RouterLink>
+      }
+    />
+    <SideNavigationItem
+      content={
+        <RouterLink
+          asComponent={CustomButton}
+          onClick={() => console.log('Nav item clicked')}
+        >
+          Consumer protection
+        </RouterLink>
+      }
+      subLevel={1}
+    />
+    <SideNavigationItem
+      disabled
+      content={<RouterLink>Finance</RouterLink>}
+      subLevel={1}
+    />
+  </SideNavigation>
+</div>;
+```

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
@@ -1,0 +1,100 @@
+### Basic usage
+
+Please use `<RouterLink>` as the child of `<SideNavigationItem>` to get inteded CSS styles. `<RouterLink>` is polymorphic, and can be rendered as any component of your choice, for example React Router Link.
+
+```js
+import {
+  SideNavigation,
+  SideNavigationItem,
+  RouterLink,
+  ExternalLink
+} from 'suomifi-ui-components';
+
+const CustomButton = (props) => {
+  const { children, ...passProps } = props;
+  return <button {...passProps}>{props.children}</button>;
+};
+
+<div style={{ width: '350px' }}>
+  <SideNavigation heading="Economy" icon="piggyBank">
+    <SideNavigationItem
+      subLevel={1}
+      content={<RouterLink href="/">Personal economy</RouterLink>}
+    >
+      <SideNavigationItem
+        subLevel={2}
+        content={
+          <RouterLink href="/">
+            Crisis situations in personal finances
+          </RouterLink>
+        }
+      >
+        <SideNavigationItem
+          subLevel={3}
+          content={
+            <RouterLink href="/">
+              If you are unable to pay your debts
+            </RouterLink>
+          }
+        />
+        <SideNavigationItem
+          subLevel={3}
+          content={
+            <RouterLink href="/">
+              Advice on banking and insurance matters
+            </RouterLink>
+          }
+          selected
+          ariaCurrent="page"
+        />
+      </SideNavigationItem>
+      <SideNavigationItem
+        subLevel={2}
+        content={
+          <RouterLink href="/">Last will and testament</RouterLink>
+        }
+      />
+    </SideNavigationItem>
+    <SideNavigationItem
+      subLevel={1}
+      content={
+        <RouterLink
+          asComponent={ExternalLink}
+          href="https://suomi.fi"
+          hideIcon
+        >
+          Taxation and public economy
+        </RouterLink>
+      }
+    />
+    <SideNavigationItem
+      content={
+        <RouterLink
+          asComponent={CustomButton}
+          onClick={() => console.log('Nav item clicked')}
+        >
+          Consumer protection
+        </RouterLink>
+      }
+      subLevel={1}
+    />
+    <SideNavigationItem
+      disabled
+      content={<RouterLink>Finance</RouterLink>}
+      subLevel={1}
+    />
+  </SideNavigation>
+</div>;
+```
+
+For frameworks where its internal link component is used as a wrapper for the actual link, for example NextJS, the following approach can be used:
+
+```jsx static
+<SideNavigationItem>
+  <NextJSLink href="/some-route" passHref>
+    <RouterLink>Economy</RouterLink>
+  </NextJSLink>
+</SideNavigationItem>
+```
+
+### Small screen variant

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
@@ -101,11 +101,13 @@ const CustomButton = (props) => {
 For frameworks where its internal link component is used as a wrapper for the actual link, for example NextJS, the following approach can be used:
 
 ```jsx static
-<SideNavigationItem>
-  <NextJSLink href="/some-route" passHref>
-    <RouterLink>Economy</RouterLink>
-  </NextJSLink>
-</SideNavigationItem>
+<SideNavigationItem
+  content={
+    <NextJSLink href="/some-route" passHref>
+      <RouterLink>Economy</RouterLink>
+    </NextJSLink>
+  }
+/>
 ```
 
 ### Small screen variant

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
@@ -16,111 +16,10 @@ const CustomButton = (props) => {
 };
 
 <div style={{ width: '350px' }}>
-  <SideNavigation heading="Economy" icon="piggyBank">
-    <SideNavigationItem
-      subLevel={1}
-      content={
-        <RouterLink href="/" aria-current="location">
-          Personal economy
-        </RouterLink>
-      }
-    >
-      <SideNavigationItem
-        subLevel={2}
-        content={
-          <RouterLink href="/" aria-current="location">
-            Crisis situations in personal finances
-          </RouterLink>
-        }
-      >
-        <SideNavigationItem
-          subLevel={3}
-          content={
-            <RouterLink href="/">
-              If you are unable to pay your debts
-            </RouterLink>
-          }
-        />
-        <SideNavigationItem
-          subLevel={3}
-          selected
-          content={
-            <RouterLink href="/" aria-current="page">
-              Advice on banking and insurance matters
-            </RouterLink>
-          }
-        />
-      </SideNavigationItem>
-      <SideNavigationItem
-        subLevel={2}
-        content={
-          <RouterLink href="/">Last will and testament</RouterLink>
-        }
-      />
-    </SideNavigationItem>
-    <SideNavigationItem
-      subLevel={1}
-      content={
-        <RouterLink
-          asComponent={ExternalLink}
-          href="https://suomi.fi"
-          hideIcon
-        >
-          Taxation and public economy
-        </RouterLink>
-      }
-    />
-    <SideNavigationItem
-      content={
-        <RouterLink
-          asComponent={CustomButton}
-          onClick={() => console.log('Nav item clicked')}
-        >
-          Consumer protection
-        </RouterLink>
-      }
-      subLevel={1}
-    />
-    <SideNavigationItem
-      disabled
-      content={<RouterLink>Finance</RouterLink>}
-      subLevel={1}
-    />
-  </SideNavigation>
-</div>;
-```
-
-For frameworks where its internal link component is used as a wrapper for the actual link, for example NextJS, the following approach can be used:
-
-```jsx static
-<SideNavigationItem>
-  <NextJSLink href="/some-route" passHref>
-    <RouterLink>Economy</RouterLink>
-  </NextJSLink>
-</SideNavigationItem>
-```
-
-### Small screen variant
-
-```js
-import {
-  SideNavigation,
-  SideNavigationItem,
-  RouterLink,
-  ExternalLink
-} from 'suomifi-ui-components';
-
-const CustomButton = (props) => {
-  const { children, ...passProps } = props;
-  return <button {...passProps}>{props.children}</button>;
-};
-
-<div style={{ width: '350px' }}>
   <SideNavigation
-    variant="smallScreen"
     heading="Economy"
     icon="piggyBank"
-    initiallyExpanded={false}
+    aria-label="Main"
   >
     <SideNavigationItem
       subLevel={1}
@@ -188,7 +87,121 @@ const CustomButton = (props) => {
     />
     <SideNavigationItem
       disabled
-      content={<RouterLink>Finance</RouterLink>}
+      content={
+        <RouterLink aria-disabled role="link">
+          Finance
+        </RouterLink>
+      }
+      subLevel={1}
+    />
+  </SideNavigation>
+</div>;
+```
+
+For frameworks where its internal link component is used as a wrapper for the actual link, for example NextJS, the following approach can be used:
+
+```jsx static
+<SideNavigationItem>
+  <NextJSLink href="/some-route" passHref>
+    <RouterLink>Economy</RouterLink>
+  </NextJSLink>
+</SideNavigationItem>
+```
+
+### Small screen variant
+
+```js
+import {
+  SideNavigation,
+  SideNavigationItem,
+  RouterLink,
+  ExternalLink
+} from 'suomifi-ui-components';
+
+const CustomButton = (props) => {
+  const { children, ...passProps } = props;
+  return <button {...passProps}>{props.children}</button>;
+};
+
+<div style={{ width: '350px' }}>
+  <SideNavigation
+    variant="smallScreen"
+    heading="Economy"
+    icon="piggyBank"
+    initiallyExpanded={false}
+    aria-label="Main"
+  >
+    <SideNavigationItem
+      subLevel={1}
+      content={
+        <RouterLink href="/" aria-current="location">
+          Personal economy
+        </RouterLink>
+      }
+    >
+      <SideNavigationItem
+        subLevel={2}
+        content={
+          <RouterLink href="/" aria-current="location">
+            Crisis situations in personal finances
+          </RouterLink>
+        }
+      >
+        <SideNavigationItem
+          subLevel={3}
+          content={
+            <RouterLink href="/">
+              If you are unable to pay your debts
+            </RouterLink>
+          }
+        />
+        <SideNavigationItem
+          subLevel={3}
+          selected
+          content={
+            <RouterLink href="/" aria-current="page">
+              Advice on banking and insurance matters
+            </RouterLink>
+          }
+        />
+      </SideNavigationItem>
+      <SideNavigationItem
+        subLevel={2}
+        content={
+          <RouterLink href="/">Last will and testament</RouterLink>
+        }
+      />
+    </SideNavigationItem>
+    <SideNavigationItem
+      subLevel={1}
+      content={
+        <RouterLink
+          asComponent={ExternalLink}
+          href="https://suomi.fi"
+          hideIcon
+        >
+          Taxation and public economy
+        </RouterLink>
+      }
+    />
+    <SideNavigationItem
+      content={
+        <RouterLink
+          asComponent={CustomButton}
+          onClick={() => console.log('Nav item clicked')}
+        >
+          Consumer protection
+        </RouterLink>
+      }
+      subLevel={1}
+    />
+    <SideNavigationItem
+      disabled
+      content={
+        <RouterLink aria-disabled role="link">
+          Finance
+        </RouterLink>
+      }
       subLevel={1}
     />
   </SideNavigation>

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
@@ -19,12 +19,16 @@ const CustomButton = (props) => {
   <SideNavigation heading="Economy" icon="piggyBank">
     <SideNavigationItem
       subLevel={1}
-      content={<RouterLink href="/">Personal economy</RouterLink>}
+      content={
+        <RouterLink href="/" aria-current="location">
+          Personal economy
+        </RouterLink>
+      }
     >
       <SideNavigationItem
         subLevel={2}
         content={
-          <RouterLink href="/">
+          <RouterLink href="/" aria-current="location">
             Crisis situations in personal finances
           </RouterLink>
         }
@@ -39,13 +43,12 @@ const CustomButton = (props) => {
         />
         <SideNavigationItem
           subLevel={3}
+          selected
           content={
-            <RouterLink href="/">
+            <RouterLink href="/" aria-current="page">
               Advice on banking and insurance matters
             </RouterLink>
           }
-          selected
-          ariaCurrent="page"
         />
       </SideNavigationItem>
       <SideNavigationItem

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
@@ -1,0 +1,80 @@
+/* import React from 'react';
+import { render } from '@testing-library/react';
+import { axeTest } from '../../../../utils/test';
+
+import { SideNavigation } from './SideNavigation';
+import { SideNavigationItem } from '../SideNavigationItem/SideNavigationItem';
+import { ExternalLink, RouterLink } from '../../../Link';
+import { StaticChip } from '../../../Chip'; 
+
+interface TestProps {
+  children: string;
+  onClick?: () => void;
+  role?: string;
+  tabIndex?: number;
+}
+
+const Comp = ({ children, ...passProps }: TestProps) => (
+  <div {...passProps}>{children}</div>
+);
+
+const TestSideNavigation = (
+  <div data-testid="test-paragraph">
+    <SideNavigation>
+      <SideNavigationItem aria-label="16 unread messages">
+        <RouterLink
+          asComponent={Comp}
+          onClick={() => console.log('Nav item clicked')}
+          role="button"
+          tabIndex={0}
+        >
+          Inbox
+          <StaticChip style={{ marginLeft: '15px' }}>16</StaticChip>
+        </RouterLink>
+      </SideNavigationItem>
+      <SideNavigationItem>
+        <RouterLink asComponent={ExternalLink} href="https://suomi.fi" hideIcon>
+          Sent
+        </RouterLink>
+      </SideNavigationItem>
+      <SideNavigationItem selected ariaCurrent="page">
+        <RouterLink
+          asComponent={ExternalLink}
+          href="https://www.suomi.fi"
+          hideIcon
+        >
+          New Message
+        </RouterLink>
+      </SideNavigationItem>
+      <SideNavigationItem>
+        <RouterLink
+          asComponent={ExternalLink}
+          href="https://www.suomi.fi"
+          hideIcon
+        >
+          Drafts
+        </RouterLink>
+      </SideNavigationItem>
+      <SideNavigationItem>
+        <RouterLink
+          asComponent={ExternalLink}
+          href="https://www.suomi.fi"
+          hideIcon
+        >
+          Settings
+        </RouterLink>
+      </SideNavigationItem>
+      <SideNavigationItem>
+        <RouterLink>Devices</RouterLink>
+      </SideNavigationItem>
+    </SideNavigation>
+  </div>
+);
+
+test('calling render with the same component on the same container does not remount', () => {
+  const ParagraphRendered = render(TestSideNavigation);
+  const { container } = ParagraphRendered;
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test('should not have basic accessibility issues', axeTest(TestSideNavigation)); */

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
@@ -22,12 +22,16 @@ const TestSideNavigation = (
   <SideNavigation heading="Economy" icon="piggyBank">
     <SideNavigationItem
       subLevel={1}
-      content={<RouterLink href="/">Personal economy</RouterLink>}
+      content={
+        <RouterLink href="/" aria-current="location">
+          Personal economy
+        </RouterLink>
+      }
     >
       <SideNavigationItem
         subLevel={2}
         content={
-          <RouterLink href="/">
+          <RouterLink href="/" aria-current="location">
             Crisis situations in personal finances
           </RouterLink>
         }
@@ -42,13 +46,12 @@ const TestSideNavigation = (
         />
         <SideNavigationItem
           subLevel={3}
+          selected
           content={
-            <RouterLink href="/">
+            <RouterLink href="/" aria-current="page">
               Advice on banking and insurance matters
             </RouterLink>
           }
-          selected
-          ariaCurrent="page"
         />
       </SideNavigationItem>
       <SideNavigationItem

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
@@ -1,11 +1,10 @@
-/* import React from 'react';
+import React from 'react';
 import { render } from '@testing-library/react';
 import { axeTest } from '../../../../utils/test';
 
 import { SideNavigation } from './SideNavigation';
 import { SideNavigationItem } from '../SideNavigationItem/SideNavigationItem';
 import { ExternalLink, RouterLink } from '../../../Link';
-import { StaticChip } from '../../../Chip'; 
 
 interface TestProps {
   children: string;
@@ -14,67 +13,80 @@ interface TestProps {
   tabIndex?: number;
 }
 
-const Comp = ({ children, ...passProps }: TestProps) => (
-  <div {...passProps}>{children}</div>
-);
+const CustomButton = (props: TestProps) => {
+  const { children, ...passProps } = props;
+  return <button {...passProps}>{props.children}</button>;
+};
 
 const TestSideNavigation = (
-  <div data-testid="test-paragraph">
-    <SideNavigation>
-      <SideNavigationItem aria-label="16 unread messages">
-        <RouterLink
-          asComponent={Comp}
-          onClick={() => console.log('Nav item clicked')}
-          role="button"
-          tabIndex={0}
-        >
-          Inbox
-          <StaticChip style={{ marginLeft: '15px' }}>16</StaticChip>
-        </RouterLink>
+  <SideNavigation heading="Economy" icon="piggyBank">
+    <SideNavigationItem
+      subLevel={1}
+      content={<RouterLink href="/">Personal economy</RouterLink>}
+    >
+      <SideNavigationItem
+        subLevel={2}
+        content={
+          <RouterLink href="/">
+            Crisis situations in personal finances
+          </RouterLink>
+        }
+      >
+        <SideNavigationItem
+          subLevel={3}
+          content={
+            <RouterLink href="/">
+              If you are unable to pay your debts
+            </RouterLink>
+          }
+        />
+        <SideNavigationItem
+          subLevel={3}
+          content={
+            <RouterLink href="/">
+              Advice on banking and insurance matters
+            </RouterLink>
+          }
+          selected
+          ariaCurrent="page"
+        />
       </SideNavigationItem>
-      <SideNavigationItem>
+      <SideNavigationItem
+        subLevel={2}
+        content={<RouterLink href="/">Last will and testament</RouterLink>}
+      />
+    </SideNavigationItem>
+    <SideNavigationItem
+      subLevel={1}
+      content={
         <RouterLink asComponent={ExternalLink} href="https://suomi.fi" hideIcon>
-          Sent
+          Taxation and public economy
         </RouterLink>
-      </SideNavigationItem>
-      <SideNavigationItem selected ariaCurrent="page">
+      }
+    />
+    <SideNavigationItem
+      content={
         <RouterLink
-          asComponent={ExternalLink}
-          href="https://www.suomi.fi"
-          hideIcon
+          asComponent={CustomButton}
+          onClick={() => console.log('Nav item clicked')}
         >
-          New Message
+          Consumer protection
         </RouterLink>
-      </SideNavigationItem>
-      <SideNavigationItem>
-        <RouterLink
-          asComponent={ExternalLink}
-          href="https://www.suomi.fi"
-          hideIcon
-        >
-          Drafts
-        </RouterLink>
-      </SideNavigationItem>
-      <SideNavigationItem>
-        <RouterLink
-          asComponent={ExternalLink}
-          href="https://www.suomi.fi"
-          hideIcon
-        >
-          Settings
-        </RouterLink>
-      </SideNavigationItem>
-      <SideNavigationItem>
-        <RouterLink>Devices</RouterLink>
-      </SideNavigationItem>
-    </SideNavigation>
-  </div>
+      }
+      subLevel={1}
+    />
+    <SideNavigationItem
+      disabled
+      content={<RouterLink>Finance</RouterLink>}
+      subLevel={1}
+    />
+  </SideNavigation>
 );
 
 test('calling render with the same component on the same container does not remount', () => {
-  const ParagraphRendered = render(TestSideNavigation);
-  const { container } = ParagraphRendered;
+  const NavRendered = render(TestSideNavigation);
+  const { container } = NavRendered;
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('should not have basic accessibility issues', axeTest(TestSideNavigation)); */
+test('should not have basic accessibility issues', axeTest(TestSideNavigation));

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
@@ -19,7 +19,7 @@ const CustomButton = (props: TestProps) => {
 };
 
 const TestSideNavigation = (
-  <SideNavigation heading="Economy" icon="piggyBank">
+  <SideNavigation heading="Economy" icon="piggyBank" aria-label="Test">
     <SideNavigationItem
       subLevel={1}
       content={

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
@@ -50,6 +50,7 @@ const smallScreenClassName = `${baseClassName}--small-screen`;
 const listClassName = `${baseClassName}_list`;
 const headingClassName = `${baseClassName}_heading`;
 const headingInnerWrapperClassName = `${baseClassName}_heading_inner`;
+const dividerClassName = `${baseClassName}_divider`;
 
 const BaseSideNavigation = ({
   children,
@@ -100,6 +101,7 @@ const BaseSideNavigation = ({
           id={id}
           {...getConditionalAriaProp('aria-label', [ariaLabel])}
         >
+          <HtmlDiv className={dividerClassName} />
           <HtmlUl className={listClassName}>{children}</HtmlUl>
         </HtmlNav>
       )}

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
@@ -1,0 +1,108 @@
+import React, { ReactNode, useState } from 'react';
+import {
+  HtmlButton,
+  HtmlDiv,
+  HtmlNav,
+  HtmlSpan,
+  HtmlUl,
+} from '../../../../reset';
+import styled from 'styled-components';
+import { SuomifiThemeConsumer } from '../../../theme';
+import { baseStyles } from './SideNavigation.baseStyles';
+import classnames from 'classnames';
+import { Icon } from '../../../Icon/Icon';
+import {
+  StaticIcon,
+  IllustrativeIconKeys,
+  DoctypeIconKeys,
+} from '../../../StaticIcon/StaticIcon';
+
+export interface SideNavigationProps {
+  children: ReactNode | ReactNode[];
+  /**
+   * Normal or small screen variant
+   * @default normal
+   */
+  variant?: 'default' | 'smallScreen';
+  /**
+   * Whether the menu is initially expanded. Only applies to smallScreen variant.
+   * @default true
+   */
+  initiallyExpanded?: boolean;
+  /** Navigation component heading text */
+  heading: string;
+  /** Icon in the nav heading. Options include suomifi static icons. */
+  icon?: IllustrativeIconKeys | DoctypeIconKeys;
+  /* Custom class to extend or customise */
+  className?: string;
+}
+
+const baseClassName = 'fi-side-navigation';
+const smallScreenClassName = `${baseClassName}--small-screen`;
+const listClassName = `${baseClassName}_list`;
+const headingClassName = `${baseClassName}_heading`;
+const headingInnerWrapperClassName = `${baseClassName}_heading_inner`;
+
+const BaseSideNavigation = ({
+  children,
+  variant,
+  initiallyExpanded,
+  heading,
+  icon,
+  className,
+}: SideNavigationProps) => {
+  const initiallyExpandedValue =
+    initiallyExpanded !== undefined ? initiallyExpanded : true;
+  const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
+    initiallyExpandedValue,
+  );
+  return (
+    <HtmlDiv
+      className={classnames(baseClassName, className, {
+        [smallScreenClassName]: variant === 'smallScreen',
+      })}
+    >
+      {variant === 'smallScreen' ? (
+        <HtmlButton
+          className={headingClassName}
+          onClick={() => setSmallScreenNavOpen(!smallScreenNavOpen)}
+          aria-expanded={smallScreenNavOpen}
+        >
+          <HtmlSpan>
+            {!!icon && <StaticIcon icon={icon} />}
+            {heading}
+          </HtmlSpan>
+          <Icon icon={smallScreenNavOpen ? 'chevronDown' : 'chevronRight'} />
+        </HtmlButton>
+      ) : (
+        <HtmlDiv className={headingClassName}>
+          <HtmlSpan className={headingInnerWrapperClassName}>
+            {!!icon && <StaticIcon icon={icon} />}
+            {heading}
+          </HtmlSpan>
+        </HtmlDiv>
+      )}
+      {((variant === 'smallScreen' && smallScreenNavOpen) ||
+        variant !== 'smallScreen') && (
+        <HtmlNav>
+          <HtmlUl className={listClassName}>{children}</HtmlUl>
+        </HtmlNav>
+      )}
+    </HtmlDiv>
+  );
+};
+
+const StyledSideNavigation = styled(BaseSideNavigation)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const SideNavigation = (props: SideNavigationProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledSideNavigation theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+SideNavigation.displayName = 'SideNavigation';
+export { SideNavigation };

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
@@ -84,7 +84,7 @@ const BaseSideNavigation = ({
             {!!icon && <StaticIcon icon={icon} />}
             {heading}
           </HtmlSpan>
-          <Icon icon={smallScreenNavOpen ? 'chevronDown' : 'chevronRight'} />
+          <Icon icon={smallScreenNavOpen ? 'chevronUp' : 'chevronDown'} />
         </HtmlButton>
       ) : (
         <HtmlDiv className={headingClassName}>

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
@@ -68,7 +68,7 @@ const BaseSideNavigation = ({
           onClick={() => setSmallScreenNavOpen(!smallScreenNavOpen)}
           aria-expanded={smallScreenNavOpen}
         >
-          <HtmlSpan>
+          <HtmlSpan className={headingInnerWrapperClassName}>
             {!!icon && <StaticIcon icon={icon} />}
             {heading}
           </HtmlSpan>

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
@@ -42,7 +42,7 @@ export interface SideNavigationProps {
   /* Custom class to extend or customise */
   className?: string;
   /** Ref is forwarded to nav element. Alternative for React `ref` attribute. */
-  forwardedRef?: React.RefObject<HTMLDivElement>;
+  forwardedRef?: React.Ref<HTMLElement>;
 }
 
 const baseClassName = 'fi-side-navigation';
@@ -117,7 +117,7 @@ const StyledSideNavigation = styled(
 `;
 
 const SideNavigation = forwardRef(
-  (props: SideNavigationProps, ref: React.RefObject<HTMLDivElement>) => (
+  (props: SideNavigationProps, ref: React.Ref<HTMLElement>) => (
     <SuomifiThemeConsumer>
       {({ suomifiTheme }) => (
         <StyledSideNavigation

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
@@ -23,7 +23,7 @@ export interface SideNavigationProps {
   children: ReactNode;
   /** Name for the navigation element. Don't use the word "navigation" since it will be read by screen reader regardless. */
   'aria-label': string;
-  /** HTML nav element will receive this id */
+  /** ID for the HTML nav element */
   id?: string;
   /**
    * Normal or small screen variant
@@ -31,7 +31,7 @@ export interface SideNavigationProps {
    */
   variant?: 'default' | 'smallScreen';
   /**
-   * Whether the menu is initially expanded. Only applies to smallScreen variant.
+   * Initial expand status for the menu. Only applies to smallScreen variant
    * @default true
    */
   initiallyExpanded?: boolean;

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { forwardRef, ReactNode, useState } from 'react';
 import {
   HtmlButton,
   HtmlDiv,
@@ -7,7 +7,7 @@ import {
   HtmlUl,
 } from '../../../../reset';
 import styled from 'styled-components';
-import { SuomifiThemeConsumer } from '../../../theme';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
 import { baseStyles } from './SideNavigation.baseStyles';
 import classnames from 'classnames';
 import { Icon } from '../../../Icon/Icon';
@@ -16,9 +16,15 @@ import {
   IllustrativeIconKeys,
   DoctypeIconKeys,
 } from '../../../StaticIcon/StaticIcon';
+import { getConditionalAriaProp } from '../../../../utils/aria';
 
 export interface SideNavigationProps {
-  children: ReactNode | ReactNode[];
+  /** Use the `<SideNavigationItem>` components as children */
+  children: ReactNode;
+  /** Name for the navigation element. Don't use the word "navigation" since it will be read by screen reader regardless. */
+  'aria-label': string;
+  /** HTML nav element will receive this id */
+  id?: string;
   /**
    * Normal or small screen variant
    * @default normal
@@ -31,10 +37,12 @@ export interface SideNavigationProps {
   initiallyExpanded?: boolean;
   /** Navigation component heading text */
   heading: string;
-  /** Icon in the nav heading. Options include suomifi static icons. */
+  /** Icon in the nav heading. Options include suomi.fi static icons. */
   icon?: IllustrativeIconKeys | DoctypeIconKeys;
   /* Custom class to extend or customise */
   className?: string;
+  /** Ref is forwarded to nav element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLDivElement>;
 }
 
 const baseClassName = 'fi-side-navigation';
@@ -45,11 +53,14 @@ const headingInnerWrapperClassName = `${baseClassName}_heading_inner`;
 
 const BaseSideNavigation = ({
   children,
+  'aria-label': ariaLabel,
+  id,
   variant,
   initiallyExpanded,
   heading,
   icon,
   className,
+  forwardedRef,
 }: SideNavigationProps) => {
   const initiallyExpandedValue =
     initiallyExpanded !== undefined ? initiallyExpanded : true;
@@ -84,7 +95,11 @@ const BaseSideNavigation = ({
       )}
       {((variant === 'smallScreen' && smallScreenNavOpen) ||
         variant !== 'smallScreen') && (
-        <HtmlNav>
+        <HtmlNav
+          forwardedRef={forwardedRef}
+          id={id}
+          {...getConditionalAriaProp('aria-label', [ariaLabel])}
+        >
           <HtmlUl className={listClassName}>{children}</HtmlUl>
         </HtmlNav>
       )}
@@ -92,16 +107,27 @@ const BaseSideNavigation = ({
   );
 };
 
-const StyledSideNavigation = styled(BaseSideNavigation)`
+const StyledSideNavigation = styled(
+  (props: SideNavigationProps & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseSideNavigation {...passProps} />;
+  },
+)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const SideNavigation = (props: SideNavigationProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledSideNavigation theme={suomifiTheme} {...props} />
-    )}
-  </SuomifiThemeConsumer>
+const SideNavigation = forwardRef(
+  (props: SideNavigationProps, ref: React.RefObject<HTMLDivElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledSideNavigation
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 SideNavigation.displayName = 'SideNavigation';

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -237,8 +237,8 @@ exports[`calling render with the same component on the same container does not r
 
 .c1.fi-side-navigation .fi-side-navigation_divider {
   height: 1px;
-  background: hsl(212,63%,90%);
-  margin: 15px 20px 15px 0;
+  background: hsl(215,100%,97%);
+  margin: 15px;
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading {
@@ -267,7 +267,7 @@ exports[`calling render with the same component on the same container does not r
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding: 10px 15px 0 0;
+  padding: 10px 15px 0 15px;
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading .fi-side-navigation_heading_inner {
@@ -347,6 +347,7 @@ exports[`calling render with the same component on the same container does not r
 .c1.fi-side-navigation--small-screen .fi-side-navigation_heading .fi-icon {
   height: 25px;
   width: 25px;
+  color: hsl(212,63%,45%);
 }
 
 .c7 {
@@ -499,7 +500,6 @@ exports[`calling render with the same component on the same container does not r
 .c7.fi-side-navigation-item--level-2 .fi-side-navigation-item_sub-list {
   margin: 5px 0 5px 30px;
   background: hsl(212,63%,95%);
-  border-radius: 4px;
 }
 
 .c7.fi-side-navigation-item--level-3 {
@@ -533,30 +533,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c7.fi-side-navigation-item--level-3 > span > .fi-link--router:hover {
   border-radius: 0;
-}
-
-.c7.fi-side-navigation-item--level-3:first-child > span > .fi-link--router {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-}
-
-.c7.fi-side-navigation-item--level-3:first-child > span > .fi-link--router:hover {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.c7.fi-side-navigation-item--level-3:last-child > span > .fi-link--router {
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
-}
-
-.c7.fi-side-navigation-item--level-3:last-child > span > .fi-link--router:hover {
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
 }
 
 .c7.fi-side-navigation-item--disabled > span > .fi-link--router {

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -235,56 +235,10 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
-.c1.fi-side-navigation--small-screen {
-  border: 1px solid hsl(202,7%,80%);
-}
-
-.c1.fi-side-navigation--small-screen .fi-side-navigation_heading {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: 600;
-  width: 100%;
-  padding: 20px;
-}
-
-.c1.fi-side-navigation--small-screen .fi-side-navigation_heading:focus {
-  position: relative;
-  outline: 0;
-}
-
-.c1.fi-side-navigation--small-screen .fi-side-navigation_heading:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
-}
-
-.c1.fi-side-navigation--small-screen .fi-side-navigation_heading .fi-icon {
-  height: 25px;
-  width: 25px;
-}
-
-.c1.fi-side-navigation--small-screen .fi-side-navigation-item:last-child:after {
-  display: none;
+.c1.fi-side-navigation .fi-side-navigation_divider {
+  height: 1px;
+  background: hsl(212,63%,90%);
+  margin: 15px 20px 15px 0;
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading {
@@ -313,7 +267,7 @@ exports[`calling render with the same component on the same container does not r
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding: 10px 15px;
+  padding: 10px 15px 0 0;
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading .fi-side-navigation_heading_inner {
@@ -337,6 +291,62 @@ exports[`calling render with the same component on the same container does not r
   list-style-type: none;
   margin: 0;
   padding: 0;
+}
+
+.c1.fi-side-navigation--small-screen {
+  border: 1px solid hsl(202,7%,80%);
+}
+
+.c1.fi-side-navigation--small-screen nav {
+  padding: 0 5px;
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation_divider {
+  margin: 5px 15px 0 15px;
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation_heading {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+  width: 100%;
+  padding: 15px;
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation_heading:focus {
+  position: relative;
+  outline: 0;
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation_heading:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation_heading .fi-icon {
+  height: 25px;
+  width: 25px;
 }
 
 .c7 {
@@ -368,21 +378,7 @@ exports[`calling render with the same component on the same container does not r
   -ms-flex-direction: column;
   flex-direction: column;
   position: relative;
-}
-
-.c7.fi-side-navigation-item:after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 2.5%;
-  width: 95%;
-  height: 1px;
-  background: hsl(215,100%,97%);
-}
-
-.c7.fi-side-navigation-item:hover:after,
-.c7.fi-side-navigation-item:active:after {
-  background: transparent;
+  margin: 5px 0;
 }
 
 .c7.fi-side-navigation-item:focus,
@@ -399,7 +395,7 @@ exports[`calling render with the same component on the same container does not r
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 10px 20px;
+  padding: 10px 10px;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -419,6 +415,7 @@ exports[`calling render with the same component on the same container does not r
   -webkit-text-decoration: none;
   text-decoration: none;
   color: hsl(0,0%,100%);
+  border-radius: 4px;
 }
 
 .c7.fi-side-navigation-item .fi-link--router:focus {
@@ -426,20 +423,8 @@ exports[`calling render with the same component on the same container does not r
   outline: 0;
   box-shadow: none;
   border: none;
-}
-
-.c7.fi-side-navigation-item .fi-link--router:focus:before {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
+  outline: 0;
   border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
 }
@@ -450,8 +435,8 @@ exports[`calling render with the same component on the same container does not r
 
 .c7.fi-side-navigation-item .fi-side-navigation-item_sub-list {
   list-style-type: none;
-  margin: 0;
   padding: 0;
+  margin: 0;
 }
 
 .c7.fi-side-navigation-item .fi-side-navigation-item_content-wrapper {
@@ -463,41 +448,28 @@ exports[`calling render with the same component on the same container does not r
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   position: relative;
 }
 
 .c7.fi-side-navigation-item .fi-side-navigation-item_content-wrapper .fi-icon {
-  width: 25px;
-  height: 25px;
+  width: 10px;
+  height: 10px;
   pointer-events: none;
-  position: absolute;
-  top: 11px;
-  right: 15px;
   color: hsl(212,63%,45%);
-}
-
-.c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected {
-  background: hsl(212,63%,45%);
-  border-left: 4px solid hsl(212,63%,45%);
+  padding: 0 10px;
 }
 
 .c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected > span > .fi-link--router {
   text-transform: uppercase;
   color: hsl(0,0%,100%);
   font-weight: 600;
-}
-
-.c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected > span > .fi-link--router:hover,
-.c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected > span > .fi-link--router:active {
   color: hsl(0,0%,100%);
-}
-
-.c7.fi-side-navigation-item--level-1.fi-side-navigation-item--child-selected {
-  border-left: 4px solid hsl(212,63%,45%);
+  background: hsl(212,63%,45%);
+  border-radius: 4px;
 }
 
 .c7.fi-side-navigation-item--level-1 > span > .fi-link--router {
@@ -508,6 +480,10 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 600;
   background: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .c7.fi-side-navigation-item--level-2.fi-side-navigation-item--selected > span > .fi-link--router + .fi-icon {
@@ -516,19 +492,19 @@ exports[`calling render with the same component on the same container does not r
 
 .c7.fi-side-navigation-item--level-2 > span > .fi-link--router {
   text-transform: none;
-  padding-left: 30px;
   padding-right: 60px;
   color: hsl(212,63%,45%);
   background: hsl(0,0%,100%);
 }
 
-.c7.fi-side-navigation-item--level-2 > span > .fi-link--router:hover + .fi-icon,
-.c7.fi-side-navigation-item--level-2 > span > .fi-link--router:active + .fi-icon {
-  color: hsl(0,0%,100%);
+.c7.fi-side-navigation-item--level-2 .fi-side-navigation-item_sub-list {
+  margin: 5px 0 5px 30px;
+  background: hsl(212,63%,95%);
+  border-radius: 4px;
 }
 
-.c7.fi-side-navigation-item--level-2 > .fi-side-navigation-item_content-wrapper:hover {
-  color: hsl(0,0%,100%);
+.c7.fi-side-navigation-item--level-3 {
+  margin: 0;
 }
 
 .c7.fi-side-navigation-item--level-3.fi-side-navigation-item--selected > span > .fi-link--router {
@@ -537,16 +513,10 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(0,0%,100%);
 }
 
-.c7.fi-side-navigation-item--level-3:hover,
-.c7.fi-side-navigation-item--level-3:active {
-  color: hsl(0,0%,100%);
-}
-
 .c7.fi-side-navigation-item--level-3 > span > .fi-link--router {
   text-transform: none;
-  padding-left: 50px;
+  padding-left: 15px;
   color: hsl(212,63%,45%);
-  background: hsl(212,63%,98%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -562,19 +532,43 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
-.c7.fi-side-navigation-item--disabled:hover,
-.c7.fi-side-navigation-item--disabled:active {
-  background: hsl(0,0%,100%);
+.c7.fi-side-navigation-item--level-3 > span > .fi-link--router:hover {
+  border-radius: 0;
 }
 
-.c7.fi-side-navigation-item--disabled .fi-link--router {
+.c7.fi-side-navigation-item--level-3:first-child > span > .fi-link--router {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.c7.fi-side-navigation-item--level-3:first-child > span > .fi-link--router:hover {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.c7.fi-side-navigation-item--level-3:last-child > span > .fi-link--router {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c7.fi-side-navigation-item--level-3:last-child > span > .fi-link--router:hover {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.c7.fi-side-navigation-item--disabled > span > .fi-link--router {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
+  background: transparent;
 }
 
-.c7.fi-side-navigation-item--disabled .fi-link--router:hover,
-.c7.fi-side-navigation-item--disabled .fi-link--router:active,
-.c7.fi-side-navigation-item--disabled .fi-link--router:visited {
+.c7.fi-side-navigation-item--disabled > span > .fi-link--router:hover,
+.c7.fi-side-navigation-item--disabled > span > .fi-link--router:active,
+.c7.fi-side-navigation-item--disabled > span > .fi-link--router:visited {
   background: transparent;
   color: hsl(202,7%,67%);
 }
@@ -768,6 +762,9 @@ exports[`calling render with the same component on the same container does not r
     aria-label="Test"
     class="c4"
   >
+    <div
+      class="c0 fi-side-navigation_divider"
+    />
     <ul
       class="c5 fi-side-navigation_list"
     >
@@ -794,13 +791,6 @@ exports[`calling render with the same component on the same container does not r
             <span
               class="c2 fi-side-navigation-item_content-wrapper"
             >
-              <a
-                aria-current="location"
-                class="c8 fi-link--router c9"
-                href="/"
-              >
-                Crisis situations in personal finances
-              </a>
               <svg
                 aria-hidden="true"
                 class="fi-icon c10"
@@ -812,11 +802,18 @@ exports[`calling render with the same component on the same container does not r
               >
                 <path
                   class="fi-icon-base-fill"
-                  d="M12.99 8.39A1.433 1.433 0 0012 8c-.358 0-.717.13-.99.39l-5.6 5.334a1.287 1.287 0 000 1.885 1.448 1.448 0 001.98 0l4.61-4.39 4.61 4.39a1.448 1.448 0 001.98 0 1.287 1.287 0 000-1.885l-5.6-5.333z"
+                  d="M1 6a1 1 0 011 1v4h18.585l-3.292-3.293a.999.999 0 111.414-1.414l4.991 4.992c.032.03.062.063.09.098l-.081-.09a1.005 1.005 0 01.293.674v.066l-.003.052L24 12a1.007 1.007 0 01-.302.715l-4.991 4.992a.997.997 0 01-1.414 0 .999.999 0 010-1.414L20.585 13H1a1 1 0 01-1-1V7a1 1 0 011-1z"
                   fill="#222"
                   fill-rule="evenodd"
                 />
               </svg>
+              <a
+                aria-current="location"
+                class="c8 fi-link--router c9"
+                href="/"
+              >
+                Crisis situations in personal finances
+              </a>
             </span>
             <ul
               class="c5 fi-side-navigation-item_sub-list"
@@ -858,6 +855,22 @@ exports[`calling render with the same component on the same container does not r
             <span
               class="c2 fi-side-navigation-item_content-wrapper"
             >
+              <svg
+                aria-hidden="true"
+                class="fi-icon c10"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M1 6a1 1 0 011 1v4h18.585l-3.292-3.293a.999.999 0 111.414-1.414l4.991 4.992c.032.03.062.063.09.098l-.081-.09a1.005 1.005 0 01.293.674v.066l-.003.052L24 12a1.007 1.007 0 01-.302.715l-4.991 4.992a.997.997 0 01-1.414 0 .999.999 0 010-1.414L20.585 13H1a1 1 0 01-1-1V7a1 1 0 011-1z"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
               <a
                 class="c8 fi-link--router c9"
                 href="/"

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -642,6 +642,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c11.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c11.fi-link--initial-underline:focus,
+.c11.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c11.fi-link--initial-underline:hover,
+.c11.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c11 .fi-link_icon {
   padding-left: 4px;
   font-size: 16px;
@@ -697,6 +714,23 @@ exports[`calling render with the same component on the same container does not r
 
 .c9.fi-link--router:visited {
   color: hsl(284,36%,45%);
+}
+
+.c9.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c9.fi-link--initial-underline:focus,
+.c9.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c9.fi-link--initial-underline:hover,
+.c9.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 <div

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -467,7 +467,6 @@ exports[`calling render with the same component on the same container does not r
   text-transform: uppercase;
   color: hsl(0,0%,100%);
   font-weight: 600;
-  color: hsl(0,0%,100%);
   background: hsl(212,63%,45%);
   border-radius: 4px;
 }

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -1,0 +1,865 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calling render with the same component on the same container does not remount 1`] = `
+.c8 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c8::before,
+.c8::after {
+  box-sizing: border-box;
+}
+
+.c8:hover,
+.c8:active,
+.c8:focus,
+.c8:focus-within {
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
+.c10 {
+  vertical-align: baseline;
+}
+
+.c10.fi-icon {
+  display: inline-block;
+}
+
+.c10 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c10 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c10.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c10.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c3 {
+  vertical-align: baseline;
+}
+
+.c3.fi-static-icon {
+  display: inline-block;
+}
+
+.c3.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c3.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c1 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c1.fi-side-navigation--small-screen {
+  background: hsl(212,63%,95%);
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation_heading {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+  width: 100%;
+  padding: 20px;
+  border: 1px solid hsl(212,63%,90%);
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation_heading .fi-icon {
+  height: 25px;
+  width: 25px;
+}
+
+.c1.fi-side-navigation .fi-side-navigation_heading {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 15px;
+}
+
+.c1.fi-side-navigation .fi-side-navigation_heading .fi-side-navigation_heading_inner {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.fi-side-navigation .fi-side-navigation_heading .fi-static-icon {
+  height: 50px;
+  width: 50px;
+  margin-right: 15px;
+}
+
+.c1.fi-side-navigation .fi-side-navigation_list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c7 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.c7.fi-side-navigation-item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+}
+
+.c7.fi-side-navigation-item:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 2.5%;
+  width: 95%;
+  height: 1px;
+  background: hsl(215,100%,97%);
+}
+
+.c7.fi-side-navigation-item:hover:after,
+.c7.fi-side-navigation-item:active:after {
+  background: transparent;
+}
+
+.c7.fi-side-navigation-item .fi-link--router {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 10px 20px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  cursor: pointer;
+  border: none;
+  color: hsl(212,63%,45%);
+  background: transparent;
+}
+
+.c7.fi-side-navigation-item .fi-link--router:visited {
+  color: hsl(212,63%,45%);
+}
+
+.c7.fi-side-navigation-item .fi-link--router:hover,
+.c7.fi-side-navigation-item .fi-link--router:active {
+  background: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item.fi-side-navigation-item--child-selected > span > .fi-link--router {
+  font-weight: 600;
+}
+
+.c7.fi-side-navigation-item .fi-side-navigation-item_sub-list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.c7.fi-side-navigation-item .fi-side-navigation-item_content-wrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  position: relative;
+}
+
+.c7.fi-side-navigation-item .fi-side-navigation-item_content-wrapper .fi-icon {
+  width: 25px;
+  height: 25px;
+  pointer-events: none;
+  position: absolute;
+  top: 11px;
+  right: 15px;
+  color: hsl(202,7%,40%);
+}
+
+.c7.fi-side-navigation-item.fi-side-navigation-item--selected:after {
+  background: hsl(212,63%,45%);
+}
+
+.c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected {
+  background: hsl(212,63%,45%);
+  border-left: 4px solid hsl(212,63%,45%);
+}
+
+.c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected > span > .fi-link--router {
+  text-transform: uppercase;
+  color: hsl(0,0%,100%);
+  font-weight: 600;
+}
+
+.c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected > span > .fi-link--router:hover,
+.c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected > span > .fi-link--router:active {
+  color: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item--level-1.fi-side-navigation-item--child-selected {
+  border-left: 4px solid hsl(212,63%,45%);
+}
+
+.c7.fi-side-navigation-item--level-1 > span > .fi-link--router {
+  text-transform: uppercase;
+}
+
+.c7.fi-side-navigation-item--level-2.fi-side-navigation-item--selected > span > .fi-link--router {
+  font-weight: 600;
+  background: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item--level-2.fi-side-navigation-item--selected > span > .fi-link--router + .fi-icon {
+  color: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item--level-2 > span > .fi-link--router {
+  text-transform: none;
+  padding-left: 30px;
+  padding-right: 60px;
+  color: hsl(212,63%,45%);
+  background: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item--level-2 > span > .fi-link--router:hover + .fi-icon,
+.c7.fi-side-navigation-item--level-2 > span > .fi-link--router:active + .fi-icon {
+  color: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item--level-2 > .fi-side-navigation-item_content-wrapper:hover {
+  color: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item--level-3.fi-side-navigation-item--selected > span > .fi-link--router {
+  font-weight: 600;
+  background: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item--level-3:hover,
+.c7.fi-side-navigation-item--level-3:active {
+  color: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item--level-3 > span > .fi-link--router {
+  text-transform: none;
+  padding-left: 50px;
+  color: hsl(212,63%,45%);
+  background: hsl(212,63%,98%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c7.fi-side-navigation-item--disabled:hover,
+.c7.fi-side-navigation-item--disabled:active {
+  background: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item--disabled .fi-link--router {
+  color: hsl(202,7%,67%);
+  cursor: not-allowed;
+}
+
+.c7.fi-side-navigation-item--disabled .fi-link--router:hover,
+.c7.fi-side-navigation-item--disabled .fi-link--router:active {
+  color: hsl(202,7%,67%);
+}
+
+.c12 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c11 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c11.fi-link {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c11.fi-link:hover,
+.c11.fi-link:active,
+.c11.fi-link:focus,
+.c11.fi-link:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c11.fi-link:focus,
+.c11.fi-link:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c11.fi-link:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c11.fi-link:hover,
+.c11.fi-link:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c11.fi-link:visited {
+  color: hsl(284,36%,45%);
+}
+
+.c11 .fi-link_icon {
+  padding-left: 4px;
+  font-size: 16px;
+  box-sizing: content-box;
+}
+
+.c9 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c9.fi-link--router {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c9.fi-link--router:hover,
+.c9.fi-link--router:active,
+.c9.fi-link--router:focus,
+.c9.fi-link--router:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c9.fi-link--router:focus,
+.c9.fi-link--router:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c9.fi-link--router:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c9.fi-link--router:hover,
+.c9.fi-link--router:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c9.fi-link--router:visited {
+  color: hsl(284,36%,45%);
+}
+
+<div
+  class="c0 fi-side-navigation c1"
+>
+  <div
+    class="c0 fi-side-navigation_heading"
+  >
+    <span
+      class="c2 fi-side-navigation_heading_inner"
+    >
+      <svg
+        aria-hidden="true"
+        class="c3 fi-icon fi-static-icon"
+        focusable="false"
+        height="1em"
+        viewBox="0 0 80 80"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <path
+            class="fi-icon-illustrative-base-fill"
+            d="M23.611 62.508c-4.253-2.836-7.23-6.604-8.611-10.896L16.904 51c1.24 3.857 3.944 7.261 7.817 9.844l-1.11 1.664M40.255 68.011c-2.825 0-5.603-.363-8.255-1.08l.522-1.93c4.968 1.342 10.509 1.34 15.472-.001l.522 1.93a31.68 31.68 0 01-8.261 1.081M57.07 63.058l-1.11-1.664c5.437-3.625 8.555-8.923 8.555-14.535 0-5.991-3.468-11.511-9.515-15.145L56.03 30c6.664 4.005 10.485 10.15 10.485 16.859 0 6.292-3.442 12.196-9.445 16.199"
+            fill="#A5ADB1"
+          />
+          <path
+            class="fi-icon-illustrative-base-fill"
+            d="M19 52.943h-8c-1.654 0-3-1.346-3-3v-6c0-1.654 1.346-3 3-3h3.296c1.081-2.761 3.332-5.604 6.704-8.466V22l8.14 5.814c2.585-1.015 4.86-1.871 7.86-1.871v2c-2.723 0-4.783.81-7.393 1.836l-.747.293L23 25.886v7.527l-.361.3c-3.516 2.916-5.827 5.868-6.687 8.537l-.223.693H11c-.552 0-1 .449-1 1v6c0 .551.448 1 1 1h8v2M33 72H23V58h2v12h6v-7h2v9M57 72H47v-9h2v7h6V58h2v14"
+            fill="#A5ADB1"
+          />
+          <path
+            class="fi-icon-illustrative-base-fill"
+            d="M26 45c-2.757 0-5-2.243-5-5h2c0 1.654 1.346 3 3 3s3-1.346 3-3h2c0 2.757-2.243 5-5 5M65 48v-2c2.757 0 5-2.243 5-5h2c0 3.86-3.141 7-7 7"
+            fill="#A5ADB1"
+          />
+          <path
+            class="fi-icon-illustrative-highlight-fill"
+            d="M49.601 32.8l-1.202-1.6A3.966 3.966 0 0050 28c0-2.206-1.794-4-4-4s-4 1.794-4 4c0 .875.277 1.705.801 2.402l-1.598 1.202A5.948 5.948 0 0140 28c0-3.309 2.691-6 6-6s6 2.691 6 6a5.956 5.956 0 01-2.399 4.8M47 14h2V8h-2z"
+            fill="#E97025"
+          />
+          <path
+            class="fi-icon-illustrative-base-fill"
+            d="M52.4 35.8C48.99 33.243 44.28 32 38 32v-2c6.729 0 11.832 1.374 15.6 4.2l-1.2 1.6"
+            fill="#A5ADB1"
+          />
+          <path
+            class="fi-icon-illustrative-highlight-fill"
+            d="M43 20h2v-6h-2zM47 18h2v-2h-2zM43 12h2v-2h-2z"
+            fill="#E97025"
+          />
+          <path
+            class="fi-icon-illustrative-base-fill"
+            d="M39 60h2v-2h-2zM43 60h2v-2h-2zM35 60h2v-2h-2zM8 72h64v-2H8z"
+            fill="#A5ADB1"
+          />
+          <path
+            d="M0 0h80v80H0z"
+          />
+        </g>
+      </svg>
+      Economy
+    </span>
+  </div>
+  <nav
+    class="c4"
+  >
+    <ul
+      class="c5 fi-side-navigation_list"
+    >
+      <li
+        class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-1 fi-side-navigation-item--child-selected"
+      >
+        <span
+          class="c2 fi-side-navigation-item_content-wrapper"
+        >
+          <a
+            class="c8 fi-link--router c9"
+            href="/"
+          >
+            Personal economy
+          </a>
+        </span>
+        <ul
+          class="c5 fi-side-navigation-item_sub-list"
+        >
+          <li
+            class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-2 fi-side-navigation-item--child-selected"
+          >
+            <span
+              class="c2 fi-side-navigation-item_content-wrapper"
+            >
+              <a
+                class="c8 fi-link--router c9"
+                href="/"
+              >
+                Crisis situations in personal finances
+              </a>
+              <svg
+                aria-hidden="true"
+                class="fi-icon c10"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M12.99 8.39A1.433 1.433 0 0012 8c-.358 0-.717.13-.99.39l-5.6 5.334a1.287 1.287 0 000 1.885 1.448 1.448 0 001.98 0l4.61-4.39 4.61 4.39a1.448 1.448 0 001.98 0 1.287 1.287 0 000-1.885l-5.6-5.333z"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+            <ul
+              class="c5 fi-side-navigation-item_sub-list"
+            >
+              <li
+                class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-3"
+              >
+                <span
+                  class="c2 fi-side-navigation-item_content-wrapper"
+                >
+                  <a
+                    class="c8 fi-link--router c9"
+                    href="/"
+                  >
+                    If you are unable to pay your debts
+                  </a>
+                </span>
+              </li>
+              <li
+                aria-current="page"
+                class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-3 fi-side-navigation-item--selected"
+              >
+                <span
+                  class="c2 fi-side-navigation-item_content-wrapper"
+                >
+                  <a
+                    class="c8 fi-link--router c9"
+                    href="/"
+                  >
+                    Advice on banking and insurance matters
+                  </a>
+                </span>
+              </li>
+            </ul>
+          </li>
+          <li
+            class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-2"
+          >
+            <span
+              class="c2 fi-side-navigation-item_content-wrapper"
+            >
+              <a
+                class="c8 fi-link--router c9"
+                href="/"
+              >
+                Last will and testament
+              </a>
+            </span>
+          </li>
+        </ul>
+      </li>
+      <li
+        class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-1"
+      >
+        <span
+          class="c2 fi-side-navigation-item_content-wrapper"
+        >
+          <a
+            class="c8 fi-link c11 fi-link--router c9 fi-link--external"
+            href="https://suomi.fi"
+            rel="noopener"
+            target="_blank"
+          >
+            Taxation and public economy
+            <span
+              class="c2 c12 fi-visually-hidden"
+            />
+          </a>
+        </span>
+      </li>
+      <li
+        class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-1"
+      >
+        <span
+          class="c2 fi-side-navigation-item_content-wrapper"
+        >
+          <button
+            class="fi-link--router c9"
+          >
+            Consumer protection
+          </button>
+        </span>
+      </li>
+      <li
+        aria-disabled="true"
+        class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-1 fi-side-navigation-item--disabled"
+      >
+        <span
+          class="c2 fi-side-navigation-item_content-wrapper"
+        >
+          <a
+            class="c8 fi-link--router c9"
+          >
+            Finance
+          </a>
+        </span>
+      </li>
+    </ul>
+  </nav>
+</div>
+`;

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -349,7 +349,7 @@ exports[`calling render with the same component on the same container does not r
 .c7.fi-side-navigation-item:after {
   content: '';
   position: absolute;
-  bottom: 0;
+  bottom: -1px;
   left: 2.5%;
   width: 95%;
   height: 1px;
@@ -725,6 +725,7 @@ exports[`calling render with the same component on the same container does not r
           class="c2 fi-side-navigation-item_content-wrapper"
         >
           <a
+            aria-current="location"
             class="c8 fi-link--router c9"
             href="/"
           >
@@ -741,6 +742,7 @@ exports[`calling render with the same component on the same container does not r
               class="c2 fi-side-navigation-item_content-wrapper"
             >
               <a
+                aria-current="location"
                 class="c8 fi-link--router c9"
                 href="/"
               >
@@ -781,13 +783,13 @@ exports[`calling render with the same component on the same container does not r
                 </span>
               </li>
               <li
-                aria-current="page"
                 class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-3 fi-side-navigation-item--selected"
               >
                 <span
                   class="c2 fi-side-navigation-item_content-wrapper"
                 >
                   <a
+                    aria-current="page"
                     class="c8 fi-link--router c9"
                     href="/"
                   >

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -635,6 +635,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c11.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c11.fi-link--initial-underline:focus,
+.c11.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c11.fi-link--initial-underline:hover,
+.c11.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c11 .fi-link_icon {
   padding-left: 4px;
   font-size: 16px;
@@ -690,6 +707,23 @@ exports[`calling render with the same component on the same container does not r
 
 .c9.fi-link--router:visited {
   color: hsl(284,36%,45%);
+}
+
+.c9.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c9.fi-link--initial-underline:focus,
+.c9.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c9.fi-link--initial-underline:hover,
+.c9.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 <div

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -480,10 +480,6 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(212,63%,45%);
 }
 
-.c7.fi-side-navigation-item.fi-side-navigation-item--selected:after {
-  background: hsl(212,63%,45%);
-}
-
 .c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected {
   background: hsl(212,63%,45%);
   border-left: 4px solid hsl(212,63%,45%);
@@ -579,6 +575,7 @@ exports[`calling render with the same component on the same container does not r
 .c7.fi-side-navigation-item--disabled .fi-link--router:hover,
 .c7.fi-side-navigation-item--disabled .fi-link--router:active,
 .c7.fi-side-navigation-item--disabled .fi-link--router:visited {
+  background: transparent;
   color: hsl(202,7%,67%);
 }
 
@@ -768,6 +765,7 @@ exports[`calling render with the same component on the same container does not r
     </span>
   </div>
   <nav
+    aria-label="Test"
     class="c4"
   >
     <ul

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c1.fi-side-navigation--small-screen {
-  border: 1px solid hsl(202,7%,80%);
+  background: hsl(212,63%,95%);
 }
 
 .c1.fi-side-navigation--small-screen .fi-side-navigation_heading {
@@ -255,36 +255,12 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 600;
   width: 100%;
   padding: 20px;
-}
-
-.c1.fi-side-navigation--small-screen .fi-side-navigation_heading:focus {
-  position: relative;
-  outline: 0;
-}
-
-.c1.fi-side-navigation--small-screen .fi-side-navigation_heading:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
+  border: 1px solid hsl(212,63%,90%);
 }
 
 .c1.fi-side-navigation--small-screen .fi-side-navigation_heading .fi-icon {
   height: 25px;
   width: 25px;
-}
-
-.c1.fi-side-navigation--small-screen .fi-side-navigation-item:last-child:after {
-  display: none;
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading {
@@ -313,7 +289,7 @@ exports[`calling render with the same component on the same container does not r
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding: 10px 15px;
+  padding: 15px;
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading .fi-side-navigation_heading_inner {
@@ -328,8 +304,8 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading .fi-static-icon {
-  height: 45px;
-  width: 45px;
+  height: 50px;
+  width: 50px;
   margin-right: 15px;
 }
 
@@ -373,7 +349,7 @@ exports[`calling render with the same component on the same container does not r
 .c7.fi-side-navigation-item:after {
   content: '';
   position: absolute;
-  bottom: -1px;
+  bottom: 0;
   left: 2.5%;
   width: 95%;
   height: 1px;
@@ -383,13 +359,6 @@ exports[`calling render with the same component on the same container does not r
 .c7.fi-side-navigation-item:hover:after,
 .c7.fi-side-navigation-item:active:after {
   background: transparent;
-}
-
-.c7.fi-side-navigation-item:focus,
-.c7.fi-side-navigation-item:focus-within {
-  outline: 0;
-  box-shadow: none;
-  border: none;
 }
 
 .c7.fi-side-navigation-item .fi-link--router {
@@ -419,29 +388,6 @@ exports[`calling render with the same component on the same container does not r
   -webkit-text-decoration: none;
   text-decoration: none;
   color: hsl(0,0%,100%);
-}
-
-.c7.fi-side-navigation-item .fi-link--router:focus {
-  position: relative;
-  outline: 0;
-  box-shadow: none;
-  border: none;
-}
-
-.c7.fi-side-navigation-item .fi-link--router:focus:before {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c7.fi-side-navigation-item.fi-side-navigation-item--child-selected > span > .fi-link--router {
@@ -477,7 +423,11 @@ exports[`calling render with the same component on the same container does not r
   position: absolute;
   top: 11px;
   right: 15px;
-  color: hsl(212,63%,45%);
+  color: hsl(202,7%,40%);
+}
+
+.c7.fi-side-navigation-item.fi-side-navigation-item--selected:after {
+  background: hsl(212,63%,45%);
 }
 
 .c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected {
@@ -573,9 +523,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c7.fi-side-navigation-item--disabled .fi-link--router:hover,
-.c7.fi-side-navigation-item--disabled .fi-link--router:active,
-.c7.fi-side-navigation-item--disabled .fi-link--router:visited {
-  background: transparent;
+.c7.fi-side-navigation-item--disabled .fi-link--router:active {
   color: hsl(202,7%,67%);
 }
 
@@ -642,23 +590,6 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
-.c11.fi-link--initial-underline {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c11.fi-link--initial-underline:focus,
-.c11.fi-link--initial-underline:focus-within {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c11.fi-link--initial-underline:hover,
-.c11.fi-link--initial-underline:active {
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
 .c11 .fi-link_icon {
   padding-left: 4px;
   font-size: 16px;
@@ -714,23 +645,6 @@ exports[`calling render with the same component on the same container does not r
 
 .c9.fi-link--router:visited {
   color: hsl(284,36%,45%);
-}
-
-.c9.fi-link--initial-underline {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c9.fi-link--initial-underline:focus,
-.c9.fi-link--initial-underline:focus-within {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c9.fi-link--initial-underline:hover,
-.c9.fi-link--initial-underline:active {
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 <div
@@ -799,7 +713,6 @@ exports[`calling render with the same component on the same container does not r
     </span>
   </div>
   <nav
-    aria-label="Test"
     class="c4"
   >
     <ul
@@ -812,7 +725,6 @@ exports[`calling render with the same component on the same container does not r
           class="c2 fi-side-navigation-item_content-wrapper"
         >
           <a
-            aria-current="location"
             class="c8 fi-link--router c9"
             href="/"
           >
@@ -829,7 +741,6 @@ exports[`calling render with the same component on the same container does not r
               class="c2 fi-side-navigation-item_content-wrapper"
             >
               <a
-                aria-current="location"
                 class="c8 fi-link--router c9"
                 href="/"
               >
@@ -870,13 +781,13 @@ exports[`calling render with the same component on the same container does not r
                 </span>
               </li>
               <li
+                aria-current="page"
                 class="c6 c7 fi-side-navigation-item fi-side-navigation-item--level-3 fi-side-navigation-item--selected"
               >
                 <span
                   class="c2 fi-side-navigation-item_content-wrapper"
                 >
                   <a
-                    aria-current="page"
                     class="c8 fi-link--router c9"
                     href="/"
                   >

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c1.fi-side-navigation--small-screen {
-  background: hsl(212,63%,95%);
+  border: 1px solid hsl(202,7%,80%);
 }
 
 .c1.fi-side-navigation--small-screen .fi-side-navigation_heading {
@@ -255,12 +255,36 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 600;
   width: 100%;
   padding: 20px;
-  border: 1px solid hsl(212,63%,90%);
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation_heading:focus {
+  position: relative;
+  outline: 0;
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation_heading:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c1.fi-side-navigation--small-screen .fi-side-navigation_heading .fi-icon {
   height: 25px;
   width: 25px;
+}
+
+.c1.fi-side-navigation--small-screen .fi-side-navigation-item:last-child:after {
+  display: none;
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading {
@@ -289,7 +313,7 @@ exports[`calling render with the same component on the same container does not r
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  padding: 15px;
+  padding: 10px 15px;
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading .fi-side-navigation_heading_inner {
@@ -304,8 +328,8 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c1.fi-side-navigation .fi-side-navigation_heading .fi-static-icon {
-  height: 50px;
-  width: 50px;
+  height: 45px;
+  width: 45px;
   margin-right: 15px;
 }
 
@@ -361,6 +385,13 @@ exports[`calling render with the same component on the same container does not r
   background: transparent;
 }
 
+.c7.fi-side-navigation-item:focus,
+.c7.fi-side-navigation-item:focus-within {
+  outline: 0;
+  box-shadow: none;
+  border: none;
+}
+
 .c7.fi-side-navigation-item .fi-link--router {
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -388,6 +419,29 @@ exports[`calling render with the same component on the same container does not r
   -webkit-text-decoration: none;
   text-decoration: none;
   color: hsl(0,0%,100%);
+}
+
+.c7.fi-side-navigation-item .fi-link--router:focus {
+  position: relative;
+  outline: 0;
+  box-shadow: none;
+  border: none;
+}
+
+.c7.fi-side-navigation-item .fi-link--router:focus:before {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c7.fi-side-navigation-item.fi-side-navigation-item--child-selected > span > .fi-link--router {
@@ -423,7 +477,7 @@ exports[`calling render with the same component on the same container does not r
   position: absolute;
   top: 11px;
   right: 15px;
-  color: hsl(202,7%,40%);
+  color: hsl(212,63%,45%);
 }
 
 .c7.fi-side-navigation-item.fi-side-navigation-item--selected:after {
@@ -523,7 +577,8 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c7.fi-side-navigation-item--disabled .fi-link--router:hover,
-.c7.fi-side-navigation-item--disabled .fi-link--router:active {
+.c7.fi-side-navigation-item--disabled .fi-link--router:active,
+.c7.fi-side-navigation-item--disabled .fi-link--router:visited {
   color: hsl(202,7%,67%);
 }
 

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -12,23 +12,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     justify-content: center;
     flex-direction: column;
     position: relative;
-
-    &:after {
-      content: '';
-      position: absolute;
-      bottom: -1px;
-      left: 2.5%;
-      width: 95%;
-      height: 1px;
-      background: ${theme.colors.depthSecondary};
-    }
-
-    &:hover,
-    &:active {
-      &:after {
-        background: transparent;
-      }
-    }
+    margin: ${theme.spacing.xxs} 0;
 
     &:focus,
     &:focus-within {
@@ -40,7 +24,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     .fi-link--router {
       text-decoration: none;
       display: flex;
-      padding: ${theme.spacing.xs} ${theme.spacing.m};
+      padding: ${theme.spacing.xs} ${theme.spacing.xs};
       flex: 1;
       cursor: pointer;
       border: none;
@@ -56,6 +40,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         background: ${theme.colors.highlightBase};
         text-decoration: none;
         color: ${theme.colors.whiteBase};
+        border-radius: ${theme.radius.modal};
       }
 
       &:focus {
@@ -64,9 +49,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         box-shadow: none;
         border: none;
 
-        &:before {
-          ${theme.focus.absoluteFocus}
-        }
+        ${theme.focus.boxShadowFocus}
+        z-index: ${theme.zindexes.focus};
       }
     }
 
@@ -78,46 +62,34 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     .fi-side-navigation-item_sub-list {
       list-style-type: none;
-      margin: 0;
       padding: 0;
+      margin: 0;
     }
 
     .fi-side-navigation-item_content-wrapper {
       display: flex;
       justify-content: space-between;
-      align-items: flex-start;
+      align-items: center;
       position: relative;
 
       .fi-icon {
-        width: 25px;
-        height: 25px;
+        width: 10px;
+        height: 10px;
         pointer-events: none;
-        position: absolute;
-        top: 11px;
-        right: 15px;
         color: ${theme.colors.highlightBase};
+        padding: 0 ${theme.spacing.xs};
       }
     }
 
     &--level-1 {
       &.fi-side-navigation-item--selected {
-        background: ${theme.colors.highlightBase};
-        border-left: 4px solid ${theme.colors.highlightBase};
-
         > span > .fi-link--router {
           text-transform: uppercase;
           color: ${theme.colors.whiteBase};
           font-weight: 600;
-
-          &:hover,
-          &:active {
-            color: ${theme.colors.whiteBase};
-          }
+          background: ${theme.colors.highlightBase};
+          border-radius: ${theme.radius.modal};
         }
-      }
-
-      &.fi-side-navigation-item--child-selected {
-        border-left: 4px solid ${theme.colors.highlightBase};
       }
 
       > span > .fi-link--router {
@@ -131,6 +103,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
           font-weight: 600;
           background: ${theme.colors.highlightBase};
           color: ${theme.colors.whiteBase};
+          border-top-left-radius: ${theme.radius.modal};
+          border-top-right-radius: ${theme.radius.modal};
+          border-bottom-left-radius: 0;
+          border-bottom-right-radius: 0;
 
           + .fi-icon {
             color: ${theme.colors.whiteBase};
@@ -140,27 +116,20 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
       > span > .fi-link--router {
         text-transform: none;
-        padding-left: ${theme.spacing.xl};
         padding-right: ${theme.spacing.xxxl};
         color: ${theme.colors.highlightBase};
         background: ${theme.colors.whiteBase};
-
-        &:hover,
-        &:active {
-          + .fi-icon {
-            color: ${theme.colors.whiteBase};
-          }
-        }
       }
 
-      > .fi-side-navigation-item_content-wrapper {
-        &:hover {
-          color: ${theme.colors.whiteBase};
-        }
+      .fi-side-navigation-item_sub-list {
+        margin: ${theme.spacing.xxs} 0 ${theme.spacing.xxs} 30px;
+        background: ${theme.colors.highlightLight3};
+        border-radius: ${theme.radius.modal};
       }
     }
 
     &--level-3 {
+      margin: 0;
       &.fi-side-navigation-item--selected {
         > span > .fi-link--router {
           font-weight: 600;
@@ -169,28 +138,51 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         }
       }
 
-      &:hover,
-      &:active {
-        color: ${theme.colors.whiteBase};
-      }
-
       > span > .fi-link--router {
         text-transform: none;
-        padding-left: 50px; /** No token for this value :( */
+        padding-left: ${theme.spacing.s};
         color: ${theme.colors.highlightBase};
-        background: ${theme.colors.highlightLight4};
         ${font(theme)('bodyTextSmall')};
+
+        &:hover {
+          border-radius: 0;
+        }
+      }
+
+      &:first-child {
+        > span > .fi-link--router {
+          border-top-left-radius: ${theme.radius.modal};
+          border-top-right-radius: ${theme.radius.modal};
+
+          &:hover {
+            border-top-left-radius: ${theme.radius.modal};
+            border-top-right-radius: ${theme.radius.modal};
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
+          }
+        }
+      }
+
+      &:last-child {
+        > span > .fi-link--router {
+          border-bottom-left-radius: ${theme.radius.modal};
+          border-bottom-right-radius: ${theme.radius.modal};
+
+          &:hover {
+            border-bottom-left-radius: ${theme.radius.modal};
+            border-bottom-right-radius: ${theme.radius.modal};
+            border-top-left-radius: 0;
+            border-top-right-radius: 0;
+          }
+        }
       }
     }
 
     &--disabled {
-      &:hover,
-      &:active {
-        background: ${theme.colors.whiteBase};
-      }
-      .fi-link--router {
+      > span > .fi-link--router {
         color: ${theme.colors.depthBase};
         cursor: not-allowed;
+        background: transparent;
 
         &:hover,
         &:active,

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -30,6 +30,13 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
 
+    &:focus,
+    &:focus-within {
+      outline: 0;
+      box-shadow: none;
+      border: none;
+    }
+
     .fi-link--router {
       text-decoration: none;
       display: flex;
@@ -49,6 +56,17 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         background: ${theme.colors.highlightBase};
         text-decoration: none;
         color: ${theme.colors.whiteBase};
+      }
+
+      &:focus {
+        position: relative;
+        outline: 0;
+        box-shadow: none;
+        border: none;
+
+        &:before {
+          ${theme.focus.absoluteFocus}
+        }
       }
     }
 
@@ -77,7 +95,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         position: absolute;
         top: 11px;
         right: 15px;
-        color: ${theme.colors.depthDark1};
+        color: ${theme.colors.highlightBase};
       }
     }
 
@@ -181,7 +199,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         cursor: not-allowed;
 
         &:hover,
-        &:active {
+        &:active,
+        &:visited {
           color: ${theme.colors.depthBase};
         }
       }

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -16,7 +16,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &:after {
       content: '';
       position: absolute;
-      bottom: 0;
+      bottom: -1px;
       left: 2.5%;
       width: 95%;
       height: 1px;

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -1,0 +1,192 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodySemiBold')};
+
+  /* stylelint-disable no-descending-specificity */
+  /* Nested :hover etc selectors do not work well with this rule. */
+  &.fi-side-navigation-item {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    position: relative;
+
+    &:after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 2.5%;
+      width: 95%;
+      height: 1px;
+      background: ${theme.colors.depthSecondary};
+    }
+
+    &:hover,
+    &:active {
+      &:after {
+        background: transparent;
+      }
+    }
+
+    .fi-link--router {
+      text-decoration: none;
+      display: flex;
+      padding: ${theme.spacing.xs} ${theme.spacing.m};
+      flex: 1;
+      cursor: pointer;
+      border: none;
+      color: ${theme.colors.highlightBase};
+      background: transparent;
+
+      &:visited {
+        color: ${theme.colors.highlightBase};
+      }
+
+      &:hover,
+      &:active {
+        background: ${theme.colors.highlightBase};
+        text-decoration: none;
+        color: ${theme.colors.whiteBase};
+      }
+    }
+
+    &.fi-side-navigation-item--child-selected {
+      > span > .fi-link--router {
+        font-weight: 600;
+      }
+    }
+
+    .fi-side-navigation-item_sub-list {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .fi-side-navigation-item_content-wrapper {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      position: relative;
+
+      .fi-icon {
+        width: 25px;
+        height: 25px;
+        pointer-events: none;
+        position: absolute;
+        top: 11px;
+        right: 15px;
+        color: ${theme.colors.depthDark1};
+      }
+    }
+
+    &.fi-side-navigation-item--selected {
+      &:after {
+        background: ${theme.colors.highlightBase};
+      }
+    }
+
+    &--level-1 {
+      &.fi-side-navigation-item--selected {
+        background: ${theme.colors.highlightBase};
+        border-left: 4px solid ${theme.colors.highlightBase};
+
+        > span > .fi-link--router {
+          text-transform: uppercase;
+          color: ${theme.colors.whiteBase};
+          font-weight: 600;
+
+          &:hover,
+          &:active {
+            color: ${theme.colors.whiteBase};
+          }
+        }
+      }
+
+      &.fi-side-navigation-item--child-selected {
+        border-left: 4px solid ${theme.colors.highlightBase};
+      }
+
+      > span > .fi-link--router {
+        text-transform: uppercase;
+      }
+    }
+
+    &--level-2 {
+      &.fi-side-navigation-item--selected {
+        > span > .fi-link--router {
+          font-weight: 600;
+          background: ${theme.colors.highlightBase};
+          color: ${theme.colors.whiteBase};
+
+          + .fi-icon {
+            color: ${theme.colors.whiteBase};
+          }
+        }
+      }
+
+      > span > .fi-link--router {
+        text-transform: none;
+        padding-left: ${theme.spacing.xl};
+        padding-right: ${theme.spacing.xxxl};
+        color: ${theme.colors.highlightBase};
+        background: ${theme.colors.whiteBase};
+
+        &:hover,
+        &:active {
+          + .fi-icon {
+            color: ${theme.colors.whiteBase};
+          }
+        }
+      }
+
+      > .fi-side-navigation-item_content-wrapper {
+        &:hover {
+          color: ${theme.colors.whiteBase};
+        }
+      }
+    }
+
+    &--level-3 {
+      &.fi-side-navigation-item--selected {
+        > span > .fi-link--router {
+          font-weight: 600;
+          background: ${theme.colors.highlightBase};
+          color: ${theme.colors.whiteBase};
+        }
+      }
+
+      &:hover,
+      &:active {
+        color: ${theme.colors.whiteBase};
+      }
+
+      > span > .fi-link--router {
+        text-transform: none;
+        padding-left: 50px; /** No token for this value :( */
+        color: ${theme.colors.highlightBase};
+        background: ${theme.colors.highlightLight4};
+        ${font(theme)('bodyTextSmall')};
+      }
+    }
+
+    &--disabled {
+      &:hover,
+      &:active {
+        background: ${theme.colors.whiteBase};
+      }
+      .fi-link--router {
+        color: ${theme.colors.depthBase};
+        cursor: not-allowed;
+
+        &:hover,
+        &:active {
+          color: ${theme.colors.depthBase};
+        }
+      }
+    }
+  }
+`;
+
+/* stylelint-enable no-descending-specificity */

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -99,12 +99,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
 
-    &.fi-side-navigation-item--selected {
-      &:after {
-        background: ${theme.colors.highlightBase};
-      }
-    }
-
     &--level-1 {
       &.fi-side-navigation-item--selected {
         background: ${theme.colors.highlightBase};
@@ -201,6 +195,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         &:hover,
         &:active,
         &:visited {
+          background: transparent;
           color: ${theme.colors.depthBase};
         }
       }

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -124,7 +124,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       .fi-side-navigation-item_sub-list {
         margin: ${theme.spacing.xxs} 0 ${theme.spacing.xxs} 30px;
         background: ${theme.colors.highlightLight3};
-        border-radius: ${theme.radius.modal};
       }
     }
 
@@ -146,34 +145,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
         &:hover {
           border-radius: 0;
-        }
-      }
-
-      &:first-child {
-        > span > .fi-link--router {
-          border-top-left-radius: ${theme.radius.modal};
-          border-top-right-radius: ${theme.radius.modal};
-
-          &:hover {
-            border-top-left-radius: ${theme.radius.modal};
-            border-top-right-radius: ${theme.radius.modal};
-            border-bottom-left-radius: 0;
-            border-bottom-right-radius: 0;
-          }
-        }
-      }
-
-      &:last-child {
-        > span > .fi-link--router {
-          border-bottom-left-radius: ${theme.radius.modal};
-          border-bottom-right-radius: ${theme.radius.modal};
-
-          &:hover {
-            border-bottom-left-radius: ${theme.radius.modal};
-            border-bottom-right-radius: ${theme.radius.modal};
-            border-top-left-radius: 0;
-            border-top-right-radius: 0;
-          }
         }
       }
     }

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
@@ -6,7 +6,7 @@ import { baseStyles } from './SideNavigationItem.baseStyles';
 import styled from 'styled-components';
 import { Icon } from '../../../Icon/Icon';
 
-interface SideNavigationItemProps {
+export interface SideNavigationItemProps {
   /** Custom class */
   className?: string;
   /** Use the polymorphic RouterLink component to get intended CSS styling */

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
@@ -1,0 +1,133 @@
+import React, { ReactElement, ReactNode } from 'react';
+import classnames from 'classnames';
+import { HtmlLi, HtmlSpan, HtmlUl } from '../../../../reset';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import { baseStyles } from './SideNavigationItem.baseStyles';
+import styled from 'styled-components';
+import { Icon } from '../../../Icon/Icon';
+
+interface BasicSideNavigationItemProps {
+  /** Custom class */
+  className?: string;
+  /** Use the polymorphic RouterLink component to get intended CSS styling */
+  content: ReactNode;
+  /** Use the polymorphic RouterLink component or as child to get intended CSS styling */
+  children?: ReactNode | ReactNode[];
+  /** Sub-level of this item. 1-3 */
+  subLevel: 1 | 2 | 3;
+  /** If this item's child is selected, this prop must be applied to get correct CSS styles */
+  childSelected?: boolean;
+  /** Disable the item */
+  disabled?: boolean;
+  /** Force the item to show its children */
+  expanded?: boolean;
+}
+
+type SelectedProps =
+  | {
+      /** Show item as the selected one */
+      selected: boolean;
+      /** Selected item information for screen reader. Required when `selected` is true */
+      ariaCurrent: 'step' | 'page' | 'location';
+    }
+  | {
+      selected?: never;
+      ariaCurrent?: never;
+    };
+
+export type SideNavigationItemProps = BasicSideNavigationItemProps &
+  SelectedProps;
+
+const baseClassName = 'fi-side-navigation-item';
+const selectedClassName = `${baseClassName}--selected`;
+const childSelectedClassName = `${baseClassName}--child-selected`;
+const disabledClassName = `${baseClassName}--disabled`;
+const subListClassName = `${baseClassName}_sub-list`;
+const contentWrapperClassName = `${baseClassName}_content-wrapper`;
+
+const BaseSideNavigationItem = ({
+  subLevel,
+  selected,
+  ariaCurrent,
+  className,
+  children,
+  content,
+  disabled,
+  expanded,
+  ...passProps
+}: SideNavigationItemProps) => {
+  let childIsSelected = false;
+  React.Children.forEach(children, (element) => {
+    if (!React.isValidElement(element)) return;
+
+    if (element.props) {
+      if (element.props.selected) {
+        childIsSelected = true;
+      } else if (element.props.children) {
+        element.props.children.forEach((c: ReactElement) => {
+          if (c.props) {
+            if (c.props.selected) {
+              childIsSelected = true;
+              return;
+            }
+          }
+        });
+      }
+    }
+  });
+
+  return (
+    <HtmlLi
+      className={classnames(
+        className,
+        baseClassName,
+        `${baseClassName}--level-${subLevel}`,
+        {
+          [selectedClassName]: selected,
+          [childSelectedClassName]: childIsSelected,
+          [disabledClassName]: disabled,
+        },
+      )}
+      aria-current={!!ariaCurrent ? ariaCurrent : undefined}
+      aria-disabled={disabled}
+      {...passProps}
+    >
+      <HtmlSpan className={contentWrapperClassName}>
+        {content}
+        {subLevel === 2 &&
+          !!children &&
+          (selected || childIsSelected || expanded) && (
+            <Icon icon="chevronUp" />
+          )}
+        {subLevel === 2 &&
+          !!children &&
+          !selected &&
+          !childIsSelected &&
+          !expanded && <Icon icon="chevronDown" />}
+      </HtmlSpan>
+      {!!children && (selected || childIsSelected || expanded) && (
+        <HtmlUl className={subListClassName}>{children}</HtmlUl>
+      )}
+    </HtmlLi>
+  );
+};
+
+const StyledSideNavigationItem = styled(
+  (props: SideNavigationItemProps & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseSideNavigationItem {...passProps} />;
+  },
+)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const SideNavigationItem = (props: SideNavigationItemProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledSideNavigationItem theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+SideNavigationItem.displayName = 'SideNavigationItem';
+export { SideNavigationItem };

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
@@ -9,15 +9,15 @@ import { Icon } from '../../../Icon/Icon';
 export interface SideNavigationItemProps {
   /** Custom class */
   className?: string;
-  /** Use the polymorphic RouterLink component as content to get intended CSS styling */
+  /** Content for the link element. Use the polymorphic RouterLink component to get intended CSS styling */
   content: ReactNode;
   /** Nested SideNavigationItems */
   children?: ReactNode;
   /** Sub-level of the item. 1-3 */
   subLevel: 1 | 2 | 3;
-  /** Show item as the selected one */
+  /** Toggle to show item as the selected one */
   selected?: boolean;
-  /** Disable the item */
+  /** Disables the item */
   disabled?: boolean;
   /** Force the item to show its children even when not selected */
   expanded?: boolean;

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
@@ -9,11 +9,11 @@ import { Icon } from '../../../Icon/Icon';
 export interface SideNavigationItemProps {
   /** Custom class */
   className?: string;
-  /** Use the polymorphic RouterLink component to get intended CSS styling */
+  /** Use the polymorphic RouterLink component as content to get intended CSS styling */
   content: ReactNode;
-  /** Use the polymorphic RouterLink component or as child to get intended CSS styling */
-  children?: ReactNode | ReactNode[];
-  /** Sub-level of this item. 1-3 */
+  /** Nested SideNavigationItems */
+  children?: ReactNode;
+  /** Sub-level of the item. 1-3 */
   subLevel: 1 | 2 | 3;
   /** Show item as the selected one */
   selected?: boolean;
@@ -40,6 +40,7 @@ const BaseSideNavigationItem = ({
   expanded,
   ...passProps
 }: SideNavigationItemProps) => {
+  // Loop through all children to check if a child of this item is selected
   let childIsSelected = false;
   React.Children.forEach(children, (element) => {
     if (!React.isValidElement(element)) return;

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
@@ -15,13 +15,11 @@ export interface SideNavigationItemProps {
   children?: ReactNode | ReactNode[];
   /** Sub-level of this item. 1-3 */
   subLevel: 1 | 2 | 3;
-  /** If this item's child is selected, this prop must be applied to get correct CSS styles */
-  childSelected?: boolean;
   /** Show item as the selected one */
   selected?: boolean;
   /** Disable the item */
   disabled?: boolean;
-  /** Force the item to show its children */
+  /** Force the item to show its children even when not selected */
   expanded?: boolean;
 }
 

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
@@ -76,17 +76,8 @@ const BaseSideNavigationItem = ({
       {...passProps}
     >
       <HtmlSpan className={contentWrapperClassName}>
+        {subLevel === 2 && <Icon icon="subDirectory" />}
         {content}
-        {subLevel === 2 &&
-          !!children &&
-          (selected || childIsSelected || expanded) && (
-            <Icon icon="chevronUp" />
-          )}
-        {subLevel === 2 &&
-          !!children &&
-          !selected &&
-          !childIsSelected &&
-          !expanded && <Icon icon="chevronDown" />}
       </HtmlSpan>
       {!!children && (selected || childIsSelected || expanded) && (
         <HtmlUl className={subListClassName}>{children}</HtmlUl>

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
@@ -43,22 +43,21 @@ const BaseSideNavigationItem = ({
   // Loop through all children to check if a child of this item is selected
   let childIsSelected = false;
   React.Children.forEach(children, (element) => {
-    if (!React.isValidElement(element)) return;
+    if (!React.isValidElement(element) || !element.props) return;
 
-    if (element.props) {
-      if (element.props.selected) {
-        childIsSelected = true;
-      } else if (element.props.children) {
-        element.props.children.forEach((c: ReactElement) => {
-          if (c.props) {
-            if (c.props.selected) {
-              childIsSelected = true;
-              return;
-            }
-          }
-        });
-      }
+    if (element.props.selected) {
+      childIsSelected = true;
+      return;
     }
+
+    if (!element.props.children) return;
+
+    element.props.children.forEach((child: ReactElement) => {
+      if (child.props?.selected) {
+        childIsSelected = true;
+        return;
+      }
+    });
   });
 
   return (

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.tsx
@@ -6,7 +6,7 @@ import { baseStyles } from './SideNavigationItem.baseStyles';
 import styled from 'styled-components';
 import { Icon } from '../../../Icon/Icon';
 
-interface BasicSideNavigationItemProps {
+interface SideNavigationItemProps {
   /** Custom class */
   className?: string;
   /** Use the polymorphic RouterLink component to get intended CSS styling */
@@ -17,26 +17,13 @@ interface BasicSideNavigationItemProps {
   subLevel: 1 | 2 | 3;
   /** If this item's child is selected, this prop must be applied to get correct CSS styles */
   childSelected?: boolean;
+  /** Show item as the selected one */
+  selected?: boolean;
   /** Disable the item */
   disabled?: boolean;
   /** Force the item to show its children */
   expanded?: boolean;
 }
-
-type SelectedProps =
-  | {
-      /** Show item as the selected one */
-      selected: boolean;
-      /** Selected item information for screen reader. Required when `selected` is true */
-      ariaCurrent: 'step' | 'page' | 'location';
-    }
-  | {
-      selected?: never;
-      ariaCurrent?: never;
-    };
-
-export type SideNavigationItemProps = BasicSideNavigationItemProps &
-  SelectedProps;
 
 const baseClassName = 'fi-side-navigation-item';
 const selectedClassName = `${baseClassName}--selected`;
@@ -48,7 +35,6 @@ const contentWrapperClassName = `${baseClassName}_content-wrapper`;
 const BaseSideNavigationItem = ({
   subLevel,
   selected,
-  ariaCurrent,
   className,
   children,
   content,
@@ -88,7 +74,6 @@ const BaseSideNavigationItem = ({
           [disabledClassName]: disabled,
         },
       )}
-      aria-current={!!ariaCurrent ? ariaCurrent : undefined}
       aria-disabled={disabled}
       {...passProps}
     >

--- a/src/core/Navigation/SideNavigation/index.ts
+++ b/src/core/Navigation/SideNavigation/index.ts
@@ -1,0 +1,8 @@
+export {
+  SideNavigation,
+  SideNavigationProps,
+} from './SideNavigation/SideNavigation';
+export {
+  SideNavigationItem,
+  SideNavigationItemProps,
+} from './SideNavigationItem/SideNavigationItem';

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
@@ -1,0 +1,58 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  &.fi-wizard-navigation {
+    .fi-wizard-navigation_heading {
+      margin-left: ${theme.spacing.m};
+      ${font(theme)('heading4')}
+    }
+    .fi-wizard-navigation_divider {
+      height: 1px;
+      background: ${theme.colors.depthLight1};
+      margin-top: ${theme.spacing.m};
+      margin-left: ${theme.spacing.m};
+      margin-right: ${theme.spacing.m};
+    }
+    .fi-wizard-navigation_list {
+      list-style-type: none;
+      margin: 0;
+      padding: 0;
+      margin-top: ${theme.spacing.s};
+      position: relative;
+    }
+
+    &--small-screen {
+      background: ${theme.colors.highlightLight3};
+      .fi-wizard-navigation_heading {
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: ${theme.spacing.s};
+        margin-left: 0;
+        position: relative;
+        ${font(theme)('heading4')}
+        &:focus {
+          outline: 0;
+          &:before {
+            ${theme.focus.absoluteFocus}
+          }
+        }
+
+        .fi-icon {
+          color: ${theme.colors.highlightBase};
+          width: 24px;
+          height: 24px;
+        }
+      }
+
+      .fi-wizard-navigation_divider {
+        margin-top: ${theme.spacing.xxs};
+        margin-left: ${theme.spacing.s};
+        margin-right: ${theme.spacing.s};
+      }
+    }
+  }
+`;

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
@@ -1,0 +1,138 @@
+### Basic usage
+
+A `<WizardNavigationItem>` can have one of these 6 statuses:
+
+- default: reachable & incomplete step
+- current: currently active step
+- completed: a step where the user has filled all necessary information
+- current-completed: a combination of current and completed statuses
+- coming: a step which is unreachable at the moment (but will become available when e.g. the previous steps have been completed)
+- disabled: disabled step, not reachable. We do not recommend the use of this status unless absolutely necessary
+
+Please use `<RouterLink>` as the child of `<WizardNavigationItem>` to get inteded CSS styles. `<RouterLink>` is polymorphic, and can be rendered as any component of your choice, for example React Router Link.
+
+```js
+import {
+  WizardNavigation,
+  WizardNavigationItem,
+  RouterLink
+} from 'suomifi-ui-components';
+
+const Comp = (props) => {
+  const { children, ...passProps } = props;
+  return <div {...passProps}>{props.children}</div>;
+};
+
+<div style={{ width: '350px' }}>
+  <WizardNavigation heading="Steps" aria-label="Main">
+    <WizardNavigationItem status="completed">
+      <RouterLink
+        href="https://suomi.fi"
+        aria-label="Step 1. This step is completed"
+      >
+        Step 1
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="default">
+      <RouterLink href="#">Step 2</RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="current">
+      <RouterLink aria-current="step" href="#">
+        Step 3
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled role="link">
+        Step 4 with a long text that wraps to the second line like
+        this
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled role="link">
+        Step 5
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="disabled">
+      <RouterLink aria-disabled role="link">
+        Step 6
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink asComponent={Comp} role="button" aria-disabled>
+        Step 7
+      </RouterLink>
+    </WizardNavigationItem>
+  </WizardNavigation>
+</div>;
+```
+
+For frameworks where its internal link component is used as a wrapper for the actual link, for example NextJS, the following approach can be used:
+
+```jsx static
+<WizardNavigationItem status="default">
+  <NextJSLink href="/some-route" passHref>
+    <RouterLink>Step 1</RouterLink>
+  </NextJSLink>
+</WizardNavigationItem>
+```
+
+### Small screen version
+
+```js
+import {
+  WizardNavigation,
+  WizardNavigationItem,
+  RouterLink
+} from 'suomifi-ui-components';
+
+const Comp = (props) => {
+  const { children, ...passProps } = props;
+  return <div {...passProps}>{props.children}</div>;
+};
+
+<div style={{ width: '300px' }}>
+  <WizardNavigation
+    variant="smallScreen"
+    heading="Steps"
+    initiallyExpanded={false}
+    aria-label="Main"
+  >
+    <WizardNavigationItem status="default">
+      <RouterLink href="https://suomi.fi">Step 1</RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="completed">
+      <RouterLink
+        href="#"
+        aria-label="Step 2. This step is completed"
+      >
+        Step 2
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="current">
+      <RouterLink aria-current="step" href="#">
+        Step 3
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled role="link">
+        Step 4
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled role="link">
+        Step 5
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="disabled">
+      <RouterLink aria-disabled role="link">
+        Step 6
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink asComponent={Comp} role="button" aria-disabled>
+        Step 7
+      </RouterLink>
+    </WizardNavigationItem>
+  </WizardNavigation>
+</div>;
+```

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axeTest } from '../../../../utils/test';
+
+import { WizardNavigation } from './WizardNavigation';
+import { WizardNavigationItem } from '../WizardNavigationItem/WizardNavigationItem';
+import { RouterLink } from '../../../Link';
+
+const TestWizardNavigation = (
+  <WizardNavigation heading="Steps" aria-label="Test">
+    <WizardNavigationItem status="default">
+      <RouterLink href="https://suomi.fi">1. Step</RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="completed">
+      <RouterLink href="#" aria-label="Step 2. This step is completed">
+        2. Step
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="current">
+      <RouterLink aria-current="step" href="#">
+        3. Step
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        4. Step
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        5. Step
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="disabled">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        6. Step
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink asComponent="button" aria-disabled tabIndex={-1}>
+        7. Step
+      </RouterLink>
+    </WizardNavigationItem>
+  </WizardNavigation>
+);
+
+test('calling render with the same component on the same container does not remount', () => {
+  const WizardNavRendered = render(TestWizardNavigation);
+  const { container } = WizardNavRendered;
+  expect(container.firstChild).toMatchSnapshot();
+});
+
+test(
+  'should not have basic accessibility issues',
+  axeTest(TestWizardNavigation),
+);

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -1,0 +1,116 @@
+import React, { forwardRef, ReactNode, useState } from 'react';
+import { HtmlButton, HtmlDiv, HtmlNav, HtmlUl } from '../../../../reset';
+import styled from 'styled-components';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import { baseStyles } from './WizardNavigation.baseStyles';
+import classnames from 'classnames';
+import { Icon } from '../../../Icon/Icon';
+import { getConditionalAriaProp } from '../../../../utils/aria';
+
+export interface WizardNavigationProps {
+  /** Use the `<WizardNavigationItem>` components as children */
+  children: ReactNode;
+  /** Name for the navigation element. Don't use the word "navigation" since it will be read by screen reader regardless. */
+  'aria-label': string;
+  /** ID for the HTML nav element */
+  id?: string;
+  /**
+   * Normal or small screen variant
+   * @default normal
+   */
+  variant?: 'default' | 'smallScreen';
+  /**
+   * Initial expand status for the menu. Only applies to smallScreen variant
+   * @default true
+   */
+  initiallyExpanded?: boolean;
+  /** Navigation component heading text */
+  heading: string;
+  /** Custom classname to extend or customize */
+  className?: string;
+  /** Ref is forwarded to nav element. Alternative for React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLElement>;
+}
+
+const baseClassName = 'fi-wizard-navigation';
+const smallScreenClassName = `${baseClassName}--small-screen`;
+const dividerClassName = `${baseClassName}_divider`;
+const listClassName = `${baseClassName}_list`;
+const headingClassName = `${baseClassName}_heading`;
+
+const BaseWizardNavigation = ({
+  children,
+  'aria-label': ariaLabel,
+  id,
+  variant,
+  initiallyExpanded,
+  heading,
+  className,
+  forwardedRef,
+}: WizardNavigationProps) => {
+  const initiallyExpandedValue =
+    initiallyExpanded !== undefined ? initiallyExpanded : true;
+  const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
+    initiallyExpandedValue,
+  );
+
+  return (
+    <HtmlDiv
+      className={classnames(baseClassName, className, {
+        [smallScreenClassName]: variant === 'smallScreen',
+      })}
+    >
+      {variant === 'smallScreen' ? (
+        <HtmlButton
+          className={headingClassName}
+          onClick={() => setSmallScreenNavOpen(!smallScreenNavOpen)}
+          aria-expanded={smallScreenNavOpen}
+        >
+          {heading}
+          <Icon icon={smallScreenNavOpen ? 'chevronDown' : 'chevronRight'} />
+        </HtmlButton>
+      ) : (
+        <HtmlDiv className={headingClassName}>{heading}</HtmlDiv>
+      )}
+      {((variant === 'smallScreen' && smallScreenNavOpen) ||
+        variant !== 'smallScreen') && (
+        <HtmlNav
+          forwardedRef={forwardedRef}
+          id={id}
+          {...getConditionalAriaProp('aria-label', [ariaLabel])}
+        >
+          <HtmlDiv className={dividerClassName} />
+          <HtmlUl className={listClassName} role="list">
+            {children}
+          </HtmlUl>
+        </HtmlNav>
+      )}
+    </HtmlDiv>
+  );
+};
+
+const StyledWizardNavigation = styled(
+  (props: WizardNavigationProps & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseWizardNavigation {...passProps} />;
+  },
+)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const WizardNavigation = forwardRef(
+  (props: WizardNavigationProps, ref: React.Ref<HTMLElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledWizardNavigation
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
+);
+
+WizardNavigation.displayName = 'WizardNavigation';
+export { WizardNavigation };

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -1,0 +1,970 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calling render with the same component on the same container does not remount 1`] = `
+.c7 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7::before,
+.c7::after {
+  box-sizing: border-box;
+}
+
+.c7:hover,
+.c7:active,
+.c7:focus,
+.c7:focus-within {
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c4 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c9 {
+  vertical-align: baseline;
+}
+
+.c9.fi-icon {
+  display: inline-block;
+}
+
+.c9 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c9 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c9.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c9.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_heading {
+  margin-left: 20px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_divider {
+  height: 1px;
+  background: hsl(202,7%,80%);
+  margin-top: 20px;
+  margin-left: 20px;
+  margin-right: 20px;
+}
+
+.c1.fi-wizard-navigation .fi-wizard-navigation_list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  margin-top: 15px;
+  position: relative;
+}
+
+.c1.fi-wizard-navigation--small-screen {
+  background: hsl(212,63%,95%);
+}
+
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_heading {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 15px;
+  margin-left: 0;
+  position: relative;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 600;
+}
+
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_heading:focus {
+  outline: 0;
+}
+
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_heading:focus:before {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_heading .fi-icon {
+  color: hsl(212,63%,45%);
+  width: 24px;
+  height: 24px;
+}
+
+.c1.fi-wizard-navigation--small-screen .fi-wizard-navigation_divider {
+  margin-top: 5px;
+  margin-left: 15px;
+  margin-right: 15px;
+}
+
+.c5.fi-wizard-navigation-item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  padding: 5px 20px;
+}
+
+.c5.fi-wizard-navigation-item:not(:last-child) {
+  margin-bottom: 10px;
+}
+
+.c5.fi-wizard-navigation-item:after {
+  content: '';
+  height: calc(100% - 26px);
+  width: 1px;
+  background: hsl(0,0%,58%);
+  position: absolute;
+  bottom: -10px;
+  left: 33px;
+}
+
+.c5.fi-wizard-navigation-item:last-child:after {
+  display: none;
+}
+
+.c5.fi-wizard-navigation-item:focus-within {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  margin-bottom: 1px;
+}
+
+.c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
+  outline: 0;
+  border: none;
+  box-shadow: none;
+}
+
+.c5.fi-wizard-navigation-item--default:hover {
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--default:hover:after {
+  left: 29px;
+}
+
+.c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  border: 1px solid hsl(0,0%,58%);
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+  background: hsl(0,0%,100%);
+}
+
+.c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(212,63%,45%);
+}
+
+.c5.fi-wizard-navigation-item--current {
+  background: hsl(212,63%,95%);
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--current:hover {
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--current:after {
+  left: 29px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  border: 1px solid hsl(0,0%,58%);
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+  background: hsl(0,0%,100%);
+}
+
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  margin-bottom: 1px;
+}
+
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-wizard-navigation-item--current-completed {
+  background: hsl(212,63%,95%);
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--current-completed:hover {
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--current-completed:after {
+  left: 29px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  border: 1px solid hsl(165,90%,27%);
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+  background: hsl(165,90%,27%);
+  color: hsl(0,0%,100%);
+}
+
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon .fi-icon {
+  width: 10px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(0,0%,16%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  margin-bottom: 1px;
+}
+
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: hsl(0,0%,16%);
+}
+
+.c5.fi-wizard-navigation-item--completed:hover {
+  border-left: 4px solid hsl(212,63%,45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--completed:hover:after {
+  left: 29px;
+}
+
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  border: 1px solid hsl(165,90%,27%);
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+  background: hsl(165,90%,27%);
+  color: hsl(0,0%,100%);
+}
+
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon .fi-icon {
+  width: 10px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(212,63%,45%);
+}
+
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  position: relative;
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+}
+
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon:after {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  content: '';
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  border: 1px solid hsl(201,7%,58%);
+  width: 5px;
+  height: 5px;
+  background: hsl(201,7%,58%);
+}
+
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(201,7%,58%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(201,7%,58%);
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  position: relative;
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  font-size: 18px;
+  margin-right: 10px;
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon:after {
+  position: absolute;
+  top: -5px;
+  right: 12px;
+  content: '';
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 1px;
+  height: 36px;
+  background: hsl(201,7%,58%);
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(201,7%,58%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5.fi-wizard-navigation-item--disabled .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(201,7%,58%);
+}
+
+.c8 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c8.fi-link--router {
+  color: hsl(212,63%,45%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c8.fi-link--router:hover,
+.c8.fi-link--router:active,
+.c8.fi-link--router:focus,
+.c8.fi-link--router:focus-within {
+  color: hsl(212,63%,45%);
+}
+
+.c8.fi-link--router:focus,
+.c8.fi-link--router:focus-within {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c8.fi-link--router:focus {
+  outline: 0;
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+}
+
+.c8.fi-link--router:hover,
+.c8.fi-link--router:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c8.fi-link--router:visited {
+  color: hsl(284,36%,45%);
+}
+
+<div
+  class="c0 fi-wizard-navigation c1"
+>
+  <div
+    class="c0 fi-wizard-navigation_heading"
+  >
+    Steps
+  </div>
+  <nav
+    aria-label="Test"
+    class="c2"
+  >
+    <div
+      class="c0 fi-wizard-navigation_divider"
+    />
+    <ul
+      class="c3 fi-wizard-navigation_list"
+      role="list"
+    >
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--default"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
+          <a
+            class="c7 fi-link--router c8"
+            href="https://suomi.fi"
+          >
+            1. Step
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--completed"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="fi-icon c9"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 20 20"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="fi-icon-base-fill"
+                d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
+                fill="#222"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <a
+            aria-label="Step 2. This step is completed"
+            class="c7 fi-link--router c8"
+            href="#"
+          >
+            2. Step
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--current"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
+          <a
+            aria-current="step"
+            class="c7 fi-link--router c8"
+            href="#"
+          >
+            3. Step
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--coming"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
+          <a
+            aria-disabled="true"
+            class="c7 fi-link--router c8"
+            href="#"
+            tabindex="-1"
+          >
+            4. Step
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--coming"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
+          <a
+            aria-disabled="true"
+            class="c7 fi-link--router c8"
+            href="#"
+            tabindex="-1"
+          >
+            5. Step
+          </a>
+        </div>
+      </li>
+      <li
+        aria-disabled="true"
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--disabled"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
+          <a
+            aria-disabled="true"
+            class="c7 fi-link--router c8"
+            href="#"
+            tabindex="-1"
+          >
+            6. Step
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--coming"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
+          <button
+            aria-disabled="true"
+            class="fi-link--router c8"
+            tabindex="-1"
+          >
+            7. Step
+          </button>
+        </div>
+      </li>
+    </ul>
+  </nav>
+</div>
+`;

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -799,6 +799,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c8.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c8.fi-link--initial-underline:focus,
+.c8.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c8.fi-link--initial-underline:hover,
+.c8.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <div
   class="c0 fi-wizard-navigation c1"
 >

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -1,0 +1,301 @@
+import { font } from '../../../theme/reset';
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  /* stylelint-disable no-descending-specificity */
+  /* Nested :hover etc selectors do not work well with this rule. */
+  &.fi-wizard-navigation-item {
+    display: flex;
+    align-items: center;
+    position: relative;
+    padding: ${theme.spacing.xxs} ${theme.spacing.m};
+
+    &:not(:last-child) {
+      margin-bottom: 10px;
+    }
+    &:after {
+      content: '';
+      height: calc(100% - 26px);
+      width: 1px;
+      background: ${theme.colors.blackLight1};
+      position: absolute;
+      bottom: -10px;
+      left: 33px;
+    }
+    &:last-child {
+      &:after {
+        display: none;
+      }
+    }
+
+    &:focus-within {
+      ${theme.focus.boxShadowFocus}
+    }
+
+    .fi-wizard-navigation-item_inner-wrapper {
+      display: flex;
+      align-items: flex-start;
+
+      .fi-wizard-navigation-item_left-icon {
+        flex-shrink: 0;
+      }
+
+      .fi-link--router {
+        background: transparent;
+        border: none;
+        padding: 0;
+        margin: 0;
+        margin-bottom: 1px; /* Compensate font size difference */
+        &:focus {
+          outline: 0;
+          border: none;
+          box-shadow: none;
+        }
+      }
+    }
+
+    &--default {
+      &:hover {
+        border-left: 4px solid ${theme.colors.highlightBase};
+        padding-left: calc(${theme.spacing.m} - 4px);
+
+        &:after {
+          left: 29px;
+        }
+      }
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_left-icon {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: 50%;
+          border: 1px solid ${theme.colors.blackLight1};
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          background: ${theme.colors.whiteBase};
+        }
+        .fi-link--router {
+          ${font(theme)('actionElementInnerText')}
+          cursor: pointer;
+          &:hover {
+            text-decoration: underline;
+          }
+          &:visited {
+            color: ${theme.colors.highlightBase};
+          }
+        }
+      }
+    }
+
+    &--current {
+      &:hover {
+        border-left: 4px solid ${theme.colors.highlightBase};
+        padding-left: calc(${theme.spacing.m} - 4px);
+      }
+      background: ${theme.colors.highlightLight3};
+      border-left: 4px solid ${theme.colors.highlightBase};
+      padding-left: calc(${theme.spacing.m} - 4px);
+
+      &:after {
+        left: 29px;
+        height: 10px;
+      }
+
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_left-icon {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: 50%;
+          border: 1px solid ${theme.colors.blackLight1};
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          background: ${theme.colors.whiteBase};
+        }
+        .fi-link--router {
+          pointer-events: none;
+          color: ${theme.colors.blackBase};
+          ${font(theme)('actionElementInnerTextBold')}
+          &:hover,
+          &:focus {
+            text-decoration: none;
+            color: ${theme.colors.blackBase};
+          }
+          margin-bottom: 1px; /* Compensate font size difference */
+        }
+      }
+    }
+
+    &--current-completed {
+      &:hover {
+        border-left: 4px solid ${theme.colors.highlightBase};
+        padding-left: calc(${theme.spacing.m} - 4px);
+      }
+
+      background: ${theme.colors.highlightLight3};
+      border-left: 4px solid ${theme.colors.highlightBase};
+      padding-left: calc(${theme.spacing.m} - 4px);
+
+      &:after {
+        left: 29px;
+        height: 10px;
+      }
+
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_left-icon {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: 50%;
+          border: 1px solid ${theme.colors.successDark1};
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          background: ${theme.colors.successDark1};
+          color: ${theme.colors.whiteBase};
+
+          .fi-icon {
+            width: 10px;
+            height: 10px;
+          }
+        }
+        .fi-link--router {
+          pointer-events: none;
+          color: ${theme.colors.blackBase};
+          ${font(theme)('actionElementInnerTextBold')}
+          &:hover,
+          &:focus {
+            text-decoration: none;
+            color: ${theme.colors.blackBase};
+          }
+          margin-bottom: 1px; /* Compensate font size difference */
+        }
+      }
+    }
+
+    &--completed {
+      &:hover {
+        border-left: 4px solid ${theme.colors.highlightBase};
+        padding-left: calc(${theme.spacing.m} - 4px);
+
+        &:after {
+          left: 29px;
+        }
+      }
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_left-icon {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: 50%;
+          border: 1px solid ${theme.colors.successDark1};
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          background: ${theme.colors.successDark1};
+          color: ${theme.colors.whiteBase};
+
+          .fi-icon {
+            width: 10px;
+            height: 10px;
+          }
+        }
+        .fi-link--router {
+          ${font(theme)('actionElementInnerText')}
+          cursor: pointer;
+          &:hover {
+            text-decoration: underline;
+          }
+          &:visited {
+            color: ${theme.colors.highlightBase};
+          }
+        }
+      }
+    }
+
+    &--coming {
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_left-icon {
+          position: relative;
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          &:after {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            content: '';
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            border-radius: 50%;
+            border: 1px solid ${theme.colors.depthDark3};
+            width: 5px;
+            height: 5px;
+            background: ${theme.colors.depthDark3};
+          }
+        }
+        .fi-link--router {
+          pointer-events: none;
+          color: ${theme.colors.depthDark3};
+          ${font(theme)('actionElementInnerText')}
+          &:hover {
+            text-decoration: none;
+          }
+          &:visited {
+            color: ${theme.colors.depthDark3};
+          }
+        }
+      }
+    }
+
+    &--disabled {
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-wizard-navigation-item_left-icon {
+          position: relative;
+          width: 26px;
+          height: 26px;
+          line-height: 26px;
+          font-size: 18px;
+          margin-right: ${theme.spacing.xs};
+          &:after {
+            position: absolute;
+            top: -5px;
+            right: 12px;
+            content: '';
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            width: 1px;
+            height: 36px;
+            background: ${theme.colors.depthDark3};
+          }
+        }
+        .fi-link--router {
+          pointer-events: none;
+          color: ${theme.colors.depthDark3};
+          ${font(theme)('actionElementInnerText')}
+          &:hover {
+            text-decoration: none;
+          }
+          &:visited {
+            color: ${theme.colors.depthDark3};
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
@@ -1,0 +1,82 @@
+import React, { ReactNode } from 'react';
+import classnames from 'classnames';
+import { HtmlDiv, HtmlLi, HtmlSpan } from '../../../../reset';
+import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import { baseStyles } from './WizardNavigationItem.baseStyles';
+import styled from 'styled-components';
+import { Icon } from '../../../Icon/Icon';
+
+export interface WizardNavigationItemProps {
+  /** Custom class */
+  className?: string;
+  /** Use the polymorphic RouterLink component as child to get intended CSS styling */
+  children: ReactNode;
+  /** Status of the item. Affects styling and element reachability */
+  status:
+    | 'default'
+    | 'current'
+    | 'current-completed'
+    | 'completed'
+    | 'coming'
+    | 'disabled';
+}
+
+const baseClassName = 'fi-wizard-navigation-item';
+const defaultClassName = `${baseClassName}--default`;
+const currentClassName = `${baseClassName}--current`;
+const currentCompletedClassName = `${baseClassName}--current-completed`;
+const completedClassName = `${baseClassName}--completed`;
+const comingClassName = `${baseClassName}--coming`;
+const disabledClassName = `${baseClassName}--disabled`;
+
+const innerWrapperClassName = `${baseClassName}_inner-wrapper`;
+const leftIconClassName = `${baseClassName}_left-icon`;
+
+const BaseWizardNavigationItem = ({
+  className,
+  children,
+  status,
+  ...passProps
+}: WizardNavigationItemProps) => (
+  <HtmlLi
+    className={classnames(className, baseClassName, {
+      [defaultClassName]: status === 'default',
+      [currentClassName]: status === 'current',
+      [currentCompletedClassName]: status === 'current-completed',
+      [completedClassName]: status === 'completed',
+      [comingClassName]: status === 'coming',
+      [disabledClassName]: status === 'disabled',
+    })}
+    aria-disabled={status === 'disabled' ? true : undefined}
+    {...passProps}
+  >
+    <HtmlDiv className={innerWrapperClassName}>
+      <HtmlSpan className={leftIconClassName}>
+        {(status === 'completed' || status === 'current-completed') && (
+          <Icon icon="check" />
+        )}
+      </HtmlSpan>
+      {children}
+    </HtmlDiv>
+  </HtmlLi>
+);
+
+const StyledWizardNavigationItem = styled(
+  (props: WizardNavigationItemProps & SuomifiThemeProp) => {
+    const { theme, ...passProps } = props;
+    return <BaseWizardNavigationItem {...passProps} />;
+  },
+)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const WizardNavigationItem = (props: WizardNavigationItemProps) => (
+  <SuomifiThemeConsumer>
+    {({ suomifiTheme }) => (
+      <StyledWizardNavigationItem theme={suomifiTheme} {...props} />
+    )}
+  </SuomifiThemeConsumer>
+);
+
+WizardNavigationItem.displayName = 'WizardNavigationItem';
+export { WizardNavigationItem };

--- a/src/core/Navigation/WizardNavigation/index.ts
+++ b/src/core/Navigation/WizardNavigation/index.ts
@@ -1,0 +1,8 @@
+export {
+  WizardNavigation,
+  WizardNavigationProps,
+} from './WizardNavigation/WizardNavigation';
+export {
+  WizardNavigationItem,
+  WizardNavigationItemProps,
+} from './WizardNavigationItem/WizardNavigationItem';

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SpacingWithoutInsetProp } from '../theme/utils/spacing';
@@ -13,6 +13,8 @@ export interface ParagraphProps extends HtmlPProps {
   color?: ColorProp;
   /** Spacing token for bottom margin */
   marginBottomSpacing?: SpacingWithoutInsetProp;
+  /** Ref object is passed to the paragraph element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLParagraphElement>;
 }
 
 const StyledParagraph = styled(
@@ -37,10 +39,14 @@ const StyledParagraph = styled(
 /**
  * Used for displaying a <p> element with correct styles
  */
-const Paragraph = (props: ParagraphProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledParagraph theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
+const Paragraph = forwardRef<HTMLParagraphElement, ParagraphProps>(
+  (props, ref) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledParagraph theme={suomifiTheme} forwardedRef={ref} {...props} />
+      )}
+    </SuomifiThemeConsumer>
+  ),
 );
 
 Paragraph.displayName = 'Paragraph';

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { ColorProp, SuomifiThemeConsumer, SuomifiThemeProp } from '../theme';
@@ -18,6 +18,8 @@ export interface TextProps extends HtmlSpanProps {
    * @default body
    */
   variant?: 'body' | 'lead' | 'bold';
+  /** Ref is passed to the span element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
 const StyledText = styled(
@@ -48,10 +50,17 @@ const StyledText = styled(
 /**
  * Used for displaying text with correct fonts
  */
-const Text = (props: TextProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledText theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
+const Text = forwardRef<HTMLSpanElement, TextProps>(
+  (props: TextProps, ref: React.Ref<HTMLSpanElement>) => {
+    const { ...passProps } = props;
+    return (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledText theme={suomifiTheme} forwardedRef={ref} {...passProps} />
+        )}
+      </SuomifiThemeConsumer>
+    );
+  },
 );
 
 Text.displayName = 'Text';

--- a/src/core/Toast/Toast.tsx
+++ b/src/core/Toast/Toast.tsx
@@ -25,10 +25,10 @@ export interface ToastProps {
   headingVariant?: Exclude<hLevels, 'h1'>;
   /** Unique id */
   id?: string;
+  /** Ref to be passed to the root div element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLDivElement>;
 }
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLDivElement>;
-}
+
 const baseClassName = 'fi-toast';
 export const toastClassNames = {
   styleWrapper: `${baseClassName}-wrapper`,
@@ -37,7 +37,7 @@ export const toastClassNames = {
   icon: `${baseClassName}_icon`,
   iconWrapper: `${baseClassName}_icon-wrapper`,
 };
-class BaseToast extends Component<ToastProps & InnerRef> {
+class BaseToast extends Component<ToastProps> {
   render() {
     const {
       ariaLiveMode = 'polite',
@@ -79,17 +79,15 @@ class BaseToast extends Component<ToastProps & InnerRef> {
     );
   }
 }
-const StyledToast = styled(
-  (props: ToastProps & InnerRef & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
-    return <BaseToast {...passProps} />;
-  },
-)`
+const StyledToast = styled((props: ToastProps & SuomifiThemeProp) => {
+  const { theme, ...passProps } = props;
+  return <BaseToast {...passProps} />;
+})`
   ${({ theme }) => baseStyles(theme)};
 `;
 
 const Toast = forwardRef(
-  (props: ToastProps, ref: React.RefObject<HTMLDivElement>) => {
+  (props: ToastProps, ref: React.Ref<HTMLDivElement>) => {
     const { ...passProps } = props;
     return (
       <SuomifiThemeConsumer>

--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -1,10 +1,4 @@
-import React, {
-  Component,
-  ReactNode,
-  forwardRef,
-  RefObject,
-  createRef,
-} from 'react';
+import React, { Component, ReactNode, forwardRef, createRef } from 'react';
 import classnames from 'classnames';
 import { TooltipContent } from './TooltipContent/TooltipContent';
 import { TooltipToggleButton } from './TooltipToggleButton/TooltipToggleButton';
@@ -36,10 +30,8 @@ export interface TooltipProps {
   onToggleButtonClick?: (event: React.MouseEvent) => void;
   /** Event handler for close button click */
   onCloseButtonClick?: (event: React.MouseEvent) => void;
-}
-
-interface InnerRef {
-  forwardedRef: React.RefObject<HTMLButtonElement>;
+  /** Ref object to be passed to the button element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
 
 type TooltipState = {
@@ -49,9 +41,7 @@ type TooltipState = {
   anchorRefObserver: ResizeObserver | null;
 };
 
-class BaseTooltip extends Component<
-  TooltipProps & InnerRef & { className?: string }
-> {
+class BaseTooltip extends Component<TooltipProps & { className?: string }> {
   state: TooltipState = {
     open: false,
     contentArrowOffsetPx: 0,
@@ -59,11 +49,11 @@ class BaseTooltip extends Component<
     anchorRefObserver: null,
   };
 
-  private toggleButtonRef: RefObject<HTMLButtonElement>;
+  private toggleButtonRef: React.RefObject<HTMLButtonElement>;
 
-  private contentRef: RefObject<HTMLDivElement>;
+  private contentRef: React.RefObject<HTMLDivElement>;
 
-  constructor(props: TooltipProps & InnerRef) {
+  constructor(props: TooltipProps) {
     super(props);
     this.toggleButtonRef = createRef();
     this.contentRef = createRef();
@@ -157,12 +147,14 @@ class BaseTooltip extends Component<
     } = this.props;
 
     const open = 'open' in this.props ? propsOpen : this.state.open;
+    // Remove the possibility to have undefined forwardedRef as a parameter for forkRefs
+    const definedRef = forwardedRef || null;
 
     return (
       <>
         <TooltipToggleButton
           className={classnames(baseClassName, toggleButtonClassName)}
-          ref={forkRefs(this.toggleButtonRef, forwardedRef)}
+          ref={forkRefs(this.toggleButtonRef, definedRef)}
           aria-label={ariaToggleButtonLabelText}
           aria-expanded={open}
           onClick={this.handleToggleClick}

--- a/src/core/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/core/VisuallyHidden/VisuallyHidden.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlSpan, HtmlSpanProps } from '../../reset/HtmlSpan/HtmlSpan';
 
 export interface VisuallyHiddenProps extends HtmlSpanProps {
   className?: string;
+  /** Ref is passed to the span element. Alternative to React `ref` attribute. */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
 const baseClassName = 'fi-visually-hidden';
@@ -22,15 +24,18 @@ const StyledVisuallyHidden = styled((props: VisuallyHiddenProps) => (
   overflow: hidden;
 `;
 
-const VisuallyHidden = (props: VisuallyHiddenProps) => {
-  const { className, ...passProps } = props;
-  return (
-    <StyledVisuallyHidden
-      {...passProps}
-      className={classnames(baseClassName, className)}
-    />
-  );
-};
+const VisuallyHidden = forwardRef(
+  (props: VisuallyHiddenProps, ref: React.Ref<HTMLSpanElement>) => {
+    const { className, ...passProps } = props;
+    return (
+      <StyledVisuallyHidden
+        forwardedRef={ref}
+        {...passProps}
+        className={classnames(baseClassName, className)}
+      />
+    );
+  },
+);
 
 VisuallyHidden.displayName = 'VisuallyHidden';
 export { VisuallyHidden };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -108,6 +108,12 @@ export {
   ServiceNavigationItemProps,
 } from './core/Navigation/ServiceNavigation';
 export {
+  SideNavigation,
+  SideNavigationProps,
+  SideNavigationItem,
+  SideNavigationItemProps,
+} from './core/Navigation/SideNavigation';
+export {
   Expander,
   ExpanderProps,
   ExpanderGroup,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,6 +96,12 @@ export {
   ModalFooterProps,
 } from './core/Modal/';
 export {
+  WizardNavigation,
+  WizardNavigationProps,
+  WizardNavigationItem,
+  WizardNavigationItemProps,
+} from './core/Navigation/WizardNavigation';
+export {
   Expander,
   ExpanderProps,
   ExpanderGroup,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -102,6 +102,12 @@ export {
   WizardNavigationItemProps,
 } from './core/Navigation/WizardNavigation';
 export {
+  ServiceNavigation,
+  ServiceNavigationProps,
+  ServiceNavigationItem,
+  ServiceNavigationItemProps,
+} from './core/Navigation/ServiceNavigation';
+export {
   Expander,
   ExpanderProps,
   ExpanderGroup,

--- a/src/reset/HtmlA/HtmlA.tsx
+++ b/src/reset/HtmlA/HtmlA.tsx
@@ -10,6 +10,11 @@ export interface HtmlAProps
   as?: asPropType;
 }
 
+export interface HtmlAWithRefProps extends HtmlAProps {
+  /** Ref for the heading element */
+  forwardedRef?: React.Ref<HTMLAnchorElement>;
+}
+
 const aResets = css`
   ${resets.normalize.html}
   ${resets.normalize.a}
@@ -19,8 +24,10 @@ const aResets = css`
   text-decoration: underline;
 `;
 
-const Ahref = styled.a`
+const Ahref = styled.a<HtmlAWithRefProps>`
   ${aResets}
 `;
 
-export const HtmlA = (props: HtmlAProps) => <Ahref {...props} />;
+export const HtmlA = ({ forwardedRef, ...passProps }: HtmlAWithRefProps) => (
+  <Ahref ref={forwardedRef} {...passProps} />
+);

--- a/src/reset/HtmlDiv/HtmlDiv.tsx
+++ b/src/reset/HtmlDiv/HtmlDiv.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { HTMLProps, forwardRef } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
 import { asPropType } from '../../utils/typescript';
@@ -25,7 +25,7 @@ export const HtmlDiv = styled(Div)`
 `;
 
 export interface HtmlDivWithRefProps extends HtmlDivProps {
-  /** Ref object for the input element */
+  /** Ref object for the div element */
   forwardedRef?: React.Ref<HTMLDivElement>;
 }
 
@@ -36,3 +36,10 @@ const DivWithRef = ({ forwardedRef, ...passProps }: HtmlDivWithRefProps) => (
 export const HtmlDivWithRef = styled(DivWithRef)`
   ${divResets}
 `;
+
+/** Passing the ref with name 'ref' needs the forwardRef function */
+export const HtmlDivWithNativeRef = forwardRef(
+  (props: HtmlDivProps, ref: React.Ref<HTMLElement>) => (
+    <HtmlDivWithRef forwardedRef={ref} {...props} />
+  ),
+);

--- a/src/reset/HtmlNav/HtmlNav.tsx
+++ b/src/reset/HtmlNav/HtmlNav.tsx
@@ -6,6 +6,7 @@ import { asPropType } from '../../utils/typescript';
 export interface HtmlNavProps
   extends Omit<HTMLProps<HTMLElement>, 'ref' | 'as'> {
   as?: asPropType;
+  forwardedRef?: React.Ref<HTMLElement>;
 }
 
 const aResets = css`
@@ -15,7 +16,9 @@ const aResets = css`
   max-width: 100%;
 `;
 
-const Nav = (props: HtmlNavProps) => <nav {...props} />;
+const Nav = ({ forwardedRef, ...passProps }: HtmlNavProps) => (
+  <nav ref={forwardedRef} {...passProps} />
+);
 
 export const HtmlNav = styled(Nav)`
   ${aResets}

--- a/src/reset/HtmlP/HtmlP.tsx
+++ b/src/reset/HtmlP/HtmlP.tsx
@@ -8,6 +8,11 @@ export interface HtmlPProps
   as?: asPropType;
 }
 
+interface InnerRef {
+  /** Forwarded ref object for the paragraph element */
+  forwardedRef: React.Ref<HTMLParagraphElement>;
+}
+
 const spanResets = css`
   ${resets.normalize.html}
   ${resets.common}
@@ -18,7 +23,9 @@ const spanResets = css`
   white-space: normal;
 `;
 
-const Span = (props: HtmlPProps) => <p {...props} />;
+const Span = ({ forwardedRef, ...passProps }: HtmlPProps & InnerRef) => (
+  <p ref={forwardedRef} {...passProps} />
+);
 
 export const HtmlP = styled(Span)`
   ${spanResets}

--- a/src/reset/HtmlSpan/HtmlSpan.tsx
+++ b/src/reset/HtmlSpan/HtmlSpan.tsx
@@ -7,6 +7,10 @@ export interface HtmlSpanProps
   extends Omit<HTMLProps<HTMLSpanElement>, 'ref' | 'as'> {
   as?: asPropType;
 }
+interface HtmlSpanWithRefProps extends HtmlSpanProps {
+  /** Ref object for the span element */
+  forwardedRef?: React.Ref<HTMLSpanElement>;
+}
 
 const spanResets = css`
   ${resets.normalize.html}
@@ -18,7 +22,9 @@ const spanResets = css`
   white-space: normal;
 `;
 
-const Span = (props: HtmlSpanProps) => <span {...props} />;
+const Span = ({ forwardedRef, ...passProps }: HtmlSpanWithRefProps) => (
+  <span ref={forwardedRef} {...passProps} />
+);
 
 export const HtmlSpan = styled(Span)`
   ${spanResets}

--- a/src/reset/HtmlTextarea/HtmlTextarea.tsx
+++ b/src/reset/HtmlTextarea/HtmlTextarea.tsx
@@ -7,7 +7,7 @@ export interface HtmlTextareaProps
   extends Omit<HTMLProps<HTMLTextAreaElement>, 'ref' | 'as'> {
   as?: asPropType;
   /** Ref object passed to the element */
-  forwardedRef?: React.RefObject<HTMLTextAreaElement>;
+  forwardedRef?: React.Ref<HTMLTextAreaElement>;
 }
 
 const textareaResets = css`

--- a/src/reset/index.ts
+++ b/src/reset/index.ts
@@ -5,6 +5,7 @@ export {
   HtmlDivProps,
   HtmlDivWithRef,
   HtmlDivWithRefProps,
+  HtmlDivWithNativeRef,
 } from './HtmlDiv/HtmlDiv';
 export { HtmlFieldSet, HtmlFieldSetProps } from './HtmlFieldSet/HtmlFieldSet';
 export { HtmlH, HtmlHProps, HtmlHWithRefProps, hLevels } from './HtmlH/HtmlH';


### PR DESCRIPTION
## Description

This PR introduces the `<SideNavigation>` component. As children, it takes `<SideNavigationItem>` components.

Differing from the other two nav components, a `<SideNavigationItem>` can have other `<SideNavigationItem>`s as children. The tree can go up to 3 levels deep. Because of this structure, the API of this component also differs slightly compared to `<WizardNavigation>` and `<ServiceNavigation>`: There is a mandatory `subLevel` prop (1-3) and the actual link content of the item must be given into the `content` prop (ReactNode). In practice, the content prop is supposed to be a `<RouterLink>` which is polymorphic and can thus be rendered as any semantic HTML element as well as third party library elements such as React Router Link, Gatsby Link etc. 

Example: 
```
<SideNavigation heading="Economy" icon="piggyBank">
  <SideNavigationItem
    subLevel={1}
      content={
        <RouterLink href="/" aria-current="location">
          Personal economy
        </RouterLink>
      }
    >
      <SideNavigationItem
        subLevel={2}
        content={
          <RouterLink href="/" aria-current="location">
            Crisis situations in personal finances
          </RouterLink>
        }
      >
        <SideNavigationItem
          subLevel={3}
          content={
            <RouterLink href="/">
              If you are unable to pay your debts
            </RouterLink>
          }
        />
        <SideNavigationItem
          subLevel={3}
          selected
          content={
            <RouterLink href="/" aria-current="page">
              Advice on banking and insurance matters
            </RouterLink>
          }
        />
      </SideNavigationItem>
  </SideNavigationItem>
</SideNavigation>
```

## Motivation and Context

We want to have ready-made navigation components available in the library. Having the polymorphic `<RouterLink>` component available was the key to implementing this component in a way which allows a wide range of usecases. 

## How Has This Been Tested?

Styleguidist, CRA app

## Screenshots
<img width="379" alt="image" src="https://user-images.githubusercontent.com/17459942/201338963-2c17beb6-8d1e-4422-940c-f0c29209fe2e.png">

## Release notes

### SideNavigation
* Introduce `<SideNavigation>` component