### PR TITLE
[Feature] Ref to RouterLink

### DIFF
--- a/src/core/Link/Link/Link.md
+++ b/src/core/Link/Link/Link.md
@@ -71,16 +71,28 @@ This component is mainly intended to be used with external libraries/frameworks.
 
 ```js
 import { RouterLink } from 'suomifi-ui-components';
+import { forwardRef, useRef } from 'react';
 
-const Component = ({ children, ...passProps }) => (
-  <a {...passProps}>Some component - {children}</a>
-);
+const Component = forwardRef((props, ref) => {
+  const { children, ...passProps } = props;
+  return (
+    <a {...passProps} ref={ref}>
+      Some component - {children}
+    </a>
+  );
+});
+
+const r = useRef();
 
 <>
+  <button onClick={() => console.log(r.current)}>
+    Log ref to console
+  </button>
   <RouterLink
-    asComponent={Component}
     href="https://suomi.fi"
     target="_blank"
+    asComponent={Component}
+    ref={r}
   >
     Testing
   </RouterLink>

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -129,7 +129,7 @@ const RouterLinkInner = <C extends React.ElementType = 'a'>(
   </SuomifiThemeConsumer>
 );
 
-// Type assertion is needed to set the function signature with generic T type.
+// Type assertion is needed to set the function signature with generic type C.
 export const RouterLink = forwardRef(RouterLinkInner) as <
   C extends React.ElementType = 'a',
 >(

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -120,9 +120,12 @@ const StyledRouterLink = styled(PolymorphicLink)`
 
 const RouterLinkInner = <C extends React.ElementType = 'a'>(
   props: RouterLinkProps<C>,
+  ref?: PolymorphicRef<C>,
 ) => (
   <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledRouterLink theme={suomifiTheme} {...props} />}
+    {({ suomifiTheme }) => (
+      <StyledRouterLink theme={suomifiTheme} forwardedRef={ref} {...props} />
+    )}
   </SuomifiThemeConsumer>
 );
 

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -103,10 +103,24 @@ const PolymorphicLink = <C extends React.ElementType>(
   } = props;
   const Component = asComponent || HtmlA;
 
+  // If asComponent is included, we assume it can take a normal ref-prop
+  if (!!asComponent) {
+    return (
+      <Component
+        className={classnames(routerLinkClassName, className)}
+        ref={forwardedRef}
+        {...passProps}
+      >
+        {children}
+      </Component>
+    );
+  }
+
+  // HtmlA (which is rendered by default) exposes a prop called forwardedRef instead
   return (
     <Component
       className={classnames(routerLinkClassName, className)}
-      ref={forwardedRef}
+      forwardedRef={forwardedRef}
       {...passProps}
     >
       {children}

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -1,5 +1,5 @@
 // import React, { Component, ReactNode } from 'react';
-import React, { ReactNode } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import { RouterLinkStyles } from './RouterLink.baseStyles';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
@@ -75,12 +75,20 @@ export type RouterLinkProps<C extends React.ElementType> =
 const PolymorphicLink = <C extends React.ElementType>(
   props: RouterLinkProps<C> & SuomifiThemeProp,
 ) => {
-  const { asComponent, children, className, theme, ...passProps } = props;
-  const Component = asComponent || HtmlA;
+  const {
+    asComponent,
+    children,
+    className,
+    theme,
+    forwardedRef,
+    ...passProps
+  } = props;
+  const Component = asComponent || 'a';
 
   return (
     <Component
       className={classnames(routerLinkClassName, className)}
+      ref={forwardedRef}
       {...passProps}
     >
       {children}
@@ -92,13 +100,25 @@ const StyledRouterLink = styled(PolymorphicLink)`
   ${({ theme }) => RouterLinkStyles(theme)}
 `;
 
-const RouterLink = <C extends React.ElementType = 'a'>(
+const RouterLinkInner = <C extends React.ElementType = 'a'>(
   props: RouterLinkProps<C>,
+  ref: React.RefObject<any>,
 ) => (
   <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledRouterLink theme={suomifiTheme} {...props} />}
+    {({ suomifiTheme }) => (
+      <StyledRouterLink theme={suomifiTheme} forwardedRef={ref} {...props} />
+    )}
   </SuomifiThemeConsumer>
 );
 
-RouterLink.displayName = 'RouterLink';
-export { RouterLink };
+// Type assertion is needed to set the function signature with generic T type.
+export const RouterLink = forwardRef(RouterLinkInner) as <
+  C extends React.ElementType = 'a',
+>(
+  props: RouterLinkProps<C> & {
+    ref?: React.ForwardedRef<any>;
+  },
+) => ReturnType<typeof RouterLinkInner>;
+
+// Because of type assertion the displayName has to be set like this
+(RouterLink as React.FC).displayName = 'RouterLink';

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -46,13 +46,31 @@ export type InheritableElementProps<
 > = ExtendableProps<PropsOf<C>, Props>;
 
 /**
+ * Allows the component's ref type to comply with "asComponent" prop
+ * E.g. asComponent = 'button', ref type must be React.Ref<HTMLButtonElement>
+ */
+type PolymorphicRef<C extends React.ElementType> =
+  React.ComponentPropsWithRef<C>['ref'];
+
+/**
+ * This type definition exists solely to provide the component with a `forwardedRef` prop which
+ * is visible in the Styleguidist API documentation ("ref" is not visible in Styleguidist)
+ */
+type ForwardedRef<C extends React.ElementType> = {
+  /** Alternative for React `ref` attribute. Ref type is derived from the `asComponent` prop value.
+   * Example: asComponent = 'button', ref type must be HTMLButtonElement
+   */
+  forwardedRef?: PolymorphicRef<C>;
+};
+
+/**
  * A more sophisticated version of `InheritableElementProps` where
  * the passed in `as` prop will determine which props can be included
  */
 export type PolymorphicComponentProps<
   C extends React.ElementType,
   Props = {},
-> = InheritableElementProps<C, Props & AsProp<C>>;
+> = InheritableElementProps<C, Props & AsProp<C> & ForwardedRef<C>>;
 
 //
 //
@@ -83,7 +101,7 @@ const PolymorphicLink = <C extends React.ElementType>(
     forwardedRef,
     ...passProps
   } = props;
-  const Component = asComponent || 'a';
+  const Component = asComponent || HtmlA;
 
   return (
     <Component
@@ -102,12 +120,9 @@ const StyledRouterLink = styled(PolymorphicLink)`
 
 const RouterLinkInner = <C extends React.ElementType = 'a'>(
   props: RouterLinkProps<C>,
-  ref: React.RefObject<any>,
 ) => (
   <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledRouterLink theme={suomifiTheme} forwardedRef={ref} {...props} />
-    )}
+    {({ suomifiTheme }) => <StyledRouterLink theme={suomifiTheme} {...props} />}
   </SuomifiThemeConsumer>
 );
 
@@ -116,7 +131,7 @@ export const RouterLink = forwardRef(RouterLinkInner) as <
   C extends React.ElementType = 'a',
 >(
   props: RouterLinkProps<C> & {
-    ref?: React.ForwardedRef<any>;
+    ref?: PolymorphicRef<C>;
   },
 ) => ReturnType<typeof RouterLinkInner>;
 

--- a/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
+++ b/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
@@ -2,6 +2,44 @@
 
 exports[`calling render with the same component on the same container does not remount 1`] = `
 .c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c0:hover,
+.c0:active,
+.c0:focus,
+.c0:focus-within {
+  color: inherit;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -17,43 +55,43 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
-.c0.fi-link--router {
+.c1.fi-link--router {
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c0.fi-link--router:hover,
-.c0.fi-link--router:active,
-.c0.fi-link--router:focus,
-.c0.fi-link--router:focus-within {
+.c1.fi-link--router:hover,
+.c1.fi-link--router:active,
+.c1.fi-link--router:focus,
+.c1.fi-link--router:focus-within {
   color: hsl(212,63%,45%);
 }
 
-.c0.fi-link--router:focus,
-.c0.fi-link--router:focus-within {
+.c1.fi-link--router:focus,
+.c1.fi-link--router:focus-within {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c0.fi-link--router:focus {
+.c1.fi-link--router:focus {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
 }
 
-.c0.fi-link--router:hover,
-.c0.fi-link--router:active {
+.c1.fi-link--router:hover,
+.c1.fi-link--router:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c0.fi-link--router:visited {
+.c1.fi-link--router:visited {
   color: hsl(284,36%,45%);
 }
 
 <a
-  class="fi-link--router c0"
+  class="c0 fi-link--router c1"
   data-testid="test-link"
   href="/"
 >

--- a/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
+++ b/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
@@ -2,44 +2,6 @@
 
 exports[`calling render with the same component on the same container does not remount 1`] = `
 .c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  background-color: transparent;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c0::before,
-.c0::after {
-  box-sizing: border-box;
-}
-
-.c0:hover,
-.c0:active,
-.c0:focus,
-.c0:focus-within {
-  color: inherit;
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
-.c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -55,43 +17,43 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
-.c1.fi-link--router {
+.c0.fi-link--router {
   color: hsl(212,63%,45%);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c1.fi-link--router:hover,
-.c1.fi-link--router:active,
-.c1.fi-link--router:focus,
-.c1.fi-link--router:focus-within {
+.c0.fi-link--router:hover,
+.c0.fi-link--router:active,
+.c0.fi-link--router:focus,
+.c0.fi-link--router:focus-within {
   color: hsl(212,63%,45%);
 }
 
-.c1.fi-link--router:focus,
-.c1.fi-link--router:focus-within {
+.c0.fi-link--router:focus,
+.c0.fi-link--router:focus-within {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c1.fi-link--router:focus {
+.c0.fi-link--router:focus {
   outline: 0;
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
 }
 
-.c1.fi-link--router:hover,
-.c1.fi-link--router:active {
+.c0.fi-link--router:hover,
+.c0.fi-link--router:active {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c1.fi-link--router:visited {
+.c0.fi-link--router:visited {
   color: hsl(284,36%,45%);
 }
 
 <a
-  class="c0 fi-link--router c1"
+  class="fi-link--router c0"
   data-testid="test-link"
   href="/"
 >


### PR DESCRIPTION
## Description
This PR introduces support for React ref to `<RouterLink>`. It complies with the polymorphic nature of the component, maintaining Typescript type integrity on the ref side as well. 

Example: `<RouterLink asComponent="button" />` only accepts a ref the type of which is `HTMLButtonElement`.

Like our other components, this one now also has a prop called `forwardedRef` in its API. It works exactly the same as `ref`.

## Motivation and Context
We want to have support for React ref in all our components. This one was still missing it. 

## How Has This Been Tested?
Typescript manual tests, Styleguidist

## Release notes
### RouterLink
* Add support for React ref