### PR TITLE
[Feature] Link underline option

### DIFF
--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -233,6 +233,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c7.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7.fi-link--initial-underline:focus,
+.c7.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7.fi-link--initial-underline:hover,
+.c7.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c8 {
   vertical-align: baseline;
 }

--- a/src/core/Link/BaseLink/BaseLink.baseStyles.ts
+++ b/src/core/Link/BaseLink/BaseLink.baseStyles.ts
@@ -27,5 +27,19 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &:visited {
       color: ${theme.colors.accentTertiaryDark1};
     }
+
+    &--initial-underline {
+      text-decoration: underline;
+
+      &:focus,
+      &:focus-within {
+        text-decoration: underline;
+      }
+
+      &:hover,
+      &:active {
+        text-decoration: none;
+      }
+    }
   }
 `;

--- a/src/core/Link/BaseLink/BaseLink.tsx
+++ b/src/core/Link/BaseLink/BaseLink.tsx
@@ -4,6 +4,11 @@ import { asPropType } from '../../../utils/typescript';
 
 export const baseClassName = 'fi-link';
 
+export const linkClassNames = {
+  linkUnderline: `${baseClassName}--initial-underline`,
+};
+
+export type UnderlineVariant = 'initial' | 'hover';
 export interface BaseLinkProps extends HtmlAProps {
   /** Link url. Link is not focusable without the href */
   href: string;
@@ -13,5 +18,16 @@ export interface BaseLinkProps extends HtmlAProps {
    * Link element displayed content
    */
   children: ReactNode;
+  /**
+   * 'initial' | 'hover'
+   *
+   * Option 'initial' shows underline in link's normal state, and no underline on hover.
+   * Option 'hover' shows underline on hover, and no underline in link's normal state.
+   *
+   * Note: default will be changed from 'hover' to 'initial', so set 'hover' explicitly when necessary.
+   *
+   * @default hover
+   */
+  underline?: UnderlineVariant;
   asProp?: asPropType;
 }

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -6,7 +6,11 @@ import { Icon } from '../../Icon/Icon';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import { ExternalLinkStyles } from './ExternalLink.baseStyles';
 import { HtmlA } from '../../../reset';
-import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
+import {
+  BaseLinkProps,
+  baseClassName,
+  linkClassNames,
+} from '../BaseLink/BaseLink';
 
 const iconClassName = 'fi-link_icon';
 const externalClassName = 'fi-link--external';
@@ -43,12 +47,15 @@ class BaseExternalLink extends Component<ExternalLinkProps> {
       toNewWindow = true,
       labelNewWindow,
       hideIcon,
+      underline = 'hover',
       ...passProps
     } = this.props;
     return (
       <HtmlA
         {...passProps}
-        className={classnames(baseClassName, className, externalClassName)}
+        className={classnames(baseClassName, className, externalClassName, {
+          [linkClassNames.linkUnderline]: underline === 'initial',
+        })}
         target={!!toNewWindow ? '_blank' : undefined}
         rel={!!toNewWindow ? 'noopener' : undefined}
         as={asProp}

--- a/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
+++ b/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
@@ -155,6 +155,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c1.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:focus,
+.c1.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:hover,
+.c1.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c1 .fi-link_icon {
   padding-left: 4px;
   font-size: 16px;

--- a/src/core/Link/Link/Link.md
+++ b/src/core/Link/Link/Link.md
@@ -5,11 +5,19 @@ import { Link, Paragraph } from 'suomifi-ui-components';
   <Link
     className="test-classname"
     href="https://www.notvisitedlink.com/"
+    underline="initial"
   >
     Not visited link
   </Link>{' '}
-  <Link className="test-classname" href="#">
+  <Link className="test-classname" href="#" underline="initial">
     Visited link
+  </Link>{' '}
+  <Link
+    className="test-classname"
+    href="https://www.notvisitedlink.com/"
+    underline="hover"
+  >
+    Link without underline
   </Link>
 </Paragraph>;
 ```

--- a/src/core/Link/Link/Link.test.tsx
+++ b/src/core/Link/Link/Link.test.tsx
@@ -10,11 +10,27 @@ const TestLink = (
   </Link>
 );
 
+const LinkVariant = (
+  <Link href="/" underline="initial">
+    Link variant
+  </Link>
+);
+
 test('calling render with the same component on the same container does not remount', () => {
   const LinkRendered = render(TestLink);
   const { getByTestId, container } = LinkRendered;
   expect(container.firstChild).toMatchSnapshot();
   expect(getByTestId('test-link').textContent).toBe('Hey this is test');
+});
+
+test('should not have underline class by default', () => {
+  const { container } = render(TestLink);
+  expect(container.firstChild).not.toHaveClass('fi-link--initial-underline');
+});
+
+test('should have option with underline', () => {
+  const { container } = render(LinkVariant);
+  expect(container.firstChild).toHaveClass('fi-link--initial-underline');
 });
 
 test('should not have basic accessibility issues', axeTest(TestLink));

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -4,7 +4,11 @@ import classnames from 'classnames';
 import { LinkStyles } from '../Link/Link.baseStyles';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlA } from '../../../reset';
-import { BaseLinkProps, baseClassName } from '../BaseLink/BaseLink';
+import {
+  BaseLinkProps,
+  baseClassName,
+  linkClassNames,
+} from '../BaseLink/BaseLink';
 
 export interface LinkProps extends BaseLinkProps {
   /** Ref  is passed to the anchor element. Alternative to React `ref` attribute. */
@@ -16,11 +20,14 @@ const StyledLink = styled(
     asProp,
     className,
     theme,
+    underline = 'hover',
     ...passProps
   }: LinkProps & SuomifiThemeProp) => (
     <HtmlA
       {...passProps}
-      className={classnames(baseClassName, className)}
+      className={classnames(baseClassName, className, {
+        [linkClassNames.linkUnderline]: underline === 'initial',
+      })}
       as={asProp}
     />
   ),

--- a/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
@@ -90,6 +90,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c1.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:focus,
+.c1.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:hover,
+.c1.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <a
   class="c0 fi-link c1"
   data-testid="test-link"

--- a/src/core/Link/RouterLink/RouterLink.baseStyles.ts
+++ b/src/core/Link/RouterLink/RouterLink.baseStyles.ts
@@ -28,4 +28,18 @@ export const RouterLinkStyles = (theme: SuomifiTheme) => css`
       color: ${theme.colors.accentTertiaryDark1};
     }
   }
+
+  &.fi-link--initial-underline {
+    text-decoration: underline;
+
+    &:focus,
+    &:focus-within {
+      text-decoration: underline;
+    }
+
+    &:hover,
+    &:active {
+      text-decoration: none;
+    }
+  }
 `;

--- a/src/core/Link/RouterLink/RouterLink.test.tsx
+++ b/src/core/Link/RouterLink/RouterLink.test.tsx
@@ -14,6 +14,16 @@ const RouterLinkAsButton = (
   <RouterLink asComponent="button">Router link as a button</RouterLink>
 );
 
+const RouterLinkVariant = (
+  <RouterLink underline="initial">RouterLink variant</RouterLink>
+);
+
+const RouterLinkButtonVariant = (
+  <RouterLink asComponent="button" underline="initial">
+    Router link as button variant
+  </RouterLink>
+);
+
 test('calling render with the same component on the same container does not remount', () => {
   const { getByTestId, container } = render(TestRouterLink);
   expect(container.firstChild).toMatchSnapshot();
@@ -23,6 +33,26 @@ test('calling render with the same component on the same container does not remo
 it('should still have the correct styles applied when rendered as something other than <a> ', () => {
   const { container } = render(RouterLinkAsButton);
   expect(container.firstChild).toHaveClass('fi-link--router');
+});
+
+test('should not have underline by default', () => {
+  const { container } = render(TestRouterLink);
+  expect(container.firstChild).not.toHaveClass('fi-link--initial-underline');
+});
+
+test('should not have underline be default when rendered as something other than <a>', () => {
+  const { container } = render(RouterLinkAsButton);
+  expect(container.firstChild).not.toHaveClass('fi-link--initial-underline');
+});
+
+test('should have option for underline', () => {
+  const { container } = render(RouterLinkVariant);
+  expect(container.firstChild).toHaveClass('fi-link--initial-underline');
+});
+
+test('should have option for underline when rendered as something other than <a>', () => {
+  const { container } = render(RouterLinkButtonVariant);
+  expect(container.firstChild).toHaveClass('fi-link--initial-underline');
 });
 
 test('should not have basic accessibility issues', axeTest(TestRouterLink));

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -3,7 +3,11 @@ import React, { forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import { RouterLinkStyles } from './RouterLink.baseStyles';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
-import { baseClassName } from '../BaseLink/BaseLink';
+import {
+  baseClassName,
+  linkClassNames,
+  UnderlineVariant,
+} from '../BaseLink/BaseLink';
 import classnames from 'classnames';
 import { HtmlA } from '../../../reset';
 
@@ -85,6 +89,17 @@ interface Props {
    * Link element displayed content
    */
   children: ReactNode;
+  /**
+   * 'initial' | 'hover'
+   *
+   * Option 'initial' shows underline in link's normal state, and no underline on hover.
+   * Option 'hover' shows underline on hover, and no underline in link's normal state.
+   *
+   * Note: default will be changed from 'hover' to 'initial', so set 'hover' explicitly when necessary.
+   *
+   * @default hover
+   */
+  underline?: UnderlineVariant;
 }
 
 export type RouterLinkProps<C extends React.ElementType> =
@@ -98,19 +113,20 @@ const PolymorphicLink = <C extends React.ElementType>(
     children,
     className,
     theme,
+    underline = 'hover',
     forwardedRef,
     ...passProps
   } = props;
   const Component = asComponent || HtmlA;
 
+  const classNames = classnames(routerLinkClassName, className, {
+    [linkClassNames.linkUnderline]: underline === 'initial',
+  });
+
   // If asComponent is included, we assume it can take a normal ref-prop
   if (!!asComponent) {
     return (
-      <Component
-        className={classnames(routerLinkClassName, className)}
-        ref={forwardedRef}
-        {...passProps}
-      >
+      <Component className={classNames} ref={forwardedRef} {...passProps}>
         {children}
       </Component>
     );
@@ -119,7 +135,7 @@ const PolymorphicLink = <C extends React.ElementType>(
   // HtmlA (which is rendered by default) exposes a prop called forwardedRef instead
   return (
     <Component
-      className={classnames(routerLinkClassName, className)}
+      className={classNames}
       forwardedRef={forwardedRef}
       {...passProps}
     >

--- a/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
+++ b/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
@@ -90,6 +90,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c1.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:focus,
+.c1.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:hover,
+.c1.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <a
   class="c0 fi-link--router c1"
   data-testid="test-link"

--- a/src/core/Link/SkipLink/SkipLink.baseStyles.ts
+++ b/src/core/Link/SkipLink/SkipLink.baseStyles.ts
@@ -13,7 +13,6 @@ export const SkipLinkStyles = (theme: SuomifiTheme) => css`
     background: ${theme.colors.highlightLight3};
     border: 1px solid ${theme.colors.depthLight1};
     color: ${theme.colors.blackBase};
-    text-decoration: none;
   }
 
   &.fi-link--skip:focus {

--- a/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
+++ b/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
@@ -90,6 +90,23 @@ exports[`should match snapshot 1`] = `
   color: hsl(284,36%,45%);
 }
 
+.c1.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:focus,
+.c1.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1.fi-link--initial-underline:hover,
+.c1.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c2 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -141,6 +158,23 @@ exports[`should match snapshot 1`] = `
   color: hsl(284,36%,45%);
 }
 
+.c2.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2.fi-link--initial-underline:focus,
+.c2.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2.fi-link--initial-underline:hover,
+.c2.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c2.fi-link--skip {
   position: absolute;
   z-index: 10000;
@@ -150,8 +184,6 @@ exports[`should match snapshot 1`] = `
   background: hsl(212,63%,95%);
   border: 1px solid hsl(202,7%,80%);
   color: hsl(0,0%,16%);
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c2.fi-link--skip:focus {

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -503,6 +503,23 @@ exports[`should match snapshot 1`] = `
   color: hsl(284,36%,45%);
 }
 
+.c10.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c10.fi-link--initial-underline:focus,
+.c10.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c10.fi-link--initial-underline:hover,
+.c10.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c10 .fi-link_icon {
   padding-left: 4px;
   font-size: 16px;
@@ -558,6 +575,23 @@ exports[`should match snapshot 1`] = `
 
 .c7.fi-link--router:visited {
   color: hsl(284,36%,45%);
+}
+
+.c7.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7.fi-link--initial-underline:focus,
+.c7.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7.fi-link--initial-underline:hover,
+.c7.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c9 {

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -799,6 +799,23 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(284,36%,45%);
 }
 
+.c8.fi-link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c8.fi-link--initial-underline:focus,
+.c8.fi-link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c8.fi-link--initial-underline:hover,
+.c8.fi-link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 <div
   class="c0 fi-wizard-navigation c1"
 >


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Adds property `underline` to components `Link`, `ExternalLink`, `SkipLink`, and `RouterLink`.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Links that have no underline can be hard to distinguish from other text content. Underlining links improves accessibility for users with decreased (or no) color discrimination.

## How Has This Been Tested?

Styleguidist and CRA.

## Screenshots:

### Link
<img width="329" alt="links" src="https://user-images.githubusercontent.com/14312917/195076659-b22507fc-3925-4e89-b7fd-15f4327d159f.PNG">

### ExternalLink
<img width="315" alt="external-link" src="https://user-images.githubusercontent.com/14312917/195078608-1902f630-db0f-4f50-90fb-4561b17e08cb.PNG">

### SkipLink
<img width="343" alt="skip-link" src="https://user-images.githubusercontent.com/14312917/195078442-68176103-0765-466e-a4ab-f1f2b2dd4d89.PNG">

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
- Add `underline` property to Link, ExternalLink, SkipLink, and RouterLink.