### PR TITLE
[Fix] Add passProps for the hidden Label

### DIFF
--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1522,6 +1522,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
       >
         <label
           class="c5 fi-visually-hidden"
+          id="test-id-label"
         >
           Dropdown test
         </label>

--- a/src/core/Form/Label/Label.tsx
+++ b/src/core/Form/Label/Label.tsx
@@ -94,7 +94,7 @@ const StyledLabel = styled(
         }
       >
         {labelMode === 'hidden' ? (
-          <VisuallyHidden as={asProp}>
+          <VisuallyHidden as={asProp} {...passProps}>
             {children}
             {optionalText && `(${optionalText})`}
           </VisuallyHidden>

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -4108,6 +4108,7 @@ exports[`props labelMode should match snapshot 1`] = `
         >
           <label
             class="c5 fi-visually-hidden"
+            for="test-id"
           >
             Label here
           </label>

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -766,6 +766,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
     >
       <label
         class="c5 fi-visually-hidden"
+        for="test-id1"
       >
         Test input
       </label>


### PR DESCRIPTION
## Description
This PR addresses a bug where the hidden variant of Label was missing the passed props
<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Motivation and Context
The bug was noticed when developing Pagination component. For example for and id tags were not properly passed to VisuallyHidden inside the Label.


<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Firefox and Chrome on mac. Styleguidist.

## Release notes

### Label
* Fix passed props on hidden variant
<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
