### PR TITLE
[Fix/BreakingChange] Multiselect onitemselect return type

### DIFF
--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -154,7 +154,7 @@ interface InternalMultiSelectProps<T extends MultiSelectData> {
   /** Controlled items; if item is in array, it is selected. If item has disabled: true, it will be disabled. */
   selectedItems?: Array<T & MultiSelectData>;
   /** Selecting the item will send event with the id */
-  onItemSelect?: (uniqueItemId: string | null) => void;
+  onItemSelect?: (uniqueItemId: string) => void;
   /** Event to be sent when pressing remove all button */
   onRemoveAll?: () => void;
   /** Disable the input */
@@ -332,7 +332,7 @@ class BaseMultiSelect<T> extends Component<
     }
 
     if (!!onItemSelect) {
-      onItemSelect(item?.uniqueItemId || null);
+      onItemSelect(item?.uniqueItemId);
     }
     if (!!onItemSelectionsChange) {
       onItemSelectionsChange(newSelectedItems);

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -332,7 +332,7 @@ class BaseMultiSelect<T> extends Component<
     }
 
     if (!!onItemSelect) {
-      onItemSelect(item?.uniqueItemId);
+      onItemSelect(item.uniqueItemId);
     }
     if (!!onItemSelectionsChange) {
       onItemSelectionsChange(newSelectedItems);


### PR DESCRIPTION
## Description

This PR removes `null` as a possible parameter in MultiSelect's `onItemSelect()` prop. Null was there because the code had been copied over from SingleSelect where `onItemSelect()` gets called also when the input is cleared. In MultiSelect there is no such behavior.

## Motivation and Context

This was reported as a bug by one of our users.

## How Has This Been Tested?

Styleguidist

## Release notes

### MultiSelect
* **Breaking change:** Remove redundant `null` from possible parameters in `onItemSelect()` prop
