### PR TITLE
[Fix] Tooltip related styleguidist examples

### DIFF
--- a/src/core/Dropdown/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown/Dropdown.md
@@ -195,7 +195,7 @@ const labelText = 'Dropdown with a tooltip';
   tooltipComponent={
     <Tooltip
       ariaToggleButtonLabelText={`${labelText}, additional information`}
-      ariaToggleButtonLabelText={`${labelText}, close additional information`}
+      ariaCloseButtonLabelText={`${labelText}, close additional information`}
     >
       <Heading variant="h5" as="h2">
         Tooltip

--- a/src/core/Form/Checkbox/Checkbox.md
+++ b/src/core/Form/Checkbox/Checkbox.md
@@ -99,7 +99,7 @@ const labelText = 'Checkboxes with a tooltip';
   tooltipComponent={
     <Tooltip
       ariaToggleButtonLabelText={`${labelText}, additional information`}
-      ariaToggleButtonLabelText={`${labelText}, close additional information`}
+      ariaCloseButtonLabelText={`${labelText}, close additional information`}
     >
       <Heading variant="h5" as="h2">
         Tooltip

--- a/src/core/Form/RadioButton/RadioButton.md
+++ b/src/core/Form/RadioButton/RadioButton.md
@@ -185,7 +185,7 @@ const labelText = 'RadioButtons with a tooltip';
   tooltipComponent={
     <Tooltip
       ariaToggleButtonLabelText={`${labelText}, additional information`}
-      ariaToggleButtonLabelText={`${labelText}, close additional information`}
+      ariaCloseButtonLabelText={`${labelText}, close additional information`}
     >
       <Heading variant="h5" as="h2">
         Tooltip

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -448,7 +448,7 @@ const labelText = 'Food';
   tooltipComponent={
     <Tooltip
       ariaToggleButtonLabelText={`${labelText}, additional information`}
-      ariaToggleButtonLabelText={`${labelText}, close additional information`}
+      ariaCloseButtonLabelText={`${labelText}, close additional information`}
     >
       <Heading variant="h5" as="h2">
         Food

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -394,7 +394,7 @@ const labelText = 'Food';
     tooltipComponent={
       <Tooltip
         ariaToggleButtonLabelText={`${labelText}, additional information`}
-        ariaToggleButtonLabelText={`${labelText}, close additional information`}
+        ariaCloseButtonLabelText={`${labelText}, close additional information`}
       >
         <Heading variant="h5" as="h2">
           Food

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -40,7 +40,7 @@ const labelTextForTooltipExample = 'TextInput with a tooltip';
     tooltipComponent={
       <Tooltip
         ariaToggleButtonLabelText={`${labelTextForTooltipExample}, additional information`}
-        ariaToggleButtonLabelText={`${labelTextForTooltipExample}, close additional information`}
+        ariaCloseButtonLabelText={`${labelTextForTooltipExample}, close additional information`}
       >
         <Heading variant="h5" as="h2">
           Tooltip

--- a/src/core/Form/Textarea/Textarea.md
+++ b/src/core/Form/Textarea/Textarea.md
@@ -44,7 +44,7 @@ const labelTextForTooltipExample = 'Textarea with a tooltip';
     tooltipComponent={
       <Tooltip
         ariaToggleButtonLabelText={`${labelTextForTooltipExample}, additional information`}
-        ariaToggleButtonLabelText={`${labelTextForTooltipExample}, close additional information`}
+        ariaCloseButtonLabelText={`${labelTextForTooltipExample}, close additional information`}
       >
         <Heading variant="h5" as="h2">
           Tooltip


### PR DESCRIPTION
## Description

This PR fixes a copy-paste mistake in Tooltip related Styleguidist examples. The prop `ariaToggleButtonLabelText` was present twice and `ariaCloseButtonLabelText` was missing altogether. 

## Release notes

-
