### PR TITLE
[Fix] SideNavigation - Add padding to level 3 list

### DIFF
--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -500,6 +500,7 @@ exports[`calling render with the same component on the same container does not r
 .c7.fi-side-navigation-item--level-2 .fi-side-navigation-item_sub-list {
   margin: 5px 0 5px 30px;
   background: hsl(212,63%,95%);
+  padding: 5px 0;
 }
 
 .c7.fi-side-navigation-item--level-3 {

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -124,6 +124,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       .fi-side-navigation-item_sub-list {
         margin: ${theme.spacing.xxs} 0 ${theme.spacing.xxs} 30px;
         background: ${theme.colors.highlightLight3};
+        padding: ${theme.spacing.xxs} 0;
       }
     }
 


### PR DESCRIPTION
## Description

This PR fixes a visual issue in `<SideNavigation>` component. There was 5px padding missing from the top and bottom of the level 3 list

## Motivation and Context

Components need to follow the design laid out by our designers :) 

## Screenshots
Before:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/17459942/202688184-1e764392-6333-47c9-8c3a-cc03d32d77c4.png">

After:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/17459942/202688253-dd7841cf-ee31-48f3-97d4-50b561fb1c01.png">


## Release notes

### SideNavigation
* Add top and bottom padding to level 3 list
