### PR TITLE
[Fix] Adjust SideNavigation focus style

### DIFF
--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -419,13 +419,24 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 4px;
 }
 
-.c7.fi-side-navigation-item .fi-link--router:focus {
+.c7.fi-side-navigation-item .fi-link--router:focus-visible {
+  outline: 0;
   position: relative;
-  outline: 0;
   box-shadow: none;
-  border: none;
-  outline: 0;
+}
+
+.c7.fi-side-navigation-item .fi-link--router:focus-visible:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
   border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
 }

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -43,14 +43,14 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         border-radius: ${theme.radius.modal};
       }
 
-      &:focus {
-        position: relative;
+      &:focus-visible {
         outline: 0;
+        position: relative;
         box-shadow: none;
-        border: none;
 
-        ${theme.focus.boxShadowFocus}
-        z-index: ${theme.zindexes.focus};
+        &:after {
+          ${theme.focus.absoluteFocus}
+        }
       }
     }
 


### PR DESCRIPTION
## Description

This PR changes SideNavigation's focus style from `boxShadowFocus` to `absoluteFocus`

## Motivation and Context

`boxShadowFocus` is placed directly to the borders of an element. This was not optimal for SideNavigation since its selected style is a deep blue color and therefore focus was not clearly visible. `absoluteFocus` is a better choice for this due to its spacing. Not a 100% optimal but better. 

## How Has This Been Tested?

Styleguidist, CRA

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/17459942/203042709-216ac28c-37d4-4034-af4c-5d711c0276d9.png)

After:
![image](https://user-images.githubusercontent.com/17459942/203042560-93055cd4-2d05-4866-9869-e7c7759868e7.png)


## Release notes

### SideNavigation
* Adjust focus style for better visibility
