### PR TITLE
[Fix] ServiceNavigation focus color

### DIFF
--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -351,6 +351,7 @@ exports[`should match snapshot 1`] = `
   outline: 0;
   border: none;
   box-shadow: none;
+  color: hsl(0,0%,16%);
 }
 
 .c5.fi-service-navigation-item .fi-link--router:hover,

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -42,6 +42,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         outline: 0;
         border: none;
         box-shadow: none;
+        color: ${theme.colors.blackBase};
       }
 
       &:hover,


### PR DESCRIPTION
## Description

This PR adds a CSS line which makes sure that a focused item gets the correct `blackBase` color in `<ServiceNavigation>` component

## Motivation and Context

During further testing it became apparent that the focus color was not explicitly set, and due to same-specificity-issues could sometimes be set as `highlightBase` instead (inherited from regular `.fi-link--router` class)

## How Has This Been Tested?

Styleguidist, DS-site

## Screenshots:
Before:
![image](https://user-images.githubusercontent.com/17459942/203322520-45757f84-dd89-4a91-b83c-54d24d5bc9f4.png)

After:
![image](https://user-images.githubusercontent.com/17459942/203322631-7710e5dc-d62a-4d6e-ab57-ce4bce0a9a3a.png)


## Release notes

### ServiceNavigation
* Fix color in focus style
