### PR TITLE
[Fix] SearchInput: NVDA focus issue when hiding Clear button

### DIFF
--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -202,7 +202,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
       ),
       ...(!!this.state.value
         ? { onClick: onSearch }
-        : { tabIndex: -1, 'aria-hidden': true }),
+        : { tabIndex: -1, hidden: true }),
     };
     const clearButtonProps = {
       className: classnames(
@@ -211,7 +211,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
       ),
       ...(!!this.state.value
         ? { onClick: onClear }
-        : { tabIndex: -1, 'aria-hidden': true }),
+        : { tabIndex: -1, hidden: true }),
     };
 
     return (

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -650,8 +650,8 @@ exports[`snapshot should have matching default structure 1`] = `
         />
       </div>
       <button
-        aria-hidden="true"
         class="c6 fi-input-clear-button c7 fi-search-input_button fi-search-input_button-clear"
+        hidden=""
         tabindex="-1"
         type="button"
       >
@@ -678,8 +678,8 @@ exports[`snapshot should have matching default structure 1`] = `
         </svg>
       </button>
       <button
-        aria-hidden="true"
         class="c6 fi-search-input_button fi-search-input_button-search"
+        hidden=""
         tabindex="-1"
         type="button"
       >


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
Fix for an issue with NVDA and clear button in SearchInput

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue


Closes https://jira.dvv.fi/browse/SFIDS-666

## Motivation and Context
Fixes a focus issue with SearchInput and NVDA. When the clear button is clicked the focus should move to the input. This doesn't work properly and the user can not type.
<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Styleguidist. Mac VoiceOver + Firefox Chrome, Safari, Edge. Windows NVDA + Chrome, Firefox. 

## Screenshots (if appropriate)
<img width="315" alt="Screenshot 2022-12-02 at 14 54 28" src="https://user-images.githubusercontent.com/14258876/205298881-1fb71943-ad89-439c-851c-a6e11ed33393.png">


## Release notes
### SearchInput
* Fix focus issue with NVDA screenreader
