### PR TITLE
[Fix]: MultiSelect & SingleSelect: Associate label with input

### DIFF
--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -184,6 +184,7 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
               [filterInputClassNames.labelIsVisible]: labelMode !== 'hidden',
             })}
             tooltipComponent={tooltipComponent}
+            htmlFor={id}
           >
             {labelText}
           </Label>

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -385,6 +385,7 @@ exports[`snapshot matches 1`] = `
     >
       <label
         class="c4 fi-label_label-span"
+        for="1"
         id="1-label"
       >
         Label

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -921,6 +921,7 @@ exports[`has matching snapshot 1`] = `
         >
           <label
             class="c5 fi-label_label-span"
+            for="1"
             id="1-label"
           >
             MultiSelect

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -634,6 +634,7 @@ exports[`has matching snapshot 1`] = `
       >
         <label
           class="c5 fi-label_label-span"
+          for="1"
           id="1-label"
         >
           SingleSelect


### PR DESCRIPTION
## Description

This PR connects the label and input in `<SingleSelect>` & `<MultiSelect>` (using the underlying `<FilterInput>` component). The label gets the input's ID as its `htmlFor` prop. 

NOTE: I tried to do the same thing for our `<Dropdown>`, but ReachUI's Listbox component does not allow an ID to be passed to the actual underlying `<input>` element. So no can do. 

## Motivation and Context

We want SingleSelect & MultiSelect to gain focus when their label is clicked

## How Has This Been Tested?
Styleguidist

## Release notes

### SingleSelect & MultiSelect
* Connect the component's label to its input via the `for` attribute to allow focus on label click
