### PR TITLE
[Fix] SideNav: Remove aria-current=location from examples

### DIFF
--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.md
@@ -23,16 +23,12 @@ const CustomButton = (props) => {
   >
     <SideNavigationItem
       subLevel={1}
-      content={
-        <RouterLink href="/" aria-current="location">
-          Personal economy
-        </RouterLink>
-      }
+      content={<RouterLink href="/">Personal economy</RouterLink>}
     >
       <SideNavigationItem
         subLevel={2}
         content={
-          <RouterLink href="/" aria-current="location">
+          <RouterLink href="/">
             Crisis situations in personal finances
           </RouterLink>
         }
@@ -135,16 +131,12 @@ const CustomButton = (props) => {
   >
     <SideNavigationItem
       subLevel={1}
-      content={
-        <RouterLink href="/" aria-current="location">
-          Personal economy
-        </RouterLink>
-      }
+      content={<RouterLink href="/">Personal economy</RouterLink>}
     >
       <SideNavigationItem
         subLevel={2}
         content={
-          <RouterLink href="/" aria-current="location">
+          <RouterLink href="/">
             Crisis situations in personal finances
           </RouterLink>
         }


### PR DESCRIPTION
## Description

This PR removes aria-current="location" attributes from `<SideNavigation>` examples. 

## Motivation and Context

This came up in accessibility clinic. Having aria-current="location" in the parents of the currently active page was seen as more confusing than helpful. Having aria-current="page" in the item which is actually active is enough.

## How Has This Been Tested?
Styleguidist, VoiceOver

## Release notes

### SideNavigation
* Remove aria-current="location" attributes from examples
