### PR TITLE
[Feature] Loading state for SingleSelect & MultiSelect

### DIFF
--- a/src/core/Form/Select/BaseSelect/SelectEmptyItem/SelectEmptyItem.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectEmptyItem/SelectEmptyItem.baseStyles.tsx
@@ -13,4 +13,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     display: inline-block;
     width: 100%;
   }
+
+  &.loading {
+    & .fi-select-empty-item_content_wrapper {
+      display: block; /* Fixes "extra padding" issue with loading spinner */
+    }
+  }
 `;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -462,7 +462,7 @@ const labelText = 'Food';
 />;
 ```
 
-### MultiSelect loading
+### Loading state
 
 ```js
 import {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -461,3 +461,30 @@ const labelText = 'Food';
   ariaOptionChipRemovedText="removed"
 />;
 ```
+
+### MultiSelect loading
+
+```js
+import {
+  MultiSelect,
+  Tooltip,
+  Heading,
+  Text
+} from 'suomifi-ui-components';
+
+const foods = [];
+
+const labelText = 'Food';
+
+<MultiSelect
+  items={foods}
+  labelText={labelText}
+  visualPlaceholder="Choose your foods"
+  noItemsText="No items"
+  loading={true}
+  loadingText="Loading data"
+  ariaSelectedAmountText="items selected"
+  ariaOptionsAvailableText="options available"
+  ariaOptionChipRemovedText="removed"
+/>;
+```

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -99,7 +99,7 @@ type AriaSelectedAmountProps =
 type LoadingProps =
   | {
       loading?: false | never;
-      loadingText?: never;
+      loadingText?: string;
     }
   | {
       /** Show the animated icon indcating that component is loading data

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -20,6 +20,7 @@ import { MultiSelectRemoveAllButton } from '../MultiSelectRemoveAllButton/MultiS
 import { baseStyles } from './MultiSelect.baseStyles';
 import { InputToggleButton } from '../../../InputToggleButton/InputToggleButton';
 import { SelectItemAddition } from '../../BaseSelect/SelectItemAddition/SelectItemAddition';
+import { LoadingSpinner } from '../../../../LoadingSpinner/LoadingSpinner';
 
 const baseClassName = 'fi-multiselect';
 const multiSelectClassNames = {
@@ -93,6 +94,20 @@ type AriaSelectedAmountProps =
        * `ariaSelectedAmountText` if both are provided.
        */
       ariaSelectedAmountTextFunction: (amount: number) => string;
+    };
+
+type LoadingProps =
+  | {
+      loading?: false | never;
+      loadingText?: never;
+    }
+  | {
+      /** Show the animated icon indcating that component is loading data
+       * @default false
+       */
+      loading?: true;
+      /** Text to show with the loading animation. Required if `loading` is true */
+      loadingText: string;
     };
 
 interface InternalMultiSelectProps<T extends MultiSelectData> {
@@ -175,7 +190,8 @@ export type MultiSelectProps<T> = InternalMultiSelectProps<
   AllowItemAdditionProps &
   AriaOptionsAvailableProps &
   AriaOptionChipRemovedProps &
-  AriaSelectedAmountProps;
+  AriaSelectedAmountProps &
+  LoadingProps;
 
 interface MultiSelectState<T extends MultiSelectData> {
   filterInputValue: string;
@@ -579,6 +595,8 @@ class BaseMultiSelect<T> extends Component<
       ariaChipActionLabel,
       removeAllButtonLabel,
       visualPlaceholder,
+      loading,
+      loadingText,
       noItemsText,
       defaultSelectedItems,
       onChange: propOnChange,
@@ -719,7 +737,8 @@ class BaseMultiSelect<T> extends Component<
                   aria-multiselectable="true"
                 >
                   <HtmlDiv>
-                    {filteredItemsWithChecked.length > 0 &&
+                    {!loading &&
+                      filteredItemsWithChecked.length > 0 &&
                       filteredItemsWithChecked.map((item) => {
                         const isCurrentlySelected =
                           item.uniqueItemId === focusedDescendantId;
@@ -740,12 +759,14 @@ class BaseMultiSelect<T> extends Component<
                         );
                       })}
 
-                    {filteredItemsWithChecked.length === 0 &&
+                    {!loading &&
+                      filteredItemsWithChecked.length === 0 &&
                       !allowItemAddition && (
                         <SelectEmptyItem>{noItemsText}</SelectEmptyItem>
                       )}
 
-                    {filterInputValue !== '' &&
+                    {!loading &&
+                      filterInputValue !== '' &&
                       !this.inputValueInItems() &&
                       allowItemAddition && (
                         <SelectItemAddition
@@ -770,6 +791,17 @@ class BaseMultiSelect<T> extends Component<
                           {filterInputValue}
                         </SelectItemAddition>
                       )}
+
+                    {loading && (
+                      <SelectEmptyItem className="loading">
+                        <LoadingSpinner
+                          status="loading"
+                          variant="small"
+                          textAlign="right"
+                          text={loadingText}
+                        />
+                      </SelectEmptyItem>
+                    )}
                   </HtmlDiv>
                 </SelectItemList>
               </Popover>

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -102,7 +102,7 @@ type LoadingProps =
       loadingText?: string;
     }
   | {
-      /** Show the animated icon indcating that component is loading data
+      /** Show the animated icon indicating that component is loading data
        * @default false
        */
       loading?: true;

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -406,7 +406,7 @@ const labelText = 'Food';
 </>;
 ```
 
-### SingleSelect in loading state
+### Loading state
 
 ```js
 import {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -405,3 +405,30 @@ const labelText = 'Food';
   />
 </>;
 ```
+
+### SingleSelect in loading state
+
+```js
+import {
+  SingleSelect,
+  Tooltip,
+  Heading,
+  Text
+} from 'suomifi-ui-components';
+const foods = [];
+const defaultSelectedFood = {};
+
+const labelText = 'Food';
+
+<>
+  <SingleSelect
+    labelText={labelText}
+    clearButtonLabel="Clear selection"
+    items={foods}
+    noItemsText="No matching options"
+    ariaOptionsAvailableText="Options available"
+    loading={true}
+    loadingText="Loading data"
+  />
+</>;
+```

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -110,7 +110,7 @@ type LoadingProps =
       loadingText?: string;
     }
   | {
-      /** Show the animated icon indcating that component is loading data
+      /** Show the animated icon indicating that component is loading data
        * @default false
        */
       loading?: true;

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -8,6 +8,7 @@ import { Debounce } from '../../../utils/Debounce/Debounce';
 import { Popover } from '../../../Popover/Popover';
 import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
 import { FilterInput, FilterInputStatus } from '../../FilterInput/FilterInput';
+import { LoadingSpinner } from '../../../LoadingSpinner/LoadingSpinner';
 import { VisuallyHidden } from '../../../VisuallyHidden/VisuallyHidden';
 import { InputClearButton } from '../../InputClearButton/InputClearButton';
 import { SelectItemList } from '../BaseSelect/SelectItemList/SelectItemList';
@@ -103,6 +104,20 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
   forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
+type LoadingProps =
+  | {
+      loading?: false | never;
+      loadingText?: never;
+    }
+  | {
+      /** Show the animated icon indcating that component is loading data
+       * @default false
+       */
+      loading?: true;
+      /** Text to show with the loading animation. Required if `loading` is true */
+      loadingText: string;
+    };
+
 type AllowItemAdditionProps =
   | {
       allowItemAddition?: false | never;
@@ -126,7 +141,8 @@ export type SingleSelectProps<T> = InternalSingleSelectProps<
   T & SingleSelectData
 > &
   AllowItemAdditionProps &
-  AriaOptionsAvailableProps;
+  AriaOptionsAvailableProps &
+  LoadingProps;
 
 interface SingleSelectState<T extends SingleSelectData> {
   filterInputValue: string;
@@ -470,6 +486,8 @@ class BaseSingleSelect<T> extends Component<
       onChange: propOnChange,
       onBlur,
       debounce,
+      loading,
+      loadingText,
       status,
       statusText,
       selectedItem: controlledItem,
@@ -616,6 +634,7 @@ class BaseSingleSelect<T> extends Component<
             >
               <HtmlDiv>
                 {popoverItems.length > 0 &&
+                  !loading &&
                   popoverItems.map((item) => {
                     const isCurrentlySelected =
                       item.uniqueItemId === focusedDescendantId;
@@ -642,13 +661,25 @@ class BaseSingleSelect<T> extends Component<
                     );
                   })}
 
-                {popoverItems.length === 0 && !allowItemAddition && (
-                  <SelectEmptyItem>{noItemsText}</SelectEmptyItem>
+                {popoverItems.length === 0 &&
+                  !allowItemAddition &&
+                  !loading && <SelectEmptyItem>{noItemsText}</SelectEmptyItem>}
+
+                {loading && (
+                  <SelectEmptyItem>
+                    <LoadingSpinner
+                      status="loading"
+                      variant="small"
+                      textAlign="right"
+                      text={loadingText}
+                    />
+                  </SelectEmptyItem>
                 )}
 
                 {filterInputValue !== '' &&
                   !this.inputValueInItems() &&
-                  allowItemAddition && (
+                  allowItemAddition &&
+                  !loading && (
                     <SelectItemAddition
                       hintText={itemAdditionHelpText}
                       hasKeyboardFocus={

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -107,7 +107,7 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
 type LoadingProps =
   | {
       loading?: false | never;
-      loadingText?: never;
+      loadingText?: string;
     }
   | {
       /** Show the animated icon indcating that component is loading data

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -666,7 +666,7 @@ class BaseSingleSelect<T> extends Component<
                   !loading && <SelectEmptyItem>{noItemsText}</SelectEmptyItem>}
 
                 {loading && (
-                  <SelectEmptyItem>
+                  <SelectEmptyItem className="loading">
                     <LoadingSpinner
                       status="loading"
                       variant="small"


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

Add support for "loading state" in MultiSelect and SingleSelect.


<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Related Issue

https://jira.dvv.fi/browse/SFIDS-510



## Motivation and Context

Provide a clear indication MultiSelect / SingleSelect is loading more data.

## How Has This Been Tested?

MacOs Firefox, Chrome, Styleguidist, CRA


## Screenshots (if appropriate):
<img width="399" alt="Screenshot 2022-12-29 at 16 28 22" src="https://user-images.githubusercontent.com/14258876/209967423-636ede73-84fb-4e2a-b037-a469960f0533.png">

## Release notes

### MultiSelect
* Add support for loading state
### SingleSelect
* Add support for loading state
