### PR TITLE
[Fix/Breaking change] Inline alert content area size to 100%

### DIFF
--- a/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
@@ -28,6 +28,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-inline-alert_text-content-wrapper {
       display: flex;
       flex-direction: column;
+      width: 100%;
       padding: 0 ${theme.spacing.s};
       margin: ${theme.spacing.s} 0;
 

--- a/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -108,6 +108,7 @@ exports[`children should match snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  width: 100%;
   padding: 0 15px;
   margin: 15px 0;
 }


### PR DESCRIPTION
## Description
This PR will make the InlineAlert content take up all available space.

## Motivation and Context
At the moment the users need to adjust internal styling of the component if they want something to span the full width of the alert. There's no reason why this couldn't be the case out of the box.

## How Has This Been Tested?
By running in styleguidist on Chrome.

## Screenshots (if appropriate):
![inlinealert](https://user-images.githubusercontent.com/54316341/214239614-68f50227-bc4b-407d-8239-21df6480ab84.png)


## Release notes
### InlineAlert
* **Breaking change:** Content will now take up all available space.
