### PR TITLE
[Fix] Select components loading state screen reader improvement

### DIFF
--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -523,7 +523,7 @@ const startup = (event) => {
   />
 
   <MultiSelect
-    items={updatedFoods}
+    items={foods}
     labelText="Load on change"
     visualPlaceholder="Choose your foods"
     noItemsText="No items"

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -465,6 +465,7 @@ const labelText = 'Food';
 ### Loading state
 
 ```js
+import { useState } from 'react';
 import {
   MultiSelect,
   Tooltip,
@@ -472,19 +473,66 @@ import {
   Text
 } from 'suomifi-ui-components';
 
-const foods = [];
+const [loading, setLoading] = useState(false);
+const [foods, setFoods] = useState([]);
+const updatedFoods = [
+  {
+    labelText: 'Pizza',
+    uniqueItemId: 'pizza-123'
+  },
+  {
+    labelText: 'Burger',
+    uniqueItemId: 'burger-123'
+  }
+];
 
-const labelText = 'Food';
+const runLoader = () => {
+  let progress = 0;
+  setLoading(true);
+  setFoods([]);
+  const id = setInterval(frame, 300);
+  function frame() {
+    if (progress >= 10) {
+      clearInterval(id);
+      setFoods(updatedFoods);
+      setLoading(false);
+      progress = 0;
+    } else {
+      progress = progress + 1;
+    }
+  }
+};
 
-<MultiSelect
-  items={foods}
-  labelText={labelText}
-  visualPlaceholder="Choose your foods"
-  noItemsText="No items"
-  loading={true}
-  loadingText="Loading data"
-  ariaSelectedAmountText="items selected"
-  ariaOptionsAvailableText="options available"
-  ariaOptionChipRemovedText="removed"
-/>;
+const startup = (event) => {
+  if (!loading) {
+    runLoader();
+  }
+};
+
+<>
+  <MultiSelect
+    items={foods}
+    labelText="Always on"
+    visualPlaceholder="Choose your foods"
+    noItemsText="No items"
+    loading={true}
+    loadingText="Loading data"
+    ariaSelectedAmountText="items selected"
+    ariaOptionsAvailableText="options available"
+    ariaOptionChipRemovedText="removed"
+  />
+
+  <MultiSelect
+    items={updatedFoods}
+    labelText="Load on change"
+    visualPlaceholder="Choose your foods"
+    noItemsText="No items"
+    loading={loading}
+    onChange={startup}
+    loadingText="Loading data"
+    ariaSelectedAmountText="items selected"
+    ariaOptionsAvailableText="options available"
+    ariaOptionChipRemovedText="removed"
+  />
+</>;
 ```

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -851,50 +851,52 @@ class BaseMultiSelect<T> extends Component<
             </MultiSelectRemoveAllButton>
           </HtmlDiv>
         </HtmlDiv>
-        {this.state.showOptionsAvailableText && (
-          <>
-            <VisuallyHidden aria-live="polite" aria-atomic="true">
-              {ariaSelectedAmountTextFunction ? (
-                <>{ariaSelectedAmountTextFunction(selectedItems.length)}</>
+
+        <VisuallyHidden aria-live="polite" aria-atomic="true">
+          {this.state.showOptionsAvailableText ? (
+            ariaSelectedAmountTextFunction ? (
+              <>{ariaSelectedAmountTextFunction(selectedItems.length)}</>
+            ) : (
+              <>
+                {selectedItems.length}
+                {ariaSelectedAmountText}
+              </>
+            )
+          ) : (
+            ''
+          )}
+        </VisuallyHidden>
+
+        <VisuallyHidden
+          aria-live="polite"
+          aria-atomic="true"
+          id={`${id}-filteredItems-length`}
+        >
+          {!loading && this.state.showOptionsAvailableText ? (
+            this.focusInInput(getOwnerDocument(this.popoverListRef)) ? (
+              ariaOptionsAvailableTextFunction ? (
+                <>{ariaOptionsAvailableTextFunction(filteredItems.length)}</>
               ) : (
                 <>
-                  {selectedItems.length}
-                  {ariaSelectedAmountText}
+                  {filteredItems.length}
+                  {ariaOptionsAvailableText}
                 </>
-              )}
-            </VisuallyHidden>
+              )
+            ) : (
+              ''
+            )
+          ) : (
+            ''
+          )}
+        </VisuallyHidden>
 
-            {!loading && (
-              <VisuallyHidden
-                aria-live="polite"
-                aria-atomic="true"
-                id={`${id}-filteredItems-length`}
-              >
-                {this.focusInInput(getOwnerDocument(this.popoverListRef)) ? (
-                  ariaOptionsAvailableTextFunction ? (
-                    <>
-                      {ariaOptionsAvailableTextFunction(filteredItems.length)}
-                    </>
-                  ) : (
-                    <>
-                      {filteredItems.length}
-                      {ariaOptionsAvailableText}
-                    </>
-                  )
-                ) : null}
-              </VisuallyHidden>
-            )}
-          </>
-        )}
-        {loading && (
-          <VisuallyHidden
-            aria-live="polite"
-            aria-atomic="true"
-            id={`${id}-loading-announce`}
-          >
-            {loadingText}
-          </VisuallyHidden>
-        )}
+        <VisuallyHidden
+          aria-live="polite"
+          aria-atomic="true"
+          id={`${id}-loading-announce`}
+        >
+          {loading ? loadingText : ''}
+        </VisuallyHidden>
         <VisuallyHidden
           aria-live="assertive"
           aria-atomic="true"

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -863,23 +863,37 @@ class BaseMultiSelect<T> extends Component<
                 </>
               )}
             </VisuallyHidden>
-            <VisuallyHidden
-              aria-live="polite"
-              aria-atomic="true"
-              id={`${id}-filteredItems-length`}
-            >
-              {this.focusInInput(getOwnerDocument(this.popoverListRef)) ? (
-                ariaOptionsAvailableTextFunction ? (
-                  <>{ariaOptionsAvailableTextFunction(filteredItems.length)}</>
-                ) : (
-                  <>
-                    {filteredItems.length}
-                    {ariaOptionsAvailableText}
-                  </>
-                )
-              ) : null}
-            </VisuallyHidden>
+
+            {!loading && (
+              <VisuallyHidden
+                aria-live="polite"
+                aria-atomic="true"
+                id={`${id}-filteredItems-length`}
+              >
+                {this.focusInInput(getOwnerDocument(this.popoverListRef)) ? (
+                  ariaOptionsAvailableTextFunction ? (
+                    <>
+                      {ariaOptionsAvailableTextFunction(filteredItems.length)}
+                    </>
+                  ) : (
+                    <>
+                      {filteredItems.length}
+                      {ariaOptionsAvailableText}
+                    </>
+                  )
+                ) : null}
+              </VisuallyHidden>
+            )}
           </>
+        )}
+        {loading && (
+          <VisuallyHidden
+            aria-live="polite"
+            aria-atomic="true"
+            id={`${id}-loading-announce`}
+          >
+            {loadingText}
+          </VisuallyHidden>
         )}
         <VisuallyHidden
           aria-live="assertive"

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -409,26 +409,71 @@ const labelText = 'Food';
 ### Loading state
 
 ```js
+import { useState } from 'react';
 import {
   SingleSelect,
   Tooltip,
   Heading,
   Text
 } from 'suomifi-ui-components';
-const foods = [];
-const defaultSelectedFood = {};
 
-const labelText = 'Food';
+const [loading, setLoading] = useState(false);
+const [foods, setFoods] = useState([]);
+
+const updatedFoods = [
+  {
+    labelText: 'Pizza',
+    uniqueItemId: 'pizza-123'
+  },
+  {
+    labelText: 'Burger',
+    uniqueItemId: 'burger-123'
+  }
+];
+
+const runLoader = () => {
+  let progress = 0;
+  setLoading(true);
+  setFoods([]);
+  const id = setInterval(frame, 300);
+  function frame() {
+    if (progress >= 10) {
+      clearInterval(id);
+      setFoods(updatedFoods);
+      setLoading(false);
+      progress = 0;
+    } else {
+      progress = progress + 1;
+    }
+  }
+};
+
+const startup = (event) => {
+  if (!loading) {
+    runLoader();
+  }
+};
 
 <>
   <SingleSelect
-    labelText={labelText}
+    labelText="Always on"
+    clearButtonLabel="Clear selection"
+    items={[]}
+    loading={true}
+    loadingText="Loading data"
+    noItemsText="No matching options"
+    ariaOptionsAvailableText="Options available"
+  />
+
+  <SingleSelect
+    labelText="Load on change"
     clearButtonLabel="Clear selection"
     items={foods}
     noItemsText="No matching options"
     ariaOptionsAvailableText="Options available"
-    loading={true}
+    loading={loading}
     loadingText="Loading data"
+    onChange={startup}
   />
 </>;
 ```

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -702,22 +702,22 @@ class BaseSingleSelect<T> extends Component<
             </SelectItemList>
           </Popover>
         )}
-        {this.state.filterMode && !loading && (
-          <VisuallyHidden aria-live="polite" aria-atomic="true">
-            {ariaOptionsAvailableTextFunction
+
+        <VisuallyHidden aria-live="polite" aria-atomic="true">
+          {this.state.filterMode && !loading
+            ? ariaOptionsAvailableTextFunction
               ? ariaOptionsAvailableTextFunction(popoverItems.length)
-              : `${popoverItems.length} ${ariaOptionsAvailableText}`}
-          </VisuallyHidden>
-        )}
-        {loading && (
-          <VisuallyHidden
-            aria-live="polite"
-            aria-atomic="true"
-            id={`${id}-loading-announce`}
-          >
-            {loadingText}
-          </VisuallyHidden>
-        )}
+              : `${popoverItems.length} ${ariaOptionsAvailableText}`
+            : ''}
+        </VisuallyHidden>
+
+        <VisuallyHidden
+          aria-live="polite"
+          aria-atomic="true"
+          id={`${id}-loading-announce`}
+        >
+          {loading ? loadingText : ''}
+        </VisuallyHidden>
       </HtmlDiv>
     );
   }

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -702,11 +702,20 @@ class BaseSingleSelect<T> extends Component<
             </SelectItemList>
           </Popover>
         )}
-        {this.state.filterMode && (
+        {this.state.filterMode && !loading && (
           <VisuallyHidden aria-live="polite" aria-atomic="true">
             {ariaOptionsAvailableTextFunction
               ? ariaOptionsAvailableTextFunction(popoverItems.length)
               : `${popoverItems.length} ${ariaOptionsAvailableText}`}
+          </VisuallyHidden>
+        )}
+        {loading && (
+          <VisuallyHidden
+            aria-live="polite"
+            aria-atomic="true"
+            id={`${id}-loading-announce`}
+          >
+            {loadingText}
           </VisuallyHidden>
         )}
       </HtmlDiv>

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -742,5 +742,16 @@ exports[`has matching snapshot 1`] = `
       </div>
     </div>
   </div>
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    class="c5 c10 fi-visually-hidden"
+  />
+  <span
+    aria-atomic="true"
+    aria-live="polite"
+    class="c5 c10 fi-visually-hidden"
+    id="2-loading-announce"
+  />
 </div>
 `;


### PR DESCRIPTION
## Description
It was noticed that the new loading state in SingleSelect and MultiSelect was not properly informed by screen readers. 
This PR adds  aria rules that will replace the "x options available" on screen reader with the "loading" text.

Also add more realistic demo in styleguidist.

## Related Issue
https://jira.dvv.fi/browse/SFIDS-720

Closes #

## Motivation and Context

Better screen reader support on select components.

## How Has This Been Tested?
Safari + Chrome + Voice Over + Styleguidist



## Release notes

These are probably covered by the original "loading state" feature in release notes?
### SingleSelect
* Add screen reader support for loading state
* Fix possible issue with NVDA and ariaOptionsAvailableText

### MultiSelect
* Add screen reader support for loading state
* Fix possible issue with NVDA and ariaSelectedAmountText