### PR TITLE
[Fix] Dynamic content snapshots

### DIFF
--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -118,9 +118,15 @@ it('should not have basic accessibility issues', async () => {
   });
 });
 
-it('has matching snapshot', () => {
-  const { container } = render(BasicMultiSelect);
-  expect(container.firstChild).toMatchSnapshot();
+it('has matching snapshot', async () => {
+  await act(async () => {
+    const { baseElement, getByRole } = render(BasicMultiSelect);
+    const textfield = getByRole('textbox') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.focus(textfield);
+    });
+    expect(baseElement).toMatchSnapshot();
+  });
 });
 
 describe('Chips', () => {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -145,6 +145,31 @@ exports[`has matching snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c17 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c17::before,
+.c17::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -171,6 +196,37 @@ exports[`has matching snapshot 1`] = `
 
 .c5::before,
 .c5::after {
+  box-sizing: border-box;
+}
+
+.c15 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c15::before,
+.c15::after {
   box-sizing: border-box;
 }
 
@@ -439,6 +495,45 @@ exports[`has matching snapshot 1`] = `
   margin-bottom: 0;
 }
 
+.c16 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style-type: none;
+  box-sizing: content-box;
+  max-height: 265px;
+  background-color: hsl(0,0%,100%);
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+  border-color: hsl(201,7%,58%);
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  margin: 0;
+  padding: 4px 0 0 0;
+}
+
+.c16:focus {
+  outline: none;
+}
+
+.c16 .fi-select-item-list_content_wrapper {
+  display: block;
+  width: 100%;
+  max-height: inherit;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
 .c10 {
   vertical-align: baseline;
 }
@@ -461,6 +556,95 @@ exports[`has matching snapshot 1`] = `
 
 .c10.fi-icon--cursor-pointer * {
   cursor: inherit;
+}
+
+.c18 {
+  position: relative;
+  padding: 8px 32px 8px 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c18:focus {
+  outline: none;
+}
+
+.c18.fi-select-item {
+  cursor: pointer;
+}
+
+.c18.fi-select-item .fi-select-item--query_highlight {
+  background-color: transparent;
+  font-weight: bold;
+}
+
+.c18.fi-select-item .fi-select-item_icon {
+  position: absolute;
+  top: 14px;
+  right: 10px;
+  height: 12px;
+  width: 12px;
+}
+
+.c18.fi-select-item--selected {
+  background-color: hsl(215,100%,95%);
+  color: hsl(0,0%,13%);
+}
+
+.c18.fi-select-item--selected .fi-select-item--query_highlight {
+  color: hsl(0,0%,13%);
+}
+
+.c18.fi-select-item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c18.fi-select-item--hasKeyboardFocus .fi-select-item--query_highlight {
+  color: hsl(0,0%,100%);
+  background-color: hsl(212,63%,45%);
+}
+
+.c18.fi-select-item--disabled {
+  color: hsl(202,7%,67%);
+  cursor: not-allowed;
+}
+
+.c18.fi-select-item--disabled .fi-select-item--query_highlight {
+  color: hsl(202,7%,67%);
+}
+
+.c18.fi-select-item--disabled.fi-select-item:hover {
+  color: hsl(202,7%,67%);
+}
+
+.c18.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
+  color: hsl(202,7%,67%);
+}
+
+.c18.fi-select-item:hover {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c18.fi-select-item:hover .fi-select-item--query_highlight {
+  color: hsl(0,0%,100%);
+}
+
+.c18 .fi-select-item_wrapper {
+  display: inline-block;
+  width: 100%;
 }
 
 .c13 {
@@ -904,146 +1088,210 @@ exports[`has matching snapshot 1`] = `
   margin-top: 10px;
 }
 
-<div
-  class="c0 fi-multiselect c1"
->
-  <div
-    class="c0 fi-multiselect_content_wrapper"
-  >
+<body>
+  <div>
     <div
-      class="c0 fi-filter-input c2"
+      class="c0 fi-multiselect c1 fi-multiselect--open"
     >
       <div
-        class="c0 fi-filter-input_wrapper"
+        class="c0 fi-multiselect_content_wrapper"
       >
         <div
-          class="c3 c4 fi-filter-input_label--visible fi-label"
+          class="c0 fi-filter-input c2"
         >
-          <label
-            class="c5 fi-label_label-span"
-            for="1"
-            id="1-label"
+          <div
+            class="c0 fi-filter-input_wrapper"
           >
-            MultiSelect
-          </label>
+            <div
+              class="c3 c4 fi-filter-input_label--visible fi-label"
+            >
+              <label
+                class="c5 fi-label_label-span"
+                for="1"
+                id="1-label"
+              >
+                MultiSelect
+              </label>
+            </div>
+            <div
+              class="c0 fi-filter-input_functionalityContainer"
+            >
+              <div
+                aria-expanded="true"
+                aria-haspopup="listbox"
+                aria-owns="3-popover"
+                class="c0 fi-filter-input_input-element-container"
+                role="combobox"
+              >
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="3-popover"
+                  aria-invalid="false"
+                  aria-labelledby="1-label"
+                  aria-multiline="false"
+                  autocapitalize="none"
+                  autocomplete="off"
+                  class="c6 fi-filter-input_input"
+                  id="1"
+                  placeholder="Choose your tool(s)"
+                  spellcheck="false"
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                class="c0 fi-filter-input_action-elements-container"
+              >
+                <button
+                  aria-hidden="true"
+                  class="c7 fi-input-toggle-button c8"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="c5 c9 fi-visually-hidden"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="fi-icon c10 fi-input-toggle-button_icon"
+                    focusable="false"
+                    height="1em"
+                    viewBox="0 0 10 10"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class="fi-icon-base-fill"
+                      d="M5 2L1 8h8z"
+                      fill="#222"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <span
+                aria-atomic="true"
+                aria-live="assertive"
+                class="c5 c11 fi-status-text"
+              />
+            </div>
+          </div>
         </div>
         <div
-          class="c0 fi-filter-input_functionalityContainer"
+          class="c0 fi-chip-list c12"
+          id="2"
         >
           <div
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            aria-owns="3-popover"
-            class="c0 fi-filter-input_input-element-container"
-            role="combobox"
-          >
-            <input
-              aria-activedescendant=""
-              aria-autocomplete="list"
-              aria-controls="3-popover"
-              aria-invalid="false"
-              aria-labelledby="1-label"
-              aria-multiline="false"
-              autocapitalize="none"
-              autocomplete="off"
-              class="c6 fi-filter-input_input"
-              id="1"
-              placeholder="Choose your tool(s)"
-              spellcheck="false"
-              type="text"
-              value=""
-            />
-          </div>
-          <div
-            class="c0 fi-filter-input_action-elements-container"
+            class="c0 fi-chip-list_content_wrapper"
           >
             <button
-              aria-hidden="true"
-              class="c7 fi-input-toggle-button c8"
-              tabindex="-1"
+              aria-disabled="true"
+              class="c7 fi-chip fi-chip--button c13 fi-chip--disabled fi-chip--removable"
               type="button"
             >
               <span
-                class="c5 c9 fi-visually-hidden"
-              />
+                class="c5 fi-chip--content"
+              >
+                Powersaw
+              </span>
               <svg
                 aria-hidden="true"
-                class="fi-icon c10 fi-input-toggle-button_icon"
+                class="fi-icon c10 fi-chip--icon fi-icon--cursor-pointer"
                 focusable="false"
                 height="1em"
-                viewBox="0 0 10 10"
+                viewBox="0 0 24 24"
                 width="1em"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
                   class="fi-icon-base-fill"
-                  d="M5 8l4-6H1z"
+                  d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
                   fill="#222"
                   fill-rule="evenodd"
                 />
               </svg>
+              <span
+                class="c5 c9 fi-visually-hidden"
+              >
+                Remove
+              </span>
+            </button>
+            <button
+              aria-disabled="false"
+              class="c7 fi-chip fi-chip--button c13 fi-chip--removable"
+              type="button"
+            >
+              <span
+                class="c5 fi-chip--content"
+              >
+                Hammer
+              </span>
+              <svg
+                aria-hidden="true"
+                class="fi-icon c10 fi-chip--icon fi-icon--cursor-pointer"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              <span
+                class="c5 c9 fi-visually-hidden"
+              >
+                Remove
+              </span>
+            </button>
+            <button
+              aria-disabled="false"
+              class="c7 fi-chip fi-chip--button c13 fi-chip--removable"
+              type="button"
+            >
+              <span
+                class="c5 fi-chip--content"
+              >
+                Rake
+              </span>
+              <svg
+                aria-hidden="true"
+                class="fi-icon c10 fi-chip--icon fi-icon--cursor-pointer"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              <span
+                class="c5 c9 fi-visually-hidden"
+              >
+                Remove
+              </span>
             </button>
           </div>
-          <span
-            aria-atomic="true"
-            aria-live="assertive"
-            class="c5 c11 fi-status-text"
-          />
         </div>
-      </div>
-    </div>
-    <div
-      class="c0 fi-chip-list c12"
-      id="2"
-    >
-      <div
-        class="c0 fi-chip-list_content_wrapper"
-      >
-        <button
-          aria-disabled="true"
-          class="c7 fi-chip fi-chip--button c13 fi-chip--disabled fi-chip--removable"
-          type="button"
-        >
-          <span
-            class="c5 fi-chip--content"
-          >
-            Powersaw
-          </span>
-          <svg
-            aria-hidden="true"
-            class="fi-icon c10 fi-chip--icon fi-icon--cursor-pointer"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fi-icon-base-fill"
-              d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-          <span
-            class="c5 c9 fi-visually-hidden"
-          >
-            Remove
-          </span>
-        </button>
         <button
           aria-disabled="false"
-          class="c7 fi-chip fi-chip--button c13 fi-chip--removable"
+          class="c7 fi-button c14 fi-multiselect_removeAllButton fi-button--link"
+          tabindex="0"
           type="button"
         >
-          <span
-            class="c5 fi-chip--content"
-          >
-            Hammer
-          </span>
           <svg
             aria-hidden="true"
-            class="fi-icon c10 fi-chip--icon fi-icon--cursor-pointer"
+            class="fi-icon c10 fi-button_icon fi-icon--cursor-pointer"
             focusable="false"
             height="1em"
             viewBox="0 0 24 24"
@@ -1052,75 +1300,206 @@ exports[`has matching snapshot 1`] = `
           >
             <path
               class="fi-icon-base-fill"
-              d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+              d="M13 0c1.654 0 3 1.346 3 3v1h5a1 1 0 010 2h-1.091l-1.804 16.117A2.143 2.143 0 0116 24H8a2.141 2.141 0 01-2.104-1.885L4.119 6H3a1 1 0 010-2h5V3c0-1.654 1.346-3 3-3h2zm4.898 6H6.132l1.753 15.896c.004.04.075.104.115.104h8c.041 0 .113-.065.118-.105L17.898 6zM13 2h-2c-.551 0-1 .448-1 1v1h4V3c0-.552-.449-1-1-1z"
               fill="#222"
               fill-rule="evenodd"
             />
           </svg>
-          <span
-            class="c5 c9 fi-visually-hidden"
-          >
-            Remove
-          </span>
-        </button>
-        <button
-          aria-disabled="false"
-          class="c7 fi-chip fi-chip--button c13 fi-chip--removable"
-          type="button"
-        >
-          <span
-            class="c5 fi-chip--content"
-          >
-            Rake
-          </span>
-          <svg
-            aria-hidden="true"
-            class="fi-icon c10 fi-chip--icon fi-icon--cursor-pointer"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fi-icon-base-fill"
-              d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-          <span
-            class="c5 c9 fi-visually-hidden"
-          >
-            Remove
-          </span>
+          Remove all selections
         </button>
       </div>
     </div>
-    <button
-      aria-disabled="false"
-      class="c7 fi-button c14 fi-multiselect_removeAllButton fi-button--link"
-      tabindex="0"
-      type="button"
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      class="c5 c9 fi-visually-hidden"
     >
-      <svg
-        aria-hidden="true"
-        class="fi-icon c10 fi-button_icon fi-icon--cursor-pointer"
-        focusable="false"
-        height="1em"
-        viewBox="0 0 24 24"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          class="fi-icon-base-fill"
-          d="M13 0c1.654 0 3 1.346 3 3v1h5a1 1 0 010 2h-1.091l-1.804 16.117A2.143 2.143 0 0116 24H8a2.141 2.141 0 01-2.104-1.885L4.119 6H3a1 1 0 010-2h5V3c0-1.654 1.346-3 3-3h2zm4.898 6H6.132l1.753 15.896c.004.04.075.104.115.104h8c.041 0 .113-.065.118-.105L17.898 6zM13 2h-2c-.551 0-1 .448-1 1v1h4V3c0-.552-.449-1-1-1z"
-          fill="#222"
-          fill-rule="evenodd"
-        />
-      </svg>
-      Remove all selections
-    </button>
+      3
+      tools selected
+    </span>
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      class="c5 c9 fi-visually-hidden"
+      id="3-filteredItems-length"
+    />
+    <span
+      aria-atomic="true"
+      aria-live="polite"
+      class="c5 c9 fi-visually-hidden"
+      id="3-loading-announce"
+    />
+    <span
+      aria-atomic="true"
+      aria-live="assertive"
+      class="c5 c9 fi-visually-hidden"
+      id="3-chip-removal-announce"
+    />
   </div>
-</div>
+  <div
+    class="fi-portal"
+    role="presentation"
+    style="position: absolute; left: 0px; top: 0px;"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+    >
+      <ul
+        aria-multiselectable="true"
+        class="c15 fi-select-item-list c16"
+        id="3-popover"
+        role="listbox"
+        tabindex="0"
+      >
+        <div
+          class="c3 fi-select-item-list_content_wrapper"
+        >
+          <div
+            class="c0"
+          >
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="3-jh2435626"
+              role="option"
+              tabindex="-1"
+            >
+              Jackhammer
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="true"
+              class="c17 fi-select-item c18 fi-select-item--selected"
+              id="3-h9823523"
+              role="option"
+              tabindex="-1"
+            >
+              Hammer
+              <svg
+                aria-hidden="true"
+                class="fi-icon c10 fi-select-item_icon"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 20 20"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="3-sh908293482"
+              role="option"
+              tabindex="-1"
+            >
+              Sledgehammer
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="3-s82502335"
+              role="option"
+              tabindex="-1"
+            >
+              Spade
+            </li>
+            <li
+              aria-disabled="true"
+              aria-selected="true"
+              class="c17 fi-select-item c18 fi-select-item--selected fi-select-item--disabled"
+              id="3-ps9081231"
+              role="option"
+              tabindex="-1"
+            >
+              Powersaw
+              <svg
+                aria-hidden="true"
+                class="fi-icon c10 fi-select-item_icon"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 20 20"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="3-s05111511"
+              role="option"
+              tabindex="-1"
+            >
+              Shovel
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="3-is3451261"
+              role="option"
+              tabindex="-1"
+            >
+              Iron stick
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="true"
+              class="c17 fi-select-item c18 fi-select-item--selected"
+              id="3-r09282626"
+              role="option"
+              tabindex="-1"
+            >
+              Rake
+              <svg
+                aria-hidden="true"
+                class="fi-icon c10 fi-select-item_icon"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 20 20"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </li>
+            <li
+              aria-disabled="true"
+              aria-selected="false"
+              class="c17 fi-select-item c18 fi-select-item--disabled"
+              id="3-ms6126266"
+              role="option"
+              tabindex="-1"
+            >
+              Motorsaw
+            </li>
+          </div>
+        </div>
+      </ul>
+    </div>
+  </div>
+</body>
 `;

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -98,9 +98,13 @@ it('should not have basic accessibility issues', async () => {
   });
 });
 
-it('has matching snapshot', () => {
-  const { container } = render(BasicSingleSelect);
-  expect(container.firstChild).toMatchSnapshot();
+it('has matching snapshot', async () => {
+  const { baseElement, getByRole } = render(BasicSingleSelect);
+  const textfield = getByRole('textbox') as HTMLInputElement;
+  await act(async () => {
+    fireEvent.focus(textfield);
+  });
+  expect(baseElement).toMatchSnapshot();
 });
 
 describe('Controlled', () => {

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -145,6 +145,31 @@ exports[`has matching snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c16 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c16::before,
+.c16::after {
+  box-sizing: border-box;
+}
+
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -171,6 +196,37 @@ exports[`has matching snapshot 1`] = `
 
 .c5::before,
 .c5::after {
+  box-sizing: border-box;
+}
+
+.c14 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c14::before,
+.c14::after {
   box-sizing: border-box;
 }
 
@@ -546,6 +602,134 @@ exports[`has matching snapshot 1`] = `
   fill: hsl(202,7%,67%);
 }
 
+.c15 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style-type: none;
+  box-sizing: content-box;
+  max-height: 265px;
+  background-color: hsl(0,0%,100%);
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+  border-color: hsl(201,7%,58%);
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  margin: 0;
+  padding: 4px 0 0 0;
+}
+
+.c15:focus {
+  outline: none;
+}
+
+.c15 .fi-select-item-list_content_wrapper {
+  display: block;
+  width: 100%;
+  max-height: inherit;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.c17 {
+  position: relative;
+  padding: 8px 32px 8px 10px;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17.fi-select-item {
+  cursor: pointer;
+}
+
+.c17.fi-select-item .fi-select-item--query_highlight {
+  background-color: transparent;
+  font-weight: bold;
+}
+
+.c17.fi-select-item .fi-select-item_icon {
+  position: absolute;
+  top: 14px;
+  right: 10px;
+  height: 12px;
+  width: 12px;
+}
+
+.c17.fi-select-item--selected {
+  background-color: hsl(215,100%,95%);
+  color: hsl(0,0%,13%);
+}
+
+.c17.fi-select-item--selected .fi-select-item--query_highlight {
+  color: hsl(0,0%,13%);
+}
+
+.c17.fi-select-item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c17.fi-select-item--hasKeyboardFocus .fi-select-item--query_highlight {
+  color: hsl(0,0%,100%);
+  background-color: hsl(212,63%,45%);
+}
+
+.c17.fi-select-item--disabled {
+  color: hsl(202,7%,67%);
+  cursor: not-allowed;
+}
+
+.c17.fi-select-item--disabled .fi-select-item--query_highlight {
+  color: hsl(202,7%,67%);
+}
+
+.c17.fi-select-item--disabled.fi-select-item:hover {
+  color: hsl(202,7%,67%);
+}
+
+.c17.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
+  color: hsl(202,7%,67%);
+}
+
+.c17.fi-select-item:hover {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c17.fi-select-item:hover .fi-select-item--query_highlight {
+  color: hsl(0,0%,100%);
+}
+
+.c17 .fi-select-item_wrapper {
+  display: inline-block;
+  width: 100%;
+}
+
 .c12 {
   width: 20px;
   height: 20px;
@@ -620,138 +804,274 @@ exports[`has matching snapshot 1`] = `
   border-bottom-right-radius: 0;
 }
 
-<div
-  class="c0 fi-single-select c1 fi-single-select--value-selected"
->
-  <div
-    class="c0 fi-filter-input c2"
-  >
+<body>
+  <div>
     <div
-      class="c0 fi-filter-input_wrapper"
+      class="c0 fi-single-select c1 fi-single-select--value-selected fi-single-select--open"
     >
       <div
-        class="c3 c4 fi-filter-input_label--visible fi-label"
-      >
-        <label
-          class="c5 fi-label_label-span"
-          for="1"
-          id="1-label"
-        >
-          SingleSelect
-        </label>
-      </div>
-      <span
-        class="c5 c6 fi-hint-text"
-        id="1-hintText"
-      >
-        You can filter options by typing in the field
-      </span>
-      <div
-        class="c0 fi-filter-input_functionalityContainer"
+        class="c0 fi-filter-input c2"
       >
         <div
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-owns="2-popover"
-          class="c0 fi-filter-input_input-element-container"
-          role="combobox"
-        >
-          <input
-            aria-activedescendant=""
-            aria-autocomplete="list"
-            aria-controls="2-popover"
-            aria-describedby="1-hintText"
-            aria-invalid="false"
-            aria-labelledby="1-label"
-            aria-multiline="false"
-            autocapitalize="none"
-            autocomplete="off"
-            class="c7 fi-filter-input_input"
-            id="1"
-            placeholder=""
-            spellcheck="false"
-            type="text"
-            value="Hammer"
-          />
-        </div>
-        <div
-          class="c0 fi-filter-input_action-elements-container"
+          class="c0 fi-filter-input_wrapper"
         >
           <div
-            class="c0 fi-single-select_clear-button_wrapper"
+            class="c3 c4 fi-filter-input_label--visible fi-label"
           >
-            <button
-              class="c8 fi-input-clear-button c9"
-              type="button"
+            <label
+              class="c5 fi-label_label-span"
+              for="1"
+              id="1-label"
             >
-              <span
-                class="c5 c10 fi-visually-hidden"
+              SingleSelect
+            </label>
+          </div>
+          <span
+            class="c5 c6 fi-hint-text"
+            id="1-hintText"
+          >
+            You can filter options by typing in the field
+          </span>
+          <div
+            class="c0 fi-filter-input_functionalityContainer"
+          >
+            <div
+              aria-expanded="true"
+              aria-haspopup="listbox"
+              aria-owns="2-popover"
+              class="c0 fi-filter-input_input-element-container"
+              role="combobox"
+            >
+              <input
+                aria-activedescendant=""
+                aria-autocomplete="list"
+                aria-controls="2-popover"
+                aria-describedby="1-hintText"
+                aria-invalid="false"
+                aria-labelledby="1-label"
+                aria-multiline="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="c7 fi-filter-input_input"
+                id="1"
+                placeholder=""
+                spellcheck="false"
+                type="text"
+                value="Hammer"
+              />
+            </div>
+            <div
+              class="c0 fi-filter-input_action-elements-container"
+            >
+              <div
+                class="c0 fi-single-select_clear-button_wrapper"
               >
-                Clear selection
-              </span>
+                <button
+                  class="c8 fi-input-clear-button c9"
+                  type="button"
+                >
+                  <span
+                    class="c5 c10 fi-visually-hidden"
+                  >
+                    Clear selection
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="fi-icon c11 fi-input-clear-button_icon"
+                    focusable="false"
+                    height="1em"
+                    viewBox="0 0 24 24"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      class="fi-icon-base-fill"
+                      d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+                      fill="#222"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <button
+                aria-hidden="true"
+                class="c8 fi-input-toggle-button c12"
+                tabindex="-1"
+                type="button"
+              >
+                <span
+                  class="c5 c10 fi-visually-hidden"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="fi-icon c11 fi-input-toggle-button_icon"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 10 10"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    class="fi-icon-base-fill"
+                    d="M5 2L1 8h8z"
+                    fill="#222"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+            <span
+              aria-atomic="true"
+              aria-live="assertive"
+              class="c5 c13 fi-status-text"
+            />
+          </div>
+        </div>
+      </div>
+      <span
+        aria-atomic="true"
+        aria-live="polite"
+        class="c5 c10 fi-visually-hidden"
+      />
+      <span
+        aria-atomic="true"
+        aria-live="polite"
+        class="c5 c10 fi-visually-hidden"
+        id="2-loading-announce"
+      />
+    </div>
+  </div>
+  <div
+    class="fi-portal"
+    role="presentation"
+    style="position: absolute; left: 0px; top: 0px; width: 0px; transform: translate(0px, 0px);"
+    tabindex="-1"
+  >
+    <div
+      class="c3"
+    >
+      <ul
+        class="c14 fi-select-item-list c15"
+        id="2-popover"
+        role="listbox"
+        tabindex="0"
+      >
+        <div
+          class="c3 fi-select-item-list_content_wrapper"
+        >
+          <div
+            class="c0"
+          >
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c16 fi-select-item c17"
+              id="2-jh2435626"
+              role="option"
+              tabindex="-1"
+            >
+              Jackhammer
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="true"
+              class="c16 fi-select-item c17 fi-select-item--selected"
+              id="2-h9823523"
+              role="option"
+              tabindex="-1"
+            >
+              Hammer
               <svg
                 aria-hidden="true"
-                class="fi-icon c11 fi-input-clear-button_icon"
+                class="fi-icon c11 fi-select-item_icon"
                 focusable="false"
                 height="1em"
-                viewBox="0 0 24 24"
+                viewBox="0 0 20 20"
                 width="1em"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
                   class="fi-icon-base-fill"
-                  d="M4.75 3.3L12 10.55l7.25-7.25a1.026 1.026 0 011.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 01-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 01-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 014.75 3.3z"
+                  d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
                   fill="#222"
                   fill-rule="evenodd"
                 />
               </svg>
-            </button>
-          </div>
-          <button
-            aria-hidden="true"
-            class="c8 fi-input-toggle-button c12"
-            tabindex="-1"
-            type="button"
-          >
-            <span
-              class="c5 c10 fi-visually-hidden"
-            />
-            <svg
-              aria-hidden="true"
-              class="fi-icon c11 fi-input-toggle-button_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 10 10"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c16 fi-select-item c17"
+              id="2-sh908293482"
+              role="option"
+              tabindex="-1"
             >
-              <path
-                class="fi-icon-base-fill"
-                d="M5 8l4-6H1z"
-                fill="#222"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </button>
+              Sledgehammer
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c16 fi-select-item c17"
+              id="2-s82502335"
+              role="option"
+              tabindex="-1"
+            >
+              Spade
+            </li>
+            <li
+              aria-disabled="true"
+              aria-selected="false"
+              class="c16 fi-select-item c17 fi-select-item--disabled"
+              id="2-ps9081231"
+              role="option"
+              tabindex="-1"
+            >
+              Powersaw
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c16 fi-select-item c17"
+              id="2-s05111511"
+              role="option"
+              tabindex="-1"
+            >
+              Shovel
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c16 fi-select-item c17"
+              id="2-is3451261"
+              role="option"
+              tabindex="-1"
+            >
+              Iron stick
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c16 fi-select-item c17"
+              id="2-r09282626"
+              role="option"
+              tabindex="-1"
+            >
+              Rake
+            </li>
+            <li
+              aria-disabled="true"
+              aria-selected="false"
+              class="c16 fi-select-item c17 fi-select-item--disabled"
+              id="2-ms6126266"
+              role="option"
+              tabindex="-1"
+            >
+              Motorsaw
+            </li>
+          </div>
         </div>
-        <span
-          aria-atomic="true"
-          aria-live="assertive"
-          class="c5 c13 fi-status-text"
-        />
-      </div>
+      </ul>
     </div>
   </div>
-  <span
-    aria-atomic="true"
-    aria-live="polite"
-    class="c5 c10 fi-visually-hidden"
-  />
-  <span
-    aria-atomic="true"
-    aria-live="polite"
-    class="c5 c10 fi-visually-hidden"
-    id="2-loading-announce"
-  />
-</div>
+</body>
 `;

--- a/src/core/LanguageMenu/LanguageMenu/LanguageMenu.test.tsx
+++ b/src/core/LanguageMenu/LanguageMenu/LanguageMenu.test.tsx
@@ -8,24 +8,25 @@ import { LanguageMenuLink } from '../LanguageMenuLink';
 
 const doNothing = () => ({});
 
-const TestMenuLanguage = (
-  <LanguageMenu className="menu-language-test" name="FI">
-    <LanguageMenuItem onSelect={doNothing} selected={true}>
+const TestLanguageMenu = (
+  <LanguageMenu className="language-menu-language-test" name="Suomeksi (FI)">
+    <LanguageMenuItem onSelect={() => doNothing()} selected>
       Suomeksi (FI)
     </LanguageMenuItem>
     <LanguageMenuLink href="/sv">På svenska (SV)</LanguageMenuLink>
+    <LanguageMenuLink href="/en">In English (EN)</LanguageMenuLink>
   </LanguageMenu>
 );
 
-test('calling render with the same component on the same container does not remount', () => {
-  const { container } = render(TestMenuLanguage);
-  expect(container).toMatchSnapshot();
+test('should match snapshot', () => {
+  const { baseElement } = render(TestLanguageMenu);
+  expect(baseElement).toMatchSnapshot();
 });
 
 // Don't validate aria-attributes since Portal is not rendered and there is no pair for aria-controls
 test(
   'should not have basic accessibility issues',
-  axeTest(TestMenuLanguage, {
+  axeTest(TestLanguageMenu, {
     rules: {
       'aria-valid-attr-value': {
         enabled: false,

--- a/src/core/LanguageMenu/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calling render with the same component on the same container does not remount 1`] = `
+exports[`should match snapshot 1`] = `
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -125,36 +125,186 @@ exports[`calling render with the same component on the same container does not r
   transform: translateY(0.2em) rotate(180deg);
 }
 
-<div>
-  <span
-    class="c0 c1 fi-language-menu"
-  >
-    <button
-      aria-controls="menu--1"
-      aria-haspopup="true"
-      class="fi-language-menu_button fi-language-menu-language_button menu-language-test"
-      data-reach-menu-button=""
-      id="menu-button--menu"
-      type="button"
+.c3[data-reach-menu-popover] {
+  color: hsl(0,0%,13%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: hsl(0,0%,100%);
+  box-shadow: 0 2px 3px 0 hsla(0,0%,13%,0.2);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  position: absolute;
+  box-sizing: content-box;
+  margin-top: 12px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+}
+
+.c3[data-reach-menu-popover]:before,
+.c3[data-reach-menu-popover]:after {
+  content: '';
+  position: absolute;
+  height: 0;
+  width: 0;
+  bottom: 100%;
+  right: 25px;
+  border: solid transparent;
+  pointer-events: none;
+}
+
+.c3[data-reach-menu-popover]:before {
+  border-bottom-color: hsl(202,7%,80%);
+  border-width: 8px;
+  margin-right: -8px;
+}
+
+.c3[data-reach-menu-popover]:after {
+  border-bottom-color: hsl(0,0%,100%);
+  border-width: 6.5px;
+  margin-right: -6.5px;
+}
+
+.c3 [data-reach-menu-items] {
+  border: 0;
+  padding: 0;
+  white-space: normal;
+}
+
+.c3 [data-reach-menu-item].fi-language-menu_item {
+  color: hsl(0,0%,13%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  word-break: break-word;
+}
+
+.c3 [data-reach-menu-item].fi-language-menu_item[data-selected] {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  color: hsl(0,0%,13%);
+  background-color: hsl(212,63%,95%);
+}
+
+.c3 [data-reach-menu-item].fi-language-menu_item.fi-language-menu-language_item,
+.c3 [data-reach-menu-item].fi-language-menu_item[data-selected].fi-language-menu-language_item {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 10px 0;
+  padding: 0 20px 0 5px;
+  border-left: 4px solid transparent;
+  background-color: transparent;
+}
+
+.c3 [data-reach-menu-item].fi-language-menu_item.fi-language-menu-language_item.fi-language-menu-lang-item-selected,
+.c3 [data-reach-menu-item].fi-language-menu_item[data-selected].fi-language-menu-language_item.fi-language-menu-lang-item-selected {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  border-left-color: hsl(212,63%,45%);
+}
+
+.c3 [data-reach-menu-item].fi-language-menu_item[data-selected].fi-language-menu-language_item {
+  border-left-color: hsl(212,63%,45%);
+}
+
+.c3 [data-reach-menu-item].fi-language-menu_item:focus {
+  outline: 0;
+}
+
+<body>
+  <div>
+    <span
+      class="c0 c1 fi-language-menu"
     >
-      FI
-      <svg
-        aria-hidden="true"
-        class="fi-icon c2 fi-language-menu-language_icon"
-        focusable="false"
-        height="1em"
-        viewBox="0 0 24 24"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
+      <button
+        aria-controls="menu--1"
+        aria-haspopup="true"
+        class="fi-language-menu_button fi-language-menu-language_button language-menu-language-test"
+        data-reach-menu-button=""
+        id="menu-button--menu"
+        type="button"
       >
-        <path
-          class="fi-icon-base-fill"
-          d="M12.99 15.61c-.273.26-.632.39-.99.39s-.717-.13-.99-.39l-5.6-5.334a1.287 1.287 0 010-1.885 1.448 1.448 0 011.98 0l4.61 4.39 4.61-4.39a1.448 1.448 0 011.98 0c.547.52.547 1.365 0 1.885l-5.6 5.333z"
-          fill="#222"
-          fill-rule="evenodd"
-        />
-      </svg>
-    </button>
-  </span>
-</div>
+        Suomeksi (FI)
+        <svg
+          aria-hidden="true"
+          class="fi-icon c2 fi-language-menu-language_icon"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            class="fi-icon-base-fill"
+            d="M12.99 15.61c-.273.26-.632.39-.99.39s-.717-.13-.99-.39l-5.6-5.334a1.287 1.287 0 010-1.885 1.448 1.448 0 011.98 0l4.61 4.39 4.61-4.39a1.448 1.448 0 011.98 0c.547.52.547 1.365 0 1.885l-5.6 5.333z"
+            fill="#222"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </button>
+    </span>
+  </div>
+  <reach-portal>
+    <div
+      class="c3"
+      data-reach-menu-popover=""
+      data-reach-popover=""
+      hidden=""
+      style="position: absolute; left: 0px; top: 0px; max-width: 0px; min-width: -2px;"
+    >
+      <div
+        aria-labelledby="menu-button--menu"
+        data-reach-menu-items=""
+        id="menu--1"
+        role="menu"
+        tabindex="-1"
+      >
+        <div
+          class="fi-language-menu_item fi-language-menu-language_item fi-language-menu-lang-item-selected"
+          data-reach-menu-item=""
+          data-valuetext="Suomeksi (FI)"
+          id="option-0--menu--1"
+          role="menuitem"
+          tabindex="-1"
+        >
+          Suomeksi (FI)
+        </div>
+        <a
+          class="fi-language-menu_item fi-language-menu-language_item"
+          data-reach-menu-item=""
+          data-reach-menu-link=""
+          data-valuetext="På svenska (SV)"
+          href="/sv"
+          id="option-1--menu--1"
+          role="menuitem"
+          tabindex="-1"
+        >
+          På svenska (SV)
+        </a>
+        <a
+          class="fi-language-menu_item fi-language-menu-language_item"
+          data-reach-menu-item=""
+          data-reach-menu-link=""
+          data-valuetext="In English (EN)"
+          href="/en"
+          id="option-2--menu--1"
+          role="menuitem"
+          tabindex="-1"
+        >
+          In English (EN)
+        </a>
+      </div>
+    </div>
+  </reach-portal>
+</body>
 `;


### PR DESCRIPTION
## Description
This PR adjusts tests for SingleSelect, MultiSelect and LanguageMenu so that the snapshot tests test the opened state of the components instead of the initial state.

## Motivation and Context
Some components with dynamic content such as single- and multiselect had snapshot tests that only tested the initial state of the component, which left a lot of content outside the snapshot. Thus something could have been broken or changed inside the component without it being caught by the test.

## How Has This Been Tested?
By running tests and manually checking the contents of the new snapshots.

## Release notes
- none needed