### PR TITLE
[Breaking change] Dropdown without Reach

### DIFF
--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -4,12 +4,35 @@ import { element, input } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   width: 290px;
-  /* stylelint-disable no-descending-specificity */
   .fi-dropdown_item-list {
     padding-top: 0;
   }
   &.fi-dropdown {
     display: inline-block;
+
+    &--open {
+      .fi-dropdown_button {
+        border-bottom: 0;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        padding-bottom: 8px;
+      }
+    }
+
+    &--error {
+      .fi-dropdown_button {
+        border-color: ${theme.colors.alertBase};
+        border-width: 2px;
+      }
+    }
+
+    &--italicize {
+      .fi-dropdown_button {
+        font-style: italic;
+        color: ${theme.colors.depthDark2};
+        opacity: 1;
+      }
+    }
 
     .fi-dropdown_label--visible {
       margin-bottom: ${theme.spacing.xs};
@@ -23,19 +46,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       line-height: 18px;
       &.fi-dropdown_statusText--has-content {
         margin-top: ${theme.spacing.xxs};
-      }
-    }
-
-    &:not(.fi-dropdown--open) {
-      .fi-dropdown_button {
-        &:focus {
-          outline: 0;
-          position: relative;
-
-          &:after {
-            ${theme.focuses.absoluteFocus}
-          }
-        }
       }
     }
 
@@ -118,27 +128,16 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
 
-    &--open {
+    &:not(.fi-dropdown--open) {
       .fi-dropdown_button {
-        border-bottom: 0;
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-        padding-bottom: 8px;
-      }
-    }
+        &:focus {
+          outline: 0;
+          position: relative;
 
-    &--error {
-      .fi-dropdown_button {
-        border-color: ${theme.colors.alertBase};
-        border-width: 2px;
-      }
-    }
-
-    &--italicize {
-      .fi-dropdown_button {
-        font-style: italic;
-        color: ${theme.colors.depthDark2};
-        opacity: 1;
+          &:after {
+            ${theme.focuses.absoluteFocus}
+          }
+        }
       }
     }
   }

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -19,7 +19,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     .fi-status-text {
-      line-height: 18px;
+      line-height: 1.1rem;
       &.fi-dropdown_statusText--has-content {
         margin-top: ${theme.spacing.xxs};
       }

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -69,7 +69,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     .fi-dropdown_display-value {
       width: 100%;
       height: 100%;
-      display: block;
+      display: inline-block;
       line-height: 1.5;
       overflow: hidden;
     }
@@ -144,7 +144,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &:not(.fi-dropdown--open) {
       .fi-dropdown_button {
         &:focus {
-          outline: 0;
+          outline: 3px solid transparent;
           position: relative;
 
           &:after {

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -89,6 +89,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
 
+    &--full-width {
+      width: 100%;
+    }
+
     &--open {
       .fi-dropdown_button {
         border-bottom: 0;

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -66,6 +66,14 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
 
+    .fi-dropdown_display-value {
+      width: 100%;
+      height: 100%;
+      display: block;
+      line-height: 1.5;
+      overflow: hidden;
+    }
+
     .fi-dropdown_popover {
       ${element(theme)}
       ${theme.typography.actionElementInnerText}

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -3,108 +3,118 @@ import { SuomifiTheme } from '../../theme';
 import { element, inputButton } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  /* stylelint-disable no-descending-specificity */
+  .fi-dropdown_item-list {
+    padding-top: 0;
+  }
   &.fi-dropdown {
     display: inline-block;
 
-    & .fi-dropdown_label--visible {
+    .fi-dropdown_label--visible {
       margin-bottom: ${theme.spacing.xs};
     }
-  }
 
-  & [data-reach-listbox-button].fi-dropdown_button {
-    ${inputButton(theme)}
-    position: relative;
-    display: inline-block;
-    word-break: break-word;
-    overflow-wrap: break-word;
-    min-height: 22px;
-    padding: 7px 38px 7px 7px;
-    border-color: ${theme.colors.depthDark3};
-    text-align: left;
-    line-height: 1.5;
-    background-color: ${theme.colors.whiteBase};
-    box-shadow: ${theme.shadows.actionElementBoxShadow};
-    cursor: pointer;
+    .fi-dropdown_input-wrapper {
+      height: 40px;
+    }
 
-    &:focus {
-      outline: 0;
+    .fi-dropdown_button {
+      ${inputButton(theme)}
       position: relative;
-
-      &:after {
-        ${theme.focuses.absoluteFocus}
-      }
-    }
-
-    &:before {
-      content: '';
-      position: absolute;
-      top: 50%;
-      right: 16px;
-      margin-top: -3px;
-      border-style: solid;
-      border-color: ${theme.colors.depthDark3} transparent transparent
-        transparent;
-      border-width: 6px 4px 0 4px;
-    }
-    &[aria-expanded='true']:before {
-      border-color: transparent transparent ${theme.colors.depthDark3}
-        transparent;
-      border-width: 0 4px 6px 4px;
-    }
-    &.fi-dropdown--disabled {
-      background-color: ${theme.colors.depthLight3};
-      color: ${theme.colors.depthBase};
-      opacity: 1;
-      cursor: not-allowed;
-      &:before {
-        border-color: ${theme.colors.depthBase} transparent transparent
-          transparent;
-      }
-    }
-  }
-  &[data-reach-listbox-popover].fi-dropdown_popover {
-    ${element(theme)}
-    ${theme.typography.actionElementInnerText}
-    margin-top: -1px;
-    padding: 0;
-    box-sizing: border-box;
-    font-size: 100%;
-    border: 0;
-    background-color: ${theme.colors.whiteBase};
-    border-color: ${theme.colors.depthDark3};
-    border-style: solid;
-    border-width: 0 1px 1px 1px;
-    border-radius: 0px 0px ${theme.radiuses.basic} ${theme.radiuses.basic};
-    max-height: 265px;
-    overflow-y: auto;
-    overflow-x: hidden;
-
-    &:focus-within {
-      outline: 0;
-      box-shadow: none;
-    }
-  }
-
-  &.fi-dropdown--noSelectedStyles {
-    & [data-reach-listbox-option][data-current-selected].fi-dropdown_item {
+      display: inline-block;
+      word-break: break-word;
+      overflow-wrap: break-word;
+      height: 40px;
+      padding: 7px 38px 7px 7px;
+      border-color: ${theme.colors.depthDark3};
+      text-align: left;
+      line-height: 1.5;
       background-color: ${theme.colors.whiteBase};
-      ${theme.typography.actionElementInnerText};
+      box-shadow: ${theme.shadows.actionElementBoxShadow};
+      cursor: pointer;
+      user-select: none;
+
+      &:focus-visible {
+        outline: none;
+      }
+
+      &:before {
+        content: '';
+        position: absolute;
+        top: 50%;
+        right: 16px;
+        margin-top: -3px;
+        border-style: solid;
+        border-color: ${theme.colors.blackBase} transparent transparent
+          transparent;
+        border-width: 6px 4px 0 4px;
+      }
+      &[aria-expanded='true']:before {
+        border-color: transparent transparent ${theme.colors.blackBase}
+          transparent;
+        border-width: 0 4px 6px 4px;
+      }
     }
 
-    & [data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-      color: ${theme.colors.blackBase};
-      background-image: none;
-      background-color: ${theme.colors.highlightLight3};
+    &:not(.fi-dropdown--open) {
+      .fi-dropdown_button {
+        &:focus {
+          outline: 0;
+          position: relative;
+
+          &:after {
+            ${theme.focuses.absoluteFocus}
+          }
+        }
+      }
+    }
+
+    .fi-dropdown_popover {
+      ${element(theme)}
+      ${theme.typography.actionElementInnerText}
+      margin-top: -1px;
+      padding: 0;
+      box-sizing: border-box;
+      font-size: 100%;
       border: 0;
-    }
-  }
+      background-color: ${theme.colors.whiteBase};
+      border-color: ${theme.colors.depthDark3};
+      border-style: solid;
+      border-width: 0 1px 1px 1px;
+      border-radius: 0px 0px ${theme.radiuses.basic} ${theme.radiuses.basic};
+      max-height: 265px;
+      overflow-y: auto;
+      overflow-x: hidden;
 
-  & [data-reach-listbox-list] {
-    border: 0;
-    padding: 0;
-    margin: 0;
-    white-space: normal;
-    word-break: break-word;
-    overflow-wrap: break-word;
+      &:focus-within {
+        outline: 0;
+        box-shadow: none;
+      }
+    }
+
+    &--disabled {
+      .fi-dropdown_input-wrapper {
+        cursor: not-allowed;
+        .fi-dropdown_button {
+          background-color: ${theme.colors.depthLight3};
+          color: ${theme.colors.depthBase};
+          opacity: 1;
+          pointer-events: none;
+          &:before {
+            border-color: ${theme.colors.depthBase} transparent transparent
+              transparent;
+          }
+        }
+      }
+    }
+
+    &--open {
+      .fi-dropdown_button {
+        border-bottom: 0;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        padding-bottom: 8px;
+      }
+    }
   }
 `;

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -10,30 +10,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-dropdown {
     display: inline-block;
 
-    &--open {
-      .fi-dropdown_button {
-        border-bottom: 0;
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-        padding-bottom: 8px;
-      }
-    }
-
-    &--error {
-      .fi-dropdown_button {
-        border-color: ${theme.colors.alertBase};
-        border-width: 2px;
-      }
-    }
-
-    &--italicize {
-      .fi-dropdown_button {
-        font-style: italic;
-        color: ${theme.colors.depthDark2};
-        opacity: 1;
-      }
-    }
-
     .fi-dropdown_label--visible {
       margin-bottom: ${theme.spacing.xs};
     }
@@ -67,6 +43,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       user-select: none;
       white-space: nowrap;
 
+      /* stylelint-disable no-descending-specificity */
       &:focus-visible {
         outline: none;
       }
@@ -109,6 +86,30 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       &:focus-within {
         outline: 0;
         box-shadow: none;
+      }
+    }
+
+    &--open {
+      .fi-dropdown_button {
+        border-bottom: 0;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        padding-bottom: 8px;
+      }
+    }
+
+    &--error {
+      .fi-dropdown_button {
+        border-color: ${theme.colors.alertBase};
+        border-width: 2px;
+      }
+    }
+
+    &--italicize {
+      .fi-dropdown_button {
+        font-style: italic;
+        color: ${theme.colors.depthDark2};
+        opacity: 1;
       }
     }
 

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -1,8 +1,9 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { element, inputButton } from '../../theme/reset';
+import { element, input } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  width: 290px;
   /* stylelint-disable no-descending-specificity */
   .fi-dropdown_item-list {
     padding-top: 0;
@@ -14,15 +15,36 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       margin-bottom: ${theme.spacing.xs};
     }
 
-    .fi-dropdown_input-wrapper {
-      height: 40px;
+    .fi-hint-text {
+      margin-bottom: ${theme.spacing.xs};
+    }
+
+    .fi-status-text {
+      line-height: 18px;
+      &.fi-dropdown_statusText--has-content {
+        margin-top: ${theme.spacing.xxs};
+      }
+    }
+
+    &:not(.fi-dropdown--open) {
+      .fi-dropdown_button {
+        &:focus {
+          outline: 0;
+          position: relative;
+
+          &:after {
+            ${theme.focuses.absoluteFocus}
+          }
+        }
+      }
     }
 
     .fi-dropdown_button {
-      ${inputButton(theme)}
+      ${input(theme)}
       position: relative;
       display: inline-block;
       word-break: break-word;
+      width: 100%;
       overflow-wrap: break-word;
       height: 40px;
       padding: 7px 38px 7px 7px;
@@ -33,6 +55,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       box-shadow: ${theme.shadows.actionElementBoxShadow};
       cursor: pointer;
       user-select: none;
+      white-space: nowrap;
 
       &:focus-visible {
         outline: none;
@@ -53,19 +76,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         border-color: transparent transparent ${theme.colors.blackBase}
           transparent;
         border-width: 0 4px 6px 4px;
-      }
-    }
-
-    &:not(.fi-dropdown--open) {
-      .fi-dropdown_button {
-        &:focus {
-          outline: 0;
-          position: relative;
-
-          &:after {
-            ${theme.focuses.absoluteFocus}
-          }
-        }
       }
     }
 
@@ -114,6 +124,21 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
         padding-bottom: 8px;
+      }
+    }
+
+    &--error {
+      .fi-dropdown_button {
+        border-color: ${theme.colors.alertBase};
+        border-width: 2px;
+      }
+    }
+
+    &--italicize {
+      .fi-dropdown_button {
+        font-style: italic;
+        color: ${theme.colors.depthDark2};
+        opacity: 1;
       }
     }
   }

--- a/src/core/Dropdown/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown/Dropdown.md
@@ -1,17 +1,34 @@
 ```js
-import { Dropdown, DropdownItem, Icon } from 'suomifi-ui-components';
+import React from 'react';
+import { Dropdown, DropdownItem } from 'suomifi-ui-components';
+
+const [selectedValue, setSelectedValue] = React.useState(null);
+const [status, setStatus] = React.useState('default');
 
 <Dropdown
   name="dropdown_example_1"
   labelText="Dropdown label"
-  defaultValue={'dropdown-item-13'}
-  onChange={(value) => console.log(value)}
+  hintText="Some informative text"
+  onChange={(value) => {
+    setStatus('default');
+    setSelectedValue(value);
+  }}
+  onBlur={() => {
+    if (!selectedValue) {
+      setStatus('error');
+    } else {
+      setStatus('default');
+    }
+  }}
+  status={status}
+  statusText={status === 'error' ? 'You must select a value.' : ''}
+  visualPlaceholder="Select a value"
 >
   <DropdownItem value={'dropdown-item-1'}>
-    Dropdown Item 1 <Icon icon="login" />
+    Dropdown Item 1
   </DropdownItem>
   <DropdownItem value={'dropdown-item-2'}>
-    <Icon icon="login" /> Dropdown Item 2
+    Dropdown Item 2
   </DropdownItem>
   <DropdownItem value={'dropdown-item-3'}>
     Dropdown Item 3
@@ -68,6 +85,7 @@ const exampleRef = createRef();
     labelMode="hidden"
     ref={exampleRef}
     onChange={() => console.log(exampleRef.current)}
+    style={{ width: '350px' }}
   >
     <DropdownItem value={'dropdown-item-1'}>
       Dropdown Item 1
@@ -102,7 +120,7 @@ const [value, setValue] = useState('');
 <Dropdown
   value={value}
   name="dropdown_example_4"
-  visualPlaceholder="Dropdown"
+  visualPlaceholder="Select a value"
   labelText="Dropdown with controlled state"
   onChange={(newValue) => {
     if (window.confirm('Change dropdown value?')) {
@@ -164,6 +182,22 @@ const dropdownProps = {
     </Dropdown>
   </Block>
 </div>;
+```
+
+### Drodown as action menu
+
+```js
+import { Dropdown, DropdownItem } from 'suomifi-ui-components';
+
+<Dropdown
+  visualPlaceholder="Action menu"
+  labelText="Dropdown as action menu"
+  alwaysShowVisualPlaceholder={true}
+  onChange={(action) => console.log(action, 'selected')}
+>
+  <DropdownItem value={'action-item-1'}>Action Item 1</DropdownItem>
+  <DropdownItem value={'action-item-2'}>Action Item 2</DropdownItem>
+</Dropdown>;
 ```
 
 ### Dropdown with a tooltip

--- a/src/core/Dropdown/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown/Dropdown.md
@@ -80,12 +80,12 @@ const exampleRef = createRef();
 <>
   <Dropdown
     name="dropdown_example_2"
-    visualPlaceholder="Dropdown with visually hidden label and ref"
+    visualPlaceholder="Wide dropdown with a visually hidden label and ref"
     labelText="Dropdown label"
     labelMode="hidden"
     ref={exampleRef}
     onChange={() => console.log(exampleRef.current)}
-    style={{ width: '350px' }}
+    fullWidth
   >
     <DropdownItem value={'dropdown-item-1'}>
       Dropdown Item 1

--- a/src/core/Dropdown/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown/Dropdown.md
@@ -1,17 +1,17 @@
 ```js
-import { Dropdown, DropdownItem } from 'suomifi-ui-components';
+import { Dropdown, DropdownItem, Icon } from 'suomifi-ui-components';
 
 <Dropdown
-  name="Dropdown"
+  name="dropdown_example_1"
   labelText="Dropdown label"
-  defaultValue={'dropdown-item-2'}
+  defaultValue={'dropdown-item-13'}
   onChange={(value) => console.log(value)}
 >
   <DropdownItem value={'dropdown-item-1'}>
-    Dropdown Item 1
+    Dropdown Item 1 <Icon icon="login" />
   </DropdownItem>
   <DropdownItem value={'dropdown-item-2'}>
-    Dropdown Item 2
+    <Icon icon="login" /> Dropdown Item 2
   </DropdownItem>
   <DropdownItem value={'dropdown-item-3'}>
     Dropdown Item 3
@@ -62,7 +62,7 @@ import { createRef } from 'react';
 const exampleRef = createRef();
 <>
   <Dropdown
-    name="Dropdown"
+    name="dropdown_example_2"
     visualPlaceholder="Dropdown with visually hidden label and ref"
     labelText="Dropdown label"
     labelMode="hidden"
@@ -78,6 +78,7 @@ const exampleRef = createRef();
   </Dropdown>
 
   <Dropdown
+    name="dropdown_example_3"
     labelText="Disabled dropdown"
     defaultValue={'dropdown-item-2'}
     disabled
@@ -93,20 +94,6 @@ const exampleRef = createRef();
 ```
 
 ```js
-import { Dropdown, DropdownItem } from 'suomifi-ui-components';
-
-<Dropdown
-  visualPlaceholder="Action menu"
-  labelText="Dropdown as action menu label"
-  alwaysShowVisualPlaceholder={true}
-  onChange={(action) => console.log(action, 'selected')}
->
-  <DropdownItem value={'action-item-1'}>Action Item 1</DropdownItem>
-  <DropdownItem value={'action-item-2'}>Action Item 2</DropdownItem>
-</Dropdown>;
-```
-
-```js
 import { useState } from 'react';
 import { Dropdown, DropdownItem } from 'suomifi-ui-components';
 
@@ -114,7 +101,7 @@ const [value, setValue] = useState('');
 
 <Dropdown
   value={value}
-  name="Dropdown"
+  name="dropdown_example_4"
   visualPlaceholder="Dropdown"
   labelText="Dropdown with controlled state"
   onChange={(newValue) => {
@@ -146,6 +133,7 @@ const dropdownProps = {
   </label>
   <Block padding="xs">
     <Dropdown
+      name="dropdown_example_5"
       defaultValue={'dropdown-1-item-1'}
       visualPlaceholder="Dropdown 1"
       labelText="Dropdown 1 label"
@@ -161,6 +149,7 @@ const dropdownProps = {
   </Block>
   <Block padding="xs">
     <Dropdown
+      name="dropdown_example_6"
       defaultValue={'dropdown-2-item-2'}
       visualPlaceholder="Dropdown 2"
       labelText="Dropdown 2 label"
@@ -191,6 +180,7 @@ import {
 const labelText = 'Dropdown with a tooltip';
 
 <Dropdown
+  name="dropdown_example_6"
   labelText={labelText}
   tooltipComponent={
     <Tooltip

--- a/src/core/Dropdown/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.test.tsx
@@ -60,10 +60,12 @@ describe('Basic dropdown', () => {
   });
 
   it('should match snapshot', async () => {
-    const promise = Promise.resolve();
-    const { container } = render(BasicDropdown);
-    expect(container).toMatchSnapshot();
-    await act(() => promise);
+    const { baseElement, getByRole } = render(BasicDropdown);
+    const menuButton = getByRole('button') as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(menuButton);
+    });
+    expect(baseElement).toMatchSnapshot();
   });
 });
 
@@ -84,10 +86,8 @@ describe('Dropdown with hidden label', () => {
   });
 
   it('should match snapshot', async () => {
-    const promise = Promise.resolve();
-    const { container } = render(DropdownWithHiddenLabel);
-    expect(container).toMatchSnapshot();
-    await act(() => promise);
+    const { baseElement } = render(DropdownWithHiddenLabel);
+    expect(baseElement).toMatchSnapshot();
   });
 });
 
@@ -133,10 +133,12 @@ describe('Controlled Dropdown', () => {
   });
 
   it('should match snapshot', async () => {
-    const promise = Promise.resolve();
-    const { container } = render(ControlledDropdown);
-    expect(container).toMatchSnapshot();
-    await act(() => promise);
+    const { baseElement, getByRole } = render(ControlledDropdown);
+    const button = getByRole('button') as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(baseElement).toMatchSnapshot();
   });
 });
 
@@ -156,10 +158,12 @@ describe('Dropdown with additional aria-label', () => {
   });
 
   it('should match snapshot', async () => {
-    const promise = Promise.resolve();
-    const { container } = render(DropdownWithExtraLabel);
-    expect(container).toMatchSnapshot();
-    await act(() => promise);
+    const { baseElement, getByRole } = render(DropdownWithExtraLabel);
+    const menuButton = getByRole('button') as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(menuButton);
+    });
+    expect(baseElement).toMatchSnapshot();
   });
 });
 

--- a/src/core/Dropdown/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.test.tsx
@@ -14,7 +14,7 @@ const dropdownProps = {
 };
 
 const TestDropdown = (props: DropdownProps, testId?: string) => (
-  <Dropdown {...props} data-testid={!!testId ? testId : ''}>
+  <Dropdown {...props} wrapperProps={{ 'data-testid': testId || '' }}>
     <DropdownItem value={'item-1'}>Item 1</DropdownItem>
     <DropdownItem value={'item-2'}>Item 2</DropdownItem>
   </Dropdown>

--- a/src/core/Dropdown/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.test.tsx
@@ -50,13 +50,14 @@ describe('Basic dropdown', () => {
   });
 
   it('should have disabled styles when disabled', async () => {
-    const { findByRole } = render(
+    const { container } = render(
       <Dropdown labelText="Dropdown" disabled>
         <DropdownItem value={'item-1'}>Item 1</DropdownItem>
       </Dropdown>,
     );
-    const button = await findByRole('button');
-    expect(button).toHaveClass('fi-dropdown--disabled');
+    const outerSpan = container.getElementsByClassName('fi-dropdown')[0];
+    console.log(outerSpan);
+    expect(outerSpan).toHaveClass('fi-dropdown--disabled');
   });
 
   it('should match snapshot', async () => {
@@ -110,17 +111,19 @@ describe('Controlled Dropdown', () => {
   });
 
   it('should use value instead of internal state', async () => {
-    const { findByRole, findByText, rerender, findByDisplayValue } =
+    const { findByRole, rerender, findByDisplayValue, baseElement } =
       render(ControlledDropdown);
-    // mouse event tests do not work properly with listbox
     const button = await findByRole('button');
     const input = await findByDisplayValue('item-2');
 
     fireEvent.click(button);
-    const option = await findByText('Item 1');
-    fireEvent.click(option);
-    expect(button).toHaveTextContent('Item 2');
-    expect(input).toBeTruthy();
+    const option = baseElement.querySelector('.fi-dropdown_item'); // Item 1
+    if (option) {
+      fireEvent.click(option);
+      expect(button).toHaveTextContent('Item 2');
+      expect(input).toBeTruthy();
+    }
+
     await act(async () => {
       rerender(TestDropdown({ ...controlledDropdownProps, value: 'item-1' }));
     });
@@ -133,35 +136,6 @@ describe('Controlled Dropdown', () => {
   it('should match snapshot', async () => {
     const promise = Promise.resolve();
     const { container } = render(ControlledDropdown);
-    expect(container).toMatchSnapshot();
-    await act(() => promise);
-  });
-});
-
-describe('Dropdown as action menu', () => {
-  const actionMenuDropdownProps = {
-    labelText: 'Dropdown test',
-    defaultValue: 'item-2',
-    visualPlaceholder: 'Action menu',
-    alwaysShowVisualPlaceholder: true,
-    name: 'dropdown-test',
-    className: 'dropdown-test',
-    id: 'test-id',
-  };
-
-  const ActionMenuDropdown = TestDropdown(actionMenuDropdownProps);
-
-  it('should always display visualPlaceholder value', async () => {
-    const { findByRole, queryByDisplayValue } = render(ActionMenuDropdown);
-    const button = await findByRole('button');
-    const input = await queryByDisplayValue('item-2');
-    expect(button).toHaveTextContent('Action menu');
-    expect(input).toBeTruthy();
-  });
-
-  it('should match snapshot', async () => {
-    const promise = Promise.resolve();
-    const { container } = render(ActionMenuDropdown);
     expect(container).toMatchSnapshot();
     await act(() => promise);
   });

--- a/src/core/Dropdown/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.test.tsx
@@ -56,7 +56,6 @@ describe('Basic dropdown', () => {
       </Dropdown>,
     );
     const outerSpan = container.getElementsByClassName('fi-dropdown')[0];
-    console.log(outerSpan);
     expect(outerSpan).toHaveClass('fi-dropdown--disabled');
   });
 
@@ -161,6 +160,54 @@ describe('Dropdown with additional aria-label', () => {
     const { container } = render(DropdownWithExtraLabel);
     expect(container).toMatchSnapshot();
     await act(() => promise);
+  });
+});
+
+describe('statusText', () => {
+  it('has status text defined by prop', () => {
+    const statusTextProps: DropdownProps = {
+      ...dropdownProps,
+      statusText: 'Test status',
+    };
+    const DropdownWithStatusText = TestDropdown(statusTextProps);
+    const { getByText } = render(DropdownWithStatusText);
+    expect(getByText('Test status')).toBeDefined();
+  });
+});
+
+describe('statusTextAriaLiveMode', () => {
+  it('has assertive aria-live by default', () => {
+    const statusTextProps: DropdownProps = {
+      ...dropdownProps,
+      statusText: 'Test status',
+    };
+    const DropdownWithStatusText = TestDropdown(statusTextProps);
+    const { getByText } = render(DropdownWithStatusText);
+    expect(getByText('Test status')).toHaveAttribute('aria-live', 'assertive');
+  });
+  it('has aria-live defined by prop', () => {
+    const statusTextProps: DropdownProps = {
+      ...dropdownProps,
+      statusText: 'Test status',
+      statusTextAriaLiveMode: 'off',
+    };
+    const DropdownWithStatusTextAriaLiveDisabled =
+      TestDropdown(statusTextProps);
+    const { getByText } = render(DropdownWithStatusTextAriaLiveDisabled);
+    expect(getByText('Test status')).toHaveAttribute('aria-live', 'off');
+  });
+});
+
+describe('hintText', () => {
+  it('has hint text', () => {
+    const hintTextProps: DropdownProps = {
+      ...dropdownProps,
+      hintText: 'Test hint text',
+    };
+    const DropdownWithHintText = TestDropdown(hintTextProps);
+    const { getByText } = render(DropdownWithHintText);
+    const span = getByText('Test hint text');
+    expect(span).toBeDefined();
   });
 });
 

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -281,8 +281,11 @@ class BaseDropdown extends Component<DropdownProps> {
         this.setState({ showPopover: !showPopover });
         if (!showPopover) {
           this.setState({ showPopover: true });
+          const nextItem = getNextItem();
+          if (nextItem) {
+            this.setState({ focusedDescendantId: nextItem.props.value });
+          }
         } else if (showPopover && focusedDescendantId) {
-          event.preventDefault();
           const focusedItem = popoverItems.find(
             (item) => item?.props.value === focusedDescendantId,
           );
@@ -294,8 +297,14 @@ class BaseDropdown extends Component<DropdownProps> {
       }
 
       case 'Enter': {
-        if (focusedDescendantId && showPopover) {
-          event.preventDefault();
+        event.preventDefault();
+        if (!showPopover) {
+          this.setState({ showPopover: true });
+          const nextItem = getNextItem();
+          if (nextItem) {
+            this.setState({ focusedDescendantId: nextItem.props.value });
+          }
+        } else if (focusedDescendantId && showPopover) {
           const focusedItem = popoverItems.find(
             (item) => item?.props.value === focusedDescendantId,
           );

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -431,7 +431,11 @@ class BaseDropdown extends Component<DropdownProps> {
               [dropdownClassNames.labelIsVisible]: labelMode !== 'hidden',
             })}
             tooltipComponent={tooltipComponent}
-            onClick={() => this.buttonRef.current?.focus()}
+            onClick={() => {
+              if (!disabled) {
+                this.buttonRef.current?.focus();
+              }
+            }}
           >
             {labelText}
           </Label>

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -455,7 +455,7 @@ class BaseDropdown extends Component<DropdownProps> {
               aria-owns={popoverItemListId}
               aria-expanded={showPopover}
               aria-activedescendant={ariaActiveDescendant}
-              onMouseDown={() => {
+              onClick={() => {
                 if (!disabled) {
                   this.setState({ showPopover: !showPopover });
                 }

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -4,13 +4,7 @@ import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import {
-  HtmlSpan,
-  HtmlDiv,
-  HtmlDivProps,
-  HtmlInput,
-  HtmlButton,
-} from '../../../reset';
+import { HtmlSpan, HtmlDiv, HtmlInput, HtmlButton } from '../../../reset';
 import { Label, LabelMode } from '../../Form/Label/Label';
 import { DropdownItemProps } from '../DropdownItem/DropdownItem';
 import { baseStyles } from './Dropdown.baseStyles';
@@ -19,6 +13,7 @@ import {
   forkRefs,
   getOwnerDocument,
   getRecursiveChildText,
+  HTMLAttributesIncludingDataAttributes,
 } from '../../../utils/common/common';
 import { Popover } from '../../../core/Popover/Popover';
 import { SelectItemList } from '../../Form/Select/BaseSelect/SelectItemList/SelectItemList';
@@ -147,7 +142,7 @@ export interface DropdownProps extends StatusTextCommonProps {
    * Props which are placed at the outermost div of the component.
    * Can be used, for example, for style
    */
-  wrapperProps?: Omit<HtmlDivProps, 'className'>;
+  wrapperProps?: Omit<HTMLAttributesIncludingDataAttributes, 'className'>;
 }
 
 class BaseDropdown extends Component<DropdownProps> {

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -33,6 +33,7 @@ export const dropdownClassNames = {
   itemList: `${baseClassName}_item-list`,
   item: `${baseClassName}_item`,
   statusTextHasContent: `${baseClassName}_statusText--has-content`,
+  displayValue: `${baseClassName}_display-value`,
   open: `${baseClassName}--open`,
   disabled: `${baseClassName}--disabled`,
   error: `${baseClassName}--error`,
@@ -500,7 +501,7 @@ class BaseDropdown extends Component<DropdownProps> {
             {labelText}
           </Label>
           <HintText id={hintTextId}>{hintText}</HintText>
-          <HtmlDiv className={classnames(dropdownClassNames.inputWrapper)}>
+          <HtmlDiv className={dropdownClassNames.inputWrapper}>
             <HtmlButton
               aria-haspopup="listbox"
               tabIndex={!disabled ? 0 : -1}
@@ -529,7 +530,9 @@ class BaseDropdown extends Component<DropdownProps> {
               onBlur={this.handleOnBlur}
               {...passProps}
             >
-              <HtmlSpan>{dropdownDisplayValue}</HtmlSpan>
+              <HtmlSpan className={dropdownClassNames.displayValue}>
+                {dropdownDisplayValue}
+              </HtmlSpan>
               <HtmlInput
                 tabIndex={-1}
                 type="hidden"

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -4,7 +4,13 @@ import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { HtmlSpan, HtmlDiv, HtmlInput, HtmlButton } from '../../../reset';
+import {
+  HtmlSpan,
+  HtmlDiv,
+  HtmlDivProps,
+  HtmlInput,
+  HtmlButton,
+} from '../../../reset';
 import { Label, LabelMode } from '../../Form/Label/Label';
 import { DropdownItemProps } from '../DropdownItem/DropdownItem';
 import { baseStyles } from './Dropdown.baseStyles';
@@ -137,6 +143,11 @@ export interface DropdownProps extends StatusTextCommonProps {
   fullWidth?: boolean;
   /** Ref object to be passed to the button element. Alternative to React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLButtonElement>;
+  /**
+   * Props which are placed at the outermost div of the component.
+   * Can be used, for example, for style
+   */
+  wrapperProps?: Omit<HtmlDivProps, 'className'>;
 }
 
 class BaseDropdown extends Component<DropdownProps> {
@@ -438,6 +449,7 @@ class BaseDropdown extends Component<DropdownProps> {
       portal = true,
       statusTextAriaLiveMode = 'assertive',
       fullWidth,
+      wrapperProps,
       ...passProps
     } = this.props;
 
@@ -481,7 +493,7 @@ class BaseDropdown extends Component<DropdownProps> {
           [dropdownClassNames.fullWidth]: fullWidth,
         })}
         id={id}
-        {...passProps}
+        {...wrapperProps}
       >
         <HtmlDiv>
           <Label
@@ -528,6 +540,7 @@ class BaseDropdown extends Component<DropdownProps> {
               }}
               onKeyDown={this.handleKeyDown}
               onBlur={this.handleOnBlur}
+              {...passProps}
             >
               <HtmlSpan id={displayValueId}>{dropdownDisplayValue}</HtmlSpan>
               <HtmlInput

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -168,7 +168,7 @@ class BaseDropdown extends Component<DropdownProps> {
     ),
     showPopover: false,
     focusedDescendantId:
-      'value' in this.props
+      'value' in this.props && !!this.props.value
         ? this.props.value
         : 'defaultValue' in this.props
         ? this.props.defaultValue

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -229,6 +229,10 @@ class BaseDropdown extends Component<DropdownProps> {
       showPopover: false,
       focusedDescendantId: itemValue,
     });
+    /**
+     * Timeout is used here to ensure screen reader reads the
+     * currently selected option when focusing back to the button
+     */
     setTimeout(() => {
       this.buttonRef.current?.focus();
     }, 200);
@@ -388,6 +392,10 @@ class BaseDropdown extends Component<DropdownProps> {
 
   private focusToButtonAndClosePopover() {
     this.setState({ showPopover: false });
+    /**
+     * Timeout is used here to ensure screen reader reads the
+     * currently selected option when focusing back to the button
+     */
     setTimeout(() => {
       this.buttonRef.current?.focus();
     }, 200);
@@ -395,6 +403,10 @@ class BaseDropdown extends Component<DropdownProps> {
 
   private openPopover() {
     this.setState({ showPopover: true });
+    /**
+     * Timeout is used here to ensure the popover
+     * exists when setting focus
+     */
     setTimeout(() => {
       this.popoverRef.current?.focus();
     }, 200);

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -229,7 +229,9 @@ class BaseDropdown extends Component<DropdownProps> {
       showPopover: false,
       focusedDescendantId: itemValue,
     });
-    this.buttonRef.current?.focus();
+    setTimeout(() => {
+      this.buttonRef.current?.focus();
+    }, 200);
   }
 
   private handleKeyDown = (event: React.KeyboardEvent) => {
@@ -385,8 +387,10 @@ class BaseDropdown extends Component<DropdownProps> {
   }
 
   private focusToButtonAndClosePopover() {
-    this.buttonRef.current?.focus();
     this.setState({ showPopover: false });
+    setTimeout(() => {
+      this.buttonRef.current?.focus();
+    }, 200);
   }
 
   private openPopover() {

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -279,9 +279,11 @@ class BaseDropdown extends Component<DropdownProps> {
         this.setState({ showPopover: !showPopover });
         if (!showPopover) {
           this.setState({ showPopover: true });
-          const nextItem = getNextItem();
-          if (nextItem) {
-            this.setState({ focusedDescendantId: nextItem.props.value });
+          if (!focusedDescendantId) {
+            const nextItem = getNextItem();
+            if (nextItem) {
+              this.setState({ focusedDescendantId: nextItem.props.value });
+            }
           }
         } else if (showPopover && focusedDescendantId) {
           const focusedItem = popoverItems.find(
@@ -298,9 +300,11 @@ class BaseDropdown extends Component<DropdownProps> {
         event.preventDefault();
         if (!showPopover) {
           this.setState({ showPopover: true });
-          const nextItem = getNextItem();
-          if (nextItem) {
-            this.setState({ focusedDescendantId: nextItem.props.value });
+          if (!focusedDescendantId) {
+            const nextItem = getNextItem();
+            if (nextItem) {
+              this.setState({ focusedDescendantId: nextItem.props.value });
+            }
           }
         } else if (focusedDescendantId && showPopover) {
           const focusedItem = popoverItems.find(

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -100,7 +100,7 @@ export interface DropdownProps extends StatusTextCommonProps {
   /** Text to mark a field optional. Will be wrapped in parentheses and shown after labelText. */
   optionalText?: string;
   /**
-   * Additional label id. E.g. form group label.
+   * ID on an additional label id. E.g. form group label.
    * Used in addition to labelText for screen readers.
    */
   'aria-labelledby'?: string;
@@ -280,6 +280,17 @@ class BaseDropdown extends Component<DropdownProps> {
       case ' ': {
         event.preventDefault();
         this.setState({ showPopover: !showPopover });
+        if (!showPopover) {
+          this.setState({ showPopover: true });
+        } else if (showPopover && focusedDescendantId) {
+          event.preventDefault();
+          const focusedItem = popoverItems.find(
+            (item) => item?.props.value === focusedDescendantId,
+          );
+          if (focusedItem) {
+            this.handleItemSelection(focusedItem.props.value);
+          }
+        }
         break;
       }
 
@@ -369,13 +380,19 @@ class BaseDropdown extends Component<DropdownProps> {
       return null;
     }
 
+    const {
+      selectedValue,
+      selectedValueText,
+      showPopover,
+      focusedDescendantId,
+    } = this.state;
+
     const labelId = `${id}-label`;
     const buttonId = `${id}_button`;
     const popoverItemListId = `${id}-popover`;
     const hintTextId = hintText ? `${id}-hintText` : undefined;
     const statusTextId = statusText ? `${id}-statusText` : undefined;
-
-    const { selectedValue, showPopover, focusedDescendantId } = this.state;
+    const displayValueId = selectedValueText ? `${id}-displayValue` : undefined;
 
     const ariaActiveDescendant = focusedDescendantId
       ? `${id}-${focusedDescendantId}`
@@ -402,6 +419,7 @@ class BaseDropdown extends Component<DropdownProps> {
         <HtmlDiv>
           <Label
             id={labelId}
+            htmlFor={buttonId}
             labelMode={labelMode}
             optionalText={optionalText}
             className={classnames({
@@ -420,10 +438,11 @@ class BaseDropdown extends Component<DropdownProps> {
               forwardedRef={forkRefs(this.buttonRef, definedRef)}
               id={buttonId}
               className={dropdownClassNames.button}
-              {...getConditionalAriaProp(
-                'aria-labelledby',
-                selectedValue === undefined ? [ariaLabelledBy, labelId] : [],
-              )}
+              {...getConditionalAriaProp('aria-labelledby', [
+                displayValueId,
+                ariaLabelledBy,
+                labelId,
+              ])}
               {...getConditionalAriaProp('aria-describedby', [
                 statusTextId,
                 hintTextId,
@@ -439,7 +458,7 @@ class BaseDropdown extends Component<DropdownProps> {
               onKeyDown={this.handleKeyDown}
               onBlur={this.handleOnBlur}
             >
-              {dropdownDisplayValue}
+              <HtmlSpan id={displayValueId}>{dropdownDisplayValue}</HtmlSpan>
               <HtmlInput
                 tabIndex={-1}
                 type="hidden"

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -483,120 +483,118 @@ class BaseDropdown extends Component<DropdownProps> {
         id={id}
         {...wrapperProps}
       >
-        <HtmlDiv>
-          <Label
-            id={labelId}
-            labelMode={labelMode}
-            optionalText={optionalText}
-            className={classnames({
-              [dropdownClassNames.labelIsVisible]: labelMode !== 'hidden',
-            })}
-            tooltipComponent={tooltipComponent}
+        <Label
+          id={labelId}
+          labelMode={labelMode}
+          optionalText={optionalText}
+          className={classnames({
+            [dropdownClassNames.labelIsVisible]: labelMode !== 'hidden',
+          })}
+          tooltipComponent={tooltipComponent}
+          onClick={() => {
+            if (!disabled) {
+              this.buttonRef.current?.focus();
+            }
+          }}
+        >
+          {labelText}
+        </Label>
+        <HintText id={hintTextId}>{hintText}</HintText>
+        <HtmlDiv className={dropdownClassNames.inputWrapper}>
+          <HtmlButton
+            aria-haspopup="listbox"
+            tabIndex={!disabled ? 0 : -1}
+            forwardedRef={forkRefs(this.buttonRef, definedRef)}
+            id={buttonId}
+            className={dropdownClassNames.button}
+            {...getConditionalAriaProp('aria-labelledby', [
+              displayValueId,
+              ariaLabelledBy,
+              labelId,
+            ])}
+            {...getConditionalAriaProp('aria-describedby', [
+              statusTextId,
+              hintTextId,
+            ])}
+            aria-owns={popoverItemListId}
+            aria-expanded={showPopover}
             onClick={() => {
-              if (!disabled) {
-                this.buttonRef.current?.focus();
+              if (!showPopover) {
+                this.openPopover();
+              } else {
+                this.focusToButtonAndClosePopover();
               }
             }}
+            onKeyDown={this.handleKeyDown}
+            onBlur={this.handleOnBlur}
+            {...passProps}
           >
-            {labelText}
-          </Label>
-          <HintText id={hintTextId}>{hintText}</HintText>
-          <HtmlDiv className={dropdownClassNames.inputWrapper}>
-            <HtmlButton
-              aria-haspopup="listbox"
-              tabIndex={!disabled ? 0 : -1}
-              forwardedRef={forkRefs(this.buttonRef, definedRef)}
-              id={buttonId}
-              className={dropdownClassNames.button}
-              {...getConditionalAriaProp('aria-labelledby', [
-                displayValueId,
-                ariaLabelledBy,
-                labelId,
-              ])}
-              {...getConditionalAriaProp('aria-describedby', [
-                statusTextId,
-                hintTextId,
-              ])}
-              aria-owns={popoverItemListId}
-              aria-expanded={showPopover}
-              onClick={() => {
-                if (!showPopover) {
-                  this.openPopover();
-                } else {
-                  this.focusToButtonAndClosePopover();
+            <HtmlSpan className={dropdownClassNames.displayValue}>
+              {dropdownDisplayValue}
+            </HtmlSpan>
+            <HtmlInput
+              tabIndex={-1}
+              type="hidden"
+              name={name}
+              value={selectedValue || ''}
+            />
+          </HtmlButton>
+          <VisuallyHidden id={displayValueId}>
+            {dropdownDisplayValue}
+          </VisuallyHidden>
+          <StatusText
+            id={statusTextId}
+            className={classnames({
+              [dropdownClassNames.statusTextHasContent]: !!statusText,
+            })}
+            status={status}
+            disabled={disabled}
+            ariaLiveMode={statusTextAriaLiveMode}
+          >
+            {statusText}
+          </StatusText>
+          {showPopover && (
+            <Popover
+              sourceRef={this.buttonRef}
+              onClickOutside={(event) => {
+                if (!this.isOutsideClick(event)) {
+                  this.setState({
+                    showPopover: false,
+                  });
                 }
               }}
+              matchWidth={true}
               onKeyDown={this.handleKeyDown}
-              onBlur={this.handleOnBlur}
-              {...passProps}
+              portal={portal}
             >
-              <HtmlSpan className={dropdownClassNames.displayValue}>
-                {dropdownDisplayValue}
-              </HtmlSpan>
-              <HtmlInput
-                tabIndex={-1}
-                type="hidden"
-                name={name}
-                value={selectedValue || ''}
-              />
-            </HtmlButton>
-            <VisuallyHidden id={displayValueId}>
-              {dropdownDisplayValue}
-            </VisuallyHidden>
-            <StatusText
-              id={statusTextId}
-              className={classnames({
-                [dropdownClassNames.statusTextHasContent]: !!statusText,
-              })}
-              status={status}
-              disabled={disabled}
-              ariaLiveMode={statusTextAriaLiveMode}
-            >
-              {statusText}
-            </StatusText>
-            {showPopover && (
-              <Popover
-                sourceRef={this.buttonRef}
-                onClickOutside={(event) => {
-                  if (!this.isOutsideClick(event)) {
-                    this.setState({
-                      showPopover: false,
-                    });
-                  }
+              <DropdownProvider
+                value={{
+                  onItemClick: (itemValue) =>
+                    this.handleItemSelection(itemValue),
+                  selectedDropdownValue: selectedValue,
+                  id,
+                  focusedItemValue: focusedDescendantId,
+                  noSelectedStyles: alwaysShowVisualPlaceholder,
+                  onItemTabPress: () => this.focusToButtonAndClosePopover(),
                 }}
-                matchWidth={true}
-                onKeyDown={this.handleKeyDown}
-                portal={portal}
               >
-                <DropdownProvider
-                  value={{
-                    onItemClick: (itemValue) =>
-                      this.handleItemSelection(itemValue),
-                    selectedDropdownValue: selectedValue,
-                    id,
-                    focusedItemValue: focusedDescendantId,
-                    noSelectedStyles: alwaysShowVisualPlaceholder,
-                    onItemTabPress: () => this.focusToButtonAndClosePopover(),
+                <SelectItemList
+                  id={popoverItemListId}
+                  ref={this.popoverRef}
+                  focusedDescendantId={ariaActiveDescendant}
+                  className={dropdownClassNames.itemList}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Tab') {
+                      event.preventDefault();
+                      this.focusToButtonAndClosePopover();
+                    }
                   }}
                 >
-                  <SelectItemList
-                    id={popoverItemListId}
-                    ref={this.popoverRef}
-                    focusedDescendantId={ariaActiveDescendant}
-                    className={dropdownClassNames.itemList}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Tab') {
-                        event.preventDefault();
-                        this.focusToButtonAndClosePopover();
-                      }
-                    }}
-                  >
-                    {children || []}
-                  </SelectItemList>
-                </DropdownProvider>
-              </Popover>
-            )}
-          </HtmlDiv>
+                  {children || []}
+                </SelectItemList>
+              </DropdownProvider>
+            </Popover>
+          )}
         </HtmlDiv>
       </HtmlDiv>
     );

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -144,7 +144,7 @@ export interface DropdownProps extends StatusTextCommonProps {
    * Can be used, for example, for style
    */
   wrapperProps?: Omit<
-    HTMLAttributesIncludingDataAttributes<HTMLSpanElement>,
+    HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
     'className'
   >;
 }
@@ -471,7 +471,7 @@ class BaseDropdown extends Component<DropdownProps> {
     const definedRef = forwardedRef || null;
 
     return (
-      <HtmlSpan
+      <HtmlDiv
         className={classnames(className, baseClassName, {
           [dropdownClassNames.disabled]: !!disabled,
           [dropdownClassNames.open]: !!showPopover,
@@ -595,7 +595,7 @@ class BaseDropdown extends Component<DropdownProps> {
             )}
           </HtmlDiv>
         </HtmlDiv>
-      </HtmlSpan>
+      </HtmlDiv>
     );
   }
 }

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -425,13 +425,13 @@ class BaseDropdown extends Component<DropdownProps> {
         <HtmlDiv>
           <Label
             id={labelId}
-            htmlFor={buttonId}
             labelMode={labelMode}
             optionalText={optionalText}
             className={classnames({
               [dropdownClassNames.labelIsVisible]: labelMode !== 'hidden',
             })}
             tooltipComponent={tooltipComponent}
+            onClick={() => this.buttonRef.current?.focus()}
           >
             {labelText}
           </Label>

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { HtmlSpan, HtmlDiv, HtmlInput } from '../../../reset';
+import { HtmlSpan, HtmlDiv, HtmlInput, HtmlButton } from '../../../reset';
 import { Label, LabelMode } from '../../Form/Label/Label';
 import { DropdownItemProps } from '../DropdownItem/DropdownItem';
 import { baseStyles } from './Dropdown.baseStyles';
@@ -46,7 +46,7 @@ export interface DropdownProviderState {
   /** Currently selected DropdownItem */
   selectedDropdownValue: string | undefined | null;
   /** Currently focused DropdownItem */
-  focusedItemID: string | null | undefined;
+  focusedItemId: string | null | undefined;
   /** ID of the Dropdown component.
    * Used in DropdownItem to create a derived ID for each item
    */
@@ -59,7 +59,7 @@ const defaultProviderValue: DropdownProviderState = {
   onItemClick: () => null,
   selectedDropdownValue: null,
   id: '',
-  focusedItemID: null,
+  focusedItemId: null,
   noSelectedStyles: false,
 };
 
@@ -431,7 +431,7 @@ class BaseDropdown extends Component<DropdownProps> {
           </Label>
           <HintText id={hintTextId}>{hintText}</HintText>
           <HtmlDiv className={classnames(dropdownClassNames.inputWrapper)}>
-            <HtmlSpan
+            <HtmlButton
               aria-haspopup="listbox"
               role="button"
               tabIndex={!disabled ? 0 : -1}
@@ -465,7 +465,7 @@ class BaseDropdown extends Component<DropdownProps> {
                 name={name}
                 value={selectedValue || ''}
               />
-            </HtmlSpan>
+            </HtmlButton>
             <StatusText
               id={statusTextId}
               className={classnames({
@@ -497,7 +497,7 @@ class BaseDropdown extends Component<DropdownProps> {
                       this.handleItemSelection(itemValue),
                     selectedDropdownValue: selectedValue,
                     id,
-                    focusedItemID: focusedDescendantId,
+                    focusedItemId: focusedDescendantId,
                     noSelectedStyles: alwaysShowVisualPlaceholder,
                   }}
                 >

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -506,45 +506,43 @@ class BaseDropdown extends Component<DropdownProps> {
             >
               {statusText}
             </StatusText>
-            {showPopover && !!children && (
-              <Popover
-                sourceRef={this.buttonRef}
-                onClickOutside={(event) => {
-                  if (!this.isOutsideClick(event)) {
-                    this.setState({
-                      showPopover: false,
-                    });
-                  }
-                }}
-                matchWidth={true}
-                onKeyDown={this.handleKeyDown}
-                portal={portal}
-                portalStyleProps={{
-                  display: showPopover && !!children ? 'block' : 'none',
+            <Popover
+              sourceRef={this.buttonRef}
+              onClickOutside={(event) => {
+                if (!this.isOutsideClick(event)) {
+                  this.setState({
+                    showPopover: false,
+                  });
+                }
+              }}
+              matchWidth={true}
+              onKeyDown={this.handleKeyDown}
+              portal={portal}
+              portalStyleProps={{
+                visibility: showPopover && !!children ? 'visible' : 'hidden',
+              }}
+            >
+              <DropdownProvider
+                value={{
+                  onItemClick: (itemValue) =>
+                    this.handleItemSelection(itemValue),
+                  selectedDropdownValue: selectedValue,
+                  id,
+                  focusedItemValue: focusedDescendantId,
+                  noSelectedStyles: alwaysShowVisualPlaceholder,
+                  onItemTabPress: () => this.focusToButtonAndClosePopover(),
                 }}
               >
-                <DropdownProvider
-                  value={{
-                    onItemClick: (itemValue) =>
-                      this.handleItemSelection(itemValue),
-                    selectedDropdownValue: selectedValue,
-                    id,
-                    focusedItemValue: focusedDescendantId,
-                    noSelectedStyles: alwaysShowVisualPlaceholder,
-                    onItemTabPress: () => this.focusToButtonAndClosePopover(),
-                  }}
+                <SelectItemList
+                  id={popoverItemListId}
+                  ref={this.popoverRef}
+                  focusedDescendantId={ariaActiveDescendant}
+                  className={dropdownClassNames.itemList}
                 >
-                  <SelectItemList
-                    id={popoverItemListId}
-                    ref={this.popoverRef}
-                    focusedDescendantId={ariaActiveDescendant}
-                    className={dropdownClassNames.itemList}
-                  >
-                    {children}
-                  </SelectItemList>
-                </DropdownProvider>
-              </Popover>
-            )}
+                  {children || []}
+                </SelectItemList>
+              </DropdownProvider>
+            </Popover>
           </HtmlDiv>
         </HtmlDiv>
       </HtmlSpan>

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -143,7 +143,10 @@ export interface DropdownProps extends StatusTextCommonProps {
    * Props which are placed at the outermost div of the component.
    * Can be used, for example, for style
    */
-  wrapperProps?: Omit<HTMLAttributesIncludingDataAttributes, 'className'>;
+  wrapperProps?: Omit<
+    HTMLAttributesIncludingDataAttributes<HTMLSpanElement>,
+    'className'
+  >;
 }
 
 class BaseDropdown extends Component<DropdownProps> {

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -35,6 +35,7 @@ export const dropdownClassNames = {
   disabled: `${baseClassName}--disabled`,
   error: `${baseClassName}--error`,
   italicize: `${baseClassName}--italicize`,
+  fullWidth: `${baseClassName}--full-width`,
 };
 
 export interface DropdownProviderState {
@@ -132,6 +133,8 @@ export interface DropdownProps extends StatusTextCommonProps {
    * @default true
    */
   portal?: boolean;
+  /** Set component's width to 100% */
+  fullWidth?: boolean;
   /** Ref object to be passed to the button element. Alternative to React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
@@ -434,6 +437,7 @@ class BaseDropdown extends Component<DropdownProps> {
       tooltipComponent,
       portal = true,
       statusTextAriaLiveMode = 'assertive',
+      fullWidth,
       ...passProps
     } = this.props;
 
@@ -474,6 +478,7 @@ class BaseDropdown extends Component<DropdownProps> {
           [dropdownClassNames.open]: !!showPopover,
           [dropdownClassNames.error]: status === 'error',
           [dropdownClassNames.italicize]: italicize,
+          [dropdownClassNames.fullWidth]: fullWidth,
         })}
         id={id}
         {...passProps}

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -158,7 +158,7 @@ class BaseDropdown extends Component<DropdownProps> {
         ? this.props.value
         : 'defaultValue' in this.props
         ? this.props.defaultValue
-        : null,
+        : this.getFirstItemValue(),
   };
 
   buttonRef: React.RefObject<HTMLButtonElement>;
@@ -259,10 +259,11 @@ class BaseDropdown extends Component<DropdownProps> {
         event.preventDefault();
         if (!showPopover) {
           this.openPopover();
-        }
-        const nextItem = getNextItem();
-        if (nextItem) {
-          this.setState({ focusedDescendantId: nextItem.props.value });
+        } else {
+          const nextItem = getNextItem();
+          if (nextItem) {
+            this.setState({ focusedDescendantId: nextItem.props.value });
+          }
         }
         break;
       }
@@ -271,10 +272,11 @@ class BaseDropdown extends Component<DropdownProps> {
         event.preventDefault();
         if (!showPopover) {
           this.openPopover();
-        }
-        const previousItem = getPreviousItem();
-        if (previousItem) {
-          this.setState({ focusedDescendantId: previousItem.props.value });
+        } else {
+          const previousItem = getPreviousItem();
+          if (previousItem) {
+            this.setState({ focusedDescendantId: previousItem.props.value });
+          }
         }
         break;
       }
@@ -363,6 +365,17 @@ class BaseDropdown extends Component<DropdownProps> {
       }
     });
   };
+
+  private getFirstItemValue() {
+    if (Array.isArray(this.props.children)) {
+      const element = this.props.children[0];
+      return element.props.value;
+    }
+    if (!!this.props.children) {
+      return this.props.children.props.value;
+    }
+    return null;
+  }
 
   private getDisplayValue() {
     if (this.props.alwaysShowVisualPlaceholder) {

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -20,8 +20,6 @@ import { HintText } from '../../Form/HintText/HintText';
 import { StatusText } from '../../Form/StatusText/StatusText';
 import { StatusTextCommonProps } from '../../Form/types';
 
-// Dropdown is a button but it also has a listbox popup
-
 const baseClassName = 'fi-dropdown';
 
 export const dropdownClassNames = {

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -21,7 +21,6 @@ import { StatusText } from '../../Form/StatusText/StatusText';
 import { StatusTextCommonProps } from '../../Form/types';
 
 // Dropdown is a button but it also has a listbox popup
-/* eslint-disable jsx-a11y/role-supports-aria-props */
 
 const baseClassName = 'fi-dropdown';
 
@@ -433,7 +432,6 @@ class BaseDropdown extends Component<DropdownProps> {
           <HtmlDiv className={classnames(dropdownClassNames.inputWrapper)}>
             <HtmlButton
               aria-haspopup="listbox"
-              role="button"
               tabIndex={!disabled ? 0 : -1}
               forwardedRef={forkRefs(this.buttonRef, definedRef)}
               id={buttonId}

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -20,6 +20,7 @@ import { SelectItemList } from '../../Form/Select/BaseSelect/SelectItemList/Sele
 import { HintText } from '../../Form/HintText/HintText';
 import { StatusText } from '../../Form/StatusText/StatusText';
 import { StatusTextCommonProps } from '../../Form/types';
+import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 
 const baseClassName = 'fi-dropdown';
 
@@ -235,16 +236,10 @@ class BaseDropdown extends Component<DropdownProps> {
         itemValue,
         this.props.children,
       ),
-      showPopover: false,
       focusedDescendantId: itemValue,
     });
-    /**
-     * Timeout is used here to ensure screen reader reads the
-     * currently selected option when focusing back to the button
-     */
-    setTimeout(() => {
-      this.buttonRef.current?.focus();
-    }, 200);
+    this.buttonRef.current?.focus();
+    this.setState({ showPopover: false });
   }
 
   private handleKeyDown = (event: React.KeyboardEvent) => {
@@ -400,14 +395,8 @@ class BaseDropdown extends Component<DropdownProps> {
   }
 
   private focusToButtonAndClosePopover() {
+    this.buttonRef.current?.focus();
     this.setState({ showPopover: false });
-    /**
-     * Timeout is used here to ensure screen reader reads the
-     * currently selected option when focusing back to the button
-     */
-    setTimeout(() => {
-      this.buttonRef.current?.focus();
-    }, 200);
   }
 
   private openPopover() {
@@ -537,7 +526,7 @@ class BaseDropdown extends Component<DropdownProps> {
               onBlur={this.handleOnBlur}
               {...passProps}
             >
-              <HtmlSpan id={displayValueId}>{dropdownDisplayValue}</HtmlSpan>
+              <HtmlSpan>{dropdownDisplayValue}</HtmlSpan>
               <HtmlInput
                 tabIndex={-1}
                 type="hidden"
@@ -545,6 +534,9 @@ class BaseDropdown extends Component<DropdownProps> {
                 value={selectedValue || ''}
               />
             </HtmlButton>
+            <VisuallyHidden id={displayValueId}>
+              {dropdownDisplayValue}
+            </VisuallyHidden>
             <StatusText
               id={statusTextId}
               className={classnames({

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -346,6 +346,10 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-shadow: none;
 }
 
+.c1.fi-dropdown--full-width {
+  width: 100%;
+}
+
 .c1.fi-dropdown--open .fi-dropdown_button {
   border-bottom: 0;
   border-bottom-left-radius: 0;
@@ -800,6 +804,10 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
+}
+
+.c1.fi-dropdown--full-width {
+  width: 100%;
 }
 
 .c1.fi-dropdown--open .fi-dropdown_button {
@@ -1258,6 +1266,10 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
+}
+
+.c1.fi-dropdown--full-width {
+  width: 100%;
 }
 
 .c1.fi-dropdown--open .fi-dropdown_button {
@@ -1726,6 +1738,10 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
+}
+
+.c1.fi-dropdown--full-width {
+  width: 100%;
 }
 
 .c1.fi-dropdown--open .fi-dropdown_button {

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -145,6 +145,31 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c11 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c11::before,
+.c11::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -171,6 +196,37 @@ exports[`Basic dropdown should match snapshot 1`] = `
 
 .c4::before,
 .c4::after {
+  box-sizing: border-box;
+}
+
+.c9 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -214,6 +270,45 @@ exports[`Basic dropdown should match snapshot 1`] = `
 
 .c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
+}
+
+.c10 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style-type: none;
+  box-sizing: content-box;
+  max-height: 265px;
+  background-color: hsl(0,0%,100%);
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+  border-color: hsl(201,7%,58%);
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  margin: 0;
+  padding: 4px 0 0 0;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10 .fi-select-item-list_content_wrapper {
+  display: block;
+  width: 100%;
+  max-height: inherit;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c8 {
@@ -424,61 +519,161 @@ exports[`Basic dropdown should match snapshot 1`] = `
   z-index: 9999;
 }
 
-<div>
-  <div
-    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
-    data-testid="dropdown-test-id"
-    id="test-id"
-  >
+.c12.fi-dropdown_item {
+  color: hsl(0,0%,13%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+  line-height: 1.5;
+  padding: 8px;
+  border: 0;
+  position: relative;
+}
+
+.c12.fi-dropdown_item:focus {
+  outline: 0;
+}
+
+.c12.fi-dropdown_item:hover {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c12.fi-dropdown_item .fi-dropdown_item_icon {
+  position: absolute;
+  top: 14px;
+  right: 10px;
+  height: 12px;
+  width: 12px;
+}
+
+.c12.fi-dropdown_item--selected {
+  background-color: hsl(215,100%,95%);
+  color: hsl(0,0%,13%);
+}
+
+.c12.fi-dropdown_item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
+  background-color: hsl(0,0%,100%);
+  color: hsl(0,0%,13%);
+}
+
+.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+@media (forced-colors:active) {
+  .c12.fi-dropdown_item--hasKeyboardFocus,
+  .c12.fi-dropdown_item:hover {
+    background-color: Highlight;
+  }
+}
+
+<body>
+  <div>
     <div
-      class="c2 c3 fi-dropdown_label--visible fi-label"
+      class="c0 c1 dropdown-test fi-dropdown fi-dropdown--open fi-dropdown--italicize"
+      data-testid="dropdown-test-id"
+      id="test-id"
     >
-      <label
-        class="c4 fi-label_label-span"
-        id="test-id-label"
+      <div
+        class="c2 c3 fi-dropdown_label--visible fi-label"
       >
-        Dropdown test
-      </label>
-    </div>
-    <div
-      class="c0 fi-dropdown_input-wrapper"
-    >
-      <button
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="test-id-label"
-        aria-owns="test-id-popover"
-        class="c5 fi-dropdown_button"
-        id="test-id_button"
-        tabindex="0"
-        type="button"
+        <label
+          class="c4 fi-label_label-span"
+          id="test-id-label"
+        >
+          Dropdown test
+        </label>
+      </div>
+      <div
+        class="c0 fi-dropdown_input-wrapper"
       >
+        <button
+          aria-expanded="true"
+          aria-haspopup="listbox"
+          aria-labelledby="test-id-label"
+          aria-owns="test-id-popover"
+          class="c5 fi-dropdown_button"
+          id="test-id_button"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="c4 fi-dropdown_display-value"
+          >
+            Dropdown
+          </span>
+          <input
+            class="c6"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value=""
+          />
+        </button>
         <span
-          class="c4 fi-dropdown_display-value"
+          class="c4 c7 fi-visually-hidden"
         >
           Dropdown
         </span>
-        <input
-          class="c6"
-          name="dropdown-test"
-          tabindex="-1"
-          type="hidden"
-          value=""
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c4 c8 fi-status-text"
         />
-      </button>
-      <span
-        class="c4 c7 fi-visually-hidden"
-      >
-        Dropdown
-      </span>
-      <span
-        aria-atomic="true"
-        aria-live="assertive"
-        class="c4 c8 fi-status-text"
-      />
+      </div>
     </div>
   </div>
-</div>
+  <div
+    class="fi-portal"
+    role="presentation"
+    style="position: absolute; left: 0px; top: 0px; width: 0px; transform: translate(0px, 0px);"
+    tabindex="-1"
+  >
+    <div
+      class="c2"
+    >
+      <ul
+        aria-activedescendant="test-id-item-1"
+        class="c9 fi-select-item-list c10 fi-dropdown_item-list"
+        id="test-id-popover"
+        role="listbox"
+        tabindex="0"
+      >
+        <div
+          class="c2 fi-select-item-list_content_wrapper"
+        >
+          <li
+            aria-selected="false"
+            class="c11 c12 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
+            id="test-id-item-1"
+            role="option"
+            tabindex="-1"
+          >
+            Item 1
+          </li>
+          <li
+            aria-selected="false"
+            class="c11 c12 fi-dropdown_item"
+            id="test-id-item-2"
+            role="option"
+            tabindex="-1"
+          >
+            Item 2
+          </li>
+        </div>
+      </ul>
+    </div>
+  </div>
+</body>
 `;
 
 exports[`Controlled Dropdown should match snapshot 1`] = `
@@ -626,6 +821,31 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c11 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c11::before,
+.c11::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -652,6 +872,37 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 
 .c4::before,
 .c4::after {
+  box-sizing: border-box;
+}
+
+.c9 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -695,6 +946,45 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 
 .c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
+}
+
+.c10 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style-type: none;
+  box-sizing: content-box;
+  max-height: 265px;
+  background-color: hsl(0,0%,100%);
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+  border-color: hsl(201,7%,58%);
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  margin: 0;
+  padding: 4px 0 0 0;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10 .fi-select-item-list_content_wrapper {
+  display: block;
+  width: 100%;
+  max-height: inherit;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c8 {
@@ -905,63 +1195,203 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   z-index: 9999;
 }
 
-<div>
-  <div
-    class="c0 c1 dropdown-test fi-dropdown"
-    data-testid=""
-    id="test-id"
-  >
+.c13 {
+  vertical-align: baseline;
+}
+
+.c13.fi-icon {
+  display: inline-block;
+}
+
+.c13 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c13 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c13.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c13.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c12.fi-dropdown_item {
+  color: hsl(0,0%,13%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+  line-height: 1.5;
+  padding: 8px;
+  border: 0;
+  position: relative;
+}
+
+.c12.fi-dropdown_item:focus {
+  outline: 0;
+}
+
+.c12.fi-dropdown_item:hover {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c12.fi-dropdown_item .fi-dropdown_item_icon {
+  position: absolute;
+  top: 14px;
+  right: 10px;
+  height: 12px;
+  width: 12px;
+}
+
+.c12.fi-dropdown_item--selected {
+  background-color: hsl(215,100%,95%);
+  color: hsl(0,0%,13%);
+}
+
+.c12.fi-dropdown_item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
+  background-color: hsl(0,0%,100%);
+  color: hsl(0,0%,13%);
+}
+
+.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+@media (forced-colors:active) {
+  .c12.fi-dropdown_item--hasKeyboardFocus,
+  .c12.fi-dropdown_item:hover {
+    background-color: Highlight;
+  }
+}
+
+<body>
+  <div>
     <div
-      class="c2 c3 fi-dropdown_label--visible fi-label"
+      class="c0 c1 dropdown-test fi-dropdown fi-dropdown--open"
+      data-testid=""
+      id="test-id"
     >
-      <label
-        class="c4 fi-label_label-span"
-        id="test-id-label"
+      <div
+        class="c2 c3 fi-dropdown_label--visible fi-label"
       >
-        Dropdown test
-      </label>
-    </div>
-    <div
-      class="c0 fi-dropdown_input-wrapper"
-    >
-      <button
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="test-id-displayValue test-id-label"
-        aria-owns="test-id-popover"
-        class="c5 fi-dropdown_button"
-        id="test-id_button"
-        tabindex="0"
-        type="button"
-        value="item-2"
+        <label
+          class="c4 fi-label_label-span"
+          id="test-id-label"
+        >
+          Dropdown test
+        </label>
+      </div>
+      <div
+        class="c0 fi-dropdown_input-wrapper"
       >
+        <button
+          aria-expanded="true"
+          aria-haspopup="listbox"
+          aria-labelledby="test-id-displayValue test-id-label"
+          aria-owns="test-id-popover"
+          class="c5 fi-dropdown_button"
+          id="test-id_button"
+          tabindex="0"
+          type="button"
+          value="item-2"
+        >
+          <span
+            class="c4 fi-dropdown_display-value"
+          >
+            Item 2
+          </span>
+          <input
+            class="c6"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value="item-2"
+          />
+        </button>
         <span
-          class="c4 fi-dropdown_display-value"
+          class="c4 c7 fi-visually-hidden"
+          id="test-id-displayValue"
         >
           Item 2
         </span>
-        <input
-          class="c6"
-          name="dropdown-test"
-          tabindex="-1"
-          type="hidden"
-          value="item-2"
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c4 c8 fi-status-text"
         />
-      </button>
-      <span
-        class="c4 c7 fi-visually-hidden"
-        id="test-id-displayValue"
-      >
-        Item 2
-      </span>
-      <span
-        aria-atomic="true"
-        aria-live="assertive"
-        class="c4 c8 fi-status-text"
-      />
+      </div>
     </div>
   </div>
-</div>
+  <div
+    class="fi-portal"
+    role="presentation"
+    style="position: absolute; left: 0px; top: 0px; width: 0px; transform: translate(0px, 0px);"
+    tabindex="-1"
+  >
+    <div
+      class="c2"
+    >
+      <ul
+        aria-activedescendant="test-id-item-2"
+        class="c9 fi-select-item-list c10 fi-dropdown_item-list"
+        id="test-id-popover"
+        role="listbox"
+        tabindex="0"
+      >
+        <div
+          class="c2 fi-select-item-list_content_wrapper"
+        >
+          <li
+            aria-selected="false"
+            class="c11 c12 fi-dropdown_item"
+            id="test-id-item-1"
+            role="option"
+            tabindex="-1"
+          >
+            Item 1
+          </li>
+          <li
+            aria-selected="true"
+            class="c11 c12 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus fi-dropdown_item--selected"
+            id="test-id-item-2"
+            role="option"
+            tabindex="-1"
+          >
+            Item 2
+            <svg
+              aria-hidden="true"
+              class="fi-icon c13 fi-dropdown_item_icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 20 20"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="fi-icon-base-fill"
+                d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
+                fill="#222"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </li>
+        </div>
+      </ul>
+    </div>
+  </div>
+</body>
 `;
 
 exports[`Dropdown with additional aria-label should match snapshot 1`] = `
@@ -1109,6 +1539,31 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c11 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c11::before,
+.c11::after {
+  box-sizing: border-box;
+}
+
 .c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1135,6 +1590,37 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 
 .c4::before,
 .c4::after {
+  box-sizing: border-box;
+}
+
+.c9 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
@@ -1178,6 +1664,45 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 
 .c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
+}
+
+.c10 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style-type: none;
+  box-sizing: content-box;
+  max-height: 265px;
+  background-color: hsl(0,0%,100%);
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+  border-color: hsl(201,7%,58%);
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  margin: 0;
+  padding: 4px 0 0 0;
+}
+
+.c10:focus {
+  outline: none;
+}
+
+.c10 .fi-select-item-list_content_wrapper {
+  display: block;
+  width: 100%;
+  max-height: inherit;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c8 {
@@ -1388,61 +1913,161 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   z-index: 9999;
 }
 
-<div>
-  <div
-    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
-    data-testid=""
-    id="test-id"
-  >
+.c12.fi-dropdown_item {
+  color: hsl(0,0%,13%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+  line-height: 1.5;
+  padding: 8px;
+  border: 0;
+  position: relative;
+}
+
+.c12.fi-dropdown_item:focus {
+  outline: 0;
+}
+
+.c12.fi-dropdown_item:hover {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c12.fi-dropdown_item .fi-dropdown_item_icon {
+  position: absolute;
+  top: 14px;
+  right: 10px;
+  height: 12px;
+  width: 12px;
+}
+
+.c12.fi-dropdown_item--selected {
+  background-color: hsl(215,100%,95%);
+  color: hsl(0,0%,13%);
+}
+
+.c12.fi-dropdown_item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
+  background-color: hsl(0,0%,100%);
+  color: hsl(0,0%,13%);
+}
+
+.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+@media (forced-colors:active) {
+  .c12.fi-dropdown_item--hasKeyboardFocus,
+  .c12.fi-dropdown_item:hover {
+    background-color: Highlight;
+  }
+}
+
+<body>
+  <div>
     <div
-      class="c2 c3 fi-dropdown_label--visible fi-label"
+      class="c0 c1 dropdown-test fi-dropdown fi-dropdown--open fi-dropdown--italicize"
+      data-testid=""
+      id="test-id"
     >
-      <label
-        class="c4 fi-label_label-span"
-        id="test-id-label"
+      <div
+        class="c2 c3 fi-dropdown_label--visible fi-label"
       >
-        Dropdown test
-      </label>
-    </div>
-    <div
-      class="c0 fi-dropdown_input-wrapper"
-    >
-      <button
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="additional-label-id test-id-label"
-        aria-owns="test-id-popover"
-        class="c5 fi-dropdown_button"
-        id="test-id_button"
-        tabindex="0"
-        type="button"
+        <label
+          class="c4 fi-label_label-span"
+          id="test-id-label"
+        >
+          Dropdown test
+        </label>
+      </div>
+      <div
+        class="c0 fi-dropdown_input-wrapper"
       >
+        <button
+          aria-expanded="true"
+          aria-haspopup="listbox"
+          aria-labelledby="additional-label-id test-id-label"
+          aria-owns="test-id-popover"
+          class="c5 fi-dropdown_button"
+          id="test-id_button"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="c4 fi-dropdown_display-value"
+          >
+            Dropdown
+          </span>
+          <input
+            class="c6"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value=""
+          />
+        </button>
         <span
-          class="c4 fi-dropdown_display-value"
+          class="c4 c7 fi-visually-hidden"
         >
           Dropdown
         </span>
-        <input
-          class="c6"
-          name="dropdown-test"
-          tabindex="-1"
-          type="hidden"
-          value=""
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c4 c8 fi-status-text"
         />
-      </button>
-      <span
-        class="c4 c7 fi-visually-hidden"
-      >
-        Dropdown
-      </span>
-      <span
-        aria-atomic="true"
-        aria-live="assertive"
-        class="c4 c8 fi-status-text"
-      />
+      </div>
     </div>
   </div>
-</div>
+  <div
+    class="fi-portal"
+    role="presentation"
+    style="position: absolute; left: 0px; top: 0px; width: 0px; transform: translate(0px, 0px);"
+    tabindex="-1"
+  >
+    <div
+      class="c2"
+    >
+      <ul
+        aria-activedescendant="test-id-item-1"
+        class="c9 fi-select-item-list c10 fi-dropdown_item-list"
+        id="test-id-popover"
+        role="listbox"
+        tabindex="0"
+      >
+        <div
+          class="c2 fi-select-item-list_content_wrapper"
+        >
+          <li
+            aria-selected="false"
+            class="c11 c12 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
+            id="test-id-item-1"
+            role="option"
+            tabindex="-1"
+          >
+            Item 1
+          </li>
+          <li
+            aria-selected="false"
+            class="c11 c12 fi-dropdown_item"
+            id="test-id-item-2"
+            role="option"
+            tabindex="-1"
+          >
+            Item 2
+          </li>
+        </div>
+      </ul>
+    </div>
+  </div>
+</body>
 `;
 
 exports[`Dropdown with hidden label should match snapshot 1`] = `
@@ -1869,59 +2494,61 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   z-index: 9999;
 }
 
-<div>
-  <div
-    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
-    data-testid="dropdown-hidden-label-test-id"
-    id="test-id"
-  >
+<body>
+  <div>
     <div
-      class="c2 c3 fi-label"
+      class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
+      data-testid="dropdown-hidden-label-test-id"
+      id="test-id"
     >
-      <label
-        class="c4 fi-visually-hidden"
-        id="test-id-label"
+      <div
+        class="c2 c3 fi-label"
       >
-        Dropdown test
-      </label>
-    </div>
-    <div
-      class="c0 fi-dropdown_input-wrapper"
-    >
-      <button
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="test-id-label"
-        aria-owns="test-id-popover"
-        class="c5 fi-dropdown_button"
-        id="test-id_button"
-        tabindex="0"
-        type="button"
+        <label
+          class="c4 fi-visually-hidden"
+          id="test-id-label"
+        >
+          Dropdown test
+        </label>
+      </div>
+      <div
+        class="c0 fi-dropdown_input-wrapper"
       >
+        <button
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="test-id-label"
+          aria-owns="test-id-popover"
+          class="c5 fi-dropdown_button"
+          id="test-id_button"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="c6 fi-dropdown_display-value"
+          >
+            Dropdown
+          </span>
+          <input
+            class="c7"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value=""
+          />
+        </button>
         <span
-          class="c6 fi-dropdown_display-value"
+          class="c6 c4 fi-visually-hidden"
         >
           Dropdown
         </span>
-        <input
-          class="c7"
-          name="dropdown-test"
-          tabindex="-1"
-          type="hidden"
-          value=""
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c6 c8 fi-status-text"
         />
-      </button>
-      <span
-        class="c6 c4 fi-visually-hidden"
-      >
-        Dropdown
-      </span>
-      <span
-        aria-atomic="true"
-        aria-live="assertive"
-        class="c6 c8 fi-status-text"
-      />
+      </div>
     </div>
   </div>
-</div>
+</body>
 `;

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -361,6 +361,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
       >
         <label
           class="c0 fi-label_label-span"
+          for="test-id_button"
           id="test-id-label"
         >
           Dropdown test
@@ -380,7 +381,11 @@ exports[`Basic dropdown should match snapshot 1`] = `
           role="button"
           tabindex="0"
         >
-          Dropdown
+          <span
+            class="c0"
+          >
+            Dropdown
+          </span>
           <input
             class="c5"
             name="dropdown-test"
@@ -762,6 +767,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
       >
         <label
           class="c0 fi-label_label-span"
+          for="test-id_button"
           id="test-id-label"
         >
           Dropdown test
@@ -774,13 +780,19 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           aria-activedescendant="test-id-item-2"
           aria-expanded="false"
           aria-haspopup="listbox"
+          aria-labelledby="test-id-displayValue test-id-label"
           aria-owns="test-id-popover"
           class="c0 fi-dropdown_button"
           id="test-id_button"
           role="button"
           tabindex="0"
         >
-          Item 2
+          <span
+            class="c0"
+            id="test-id-displayValue"
+          >
+            Item 2
+          </span>
           <input
             class="c5"
             name="dropdown-test"
@@ -1161,6 +1173,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
       >
         <label
           class="c0 fi-label_label-span"
+          for="test-id_button"
           id="test-id-label"
         >
           Dropdown test
@@ -1180,7 +1193,11 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           role="button"
           tabindex="0"
         >
-          Dropdown
+          <span
+            class="c0"
+          >
+            Dropdown
+          </span>
           <input
             class="c5"
             name="dropdown-test"
@@ -1573,6 +1590,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
       >
         <label
           class="c5 fi-visually-hidden"
+          for="test-id_button"
           id="test-id-label"
         >
           Dropdown test
@@ -1592,7 +1610,11 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
           role="button"
           tabindex="0"
         >
-          Dropdown
+          <span
+            class="c0"
+          >
+            Dropdown
+          </span>
           <input
             class="c6"
             name="dropdown-test"

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -335,7 +335,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
   height: 100%;
-  display: block;
+  display: inline-block;
   line-height: 1.5;
   overflow: hidden;
 }
@@ -404,7 +404,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
 }
 
 .c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
+  outline: 3px solid transparent;
   position: relative;
 }
 
@@ -431,55 +431,51 @@ exports[`Basic dropdown should match snapshot 1`] = `
     id="test-id"
   >
     <div
-      class="c0"
+      class="c2 c3 fi-dropdown_label--visible fi-label"
     >
-      <div
-        class="c2 c3 fi-dropdown_label--visible fi-label"
+      <label
+        class="c4 fi-label_label-span"
+        id="test-id-label"
       >
-        <label
-          class="c4 fi-label_label-span"
-          id="test-id-label"
-        >
-          Dropdown test
-        </label>
-      </div>
-      <div
-        class="c0 fi-dropdown_input-wrapper"
+        Dropdown test
+      </label>
+    </div>
+    <div
+      class="c0 fi-dropdown_input-wrapper"
+    >
+      <button
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="test-id-label"
+        aria-owns="test-id-popover"
+        class="c5 fi-dropdown_button"
+        id="test-id_button"
+        tabindex="0"
+        type="button"
       >
-        <button
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="test-id-label"
-          aria-owns="test-id-popover"
-          class="c5 fi-dropdown_button"
-          id="test-id_button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="c4 fi-dropdown_display-value"
-          >
-            Dropdown
-          </span>
-          <input
-            class="c6"
-            name="dropdown-test"
-            tabindex="-1"
-            type="hidden"
-            value=""
-          />
-        </button>
         <span
-          class="c4 c7 fi-visually-hidden"
+          class="c4 fi-dropdown_display-value"
         >
           Dropdown
         </span>
-        <span
-          aria-atomic="true"
-          aria-live="assertive"
-          class="c4 c8 fi-status-text"
+        <input
+          class="c6"
+          name="dropdown-test"
+          tabindex="-1"
+          type="hidden"
+          value=""
         />
-      </div>
+      </button>
+      <span
+        class="c4 c7 fi-visually-hidden"
+      >
+        Dropdown
+      </span>
+      <span
+        aria-atomic="true"
+        aria-live="assertive"
+        class="c4 c8 fi-status-text"
+      />
     </div>
   </div>
 </div>
@@ -820,7 +816,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
   height: 100%;
-  display: block;
+  display: inline-block;
   line-height: 1.5;
   overflow: hidden;
 }
@@ -889,7 +885,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 }
 
 .c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
+  outline: 3px solid transparent;
   position: relative;
 }
 
@@ -916,57 +912,53 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
     id="test-id"
   >
     <div
-      class="c0"
+      class="c2 c3 fi-dropdown_label--visible fi-label"
     >
-      <div
-        class="c2 c3 fi-dropdown_label--visible fi-label"
+      <label
+        class="c4 fi-label_label-span"
+        id="test-id-label"
       >
-        <label
-          class="c4 fi-label_label-span"
-          id="test-id-label"
-        >
-          Dropdown test
-        </label>
-      </div>
-      <div
-        class="c0 fi-dropdown_input-wrapper"
+        Dropdown test
+      </label>
+    </div>
+    <div
+      class="c0 fi-dropdown_input-wrapper"
+    >
+      <button
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="test-id-displayValue test-id-label"
+        aria-owns="test-id-popover"
+        class="c5 fi-dropdown_button"
+        id="test-id_button"
+        tabindex="0"
+        type="button"
+        value="item-2"
       >
-        <button
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="test-id-displayValue test-id-label"
-          aria-owns="test-id-popover"
-          class="c5 fi-dropdown_button"
-          id="test-id_button"
-          tabindex="0"
-          type="button"
-          value="item-2"
-        >
-          <span
-            class="c4 fi-dropdown_display-value"
-          >
-            Item 2
-          </span>
-          <input
-            class="c6"
-            name="dropdown-test"
-            tabindex="-1"
-            type="hidden"
-            value="item-2"
-          />
-        </button>
         <span
-          class="c4 c7 fi-visually-hidden"
-          id="test-id-displayValue"
+          class="c4 fi-dropdown_display-value"
         >
           Item 2
         </span>
-        <span
-          aria-atomic="true"
-          aria-live="assertive"
-          class="c4 c8 fi-status-text"
+        <input
+          class="c6"
+          name="dropdown-test"
+          tabindex="-1"
+          type="hidden"
+          value="item-2"
         />
-      </div>
+      </button>
+      <span
+        class="c4 c7 fi-visually-hidden"
+        id="test-id-displayValue"
+      >
+        Item 2
+      </span>
+      <span
+        aria-atomic="true"
+        aria-live="assertive"
+        class="c4 c8 fi-status-text"
+      />
     </div>
   </div>
 </div>
@@ -1307,7 +1299,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
   height: 100%;
-  display: block;
+  display: inline-block;
   line-height: 1.5;
   overflow: hidden;
 }
@@ -1376,7 +1368,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 }
 
 .c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
+  outline: 3px solid transparent;
   position: relative;
 }
 
@@ -1403,55 +1395,51 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
     id="test-id"
   >
     <div
-      class="c0"
+      class="c2 c3 fi-dropdown_label--visible fi-label"
     >
-      <div
-        class="c2 c3 fi-dropdown_label--visible fi-label"
+      <label
+        class="c4 fi-label_label-span"
+        id="test-id-label"
       >
-        <label
-          class="c4 fi-label_label-span"
-          id="test-id-label"
-        >
-          Dropdown test
-        </label>
-      </div>
-      <div
-        class="c0 fi-dropdown_input-wrapper"
+        Dropdown test
+      </label>
+    </div>
+    <div
+      class="c0 fi-dropdown_input-wrapper"
+    >
+      <button
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="additional-label-id test-id-label"
+        aria-owns="test-id-popover"
+        class="c5 fi-dropdown_button"
+        id="test-id_button"
+        tabindex="0"
+        type="button"
       >
-        <button
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="additional-label-id test-id-label"
-          aria-owns="test-id-popover"
-          class="c5 fi-dropdown_button"
-          id="test-id_button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="c4 fi-dropdown_display-value"
-          >
-            Dropdown
-          </span>
-          <input
-            class="c6"
-            name="dropdown-test"
-            tabindex="-1"
-            type="hidden"
-            value=""
-          />
-        </button>
         <span
-          class="c4 c7 fi-visually-hidden"
+          class="c4 fi-dropdown_display-value"
         >
           Dropdown
         </span>
-        <span
-          aria-atomic="true"
-          aria-live="assertive"
-          class="c4 c8 fi-status-text"
+        <input
+          class="c6"
+          name="dropdown-test"
+          tabindex="-1"
+          type="hidden"
+          value=""
         />
-      </div>
+      </button>
+      <span
+        class="c4 c7 fi-visually-hidden"
+      >
+        Dropdown
+      </span>
+      <span
+        aria-atomic="true"
+        aria-live="assertive"
+        class="c4 c8 fi-status-text"
+      />
     </div>
   </div>
 </div>
@@ -1792,7 +1780,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
   height: 100%;
-  display: block;
+  display: inline-block;
   line-height: 1.5;
   overflow: hidden;
 }
@@ -1861,7 +1849,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 }
 
 .c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
+  outline: 3px solid transparent;
   position: relative;
 }
 
@@ -1888,55 +1876,51 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
     id="test-id"
   >
     <div
-      class="c0"
+      class="c2 c3 fi-label"
     >
-      <div
-        class="c2 c3 fi-label"
+      <label
+        class="c4 fi-visually-hidden"
+        id="test-id-label"
       >
-        <label
-          class="c4 fi-visually-hidden"
-          id="test-id-label"
-        >
-          Dropdown test
-        </label>
-      </div>
-      <div
-        class="c0 fi-dropdown_input-wrapper"
+        Dropdown test
+      </label>
+    </div>
+    <div
+      class="c0 fi-dropdown_input-wrapper"
+    >
+      <button
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="test-id-label"
+        aria-owns="test-id-popover"
+        class="c5 fi-dropdown_button"
+        id="test-id_button"
+        tabindex="0"
+        type="button"
       >
-        <button
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="test-id-label"
-          aria-owns="test-id-popover"
-          class="c5 fi-dropdown_button"
-          id="test-id_button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="c6 fi-dropdown_display-value"
-          >
-            Dropdown
-          </span>
-          <input
-            class="c7"
-            name="dropdown-test"
-            tabindex="-1"
-            type="hidden"
-            value=""
-          />
-        </button>
         <span
-          class="c6 c4 fi-visually-hidden"
+          class="c6 fi-dropdown_display-value"
         >
           Dropdown
         </span>
-        <span
-          aria-atomic="true"
-          aria-live="assertive"
-          class="c6 c8 fi-status-text"
+        <input
+          class="c7"
+          name="dropdown-test"
+          tabindex="-1"
+          type="hidden"
+          value=""
         />
-      </div>
+      </button>
+      <span
+        class="c6 c4 fi-visually-hidden"
+      >
+        Dropdown
+      </span>
+      <span
+        aria-atomic="true"
+        aria-live="assertive"
+        class="c6 c8 fi-status-text"
+      />
     </div>
   </div>
 </div>

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -243,24 +243,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
   display: inline-block;
 }
 
-.c1.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
-}
-
-.c1.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c1.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
-}
-
 .c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
@@ -364,6 +346,24 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-shadow: none;
 }
 
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 .c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
   cursor: not-allowed;
 }
@@ -431,7 +431,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
           aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
           id="test-id_button"
-          role="button"
           tabindex="0"
           type="button"
         >
@@ -702,24 +701,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   display: inline-block;
 }
 
-.c1.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
-}
-
-.c1.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c1.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
-}
-
 .c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
@@ -823,6 +804,24 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-shadow: none;
 }
 
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 .c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
   cursor: not-allowed;
 }
@@ -891,7 +890,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
           id="test-id_button"
-          role="button"
           tabindex="0"
           type="button"
         >
@@ -1163,24 +1161,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   display: inline-block;
 }
 
-.c1.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
-}
-
-.c1.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c1.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
-}
-
 .c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
@@ -1284,6 +1264,24 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-shadow: none;
 }
 
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 .c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
   cursor: not-allowed;
 }
@@ -1351,7 +1349,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
           id="test-id_button"
-          role="button"
           tabindex="0"
           type="button"
         >
@@ -1634,24 +1631,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   display: inline-block;
 }
 
-.c1.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
-}
-
-.c1.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c1.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
-}
-
 .c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
@@ -1755,6 +1734,24 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   box-shadow: none;
 }
 
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 .c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
   cursor: not-allowed;
 }
@@ -1822,7 +1819,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
           aria-owns="test-id-popover"
           class="c6 fi-dropdown_button"
           id="test-id_button"
-          role="button"
           tabindex="0"
           type="button"
         >

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,70 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Basic dropdown should match snapshot 1`] = `
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
 .c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   margin: 0;
   overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
   margin: 0;
   padding: 0;
   border: 0;
@@ -80,11 +24,29 @@ exports[`Basic dropdown should match snapshot 1`] = `
   cursor: inherit;
   display: inline-block;
   max-width: 100%;
+  cursor: pointer;
 }
 
-.c5::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
+.c5:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c5::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c5::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c5::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c5::-webkit-outer-spin-button {
+  height: auto;
 }
 
 .c5::before,
@@ -92,1132 +54,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c0::before,
-.c0::after {
-  box-sizing: border-box;
-}
-
-.c4.fi-label .fi-label_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
-  color: hsl(0,0%,13%);
-}
-
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c4.fi-label .fi-label_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c6 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(0,0%,13%);
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c6.fi-status-text {
-  display: block;
-}
-
-.c6.fi-status-text.fi-status-text--error {
-  color: hsl(3,59%,48%);
-}
-
-.c1 {
-  width: 290px;
-}
-
-.c1 .fi-dropdown_item-list {
-  padding-top: 0;
-}
-
-.c1.fi-dropdown {
-  display: inline-block;
-}
-
-.c1.fi-dropdown .fi-dropdown_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-dropdown .fi-hint-text {
-  margin-bottom: 10px;
-}
-
-.c1.fi-dropdown .fi-status-text {
-  line-height: 18px;
-}
-
-.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
-  margin-top: 5px;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
-}
-
-.c1.fi-dropdown .fi-dropdown_button {
-  color: hsl(0,0%,13%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  min-width: 245px;
-  max-width: 100%;
-  padding: 8px 16px;
-  border: 1px solid hsl(202,7%,80%);
-  border-radius: 2px;
-  line-height: 1;
-  position: relative;
-  display: inline-block;
-  word-break: break-word;
-  width: 100%;
-  overflow-wrap: break-word;
-  height: 40px;
-  padding: 7px 38px 7px 7px;
-  border-color: hsl(201,7%,58%);
-  text-align: left;
-  line-height: 1.5;
-  background-color: hsl(0,0%,100%);
-  box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  white-space: nowrap;
-}
-
-.c1.fi-dropdown .fi-dropdown_button:focus-visible {
-  outline: none;
-}
-
-.c1.fi-dropdown .fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(0,0%,13%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(0,0%,13%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c1.fi-dropdown .fi-dropdown_popover {
-  color: hsl(0,0%,13%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  margin-top: -1px;
-  padding: 0;
-  box-sizing: border-box;
-  font-size: 100%;
-  border: 0;
-  background-color: hsl(0,0%,100%);
-  border-color: hsl(201,7%,58%);
-  border-style: solid;
-  border-width: 0 1px 1px 1px;
-  border-radius: 0px 0px 2px 2px;
-  max-height: 265px;
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-.c1.fi-dropdown .fi-dropdown_popover:focus-within {
-  outline: 0;
-  box-shadow: none;
-}
-
-.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
-  cursor: not-allowed;
-}
-
-.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  pointer-events: none;
-}
-
-.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c1.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
-}
-
-.c1.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c1.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
-}
-
-<div>
-  <span
-    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
-    data-testid="dropdown-test-id"
-    id="test-id"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3 c4 fi-dropdown_label--visible fi-label"
-      >
-        <label
-          class="c0 fi-label_label-span"
-          for="test-id_button"
-          id="test-id-label"
-        >
-          Dropdown test
-        </label>
-      </div>
-      <div
-        class="c2 fi-dropdown_input-wrapper"
-      >
-        <span
-          aria-activedescendant=""
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="test-id-label"
-          aria-owns="test-id-popover"
-          class="c0 fi-dropdown_button"
-          id="test-id_button"
-          role="button"
-          tabindex="0"
-        >
-          <span
-            class="c0"
-          >
-            Dropdown
-          </span>
-          <input
-            class="c5"
-            name="dropdown-test"
-            tabindex="-1"
-            type="hidden"
-            value=""
-          />
-        </span>
-        <span
-          aria-atomic="true"
-          aria-live="assertive"
-          class="c0 c6 fi-status-text"
-        />
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`Controlled Dropdown should match snapshot 1`] = `
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
-.c5 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  overflow: visible;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline-block;
-  max-width: 100%;
-}
-
-.c5::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
-.c5::before,
-.c5::after {
-  box-sizing: border-box;
-}
-
-.c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c0::before,
-.c0::after {
-  box-sizing: border-box;
-}
-
-.c4.fi-label .fi-label_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
-  color: hsl(0,0%,13%);
-}
-
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c4.fi-label .fi-label_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c6 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(0,0%,13%);
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c6.fi-status-text {
-  display: block;
-}
-
-.c6.fi-status-text.fi-status-text--error {
-  color: hsl(3,59%,48%);
-}
-
-.c1 {
-  width: 290px;
-}
-
-.c1 .fi-dropdown_item-list {
-  padding-top: 0;
-}
-
-.c1.fi-dropdown {
-  display: inline-block;
-}
-
-.c1.fi-dropdown .fi-dropdown_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-dropdown .fi-hint-text {
-  margin-bottom: 10px;
-}
-
-.c1.fi-dropdown .fi-status-text {
-  line-height: 18px;
-}
-
-.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
-  margin-top: 5px;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
-}
-
-.c1.fi-dropdown .fi-dropdown_button {
-  color: hsl(0,0%,13%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  min-width: 245px;
-  max-width: 100%;
-  padding: 8px 16px;
-  border: 1px solid hsl(202,7%,80%);
-  border-radius: 2px;
-  line-height: 1;
-  position: relative;
-  display: inline-block;
-  word-break: break-word;
-  width: 100%;
-  overflow-wrap: break-word;
-  height: 40px;
-  padding: 7px 38px 7px 7px;
-  border-color: hsl(201,7%,58%);
-  text-align: left;
-  line-height: 1.5;
-  background-color: hsl(0,0%,100%);
-  box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  white-space: nowrap;
-}
-
-.c1.fi-dropdown .fi-dropdown_button:focus-visible {
-  outline: none;
-}
-
-.c1.fi-dropdown .fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(0,0%,13%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(0,0%,13%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c1.fi-dropdown .fi-dropdown_popover {
-  color: hsl(0,0%,13%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  margin-top: -1px;
-  padding: 0;
-  box-sizing: border-box;
-  font-size: 100%;
-  border: 0;
-  background-color: hsl(0,0%,100%);
-  border-color: hsl(201,7%,58%);
-  border-style: solid;
-  border-width: 0 1px 1px 1px;
-  border-radius: 0px 0px 2px 2px;
-  max-height: 265px;
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-.c1.fi-dropdown .fi-dropdown_popover:focus-within {
-  outline: 0;
-  box-shadow: none;
-}
-
-.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
-  cursor: not-allowed;
-}
-
-.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  pointer-events: none;
-}
-
-.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c1.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
-}
-
-.c1.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c1.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
-}
-
-<div>
-  <span
-    class="c0 c1 dropdown-test fi-dropdown"
-    data-testid=""
-    id="test-id"
-    value="item-2"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3 c4 fi-dropdown_label--visible fi-label"
-      >
-        <label
-          class="c0 fi-label_label-span"
-          for="test-id_button"
-          id="test-id-label"
-        >
-          Dropdown test
-        </label>
-      </div>
-      <div
-        class="c2 fi-dropdown_input-wrapper"
-      >
-        <span
-          aria-activedescendant="test-id-item-2"
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="test-id-displayValue test-id-label"
-          aria-owns="test-id-popover"
-          class="c0 fi-dropdown_button"
-          id="test-id_button"
-          role="button"
-          tabindex="0"
-        >
-          <span
-            class="c0"
-            id="test-id-displayValue"
-          >
-            Item 2
-          </span>
-          <input
-            class="c5"
-            name="dropdown-test"
-            tabindex="-1"
-            type="hidden"
-            value="item-2"
-          />
-        </span>
-        <span
-          aria-atomic="true"
-          aria-live="assertive"
-          class="c0 c6 fi-status-text"
-        />
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`Dropdown with additional aria-label should match snapshot 1`] = `
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
-.c5 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  overflow: visible;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline-block;
-  max-width: 100%;
-}
-
-.c5::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
-.c5::before,
-.c5::after {
-  box-sizing: border-box;
-}
-
-.c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c0::before,
-.c0::after {
-  box-sizing: border-box;
-}
-
-.c4.fi-label .fi-label_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
-  color: hsl(0,0%,13%);
-}
-
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c4.fi-label .fi-label_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c6 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(0,0%,13%);
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c6.fi-status-text {
-  display: block;
-}
-
-.c6.fi-status-text.fi-status-text--error {
-  color: hsl(3,59%,48%);
-}
-
-.c1 {
-  width: 290px;
-}
-
-.c1 .fi-dropdown_item-list {
-  padding-top: 0;
-}
-
-.c1.fi-dropdown {
-  display: inline-block;
-}
-
-.c1.fi-dropdown .fi-dropdown_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-dropdown .fi-hint-text {
-  margin-bottom: 10px;
-}
-
-.c1.fi-dropdown .fi-status-text {
-  line-height: 18px;
-}
-
-.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
-  margin-top: 5px;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
-}
-
-.c1.fi-dropdown .fi-dropdown_button {
-  color: hsl(0,0%,13%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  min-width: 245px;
-  max-width: 100%;
-  padding: 8px 16px;
-  border: 1px solid hsl(202,7%,80%);
-  border-radius: 2px;
-  line-height: 1;
-  position: relative;
-  display: inline-block;
-  word-break: break-word;
-  width: 100%;
-  overflow-wrap: break-word;
-  height: 40px;
-  padding: 7px 38px 7px 7px;
-  border-color: hsl(201,7%,58%);
-  text-align: left;
-  line-height: 1.5;
-  background-color: hsl(0,0%,100%);
-  box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  white-space: nowrap;
-}
-
-.c1.fi-dropdown .fi-dropdown_button:focus-visible {
-  outline: none;
-}
-
-.c1.fi-dropdown .fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(0,0%,13%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(0,0%,13%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c1.fi-dropdown .fi-dropdown_popover {
-  color: hsl(0,0%,13%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  margin-top: -1px;
-  padding: 0;
-  box-sizing: border-box;
-  font-size: 100%;
-  border: 0;
-  background-color: hsl(0,0%,100%);
-  border-color: hsl(201,7%,58%);
-  border-style: solid;
-  border-width: 0 1px 1px 1px;
-  border-radius: 0px 0px 2px 2px;
-  max-height: 265px;
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-.c1.fi-dropdown .fi-dropdown_popover:focus-within {
-  outline: 0;
-  box-shadow: none;
-}
-
-.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
-  cursor: not-allowed;
-}
-
-.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  pointer-events: none;
-}
-
-.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c1.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
-}
-
-.c1.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c1.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
-}
-
-<div>
-  <span
-    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
-    data-testid=""
-    id="test-id"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3 c4 fi-dropdown_label--visible fi-label"
-      >
-        <label
-          class="c0 fi-label_label-span"
-          for="test-id_button"
-          id="test-id-label"
-        >
-          Dropdown test
-        </label>
-      </div>
-      <div
-        class="c2 fi-dropdown_input-wrapper"
-      >
-        <span
-          aria-activedescendant=""
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="additional-label-id test-id-label"
-          aria-owns="test-id-popover"
-          class="c0 fi-dropdown_button"
-          id="test-id_button"
-          role="button"
-          tabindex="0"
-        >
-          <span
-            class="c0"
-          >
-            Dropdown
-          </span>
-          <input
-            class="c5"
-            name="dropdown-test"
-            tabindex="-1"
-            type="hidden"
-            value=""
-          />
-        </span>
-        <span
-          aria-atomic="true"
-          aria-live="assertive"
-          class="c0 c6 fi-status-text"
-        />
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`Dropdown with hidden label should match snapshot 1`] = `
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1338,18 +174,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-}
-
 .c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1419,6 +243,24 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   display: inline-block;
 }
 
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 .c1.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
@@ -1433,27 +275,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 
 .c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
   margin-top: 5px;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c1.fi-dropdown .fi-dropdown_button {
@@ -1558,6 +379,329 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   border-color: hsl(202,7%,67%) transparent transparent transparent;
 }
 
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+<div>
+  <span
+    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
+    data-testid="dropdown-test-id"
+    id="test-id"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3 c4 fi-dropdown_label--visible fi-label"
+      >
+        <label
+          class="c0 fi-label_label-span"
+          for="test-id_button"
+          id="test-id-label"
+        >
+          Dropdown test
+        </label>
+      </div>
+      <div
+        class="c2 fi-dropdown_input-wrapper"
+      >
+        <button
+          aria-activedescendant=""
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="test-id-label"
+          aria-owns="test-id-popover"
+          class="c5 fi-dropdown_button"
+          id="test-id_button"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="c0"
+          >
+            Dropdown
+          </span>
+          <input
+            class="c6"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value=""
+          />
+        </button>
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c0 c7 fi-status-text"
+        />
+      </div>
+    </div>
+  </span>
+</div>
+`;
+
+exports[`Controlled Dropdown should match snapshot 1`] = `
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+  cursor: pointer;
+}
+
+.c5:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c5::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c5::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c5::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c5::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c6::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c4.fi-label .fi-label_label-span {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  display: inline-block;
+  vertical-align: middle;
+  color: hsl(0,0%,13%);
+}
+
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c4.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c7 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c7.fi-status-text {
+  display: block;
+}
+
+.c7.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c1 {
+  width: 290px;
+}
+
+.c1 .fi-dropdown_item-list {
+  padding-top: 0;
+}
+
+.c1.fi-dropdown {
+  display: inline-block;
+}
+
 .c1.fi-dropdown--open .fi-dropdown_button {
   border-bottom: 0;
   border-bottom-left-radius: 0;
@@ -1574,6 +718,1077 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   font-style: italic;
   color: hsl(201,7%,46%);
   opacity: 1;
+}
+
+.c1.fi-dropdown .fi-dropdown_label--visible {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-status-text {
+  line-height: 18px;
+}
+
+.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button {
+  color: hsl(0,0%,13%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  position: relative;
+  display: inline-block;
+  word-break: break-word;
+  width: 100%;
+  overflow-wrap: break-word;
+  height: 40px;
+  padding: 7px 38px 7px 7px;
+  border-color: hsl(201,7%,58%);
+  text-align: left;
+  line-height: 1.5;
+  background-color: hsl(0,0%,100%);
+  box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:focus-visible {
+  outline: none;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(0,0%,13%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(0,0%,13%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_popover {
+  color: hsl(0,0%,13%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  margin-top: -1px;
+  padding: 0;
+  box-sizing: border-box;
+  font-size: 100%;
+  border: 0;
+  background-color: hsl(0,0%,100%);
+  border-color: hsl(201,7%,58%);
+  border-style: solid;
+  border-width: 0 1px 1px 1px;
+  border-radius: 0px 0px 2px 2px;
+  max-height: 265px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.c1.fi-dropdown .fi-dropdown_popover:focus-within {
+  outline: 0;
+  box-shadow: none;
+}
+
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
+  cursor: not-allowed;
+}
+
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  pointer-events: none;
+}
+
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+<div>
+  <span
+    class="c0 c1 dropdown-test fi-dropdown"
+    data-testid=""
+    id="test-id"
+    value="item-2"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3 c4 fi-dropdown_label--visible fi-label"
+      >
+        <label
+          class="c0 fi-label_label-span"
+          for="test-id_button"
+          id="test-id-label"
+        >
+          Dropdown test
+        </label>
+      </div>
+      <div
+        class="c2 fi-dropdown_input-wrapper"
+      >
+        <button
+          aria-activedescendant="test-id-item-2"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="test-id-displayValue test-id-label"
+          aria-owns="test-id-popover"
+          class="c5 fi-dropdown_button"
+          id="test-id_button"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="c0"
+            id="test-id-displayValue"
+          >
+            Item 2
+          </span>
+          <input
+            class="c6"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value="item-2"
+          />
+        </button>
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c0 c7 fi-status-text"
+        />
+      </div>
+    </div>
+  </span>
+</div>
+`;
+
+exports[`Dropdown with additional aria-label should match snapshot 1`] = `
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+  cursor: pointer;
+}
+
+.c5:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c5::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c5::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c5::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c5::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c6::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c4.fi-label .fi-label_label-span {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  display: inline-block;
+  vertical-align: middle;
+  color: hsl(0,0%,13%);
+}
+
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c4.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c7 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c7.fi-status-text {
+  display: block;
+}
+
+.c7.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c1 {
+  width: 290px;
+}
+
+.c1 .fi-dropdown_item-list {
+  padding-top: 0;
+}
+
+.c1.fi-dropdown {
+  display: inline-block;
+}
+
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
+.c1.fi-dropdown .fi-dropdown_label--visible {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-status-text {
+  line-height: 18px;
+}
+
+.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button {
+  color: hsl(0,0%,13%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  position: relative;
+  display: inline-block;
+  word-break: break-word;
+  width: 100%;
+  overflow-wrap: break-word;
+  height: 40px;
+  padding: 7px 38px 7px 7px;
+  border-color: hsl(201,7%,58%);
+  text-align: left;
+  line-height: 1.5;
+  background-color: hsl(0,0%,100%);
+  box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:focus-visible {
+  outline: none;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(0,0%,13%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(0,0%,13%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_popover {
+  color: hsl(0,0%,13%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  margin-top: -1px;
+  padding: 0;
+  box-sizing: border-box;
+  font-size: 100%;
+  border: 0;
+  background-color: hsl(0,0%,100%);
+  border-color: hsl(201,7%,58%);
+  border-style: solid;
+  border-width: 0 1px 1px 1px;
+  border-radius: 0px 0px 2px 2px;
+  max-height: 265px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.c1.fi-dropdown .fi-dropdown_popover:focus-within {
+  outline: 0;
+  box-shadow: none;
+}
+
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
+  cursor: not-allowed;
+}
+
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  pointer-events: none;
+}
+
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+<div>
+  <span
+    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
+    data-testid=""
+    id="test-id"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3 c4 fi-dropdown_label--visible fi-label"
+      >
+        <label
+          class="c0 fi-label_label-span"
+          for="test-id_button"
+          id="test-id-label"
+        >
+          Dropdown test
+        </label>
+      </div>
+      <div
+        class="c2 fi-dropdown_input-wrapper"
+      >
+        <button
+          aria-activedescendant=""
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="additional-label-id test-id-label"
+          aria-owns="test-id-popover"
+          class="c5 fi-dropdown_button"
+          id="test-id_button"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="c0"
+          >
+            Dropdown
+          </span>
+          <input
+            class="c6"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value=""
+          />
+        </button>
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c0 c7 fi-status-text"
+        />
+      </div>
+    </div>
+  </span>
+</div>
+`;
+
+exports[`Dropdown with hidden label should match snapshot 1`] = `
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+  cursor: pointer;
+}
+
+.c6:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c6::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c6::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c6::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c6::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.c6::before,
+.c6::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c2::before,
+.c2::after {
+  box-sizing: border-box;
+}
+
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c7 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c7::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c7::before,
+.c7::after {
+  box-sizing: border-box;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c5 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
+.c4.fi-label .fi-label_label-span {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  display: inline-block;
+  vertical-align: middle;
+  color: hsl(0,0%,13%);
+}
+
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c4.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
+}
+
+.c8 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c8.fi-status-text {
+  display: block;
+}
+
+.c8.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c1 {
+  width: 290px;
+}
+
+.c1 .fi-dropdown_item-list {
+  padding-top: 0;
+}
+
+.c1.fi-dropdown {
+  display: inline-block;
+}
+
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
+.c1.fi-dropdown .fi-dropdown_label--visible {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-status-text {
+  line-height: 18px;
+}
+
+.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button {
+  color: hsl(0,0%,13%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  min-width: 245px;
+  max-width: 100%;
+  padding: 8px 16px;
+  border: 1px solid hsl(202,7%,80%);
+  border-radius: 2px;
+  line-height: 1;
+  position: relative;
+  display: inline-block;
+  word-break: break-word;
+  width: 100%;
+  overflow-wrap: break-word;
+  height: 40px;
+  padding: 7px 38px 7px 7px;
+  border-color: hsl(201,7%,58%);
+  text-align: left;
+  line-height: 1.5;
+  background-color: hsl(0,0%,100%);
+  box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:focus-visible {
+  outline: none;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(0,0%,13%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(0,0%,13%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_popover {
+  color: hsl(0,0%,13%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  margin-top: -1px;
+  padding: 0;
+  box-sizing: border-box;
+  font-size: 100%;
+  border: 0;
+  background-color: hsl(0,0%,100%);
+  border-color: hsl(201,7%,58%);
+  border-style: solid;
+  border-width: 0 1px 1px 1px;
+  border-radius: 0px 0px 2px 2px;
+  max-height: 265px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.c1.fi-dropdown .fi-dropdown_popover:focus-within {
+  outline: 0;
+  box-shadow: none;
+}
+
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
+  cursor: not-allowed;
+}
+
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  pointer-events: none;
+}
+
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 <div>
@@ -1599,16 +1814,17 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
       <div
         class="c2 fi-dropdown_input-wrapper"
       >
-        <span
+        <button
           aria-activedescendant=""
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-label"
           aria-owns="test-id-popover"
-          class="c0 fi-dropdown_button"
+          class="c6 fi-dropdown_button"
           id="test-id_button"
           role="button"
           tabindex="0"
+          type="button"
         >
           <span
             class="c0"
@@ -1616,17 +1832,17 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
             Dropdown
           </span>
           <input
-            class="c6"
+            class="c7"
             name="dropdown-test"
             tabindex="-1"
             type="hidden"
             value=""
           />
-        </span>
+        </button>
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c0 c7 fi-status-text"
+          class="c0 c8 fi-status-text"
         />
       </div>
     </div>

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -59,6 +59,39 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c5::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -118,6 +151,10 @@ exports[`Basic dropdown should match snapshot 1`] = `
   margin-left: 6px;
 }
 
+.c1 .fi-dropdown_item-list {
+  padding-top: 0;
+}
+
 .c1.fi-dropdown {
   display: inline-block;
 }
@@ -126,7 +163,11 @@ exports[`Basic dropdown should match snapshot 1`] = `
   margin-bottom: 10px;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button {
+.c1.fi-dropdown .fi-dropdown_input-wrapper {
+  height: 40px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -151,7 +192,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   display: inline-block;
   word-break: break-word;
   overflow-wrap: break-word;
-  min-height: 22px;
+  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201,7%,58%);
   text-align: left;
@@ -159,14 +200,38 @@ exports[`Basic dropdown should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus {
+.c1.fi-dropdown .fi-dropdown_button:focus-visible {
+  outline: none;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(0,0%,13%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(0,0%,13%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
   outline: 0;
   position: relative;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus:after {
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -182,34 +247,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(201,7%,58%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(201,7%,58%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  cursor: not-allowed;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c1[data-reach-listbox-popover].fi-dropdown_popover {
+.c1.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -230,33 +268,31 @@ exports[`Basic dropdown should match snapshot 1`] = `
   overflow-x: hidden;
 }
 
-.c1[data-reach-listbox-popover].fi-dropdown_popover:focus-within {
+.c1.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
 }
 
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-  background-color: hsl(0,0%,100%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
+  cursor: not-allowed;
 }
 
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  pointer-events: none;
 }
 
-.c1 [data-reach-listbox-list] {
-  border: 0;
-  padding: 0;
-  margin: 0;
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: break-word;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
 }
 
 <div>
@@ -279,26 +315,23 @@ exports[`Basic dropdown should match snapshot 1`] = `
         </label>
       </div>
       <div
-        data-reach-listbox-input=""
-        data-state="closed"
-        data-value=""
-        id="listbox-input--21"
+        class="c2 fi-dropdown_input-wrapper"
       >
         <span
+          aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-label"
-          class="fi-dropdown_button"
-          data-reach-listbox-button=""
-          id="button--listbox-input--21"
+          aria-owns="test-id-popover"
+          class="c0 fi-dropdown_button"
+          id="test-id_button"
           role="button"
           tabindex="0"
         >
           Dropdown
         </span>
         <input
-          data-reach-listbox-hidden-input=""
+          class="c5"
           name="dropdown-test"
-          readonly=""
           tabindex="-1"
           type="hidden"
           value=""
@@ -368,6 +401,39 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c5::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -427,6 +493,10 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   margin-left: 6px;
 }
 
+.c1 .fi-dropdown_item-list {
+  padding-top: 0;
+}
+
 .c1.fi-dropdown {
   display: inline-block;
 }
@@ -435,7 +505,11 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   margin-bottom: 10px;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button {
+.c1.fi-dropdown .fi-dropdown_input-wrapper {
+  height: 40px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -460,7 +534,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   display: inline-block;
   word-break: break-word;
   overflow-wrap: break-word;
-  min-height: 22px;
+  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201,7%,58%);
   text-align: left;
@@ -468,14 +542,38 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus {
+.c1.fi-dropdown .fi-dropdown_button:focus-visible {
+  outline: none;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(0,0%,13%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(0,0%,13%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
   outline: 0;
   position: relative;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus:after {
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -491,34 +589,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(201,7%,58%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(201,7%,58%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  cursor: not-allowed;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c1[data-reach-listbox-popover].fi-dropdown_popover {
+.c1.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -539,33 +610,31 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   overflow-x: hidden;
 }
 
-.c1[data-reach-listbox-popover].fi-dropdown_popover:focus-within {
+.c1.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
 }
 
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-  background-color: hsl(0,0%,100%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
+  cursor: not-allowed;
 }
 
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  pointer-events: none;
 }
 
-.c1 [data-reach-listbox-list] {
-  border: 0;
-  padding: 0;
-  margin: 0;
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: break-word;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
 }
 
 <div>
@@ -589,335 +658,20 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
         </label>
       </div>
       <div
-        data-reach-listbox-input=""
-        data-state="closed"
-        data-value="item-2"
-        id="listbox-input--48"
+        class="c2 fi-dropdown_input-wrapper"
       >
         <span
+          aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="test-id-label button--listbox-input--48"
-          class="fi-dropdown_button"
-          data-reach-listbox-button=""
-          id="button--listbox-input--48"
+          aria-owns="test-id-popover"
+          class="c0 fi-dropdown_button"
+          id="test-id_button"
           role="button"
           tabindex="0"
-        >
-          Item 2
-        </span>
-        <input
-          data-reach-listbox-hidden-input=""
-          name="dropdown-test"
-          readonly=""
-          tabindex="-1"
-          type="hidden"
-          value="item-2"
         />
-      </div>
-    </div>
-  </span>
-</div>
-`;
-
-exports[`Dropdown as action menu should match snapshot 1`] = `
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
-  box-sizing: border-box;
-}
-
-.c0 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c0::before,
-.c0::after {
-  box-sizing: border-box;
-}
-
-.c4.fi-label .fi-label_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
-  color: hsl(0,0%,13%);
-}
-
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c4.fi-label .fi-label_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
-.c1.fi-dropdown {
-  display: inline-block;
-}
-
-.c1.fi-dropdown .fi-dropdown_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button {
-  color: hsl(0,0%,13%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  min-width: 245px;
-  max-width: 100%;
-  padding: 8px 16px;
-  border: 1px solid hsl(202,7%,80%);
-  border-radius: 2px;
-  line-height: 1;
-  position: relative;
-  display: inline-block;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  min-height: 22px;
-  padding: 7px 38px 7px 7px;
-  border-color: hsl(201,7%,58%);
-  text-align: left;
-  line-height: 1.5;
-  background-color: hsl(0,0%,100%);
-  box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
-  cursor: pointer;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(201,7%,58%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(201,7%,58%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  cursor: not-allowed;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c1[data-reach-listbox-popover].fi-dropdown_popover {
-  color: hsl(0,0%,13%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  margin-top: -1px;
-  padding: 0;
-  box-sizing: border-box;
-  font-size: 100%;
-  border: 0;
-  background-color: hsl(0,0%,100%);
-  border-color: hsl(201,7%,58%);
-  border-style: solid;
-  border-width: 0 1px 1px 1px;
-  border-radius: 0px 0px 2px 2px;
-  max-height: 265px;
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-.c1[data-reach-listbox-popover].fi-dropdown_popover:focus-within {
-  outline: 0;
-  box-shadow: none;
-}
-
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-  background-color: hsl(0,0%,100%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
-}
-
-.c1 [data-reach-listbox-list] {
-  border: 0;
-  padding: 0;
-  margin: 0;
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: break-word;
-}
-
-<div>
-  <span
-    class="c0 c1 dropdown-test fi-dropdown"
-    data-testid=""
-    id="test-id"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3 c4 fi-dropdown_label--visible fi-label"
-      >
-        <label
-          class="c0 fi-label_label-span"
-          id="test-id-label"
-        >
-          Dropdown test
-        </label>
-      </div>
-      <div
-        data-reach-listbox-input=""
-        data-state="closed"
-        data-value="item-2"
-        id="listbox-input--58"
-      >
-        <span
-          aria-haspopup="listbox"
-          aria-labelledby="test-id-label button--listbox-input--58"
-          class="fi-dropdown_button"
-          data-reach-listbox-button=""
-          id="button--listbox-input--58"
-          role="button"
-          tabindex="0"
-        >
-          Action menu
-        </span>
         <input
-          data-reach-listbox-hidden-input=""
+          class="c5"
           name="dropdown-test"
-          readonly=""
           tabindex="-1"
           type="hidden"
           value="item-2"
@@ -987,6 +741,39 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c5 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c5::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1046,6 +833,10 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   margin-left: 6px;
 }
 
+.c1 .fi-dropdown_item-list {
+  padding-top: 0;
+}
+
 .c1.fi-dropdown {
   display: inline-block;
 }
@@ -1054,7 +845,11 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   margin-bottom: 10px;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button {
+.c1.fi-dropdown .fi-dropdown_input-wrapper {
+  height: 40px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1079,7 +874,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   display: inline-block;
   word-break: break-word;
   overflow-wrap: break-word;
-  min-height: 22px;
+  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201,7%,58%);
   text-align: left;
@@ -1087,14 +882,38 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus {
+.c1.fi-dropdown .fi-dropdown_button:focus-visible {
+  outline: none;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(0,0%,13%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(0,0%,13%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
   outline: 0;
   position: relative;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus:after {
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -1110,34 +929,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(201,7%,58%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(201,7%,58%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  cursor: not-allowed;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c1[data-reach-listbox-popover].fi-dropdown_popover {
+.c1.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -1158,33 +950,31 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   overflow-x: hidden;
 }
 
-.c1[data-reach-listbox-popover].fi-dropdown_popover:focus-within {
+.c1.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
 }
 
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-  background-color: hsl(0,0%,100%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
+  cursor: not-allowed;
 }
 
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  pointer-events: none;
 }
 
-.c1 [data-reach-listbox-list] {
-  border: 0;
-  padding: 0;
-  margin: 0;
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: break-word;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
 }
 
 <div>
@@ -1207,26 +997,23 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
         </label>
       </div>
       <div
-        data-reach-listbox-input=""
-        data-state="closed"
-        data-value=""
-        id="listbox-input--68"
+        class="c2 fi-dropdown_input-wrapper"
       >
         <span
+          aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="additional-label-id test-id-label"
-          class="fi-dropdown_button"
-          data-reach-listbox-button=""
-          id="button--listbox-input--68"
+          aria-owns="test-id-popover"
+          class="c0 fi-dropdown_button"
+          id="test-id_button"
           role="button"
           tabindex="0"
         >
           Dropdown
         </span>
         <input
-          data-reach-listbox-hidden-input=""
+          class="c5"
           name="dropdown-test"
-          readonly=""
           tabindex="-1"
           type="hidden"
           value=""
@@ -1293,6 +1080,39 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 
 .c3::before,
 .c3::after {
+  box-sizing: border-box;
+}
+
+.c6 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+}
+
+.c6::-webkit-input-placeholder {
+  color: inherit;
+  opacity: 0.54;
+}
+
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
@@ -1367,6 +1187,10 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   margin-left: 6px;
 }
 
+.c1 .fi-dropdown_item-list {
+  padding-top: 0;
+}
+
 .c1.fi-dropdown {
   display: inline-block;
 }
@@ -1375,7 +1199,11 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   margin-bottom: 10px;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button {
+.c1.fi-dropdown .fi-dropdown_input-wrapper {
+  height: 40px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1400,7 +1228,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   display: inline-block;
   word-break: break-word;
   overflow-wrap: break-word;
-  min-height: 22px;
+  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201,7%,58%);
   text-align: left;
@@ -1408,14 +1236,38 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus {
+.c1.fi-dropdown .fi-dropdown_button:focus-visible {
+  outline: none;
+}
+
+.c1.fi-dropdown .fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(0,0%,13%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(0,0%,13%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
   outline: 0;
   position: relative;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:focus:after {
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -1431,34 +1283,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c1 [data-reach-listbox-button].fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(201,7%,58%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(201,7%,58%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  cursor: not-allowed;
-}
-
-.c1 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c1[data-reach-listbox-popover].fi-dropdown_popover {
+.c1.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -1479,33 +1304,31 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   overflow-x: hidden;
 }
 
-.c1[data-reach-listbox-popover].fi-dropdown_popover:focus-within {
+.c1.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
 }
 
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-  background-color: hsl(0,0%,100%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper {
+  cursor: not-allowed;
 }
 
-.c1.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  pointer-events: none;
 }
 
-.c1 [data-reach-listbox-list] {
-  border: 0;
-  padding: 0;
-  margin: 0;
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: break-word;
+.c1.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
+}
+
+.c1.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
 }
 
 <div>
@@ -1528,26 +1351,23 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
         </label>
       </div>
       <div
-        data-reach-listbox-input=""
-        data-state="closed"
-        data-value=""
-        id="listbox-input--31"
+        class="c2 fi-dropdown_input-wrapper"
       >
         <span
+          aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-label"
-          class="fi-dropdown_button"
-          data-reach-listbox-button=""
-          id="button--listbox-input--31"
+          aria-owns="test-id-popover"
+          class="c0 fi-dropdown_button"
+          id="test-id_button"
           role="button"
           tabindex="0"
         >
           Dropdown
         </span>
         <input
-          data-reach-listbox-hidden-input=""
+          class="c6"
           name="dropdown-test"
-          readonly=""
           tabindex="-1"
           type="hidden"
           value=""

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -423,7 +423,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
         class="c2 fi-dropdown_input-wrapper"
       >
         <button
-          aria-activedescendant=""
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-label"
@@ -881,7 +880,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
         class="c2 fi-dropdown_input-wrapper"
       >
         <button
-          aria-activedescendant="test-id-item-2"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-displayValue test-id-label"
@@ -1339,7 +1337,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
         class="c2 fi-dropdown_input-wrapper"
       >
         <button
-          aria-activedescendant=""
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="additional-label-id test-id-label"
@@ -1808,7 +1805,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
         class="c2 fi-dropdown_input-wrapper"
       >
         <button
-          aria-activedescendant=""
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-label"

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -174,6 +174,18 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c7 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
 .c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -204,7 +216,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   margin-left: 6px;
 }
 
-.c7 {
+.c8 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -223,11 +235,11 @@ exports[`Basic dropdown should match snapshot 1`] = `
   line-height: 20px;
 }
 
-.c7.fi-status-text {
+.c8.fi-status-text {
   display: block;
 }
 
-.c7.fi-status-text.fi-status-text--error {
+.c8.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
 }
 
@@ -450,9 +462,14 @@ exports[`Basic dropdown should match snapshot 1`] = `
           />
         </button>
         <span
+          class="c0 c7 fi-visually-hidden"
+        >
+          Dropdown
+        </span>
+        <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c0 c7 fi-status-text"
+          class="c0 c8 fi-status-text"
         />
       </div>
     </div>
@@ -634,6 +651,18 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c7 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
 .c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -664,7 +693,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   margin-left: 6px;
 }
 
-.c7 {
+.c8 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -683,11 +712,11 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   line-height: 20px;
 }
 
-.c7.fi-status-text {
+.c8.fi-status-text {
   display: block;
 }
 
-.c7.fi-status-text.fi-status-text--error {
+.c8.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
 }
 
@@ -899,7 +928,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
         >
           <span
             class="c0"
-            id="test-id-displayValue"
           >
             Item 2
           </span>
@@ -912,9 +940,15 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           />
         </button>
         <span
+          class="c0 c7 fi-visually-hidden"
+          id="test-id-displayValue"
+        >
+          Item 2
+        </span>
+        <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c0 c7 fi-status-text"
+          class="c0 c8 fi-status-text"
         />
       </div>
     </div>
@@ -1096,6 +1130,18 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c7 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+}
+
 .c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1126,7 +1172,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   margin-left: 6px;
 }
 
-.c7 {
+.c8 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1145,11 +1191,11 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   line-height: 20px;
 }
 
-.c7.fi-status-text {
+.c8.fi-status-text {
   display: block;
 }
 
-.c7.fi-status-text.fi-status-text--error {
+.c8.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
 }
 
@@ -1372,9 +1418,14 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           />
         </button>
         <span
+          class="c0 c7 fi-visually-hidden"
+        >
+          Dropdown
+        </span>
+        <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c0 c7 fi-status-text"
+          class="c0 c8 fi-status-text"
         />
       </div>
     </div>
@@ -1843,6 +1894,11 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
             value=""
           />
         </button>
+        <span
+          class="c0 c5 fi-visually-hidden"
+        >
+          Dropdown
+        </span>
         <span
           aria-atomic="true"
           aria-live="assertive"

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -151,6 +151,37 @@ exports[`Basic dropdown should match snapshot 1`] = `
   margin-left: 6px;
 }
 
+.c6 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c6.fi-status-text {
+  display: block;
+}
+
+.c6.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c1 {
+  width: 290px;
+}
+
 .c1 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -163,8 +194,37 @@ exports[`Basic dropdown should match snapshot 1`] = `
   margin-bottom: 10px;
 }
 
-.c1.fi-dropdown .fi-dropdown_input-wrapper {
-  height: 40px;
+.c1.fi-dropdown .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-status-text {
+  line-height: 18px;
+}
+
+.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c1.fi-dropdown .fi-dropdown_button {
@@ -191,6 +251,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   position: relative;
   display: inline-block;
   word-break: break-word;
+  width: 100%;
   overflow-wrap: break-word;
   height: 40px;
   padding: 7px 38px 7px 7px;
@@ -204,6 +265,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -224,27 +286,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
   border-color: transparent transparent hsl(0,0%,13%) transparent;
   border-width: 0 4px 6px 4px;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c1.fi-dropdown .fi-dropdown_popover {
@@ -295,9 +336,20 @@ exports[`Basic dropdown should match snapshot 1`] = `
   padding-bottom: 8px;
 }
 
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 <div>
   <span
-    class="c0 c1 dropdown-test fi-dropdown"
+    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
     data-testid="dropdown-test-id"
     id="test-id"
   >
@@ -318,6 +370,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
         class="c2 fi-dropdown_input-wrapper"
       >
         <span
+          aria-activedescendant=""
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-label"
@@ -328,13 +381,18 @@ exports[`Basic dropdown should match snapshot 1`] = `
           tabindex="0"
         >
           Dropdown
+          <input
+            class="c5"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value=""
+          />
         </span>
-        <input
-          class="c5"
-          name="dropdown-test"
-          tabindex="-1"
-          type="hidden"
-          value=""
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c0 c6 fi-status-text"
         />
       </div>
     </div>
@@ -493,6 +551,37 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   margin-left: 6px;
 }
 
+.c6 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c6.fi-status-text {
+  display: block;
+}
+
+.c6.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c1 {
+  width: 290px;
+}
+
 .c1 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -505,8 +594,37 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   margin-bottom: 10px;
 }
 
-.c1.fi-dropdown .fi-dropdown_input-wrapper {
-  height: 40px;
+.c1.fi-dropdown .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-status-text {
+  line-height: 18px;
+}
+
+.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c1.fi-dropdown .fi-dropdown_button {
@@ -533,6 +651,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   position: relative;
   display: inline-block;
   word-break: break-word;
+  width: 100%;
   overflow-wrap: break-word;
   height: 40px;
   padding: 7px 38px 7px 7px;
@@ -546,6 +665,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -566,27 +686,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
   border-color: transparent transparent hsl(0,0%,13%) transparent;
   border-width: 0 4px 6px 4px;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c1.fi-dropdown .fi-dropdown_popover {
@@ -637,6 +736,17 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   padding-bottom: 8px;
 }
 
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown"
@@ -661,6 +771,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
         class="c2 fi-dropdown_input-wrapper"
       >
         <span
+          aria-activedescendant="test-id-item-2"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-owns="test-id-popover"
@@ -668,13 +779,20 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           id="test-id_button"
           role="button"
           tabindex="0"
-        />
-        <input
-          class="c5"
-          name="dropdown-test"
-          tabindex="-1"
-          type="hidden"
-          value="item-2"
+        >
+          Item 2
+          <input
+            class="c5"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value="item-2"
+          />
+        </span>
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c0 c6 fi-status-text"
         />
       </div>
     </div>
@@ -833,6 +951,37 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   margin-left: 6px;
 }
 
+.c6 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c6.fi-status-text {
+  display: block;
+}
+
+.c6.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c1 {
+  width: 290px;
+}
+
 .c1 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -845,8 +994,37 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   margin-bottom: 10px;
 }
 
-.c1.fi-dropdown .fi-dropdown_input-wrapper {
-  height: 40px;
+.c1.fi-dropdown .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-status-text {
+  line-height: 18px;
+}
+
+.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c1.fi-dropdown .fi-dropdown_button {
@@ -873,6 +1051,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   position: relative;
   display: inline-block;
   word-break: break-word;
+  width: 100%;
   overflow-wrap: break-word;
   height: 40px;
   padding: 7px 38px 7px 7px;
@@ -886,6 +1065,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -906,27 +1086,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
   border-color: transparent transparent hsl(0,0%,13%) transparent;
   border-width: 0 4px 6px 4px;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c1.fi-dropdown .fi-dropdown_popover {
@@ -977,9 +1136,20 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   padding-bottom: 8px;
 }
 
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 <div>
   <span
-    class="c0 c1 dropdown-test fi-dropdown"
+    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
     data-testid=""
     id="test-id"
   >
@@ -1000,6 +1170,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
         class="c2 fi-dropdown_input-wrapper"
       >
         <span
+          aria-activedescendant=""
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="additional-label-id test-id-label"
@@ -1010,13 +1181,18 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           tabindex="0"
         >
           Dropdown
+          <input
+            class="c5"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value=""
+          />
         </span>
-        <input
-          class="c5"
-          name="dropdown-test"
-          tabindex="-1"
-          type="hidden"
-          value=""
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c0 c6 fi-status-text"
         />
       </div>
     </div>
@@ -1187,6 +1363,37 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   margin-left: 6px;
 }
 
+.c7 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c7.fi-status-text {
+  display: block;
+}
+
+.c7.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c1 {
+  width: 290px;
+}
+
 .c1 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -1199,8 +1406,37 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   margin-bottom: 10px;
 }
 
-.c1.fi-dropdown .fi-dropdown_input-wrapper {
-  height: 40px;
+.c1.fi-dropdown .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c1.fi-dropdown .fi-status-text {
+  line-height: 18px;
+}
+
+.c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c1.fi-dropdown .fi-dropdown_button {
@@ -1227,6 +1463,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   position: relative;
   display: inline-block;
   word-break: break-word;
+  width: 100%;
   overflow-wrap: break-word;
   height: 40px;
   padding: 7px 38px 7px 7px;
@@ -1240,6 +1477,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -1260,27 +1498,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 .c1.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
   border-color: transparent transparent hsl(0,0%,13%) transparent;
   border-width: 0 4px 6px 4px;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c1.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c1.fi-dropdown .fi-dropdown_popover {
@@ -1331,9 +1548,20 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   padding-bottom: 8px;
 }
 
+.c1.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c1.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 <div>
   <span
-    class="c0 c1 dropdown-test fi-dropdown"
+    class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
     data-testid="dropdown-hidden-label-test-id"
     id="test-id"
   >
@@ -1354,6 +1582,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
         class="c2 fi-dropdown_input-wrapper"
       >
         <span
+          aria-activedescendant=""
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-label"
@@ -1364,13 +1593,18 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
           tabindex="0"
         >
           Dropdown
+          <input
+            class="c6"
+            name="dropdown-test"
+            tabindex="-1"
+            type="hidden"
+            value=""
+          />
         </span>
-        <input
-          class="c6"
-          name="dropdown-test"
-          tabindex="-1"
-          type="hidden"
-          value=""
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c0 c7 fi-status-text"
         />
       </div>
     </div>

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -332,6 +332,14 @@ exports[`Basic dropdown should match snapshot 1`] = `
   border-width: 0 4px 6px 4px;
 }
 
+.c1.fi-dropdown .fi-dropdown_display-value {
+  width: 100%;
+  height: 100%;
+  display: block;
+  line-height: 1.5;
+  overflow: hidden;
+}
+
 .c1.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -449,7 +457,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
           type="button"
         >
           <span
-            class="c4"
+            class="c4 fi-dropdown_display-value"
           >
             Dropdown
           </span>
@@ -809,6 +817,14 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   border-width: 0 4px 6px 4px;
 }
 
+.c1.fi-dropdown .fi-dropdown_display-value {
+  width: 100%;
+  height: 100%;
+  display: block;
+  line-height: 1.5;
+  overflow: hidden;
+}
+
 .c1.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -927,7 +943,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           value="item-2"
         >
           <span
-            class="c4"
+            class="c4 fi-dropdown_display-value"
           >
             Item 2
           </span>
@@ -1288,6 +1304,14 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   border-width: 0 4px 6px 4px;
 }
 
+.c1.fi-dropdown .fi-dropdown_display-value {
+  width: 100%;
+  height: 100%;
+  display: block;
+  line-height: 1.5;
+  overflow: hidden;
+}
+
 .c1.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -1405,7 +1429,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           type="button"
         >
           <span
-            class="c4"
+            class="c4 fi-dropdown_display-value"
           >
             Dropdown
           </span>
@@ -1765,6 +1789,14 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   border-width: 0 4px 6px 4px;
 }
 
+.c1.fi-dropdown .fi-dropdown_display-value {
+  width: 100%;
+  height: 100%;
+  display: block;
+  line-height: 1.5;
+  overflow: hidden;
+}
+
 .c1.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -1882,7 +1914,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
           type="button"
         >
           <span
-            class="c6"
+            class="c6 fi-dropdown_display-value"
           >
             Dropdown
           </span>

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -252,7 +252,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
 }
 
 .c1.fi-dropdown .fi-status-text {
-  line-height: 18px;
+  line-height: 1.1rem;
 }
 
 .c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
@@ -710,7 +710,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 }
 
 .c1.fi-dropdown .fi-status-text {
-  line-height: 18px;
+  line-height: 1.1rem;
 }
 
 .c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
@@ -1170,7 +1170,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 }
 
 .c1.fi-dropdown .fi-status-text {
-  line-height: 18px;
+  line-height: 1.1rem;
 }
 
 .c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
@@ -1640,7 +1640,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 }
 
 .c1.fi-dropdown .fi-status-text {
-  line-height: 18px;
+  line-height: 1.1rem;
 }
 
 .c1.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -54,6 +54,35 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -80,35 +109,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
 
 .c2::before,
 .c2::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
   box-sizing: border-box;
 }
 
@@ -145,7 +145,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c0 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -169,8 +169,8 @@ exports[`Basic dropdown should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c0::before,
-.c0::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
@@ -186,7 +186,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -205,14 +205,14 @@ exports[`Basic dropdown should match snapshot 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -417,26 +417,26 @@ exports[`Basic dropdown should match snapshot 1`] = `
 }
 
 <div>
-  <span
+  <div
     class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
     data-testid="dropdown-test-id"
     id="test-id"
   >
     <div
-      class="c2"
+      class="c0"
     >
       <div
-        class="c3 c4 fi-dropdown_label--visible fi-label"
+        class="c2 c3 fi-dropdown_label--visible fi-label"
       >
         <label
-          class="c0 fi-label_label-span"
+          class="c4 fi-label_label-span"
           id="test-id-label"
         >
           Dropdown test
         </label>
       </div>
       <div
-        class="c2 fi-dropdown_input-wrapper"
+        class="c0 fi-dropdown_input-wrapper"
       >
         <button
           aria-expanded="false"
@@ -449,7 +449,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
           type="button"
         >
           <span
-            class="c0"
+            class="c4"
           >
             Dropdown
           </span>
@@ -462,18 +462,18 @@ exports[`Basic dropdown should match snapshot 1`] = `
           />
         </button>
         <span
-          class="c0 c7 fi-visually-hidden"
+          class="c4 c7 fi-visually-hidden"
         >
           Dropdown
         </span>
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c0 c8 fi-status-text"
+          class="c4 c8 fi-status-text"
         />
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
@@ -531,6 +531,35 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -557,35 +586,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 
 .c2::before,
 .c2::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
   box-sizing: border-box;
 }
 
@@ -622,7 +622,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c0 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -646,8 +646,8 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c0::before,
-.c0::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
@@ -663,7 +663,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -682,14 +682,14 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -894,26 +894,26 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 }
 
 <div>
-  <span
+  <div
     class="c0 c1 dropdown-test fi-dropdown"
     data-testid=""
     id="test-id"
   >
     <div
-      class="c2"
+      class="c0"
     >
       <div
-        class="c3 c4 fi-dropdown_label--visible fi-label"
+        class="c2 c3 fi-dropdown_label--visible fi-label"
       >
         <label
-          class="c0 fi-label_label-span"
+          class="c4 fi-label_label-span"
           id="test-id-label"
         >
           Dropdown test
         </label>
       </div>
       <div
-        class="c2 fi-dropdown_input-wrapper"
+        class="c0 fi-dropdown_input-wrapper"
       >
         <button
           aria-expanded="false"
@@ -927,7 +927,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           value="item-2"
         >
           <span
-            class="c0"
+            class="c4"
           >
             Item 2
           </span>
@@ -940,7 +940,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           />
         </button>
         <span
-          class="c0 c7 fi-visually-hidden"
+          class="c4 c7 fi-visually-hidden"
           id="test-id-displayValue"
         >
           Item 2
@@ -948,11 +948,11 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c0 c8 fi-status-text"
+          class="c4 c8 fi-status-text"
         />
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
@@ -1010,6 +1010,35 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -1036,35 +1065,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 
 .c2::before,
 .c2::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
   box-sizing: border-box;
 }
 
@@ -1101,7 +1101,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c0 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1125,8 +1125,8 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c0::before,
-.c0::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
@@ -1142,7 +1142,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1161,14 +1161,14 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -1373,26 +1373,26 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 }
 
 <div>
-  <span
+  <div
     class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
     data-testid=""
     id="test-id"
   >
     <div
-      class="c2"
+      class="c0"
     >
       <div
-        class="c3 c4 fi-dropdown_label--visible fi-label"
+        class="c2 c3 fi-dropdown_label--visible fi-label"
       >
         <label
-          class="c0 fi-label_label-span"
+          class="c4 fi-label_label-span"
           id="test-id-label"
         >
           Dropdown test
         </label>
       </div>
       <div
-        class="c2 fi-dropdown_input-wrapper"
+        class="c0 fi-dropdown_input-wrapper"
       >
         <button
           aria-expanded="false"
@@ -1405,7 +1405,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           type="button"
         >
           <span
-            class="c0"
+            class="c4"
           >
             Dropdown
           </span>
@@ -1418,23 +1418,23 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           />
         </button>
         <span
-          class="c0 c7 fi-visually-hidden"
+          class="c4 c7 fi-visually-hidden"
         >
           Dropdown
         </span>
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c0 c8 fi-status-text"
+          class="c4 c8 fi-status-text"
         />
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Dropdown with hidden label should match snapshot 1`] = `
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1460,30 +1460,59 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   cursor: pointer;
 }
 
-.c6:-moz-focusring {
+.c5:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
-.c6::-moz-focus-inner {
+.c5::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
 
-.c6::-webkit-file-upload-button {
+.c5::-webkit-file-upload-button {
   -webkit-appearance: button;
   font: inherit;
 }
 
-.c6::-webkit-inner-spin-button {
+.c5::-webkit-inner-spin-button {
   height: auto;
 }
 
-.c6::-webkit-outer-spin-button {
+.c5::-webkit-outer-spin-button {
   height: auto;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
+  box-sizing: border-box;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+.c0::before,
+.c0::after {
   box-sizing: border-box;
 }
 
@@ -1513,35 +1542,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 
 .c2::before,
 .c2::after {
-  box-sizing: border-box;
-}
-
-.c3 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c3::before,
-.c3::after {
   box-sizing: border-box;
 }
 
@@ -1578,7 +1578,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c0 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1602,12 +1602,12 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   white-space: normal;
 }
 
-.c0::before,
-.c0::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c5 {
+.c4 {
   position: absolute;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -1619,7 +1619,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1638,14 +1638,14 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -1850,39 +1850,39 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 }
 
 <div>
-  <span
+  <div
     class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
     data-testid="dropdown-hidden-label-test-id"
     id="test-id"
   >
     <div
-      class="c2"
+      class="c0"
     >
       <div
-        class="c3 c4 fi-label"
+        class="c2 c3 fi-label"
       >
         <label
-          class="c5 fi-visually-hidden"
+          class="c4 fi-visually-hidden"
           id="test-id-label"
         >
           Dropdown test
         </label>
       </div>
       <div
-        class="c2 fi-dropdown_input-wrapper"
+        class="c0 fi-dropdown_input-wrapper"
       >
         <button
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-label"
           aria-owns="test-id-popover"
-          class="c6 fi-dropdown_button"
+          class="c5 fi-dropdown_button"
           id="test-id_button"
           tabindex="0"
           type="button"
         >
           <span
-            class="c0"
+            class="c6"
           >
             Dropdown
           </span>
@@ -1895,17 +1895,17 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
           />
         </button>
         <span
-          class="c0 c5 fi-visually-hidden"
+          class="c6 c4 fi-visually-hidden"
         >
           Dropdown
         </span>
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c0 c8 fi-status-text"
+          class="c6 c8 fi-status-text"
         />
       </div>
     </div>
-  </span>
+  </div>
 </div>
 `;

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -407,6 +407,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
+    data-testid="dropdown-test-id"
     id="test-id"
   >
     <div
@@ -431,7 +432,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
           aria-labelledby="test-id-label"
           aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
-          data-testid="dropdown-test-id"
           id="test-id_button"
           tabindex="0"
           type="button"
@@ -867,6 +867,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown"
+    data-testid=""
     id="test-id"
   >
     <div
@@ -891,7 +892,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           aria-labelledby="test-id-displayValue test-id-label"
           aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
-          data-testid=""
           id="test-id_button"
           tabindex="0"
           type="button"
@@ -1329,6 +1329,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
+    data-testid=""
     id="test-id"
   >
     <div
@@ -1353,7 +1354,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           aria-labelledby="additional-label-id test-id-label"
           aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
-          data-testid=""
           id="test-id_button"
           tabindex="0"
           type="button"
@@ -1801,6 +1801,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
+    data-testid="dropdown-hidden-label-test-id"
     id="test-id"
   >
     <div
@@ -1825,7 +1826,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
           aria-labelledby="test-id-label"
           aria-owns="test-id-popover"
           class="c6 fi-dropdown_button"
-          data-testid="dropdown-hidden-label-test-id"
           id="test-id_button"
           tabindex="0"
           type="button"

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -414,7 +414,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
       >
         <label
           class="c0 fi-label_label-span"
-          for="test-id_button"
           id="test-id-label"
         >
           Dropdown test
@@ -873,7 +872,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
       >
         <label
           class="c0 fi-label_label-span"
-          for="test-id_button"
           id="test-id-label"
         >
           Dropdown test
@@ -1332,7 +1330,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
       >
         <label
           class="c0 fi-label_label-span"
-          for="test-id_button"
           id="test-id-label"
         >
           Dropdown test
@@ -1802,7 +1799,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
       >
         <label
           class="c5 fi-visually-hidden"
-          for="test-id_button"
           id="test-id-label"
         >
           Dropdown test

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -407,7 +407,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
-    data-testid="dropdown-test-id"
     id="test-id"
   >
     <div
@@ -432,6 +431,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
           aria-labelledby="test-id-label"
           aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
+          data-testid="dropdown-test-id"
           id="test-id_button"
           tabindex="0"
           type="button"
@@ -867,9 +867,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown"
-    data-testid=""
     id="test-id"
-    value="item-2"
   >
     <div
       class="c2"
@@ -893,9 +891,11 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           aria-labelledby="test-id-displayValue test-id-label"
           aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
+          data-testid=""
           id="test-id_button"
           tabindex="0"
           type="button"
+          value="item-2"
         >
           <span
             class="c0"
@@ -1329,7 +1329,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
-    data-testid=""
     id="test-id"
   >
     <div
@@ -1354,6 +1353,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           aria-labelledby="additional-label-id test-id-label"
           aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
+          data-testid=""
           id="test-id_button"
           tabindex="0"
           type="button"
@@ -1801,7 +1801,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 <div>
   <span
     class="c0 c1 dropdown-test fi-dropdown fi-dropdown--italicize"
-    data-testid="dropdown-hidden-label-test-id"
     id="test-id"
   >
     <div
@@ -1826,6 +1825,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
           aria-labelledby="test-id-label"
           aria-owns="test-id-popover"
           class="c6 fi-dropdown_button"
+          data-testid="dropdown-hidden-label-test-id"
           id="test-id_button"
           tabindex="0"
           type="button"

--- a/src/core/Dropdown/DropdownItem/DropdownItem.basestyles.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.basestyles.tsx
@@ -10,21 +10,43 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     line-height: 1.5;
     padding: ${theme.spacing.insetM};
     border: 0;
+    position: relative;
     &:focus {
       outline: 0;
     }
     &:hover {
-      background-color: ${theme.colors.highlightLight3};
+      background-color: ${theme.colors.highlightBase};
+      color: ${theme.colors.whiteBase};
+    }
+
+    .fi-dropdown_item_icon {
+      position: absolute;
+      top: 14px;
+      right: 10px;
+      height: 12px;
+      width: 12px;
     }
 
     &--selected {
-      ${theme.typography.actionElementInnerTextBold}
-      background-color: ${theme.colors.highlightLight3};
-      border: 0;
+      background-color: ${theme.colors.depthSecondaryDark1};
+      color: ${theme.colors.blackBase};
     }
 
     &--hasKeyboardFocus {
-      background-color: ${theme.colors.highlightLight3};
+      background-color: ${theme.colors.highlightBase};
+      color: ${theme.colors.whiteBase};
+    }
+
+    &--noSelectedStyles {
+      &.fi-dropdown_item--selected {
+        background-color: ${theme.colors.whiteBase};
+        color: ${theme.colors.blackBase};
+
+        &.fi-dropdown_item--hasKeyboardFocus {
+          background-color: ${theme.colors.highlightBase};
+          color: ${theme.colors.whiteBase};
+        }
+      }
     }
   }
 `;

--- a/src/core/Dropdown/DropdownItem/DropdownItem.basestyles.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.basestyles.tsx
@@ -48,5 +48,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         }
       }
     }
+
+    @media (forced-colors: active) {
+      &--hasKeyboardFocus,
+      &:hover {
+        background-color: Highlight;
+      }
+    }
   }
 `;

--- a/src/core/Dropdown/DropdownItem/DropdownItem.basestyles.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.basestyles.tsx
@@ -3,7 +3,7 @@ import { SuomifiTheme } from '../../theme';
 import { element } from '../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  &[data-reach-listbox-option].fi-dropdown_item {
+  &.fi-dropdown_item {
     ${element(theme)}
     ${theme.typography.actionElementInnerText}
     cursor: pointer;
@@ -13,19 +13,18 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &:focus {
       outline: 0;
     }
-  }
+    &:hover {
+      background-color: ${theme.colors.highlightLight3};
+    }
 
-  &[data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-    ${theme.typography.actionElementInnerTextBold}
-    background-image: none;
-    background-color: ${theme.colors.highlightLight3};
-    border: 0;
-  }
+    &--selected {
+      ${theme.typography.actionElementInnerTextBold}
+      background-color: ${theme.colors.highlightLight3};
+      border: 0;
+    }
 
-  &[data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-    color: ${theme.colors.blackBase};
-    background-image: none;
-    background-color: ${theme.colors.highlightLight3};
-    border: 0;
+    &--hasKeyboardFocus {
+      background-color: ${theme.colors.highlightLight3};
+    }
   }
 `;

--- a/src/core/Dropdown/DropdownItem/DropdownItem.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.tsx
@@ -1,10 +1,14 @@
 import React, { ReactNode } from 'react';
-import { ListboxOption } from '@reach/listbox';
 import { default as styled } from 'styled-components';
 import { baseStyles } from './DropdownItem.basestyles';
-import { dropdownClassNames } from '../Dropdown/Dropdown';
+import {
+  dropdownClassNames,
+  DropdownConsumer,
+  DropdownProviderState,
+} from '../Dropdown/Dropdown';
 import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import { HtmlLi } from '../../../reset';
 
 export interface DropdownItemProps {
   /** Item value */
@@ -15,11 +19,33 @@ export interface DropdownItemProps {
   className?: string;
 }
 
-const BaseDropdownItem = (props: DropdownItemProps & SuomifiThemeProp) => {
-  const { className, theme, ...passProps } = props;
+interface BaseDropdownItemProps extends DropdownItemProps {
+  consumer: DropdownProviderState;
+}
+
+const dropdownItemClassNames = {
+  hasKeyboardFocus: `${dropdownClassNames.item}--hasKeyboardFocus`,
+  selected: `${dropdownClassNames.item}--selected`,
+};
+
+const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
+  const { className, theme, consumer, value, ...passProps } = props;
+  const selected = consumer.selectedDropdownValue === value;
+  const hasKeyboardFocus = consumer.focusedItemID === value;
   return (
-    <ListboxOption
-      className={classnames(className, dropdownClassNames.item)}
+    <HtmlLi
+      className={classnames(className, dropdownClassNames.item, {
+        [dropdownItemClassNames.hasKeyboardFocus]: hasKeyboardFocus,
+        [dropdownItemClassNames.selected]: selected,
+      })}
+      tabIndex={-1}
+      role="option"
+      aria-selected={selected}
+      id={`${consumer.id}-${value}`}
+      onClick={(event) => {
+        console.log(event);
+        consumer.onItemClick(value);
+      }}
       {...passProps}
     />
   );
@@ -32,7 +58,15 @@ const StyledDropdownItem = styled(BaseDropdownItem)`
 const DropdownItem = (props: DropdownItemProps) => (
   <SuomifiThemeConsumer>
     {({ suomifiTheme }) => (
-      <StyledDropdownItem theme={suomifiTheme} {...props} />
+      <DropdownConsumer>
+        {(consumer) => (
+          <StyledDropdownItem
+            theme={suomifiTheme}
+            consumer={consumer}
+            {...props}
+          />
+        )}
+      </DropdownConsumer>
     )}
   </SuomifiThemeConsumer>
 );

--- a/src/core/Dropdown/DropdownItem/DropdownItem.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useLayoutEffect, useRef } from 'react';
 import { default as styled } from 'styled-components';
 import { baseStyles } from './DropdownItem.basestyles';
 import {
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlLi } from '../../../reset';
 import { Icon } from '../../Icon/Icon';
+import { getOwnerDocument } from '../../../utils/common/common';
 
 export interface DropdownItemProps {
   /** Item value */
@@ -34,7 +35,19 @@ const dropdownItemClassNames = {
 const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
   const { children, className, theme, consumer, value, ...passProps } = props;
   const selected = consumer.selectedDropdownValue === value;
-  const hasKeyboardFocus = consumer.focusedItemId === value;
+  const hasKeyboardFocus = consumer.focusedItemValue === value;
+
+  const listElementRef = useRef<HTMLLIElement>(null);
+
+  const listElementId = `${consumer.id}-${value}`;
+
+  useLayoutEffect(() => {
+    const ownerDocument = getOwnerDocument(listElementRef);
+    if (ownerDocument.activeElement?.id !== listElementId && hasKeyboardFocus) {
+      listElementRef.current?.focus({ preventScroll: true });
+    }
+  }, [consumer.focusedItemValue]);
+
   return (
     <HtmlLi
       className={classnames(className, dropdownClassNames.item, {
@@ -42,17 +55,20 @@ const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
         [dropdownItemClassNames.selected]: selected,
         [dropdownItemClassNames.noSelectedStyles]: consumer.noSelectedStyles,
       })}
-      tabIndex={-1}
+      tabIndex={hasKeyboardFocus ? 0 : -1}
       role="option"
       aria-selected={selected}
-      id={`${consumer.id}-${value}`}
-      onMouseDown={(event) => {
-        // prevent blur on Dropdown button element
-        event.preventDefault();
+      id={listElementId}
+      onKeyDown={(event: React.KeyboardEvent) => {
+        if (event.key === 'Tab') {
+          event.preventDefault();
+          consumer.onItemTabPress();
+        }
       }}
       onClick={() => {
         consumer.onItemClick(value);
       }}
+      forwardedRef={listElementRef}
       {...passProps}
     >
       {children}

--- a/src/core/Dropdown/DropdownItem/DropdownItem.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.tsx
@@ -9,6 +9,7 @@ import {
 import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlLi } from '../../../reset';
+import { Icon } from '../../Icon/Icon';
 
 export interface DropdownItemProps {
   /** Item value */
@@ -26,10 +27,12 @@ interface BaseDropdownItemProps extends DropdownItemProps {
 const dropdownItemClassNames = {
   hasKeyboardFocus: `${dropdownClassNames.item}--hasKeyboardFocus`,
   selected: `${dropdownClassNames.item}--selected`,
+  noSelectedStyles: `${dropdownClassNames.item}--noSelectedStyles`,
+  icon: `${dropdownClassNames.item}_icon`,
 };
 
 const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
-  const { className, theme, consumer, value, ...passProps } = props;
+  const { children, className, theme, consumer, value, ...passProps } = props;
   const selected = consumer.selectedDropdownValue === value;
   const hasKeyboardFocus = consumer.focusedItemID === value;
   return (
@@ -37,17 +40,30 @@ const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
       className={classnames(className, dropdownClassNames.item, {
         [dropdownItemClassNames.hasKeyboardFocus]: hasKeyboardFocus,
         [dropdownItemClassNames.selected]: selected,
+        [dropdownItemClassNames.noSelectedStyles]: consumer.noSelectedStyles,
       })}
       tabIndex={-1}
       role="option"
       aria-selected={selected}
       id={`${consumer.id}-${value}`}
-      onClick={(event) => {
-        console.log(event);
+      onMouseDown={(event) => {
+        // prevent blur on Dropdown button element
+        event.preventDefault();
+      }}
+      onClick={() => {
         consumer.onItemClick(value);
       }}
       {...passProps}
-    />
+    >
+      {children}
+      {selected && !consumer.noSelectedStyles && (
+        <Icon
+          icon="check"
+          className={dropdownItemClassNames.icon}
+          aria-hidden={true}
+        />
+      )}
+    </HtmlLi>
   );
 };
 

--- a/src/core/Dropdown/DropdownItem/DropdownItem.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useLayoutEffect, useRef } from 'react';
+import React, { ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import { baseStyles } from './DropdownItem.basestyles';
 import {
@@ -10,7 +10,6 @@ import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlLi } from '../../../reset';
 import { Icon } from '../../Icon/Icon';
-import { getOwnerDocument } from '../../../utils/common/common';
 
 export interface DropdownItemProps {
   /** Item value */
@@ -37,16 +36,7 @@ const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
   const selected = consumer.selectedDropdownValue === value;
   const hasKeyboardFocus = consumer.focusedItemValue === value;
 
-  const listElementRef = useRef<HTMLLIElement>(null);
-
   const listElementId = `${consumer.id}-${value}`;
-
-  useLayoutEffect(() => {
-    const ownerDocument = getOwnerDocument(listElementRef);
-    if (ownerDocument.activeElement?.id !== listElementId && hasKeyboardFocus) {
-      listElementRef.current?.focus({ preventScroll: true });
-    }
-  }, [consumer.focusedItemValue]);
 
   return (
     <HtmlLi
@@ -55,20 +45,13 @@ const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
         [dropdownItemClassNames.selected]: selected,
         [dropdownItemClassNames.noSelectedStyles]: consumer.noSelectedStyles,
       })}
-      tabIndex={hasKeyboardFocus ? 0 : -1}
+      tabIndex={-1}
       role="option"
       aria-selected={selected}
       id={listElementId}
-      onKeyDown={(event: React.KeyboardEvent) => {
-        if (event.key === 'Tab') {
-          event.preventDefault();
-          consumer.onItemTabPress();
-        }
-      }}
       onClick={() => {
         consumer.onItemClick(value);
       }}
-      forwardedRef={listElementRef}
       {...passProps}
     >
       {children}

--- a/src/core/Dropdown/DropdownItem/DropdownItem.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.tsx
@@ -34,7 +34,7 @@ const dropdownItemClassNames = {
 const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
   const { children, className, theme, consumer, value, ...passProps } = props;
   const selected = consumer.selectedDropdownValue === value;
-  const hasKeyboardFocus = consumer.focusedItemID === value;
+  const hasKeyboardFocus = consumer.focusedItemId === value;
   return (
     <HtmlLi
       className={classnames(className, dropdownClassNames.item, {

--- a/src/core/Form/DateInput/DateInput.test.tsx
+++ b/src/core/Form/DateInput/DateInput.test.tsx
@@ -282,7 +282,7 @@ describe('props', () => {
       );
       const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
       if (dropdownButton) {
-        fireEvent.mouseDown(dropdownButton);
+        fireEvent.click(dropdownButton);
         const lis = dropdown?.querySelectorAll('li');
         expect(lis?.length).toBe(11);
         expect(lis?.[10]).toHaveTextContent('2020');
@@ -303,7 +303,7 @@ describe('props', () => {
       );
       const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
       if (dropdownButton) {
-        fireEvent.mouseDown(dropdownButton);
+        fireEvent.click(dropdownButton);
         const lis = dropdown?.querySelectorAll('li');
         expect(lis?.[0]).toHaveTextContent('Tammikuu');
         expect(lis?.length).toBe(1);
@@ -362,7 +362,7 @@ describe('props', () => {
       );
       const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
       if (dropdownButton) {
-        fireEvent.mouseDown(dropdownButton);
+        fireEvent.click(dropdownButton);
         const lis = dropdown?.querySelectorAll('li');
         expect(lis?.[0]).toHaveTextContent('2020');
         expect(lis?.length).toBe(11);
@@ -383,7 +383,7 @@ describe('props', () => {
       );
       const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
       if (dropdownButton) {
-        fireEvent.mouseDown(dropdownButton);
+        fireEvent.click(dropdownButton);
         const lis = dropdown?.querySelectorAll('li');
         expect(lis?.[0]).toHaveTextContent('Heinäkuu');
         expect(lis?.length).toBe(6);

--- a/src/core/Form/DateInput/DateInput.test.tsx
+++ b/src/core/Form/DateInput/DateInput.test.tsx
@@ -280,9 +280,13 @@ describe('props', () => {
       const dropdown = baseElement.querySelector(
         '.fi-date-selectors_year-select',
       );
-      const lis = dropdown?.querySelectorAll('li');
-      expect(lis?.length).toBe(11);
-      expect(lis?.[10]).toHaveTextContent('2020');
+      const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
+      if (dropdownButton) {
+        fireEvent.mouseDown(dropdownButton);
+        const lis = dropdown?.querySelectorAll('li');
+        expect(lis?.length).toBe(11);
+        expect(lis?.[10]).toHaveTextContent('2020');
+      }
     });
 
     it('has next months removed from dropdown', () => {
@@ -297,9 +301,13 @@ describe('props', () => {
       const dropdown = baseElement.querySelector(
         '.fi-date-selectors_month-select',
       );
-      const lis = dropdown?.querySelectorAll('li');
-      expect(lis?.[0]).toHaveTextContent('Tammikuu');
-      expect(lis?.length).toBe(1);
+      const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
+      if (dropdownButton) {
+        fireEvent.mouseDown(dropdownButton);
+        const lis = dropdown?.querySelectorAll('li');
+        expect(lis?.[0]).toHaveTextContent('Tammikuu');
+        expect(lis?.length).toBe(1);
+      }
     });
 
     it('has next month button disabled', () => {
@@ -352,9 +360,13 @@ describe('props', () => {
       const dropdown = baseElement.querySelector(
         '.fi-date-selectors_year-select',
       );
-      const lis = dropdown?.querySelectorAll('li');
-      expect(lis?.[0]).toHaveTextContent('2020');
-      expect(lis?.length).toBe(11);
+      const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
+      if (dropdownButton) {
+        fireEvent.mouseDown(dropdownButton);
+        const lis = dropdown?.querySelectorAll('li');
+        expect(lis?.[0]).toHaveTextContent('2020');
+        expect(lis?.length).toBe(11);
+      }
     });
 
     it('has previous months removed from dropdown', () => {
@@ -369,9 +381,13 @@ describe('props', () => {
       const dropdown = baseElement.querySelector(
         '.fi-date-selectors_month-select',
       );
-      const lis = dropdown?.querySelectorAll('li');
-      expect(lis?.[0]).toHaveTextContent('Heinäkuu');
-      expect(lis?.length).toBe(6);
+      const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
+      if (dropdownButton) {
+        fireEvent.mouseDown(dropdownButton);
+        const lis = dropdown?.querySelectorAll('li');
+        expect(lis?.[0]).toHaveTextContent('Heinäkuu');
+        expect(lis?.length).toBe(6);
+      }
     });
 
     it('has previous month button disabled', () => {

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -208,16 +208,15 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   const globalKeyDownHandler = (event: KeyboardEvent) => {
     if (
       event.key === 'Escape' &&
-      !(yearSelectRef.current?.getAttribute('data-state') === 'expanded') &&
-      !(monthSelectRef.current?.getAttribute('data-state') === 'expanded')
+      !(yearSelectRef.current?.getAttribute('aria-expanded') === 'true') &&
+      !(monthSelectRef.current?.getAttribute('aria-expanded') === 'true')
     ) {
       handleClose(true);
     }
 
     if (event.key === 'Tab') {
       // Trap focus to dialog
-      const firstElement = yearSelectRef.current
-        ?.childNodes[0] as HTMLSpanElement;
+      const firstElement = yearSelectRef.current;
       const lastElement = confirmButtonRef?.current;
       if (event.shiftKey && document.activeElement === firstElement) {
         event.preventDefault();

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -96,8 +96,8 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
 
   const sliderWrapperRef = useRef<HTMLDivElement>(null);
   const smallScreenAppRef = useRef<HTMLDivElement>(null);
-  const yearSelectRef = useRef<HTMLDivElement>(null);
-  const monthSelectRef = useRef<HTMLDivElement>(null);
+  const yearSelectRef = useRef<HTMLButtonElement>(null);
+  const monthSelectRef = useRef<HTMLButtonElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const dayButtonRef = useRef<HTMLButtonElement>(null);
 

--- a/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
@@ -12,17 +12,17 @@ export const baseStyles = (
 
   & .fi-date-selectors_year-select {
     margin-right: ${theme.spacing.xs};
-    min-width: ${yearSelectWidth}px;
+    width: ${yearSelectWidth}px;
     .fi-dropdown_button {
-      min-width: 60px;
+      min-width: 90px;
     }
   }
 
   & .fi-date-selectors_month-select {
     margin-right: ${theme.spacing.xs};
-    min-width: ${monthSelectWidth}px;
+    width: ${monthSelectWidth}px;
     .fi-dropdown_button {
-      min-width: 125px;
+      min-width: 145px;
     }
   }
 

--- a/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
@@ -14,7 +14,7 @@ export const baseStyles = (
     margin-right: ${theme.spacing.xs};
     min-width: ${yearSelectWidth}px;
     .fi-dropdown_button {
-      min-width: 33px;
+      min-width: 60px;
     }
   }
 
@@ -22,7 +22,7 @@ export const baseStyles = (
     margin-right: ${theme.spacing.xs};
     min-width: ${monthSelectWidth}px;
     .fi-dropdown_button {
-      min-width: 78px;
+      min-width: 125px;
     }
   }
 

--- a/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.tsx
+++ b/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.tsx
@@ -113,13 +113,13 @@ export const BaseDateSelectors = (props: DateSelectorsProps) => {
   return (
     <HtmlDiv className={classnames(className, selectorsClassNames.container)}>
       <Dropdown
-        dropdownPopoverProps={{ portal: false, children: [] }}
         forwardedRef={yearSelect}
         labelText={texts.yearSelectLabel}
         labelMode="hidden"
         value={String(focusableDate.getFullYear())}
         onChange={handleYearSelect}
         className={selectorsClassNames.yearSelect}
+        portal={false}
       >
         {yearOptions(minDate, maxDate).map((year: number) => (
           <DropdownItem value={String(year)} key={year}>
@@ -128,13 +128,13 @@ export const BaseDateSelectors = (props: DateSelectorsProps) => {
         ))}
       </Dropdown>
       <Dropdown
-        dropdownPopoverProps={{ portal: false, children: [] }}
         forwardedRef={monthSelect}
         labelText={texts.monthSelectLabel}
         labelMode="hidden"
         value={String(focusableDate.getMonth())}
         onChange={handleMonthSelect}
         className={selectorsClassNames.monthSelect}
+        portal={false}
       >
         {monthOptions(focusableDate, minDate, maxDate, texts).map(
           (month: MonthOption) => (

--- a/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.tsx
+++ b/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.tsx
@@ -36,9 +36,9 @@ interface DateSelectorsProps {
   /** Callback for date select  */
   onChange: (date: Date) => void;
   /** Year select element reference for focus trap and calculating dropdown width */
-  yearSelect: React.RefObject<HTMLDivElement>;
+  yearSelect: React.RefObject<HTMLButtonElement>;
   /** Month select element reference for calculating dropdown width */
-  monthSelect: React.RefObject<HTMLDivElement>;
+  monthSelect: React.RefObject<HTMLButtonElement>;
   /** Date that is focused in calendar */
   focusableDate: Date;
   /** Minimum date user can select from date picker. */

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -1090,6 +1090,27 @@ exports[`snapshots match date input hint text 1`] = `
   margin-left: 6px;
 }
 
+.c5 {
+  color: hsl(0,0%,13%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c5.fi-hint-text {
+  display: block;
+}
+
 .c7 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1115,27 +1136,6 @@ exports[`snapshots match date input hint text 1`] = `
 
 .c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
-}
-
-.c5 {
-  color: hsl(0,0%,13%);
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c5.fi-hint-text {
-  display: block;
 }
 
 .c1 {
@@ -3425,6 +3425,37 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin-left: 6px;
 }
 
+.c9 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c9.fi-status-text {
+  display: block;
+}
+
+.c9.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c12 {
+  width: 290px;
+}
+
 .c12 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -3437,8 +3468,37 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin-bottom: 10px;
 }
 
-.c12.fi-dropdown .fi-dropdown_input-wrapper {
-  height: 40px;
+.c12.fi-dropdown .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c12.fi-dropdown .fi-status-text {
+  line-height: 18px;
+}
+
+.c12.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c12.fi-dropdown .fi-dropdown_button {
@@ -3465,6 +3525,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   position: relative;
   display: inline-block;
   word-break: break-word;
+  width: 100%;
   overflow-wrap: break-word;
   height: 40px;
   padding: 7px 38px 7px 7px;
@@ -3478,6 +3539,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  white-space: nowrap;
 }
 
 .c12.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -3498,27 +3560,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
 .c12.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
   border-color: transparent transparent hsl(0,0%,13%) transparent;
   border-width: 0 4px 6px 4px;
-}
-
-.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c12.fi-dropdown .fi-dropdown_popover {
@@ -3567,6 +3608,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   padding-bottom: 8px;
+}
+
+.c12.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c12.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
 }
 
 .c11 .fi-date-selectors_container {
@@ -3765,33 +3817,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-}
-
-.c9 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(0,0%,13%);
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c9.fi-status-text {
-  display: block;
-}
-
-.c9.fi-status-text.fi-status-text--error {
-  color: hsl(3,59%,48%);
 }
 
 .c1 {
@@ -4147,12 +4172,19 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 id="16_button"
                 role="button"
                 tabindex="0"
-              />
-              <input
-                class="c5"
-                tabindex="-1"
-                type="hidden"
-                value="2020"
+              >
+                2020
+                <input
+                  class="c5"
+                  tabindex="-1"
+                  type="hidden"
+                  value="2020"
+                />
+              </span>
+              <span
+                aria-atomic="true"
+                aria-live="assertive"
+                class="c2 c9 fi-status-text"
               />
             </div>
           </div>
@@ -4186,12 +4218,19 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 id="17_button"
                 role="button"
                 tabindex="0"
-              />
-              <input
-                class="c5"
-                tabindex="-1"
-                type="hidden"
-                value="0"
+              >
+                Tammikuu
+                <input
+                  class="c5"
+                  tabindex="-1"
+                  type="hidden"
+                  value="0"
+                />
+              </span>
+              <span
+                aria-atomic="true"
+                aria-live="assertive"
+                class="c2 c9 fi-status-text"
               />
             </div>
           </div>

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -4156,7 +4156,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <label
                 class="c7 fi-visually-hidden"
-                for="16_button"
                 id="16-label"
               >
                 Valitse vuosi
@@ -4210,7 +4209,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <label
                 class="c7 fi-visually-hidden"
-                for="17_button"
                 id="17-label"
               >
                 Valitse kuukausi
@@ -5715,7 +5713,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 }
 
 .c12.fi-dropdown .fi-status-text {
-  line-height: 18px;
+  line-height: 1.1rem;
 }
 
 .c12.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
@@ -6407,7 +6405,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <label
                   class="c7 fi-visually-hidden"
-                  for="9_button"
                   id="9-label"
                 >
                   Valitse vuosi
@@ -6461,7 +6458,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <label
                   class="c7 fi-visually-hidden"
-                  for="10_button"
                   id="10-label"
                 >
                   Valitse kuukausi

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3630,20 +3630,20 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c11 .fi-date-selectors_year-select {
   margin-right: 10px;
-  min-width: 0px;
+  width: 0px;
 }
 
 .c11 .fi-date-selectors_year-select .fi-dropdown_button {
-  min-width: 60px;
+  min-width: 90px;
 }
 
 .c11 .fi-date-selectors_month-select {
   margin-right: 10px;
-  min-width: 0px;
+  width: 0px;
 }
 
 .c11 .fi-date-selectors_month-select .fi-dropdown_button {
-  min-width: 125px;
+  min-width: 145px;
 }
 
 .c11 .fi-date-selectors_month-button {
@@ -4156,6 +4156,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <label
                 class="c7 fi-visually-hidden"
+                for="16_button"
                 id="16-label"
               >
                 Valitse vuosi
@@ -4165,15 +4166,22 @@ exports[`snapshots match date input with datepicker with controlled input value 
               class="c0 fi-dropdown_input-wrapper"
             >
               <span
+                aria-activedescendant="16-2020"
                 aria-expanded="false"
                 aria-haspopup="listbox"
+                aria-labelledby="16-displayValue 16-label"
                 aria-owns="16-popover"
                 class="c2 fi-dropdown_button"
                 id="16_button"
                 role="button"
                 tabindex="0"
               >
-                2020
+                <span
+                  class="c2"
+                  id="16-displayValue"
+                >
+                  2020
+                </span>
                 <input
                   class="c5"
                   tabindex="-1"
@@ -4202,6 +4210,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <label
                 class="c7 fi-visually-hidden"
+                for="17_button"
                 id="17-label"
               >
                 Valitse kuukausi
@@ -4211,15 +4220,22 @@ exports[`snapshots match date input with datepicker with controlled input value 
               class="c0 fi-dropdown_input-wrapper"
             >
               <span
+                aria-activedescendant="17-0"
                 aria-expanded="false"
                 aria-haspopup="listbox"
+                aria-labelledby="17-displayValue 17-label"
                 aria-owns="17-popover"
                 class="c2 fi-dropdown_button"
                 id="17_button"
                 role="button"
                 tabindex="0"
               >
-                Tammikuu
+                <span
+                  class="c2"
+                  id="17-displayValue"
+                >
+                  Tammikuu
+                </span>
                 <input
                   class="c5"
                   tabindex="-1"
@@ -5651,6 +5667,37 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   margin-left: 6px;
 }
 
+.c9 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c9.fi-status-text {
+  display: block;
+}
+
+.c9.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,48%);
+}
+
+.c12 {
+  width: 290px;
+}
+
 .c12 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -5663,8 +5710,37 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   margin-bottom: 10px;
 }
 
-.c12.fi-dropdown .fi-dropdown_input-wrapper {
-  height: 40px;
+.c12.fi-dropdown .fi-hint-text {
+  margin-bottom: 10px;
+}
+
+.c12.fi-dropdown .fi-status-text {
+  line-height: 18px;
+}
+
+.c12.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
+  margin-top: 5px;
+}
+
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
+}
+
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c12.fi-dropdown .fi-dropdown_button {
@@ -5691,6 +5767,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   position: relative;
   display: inline-block;
   word-break: break-word;
+  width: 100%;
   overflow-wrap: break-word;
   height: 40px;
   padding: 7px 38px 7px 7px;
@@ -5704,6 +5781,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  white-space: nowrap;
 }
 
 .c12.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -5724,27 +5802,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 .c12.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
   border-color: transparent transparent hsl(0,0%,13%) transparent;
   border-width: 0 4px 6px 4px;
-}
-
-.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c12.fi-dropdown .fi-dropdown_popover {
@@ -5795,6 +5852,17 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   padding-bottom: 8px;
 }
 
+.c12.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c12.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 .c11 .fi-date-selectors_container {
   display: -webkit-box;
   display: -webkit-flex;
@@ -5804,20 +5872,20 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 
 .c11 .fi-date-selectors_year-select {
   margin-right: 10px;
-  min-width: 0px;
+  width: 0px;
 }
 
 .c11 .fi-date-selectors_year-select .fi-dropdown_button {
-  min-width: 60px;
+  min-width: 90px;
 }
 
 .c11 .fi-date-selectors_month-select {
   margin-right: 10px;
-  min-width: 0px;
+  width: 0px;
 }
 
 .c11 .fi-date-selectors_month-select .fi-dropdown_button {
-  min-width: 125px;
+  min-width: 145px;
 }
 
 .c11 .fi-date-selectors_month-button {
@@ -5991,33 +6059,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-}
-
-.c9 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(0,0%,13%);
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c9.fi-status-text {
-  display: block;
-}
-
-.c9.fi-status-text.fi-status-text--error {
-  color: hsl(3,59%,48%);
 }
 
 .c1 {
@@ -6366,6 +6407,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <label
                   class="c7 fi-visually-hidden"
+                  for="9_button"
                   id="9-label"
                 >
                   Valitse vuosi
@@ -6375,19 +6417,33 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 class="c0 fi-dropdown_input-wrapper"
               >
                 <span
+                  aria-activedescendant="9-2020"
                   aria-expanded="false"
                   aria-haspopup="listbox"
+                  aria-labelledby="9-displayValue 9-label"
                   aria-owns="9-popover"
                   class="c2 fi-dropdown_button"
                   id="9_button"
                   role="button"
                   tabindex="0"
-                />
-                <input
-                  class="c5"
-                  tabindex="-1"
-                  type="hidden"
-                  value="2020"
+                >
+                  <span
+                    class="c2"
+                    id="9-displayValue"
+                  >
+                    2020
+                  </span>
+                  <input
+                    class="c5"
+                    tabindex="-1"
+                    type="hidden"
+                    value="2020"
+                  />
+                </span>
+                <span
+                  aria-atomic="true"
+                  aria-live="assertive"
+                  class="c2 c9 fi-status-text"
                 />
               </div>
             </div>
@@ -6405,6 +6461,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <label
                   class="c7 fi-visually-hidden"
+                  for="10_button"
                   id="10-label"
                 >
                   Valitse kuukausi
@@ -6414,19 +6471,33 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 class="c0 fi-dropdown_input-wrapper"
               >
                 <span
+                  aria-activedescendant="10-0"
                   aria-expanded="false"
                   aria-haspopup="listbox"
+                  aria-labelledby="10-displayValue 10-label"
                   aria-owns="10-popover"
                   class="c2 fi-dropdown_button"
                   id="10_button"
                   role="button"
                   tabindex="0"
-                />
-                <input
-                  class="c5"
-                  tabindex="-1"
-                  type="hidden"
-                  value="0"
+                >
+                  <span
+                    class="c2"
+                    id="10-displayValue"
+                  >
+                    Tammikuu
+                  </span>
+                  <input
+                    class="c5"
+                    tabindex="-1"
+                    type="hidden"
+                    value="0"
+                  />
+                </span>
+                <span
+                  aria-atomic="true"
+                  aria-live="assertive"
+                  class="c2 c9 fi-status-text"
                 />
               </div>
             </div>

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3464,24 +3464,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
   display: inline-block;
 }
 
-.c12.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
-}
-
-.c12.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c12.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
-}
-
 .c12.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
@@ -3583,6 +3565,24 @@ exports[`snapshots match date input with datepicker with controlled input value 
 .c12.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
+}
+
+.c12.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c12.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c12.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
 }
 
 .c12.fi-dropdown--disabled .fi-dropdown_input-wrapper {
@@ -4173,7 +4173,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 aria-owns="16-popover"
                 class="c6 fi-dropdown_button"
                 id="16_button"
-                role="button"
                 tabindex="0"
                 type="button"
               >
@@ -4228,7 +4227,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 aria-owns="17-popover"
                 class="c6 fi-dropdown_button"
                 id="17_button"
-                role="button"
                 tabindex="0"
                 type="button"
               >
@@ -5708,24 +5706,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   display: inline-block;
 }
 
-.c12.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
-}
-
-.c12.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c12.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
-}
-
 .c12.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
@@ -5827,6 +5807,24 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 .c12.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
+}
+
+.c12.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c12.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c12.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
 }
 
 .c12.fi-dropdown--disabled .fi-dropdown_input-wrapper {
@@ -6426,7 +6424,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   aria-owns="9-popover"
                   class="c6 fi-dropdown_button"
                   id="9_button"
-                  role="button"
                   tabindex="0"
                   type="button"
                 >
@@ -6481,7 +6478,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   aria-owns="10-popover"
                   class="c6 fi-dropdown_button"
                   id="10_button"
-                  role="button"
                   tabindex="0"
                   type="button"
                 >

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3464,6 +3464,24 @@ exports[`snapshots match date input with datepicker with controlled input value 
   display: inline-block;
 }
 
+.c12.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c12.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c12.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 .c12.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
@@ -3478,27 +3496,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c12.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
   margin-top: 5px;
-}
-
-.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c12.fi-dropdown .fi-dropdown_button {
@@ -3603,22 +3600,25 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%) transparent transparent transparent;
 }
 
-.c12.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
 }
 
-.c12.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c12.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c11 .fi-date-selectors_container {
@@ -4165,16 +4165,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
             <div
               class="c0 fi-dropdown_input-wrapper"
             >
-              <span
+              <button
                 aria-activedescendant="16-2020"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="16-displayValue 16-label"
                 aria-owns="16-popover"
-                class="c2 fi-dropdown_button"
+                class="c6 fi-dropdown_button"
                 id="16_button"
                 role="button"
                 tabindex="0"
+                type="button"
               >
                 <span
                   class="c2"
@@ -4188,7 +4189,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   type="hidden"
                   value="2020"
                 />
-              </span>
+              </button>
               <span
                 aria-atomic="true"
                 aria-live="assertive"
@@ -4219,16 +4220,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
             <div
               class="c0 fi-dropdown_input-wrapper"
             >
-              <span
+              <button
                 aria-activedescendant="17-0"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="17-displayValue 17-label"
                 aria-owns="17-popover"
-                class="c2 fi-dropdown_button"
+                class="c6 fi-dropdown_button"
                 id="17_button"
                 role="button"
                 tabindex="0"
+                type="button"
               >
                 <span
                   class="c2"
@@ -4242,7 +4244,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   type="hidden"
                   value="0"
                 />
-              </span>
+              </button>
               <span
                 aria-atomic="true"
                 aria-live="assertive"
@@ -5706,6 +5708,24 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   display: inline-block;
 }
 
+.c12.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
+}
+
+.c12.fi-dropdown--error .fi-dropdown_button {
+  border-color: hsl(3,59%,48%);
+  border-width: 2px;
+}
+
+.c12.fi-dropdown--italicize .fi-dropdown_button {
+  font-style: italic;
+  color: hsl(201,7%,46%);
+  opacity: 1;
+}
+
 .c12.fi-dropdown .fi-dropdown_label--visible {
   margin-bottom: 10px;
 }
@@ -5720,27 +5740,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 
 .c12.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {
   margin-top: 5px;
-}
-
-.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
-  position: relative;
-}
-
-.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c12.fi-dropdown .fi-dropdown_button {
@@ -5845,22 +5844,25 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border-color: hsl(202,7%,67%) transparent transparent transparent;
 }
 
-.c12.fi-dropdown--open .fi-dropdown_button {
-  border-bottom: 0;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  padding-bottom: 8px;
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
+  outline: 0;
+  position: relative;
 }
 
-.c12.fi-dropdown--error .fi-dropdown_button {
-  border-color: hsl(3,59%,48%);
-  border-width: 2px;
-}
-
-.c12.fi-dropdown--italicize .fi-dropdown_button {
-  font-style: italic;
-  color: hsl(201,7%,46%);
-  opacity: 1;
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
 }
 
 .c11 .fi-date-selectors_container {
@@ -6416,16 +6418,17 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               <div
                 class="c0 fi-dropdown_input-wrapper"
               >
-                <span
+                <button
                   aria-activedescendant="9-2020"
                   aria-expanded="false"
                   aria-haspopup="listbox"
                   aria-labelledby="9-displayValue 9-label"
                   aria-owns="9-popover"
-                  class="c2 fi-dropdown_button"
+                  class="c6 fi-dropdown_button"
                   id="9_button"
                   role="button"
                   tabindex="0"
+                  type="button"
                 >
                   <span
                     class="c2"
@@ -6439,7 +6442,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     type="hidden"
                     value="2020"
                   />
-                </span>
+                </button>
                 <span
                   aria-atomic="true"
                   aria-live="assertive"
@@ -6470,16 +6473,17 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               <div
                 class="c0 fi-dropdown_input-wrapper"
               >
-                <span
+                <button
                   aria-activedescendant="10-0"
                   aria-expanded="false"
                   aria-haspopup="listbox"
                   aria-labelledby="10-displayValue 10-label"
                   aria-owns="10-popover"
-                  class="c2 fi-dropdown_button"
+                  class="c6 fi-dropdown_button"
                   id="10_button"
                   role="button"
                   tabindex="0"
+                  type="button"
                 >
                   <span
                     class="c2"
@@ -6493,7 +6497,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     type="hidden"
                     value="0"
                   />
-                </span>
+                </button>
                 <span
                   aria-atomic="true"
                   aria-live="assertive"

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3473,7 +3473,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 }
 
 .c12.fi-dropdown .fi-status-text {
-  line-height: 18px;
+  line-height: 1.1rem;
 }
 
 .c12.fi-dropdown .fi-status-text.fi-dropdown_statusText--has-content {

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3567,6 +3567,10 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-shadow: none;
 }
 
+.c12.fi-dropdown--full-width {
+  width: 100%;
+}
+
 .c12.fi-dropdown--open .fi-dropdown_button {
   border-bottom: 0;
   border-bottom-left-radius: 0;
@@ -5803,6 +5807,10 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 .c12.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
+}
+
+.c12.fi-dropdown--full-width {
+  width: 100%;
 }
 
 .c12.fi-dropdown--open .fi-dropdown_button {

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -2964,31 +2964,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-sizing: border-box;
 }
 
-.c15 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: list-item;
-}
-
-.c15::before,
-.c15::after {
-  box-sizing: border-box;
-}
-
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -3018,37 +2993,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-sizing: border-box;
 }
 
-.c13 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: block;
-  list-style-type: decimal;
-  margin-top: 1em;
-  margin-bottom: 1em;
-  margin-left: 0;
-  margin-right: 0;
-  padding-left: 40px;
-}
-
-.c13::before,
-.c13::after {
-  box-sizing: border-box;
-}
-
 .c8 {
   vertical-align: baseline;
 }
@@ -3073,7 +3017,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: inherit;
 }
 
-.c17 {
+.c13 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -3100,12 +3044,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: pointer;
 }
 
-.c17:focus {
+.c13:focus {
   outline: none;
   position: relative;
 }
 
-.c17:focus::after {
+.c13:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3121,17 +3065,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c17:hover {
+.c13:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
 }
 
-.c17:active {
+.c13:active {
   background: hsl(212,63%,37%);
 }
 
-.c17.fi-button--disabled,
-.c17[disabled],
-.c17:disabled {
+.c13.fi-button--disabled,
+.c13[disabled],
+.c13:disabled {
   text-shadow: 0 1px 1px rgba(33,33,33,0.5);
   background: linear-gradient(0deg,hsl(202,7%,67%) 0%,hsl(202,7%,80%) 100%);
   -webkit-user-select: none;
@@ -3141,41 +3085,41 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: not-allowed;
 }
 
-.c17.fi-button--disabled::after {
+.c13.fi-button--disabled::after {
   border: none;
   box-shadow: none;
 }
 
-.c17.fi-button--fullwidth {
+.c13.fi-button--fullwidth {
   display: block;
   width: 100%;
 }
 
-.c17.fi-button--inverted {
+.c13.fi-button--inverted {
   background: none;
   background-color: hsl(212,63%,45%);
   border: 1px solid hsl(0,0%,100%);
   text-shadow: none;
 }
 
-.c17.fi-button--inverted:hover {
+.c13.fi-button--inverted:hover {
   background: linear-gradient(-180deg,hsla(0,0%,100%,0.1) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c17.fi-button--inverted:active {
+.c13.fi-button--inverted:active {
   background: none;
   background-color: hsl(212,63%,45%);
 }
 
-.c17.fi-button--inverted.fi-button--disabled,
-.c17.fi-button--inverted[disabled],
-.c17.fi-button--inverted:disabled {
+.c13.fi-button--inverted.fi-button--disabled,
+.c13.fi-button--inverted[disabled],
+.c13.fi-button--inverted:disabled {
   opacity: 0.41;
   background: none;
   background-color: none;
 }
 
-.c17.fi-button--secondary {
+.c13.fi-button--secondary {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -3183,18 +3127,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   text-shadow: none;
 }
 
-.c17.fi-button--secondary:hover {
+.c13.fi-button--secondary:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c17.fi-button--secondary:active {
+.c13.fi-button--secondary:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c17.fi-button--secondary.fi-button--disabled,
-.c17.fi-button--secondary[disabled],
-.c17.fi-button--secondary:disabled {
+.c13.fi-button--secondary.fi-button--disabled,
+.c13.fi-button--secondary[disabled],
+.c13.fi-button--secondary:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3202,7 +3146,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c17.fi-button--secondary-noborder {
+.c13.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -3212,18 +3156,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   background-color: transparent;
 }
 
-.c17.fi-button--secondary-noborder:hover {
+.c13.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c17.fi-button--secondary-noborder:active {
+.c13.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c17.fi-button--secondary-noborder.fi-button--disabled,
-.c17.fi-button--secondary-noborder[disabled],
-.c17.fi-button--secondary-noborder:disabled {
+.c13.fi-button--secondary-noborder.fi-button--disabled,
+.c13.fi-button--secondary-noborder[disabled],
+.c13.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3231,7 +3175,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c17.fi-button--link {
+.c13.fi-button--link {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -3242,18 +3186,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border: none;
 }
 
-.c17.fi-button--link:hover {
+.c13.fi-button--link:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c17.fi-button--link:active {
+.c13.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c17.fi-button--link.fi-button--disabled,
-.c17.fi-button--link[disabled],
-.c17.fi-button--link:disabled {
+.c13.fi-button--link.fi-button--disabled,
+.c13.fi-button--link[disabled],
+.c13.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3261,23 +3205,23 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c17.fi-button--link:hover {
+.c13.fi-button--link:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c17.fi-button--link:active {
+.c13.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c17.fi-button--link.fi-button--disabled,
-.c17.fi-button--link[disabled],
-.c17.fi-button--link:disabled {
+.c13.fi-button--link.fi-button--disabled,
+.c13.fi-button--link[disabled],
+.c13.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
 }
 
-.c17 > .fi-button_icon {
+.c13 > .fi-button_icon {
   width: 16px;
   height: 16px;
   margin-right: 8px;
@@ -3287,12 +3231,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   transform: translateY(-0.1em);
 }
 
-.c17 > .fi-button_icon.fi-button_icon--right {
+.c13 > .fi-button_icon.fi-button_icon--right {
   margin-right: 0;
   margin-left: 8px;
 }
 
-.c17.fi-button--disabled > .fi-button_icon {
+.c13.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
 
@@ -3308,40 +3252,40 @@ exports[`snapshots match date input with datepicker with controlled input value 
   overflow: hidden;
 }
 
-.c19.fi-month-day {
+.c15.fi-month-day {
   padding: 1px;
   text-align: center;
   min-width: 36px;
   height: 38px;
 }
 
-.c19.fi-month-day--disabled {
+.c15.fi-month-day--disabled {
   color: hsl(202,7%,67%);
 }
 
-.c19 .fi-month-day_current {
+.c15 .fi-month-day_current {
   margin: 0 6px;
   padding: 3px 0;
   border-bottom: 1px solid hsl(202,7%,67%);
   text-align: center;
 }
 
-.c19 .fi-month-day_button_current {
+.c15 .fi-month-day_button_current {
   margin: 0 6px;
   padding: 3px 0;
   border-bottom: 1px solid hsl(0,0%,13%);
   text-align: center;
 }
 
-.c19 .fi-month-day_button--disabled {
+.c15 .fi-month-day_button--disabled {
   color: hsl(202,7%,67%);
 }
 
-.c19 .fi-month-day_button--disabled .fi-month-day_button_current {
+.c15 .fi-month-day_button--disabled .fi-month-day_button_current {
   border-bottom: 1px solid hsl(202,7%,67%);
 }
 
-.c19 .fi-month-day_button {
+.c15 .fi-month-day_button {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3362,13 +3306,13 @@ exports[`snapshots match date input with datepicker with controlled input value 
   text-align: center;
 }
 
-.c19 .fi-month-day_button:focus {
+.c15 .fi-month-day_button:focus {
   box-shadow: none;
   position: relative;
   outline: 3px solid transparent;
 }
 
-.c19 .fi-month-day_button:focus:after {
+.c15 .fi-month-day_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3384,16 +3328,16 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c19 .fi-month-day_button:not(.fi-month-day_button--disabled):hover {
+.c15 .fi-month-day_button:not(.fi-month-day_button--disabled):hover {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c19 .fi-month-day_button:not(.fi-month-day_button--disabled):hover .fi-month-day_button_current {
+.c15 .fi-month-day_button:not(.fi-month-day_button--disabled):hover .fi-month-day_button_current {
   border-bottom: 1px solid hsl(0,0%,100%);
 }
 
-.c19 .fi-month-day_button--selected {
+.c15 .fi-month-day_button--selected {
   border: 1px solid hsl(212,63%,45%);
   background-color: hsl(212,63%,95%);
   -webkit-text-decoration: none;
@@ -3401,12 +3345,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   font-weight: 600;
 }
 
-.c19 .fi-month-day_button--selected:focus {
+.c15 .fi-month-day_button--selected:focus {
   box-shadow: none;
   position: relative;
 }
 
-.c19 .fi-month-day_button--selected:focus:after {
+.c15 .fi-month-day_button--selected:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3422,11 +3366,11 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c19 .fi-month-day_button--selected:hover {
+.c15 .fi-month-day_button--selected:hover {
   font-weight: 400;
 }
 
-.c18.fi-month-table {
+.c14.fi-month-table {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3444,7 +3388,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin-bottom: 10px;
 }
 
-.c18 .fi-month-table_thead-cell {
+.c14 .fi-month-table_thead-cell {
   padding: 1px;
   text-align: center;
   min-width: 36px;
@@ -3479,45 +3423,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
-}
-
-.c14 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
-  list-style-type: none;
-  box-sizing: content-box;
-  max-height: 265px;
-  background-color: hsl(0,0%,100%);
-  border-width: 0 1px 1px 1px;
-  border-style: solid;
-  border-color: hsl(201,7%,58%);
-  border-bottom-left-radius: 2px;
-  border-bottom-right-radius: 2px;
-  margin: 0;
-  padding: 4px 0 0 0;
-}
-
-.c14:focus {
-  outline: none;
-}
-
-.c14 .fi-select-item-list_content_wrapper {
-  display: block;
-  width: 100%;
-  max-height: inherit;
-  overflow-y: auto;
-  overflow-x: hidden;
 }
 
 .c9 {
@@ -3714,56 +3619,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
-}
-
-.c16.fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  cursor: pointer;
-  line-height: 1.5;
-  padding: 8px;
-  border: 0;
-  position: relative;
-}
-
-.c16.fi-dropdown_item:focus {
-  outline: 0;
-}
-
-.c16.fi-dropdown_item:hover {
-  background-color: hsl(212,63%,45%);
-  color: hsl(0,0%,100%);
-}
-
-.c16.fi-dropdown_item .fi-dropdown_item_icon {
-  position: absolute;
-  top: 14px;
-  right: 10px;
-  height: 12px;
-  width: 12px;
-}
-
-.c16.fi-dropdown_item--selected {
-  background-color: hsl(215,100%,95%);
-  color: hsl(0,0%,13%);
-}
-
-.c16.fi-dropdown_item--hasKeyboardFocus {
-  background-color: hsl(212,63%,45%);
-  color: hsl(0,0%,100%);
-}
-
-.c16.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
-  background-color: hsl(0,0%,100%);
-  color: hsl(0,0%,13%);
-}
-
-.c16.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
-  background-color: hsl(212,63%,45%);
-  color: hsl(0,0%,100%);
 }
 
 .c11 .fi-date-selectors_container {
@@ -4310,7 +4165,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
               class="c0 fi-dropdown_input-wrapper"
             >
               <button
-                aria-activedescendant="16-2020"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="16-displayValue 16-label"
@@ -4338,232 +4192,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 aria-live="assertive"
                 class="c2 c9 fi-status-text"
               />
-              <div
-                role="presentation"
-                style="position: absolute; left: 0px; top: 0px; visibility: hidden; width: 0px;"
-                tabindex="-1"
-              >
-                <div
-                  class="c3"
-                >
-                  <ul
-                    class="c13 fi-select-item-list c14 fi-dropdown_item-list"
-                    id="9-popover"
-                    role="listbox"
-                    tabindex="0"
-                  >
-                    <div
-                      class="c3 fi-select-item-list_content_wrapper"
-                    >
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2010"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2010
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2011"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2011
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2012"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2012
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2013"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2013
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2014"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2014
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2015"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2015
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2016"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2016
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2017"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2017
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2018"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2018
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2019"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2019
-                      </li>
-                      <li
-                        aria-selected="true"
-                        class="c15 c16 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus fi-dropdown_item--selected"
-                        id="9-2020"
-                        role="option"
-                        tabindex="0"
-                      >
-                        2020
-                        <svg
-                          aria-hidden="true"
-                          class="fi-icon c8 fi-dropdown_item_icon"
-                          focusable="false"
-                          height="1em"
-                          viewBox="0 0 20 20"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            class="fi-icon-base-fill"
-                            d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
-                            fill="#222"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2021"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2021
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2022"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2022
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2023"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2023
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2024"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2024
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2025"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2025
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2026"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2026
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2027"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2027
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2028"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2028
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2029"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2029
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="9-2030"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        2030
-                      </li>
-                    </div>
-                  </ul>
-                </div>
-              </div>
             </div>
           </div>
         </span>
@@ -4589,7 +4217,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
               class="c0 fi-dropdown_input-wrapper"
             >
               <button
-                aria-activedescendant="17-0"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="17-displayValue 17-label"
@@ -4617,158 +4244,13 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 aria-live="assertive"
                 class="c2 c9 fi-status-text"
               />
-              <div
-                role="presentation"
-                style="position: absolute; left: 0px; top: 0px; visibility: hidden; width: 0px;"
-                tabindex="-1"
-              >
-                <div
-                  class="c3"
-                >
-                  <ul
-                    class="c13 fi-select-item-list c14 fi-dropdown_item-list"
-                    id="10-popover"
-                    role="listbox"
-                    tabindex="0"
-                  >
-                    <div
-                      class="c3 fi-select-item-list_content_wrapper"
-                    >
-                      <li
-                        aria-selected="true"
-                        class="c15 c16 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus fi-dropdown_item--selected"
-                        id="10-0"
-                        role="option"
-                        tabindex="0"
-                      >
-                        Tammikuu
-                        <svg
-                          aria-hidden="true"
-                          class="fi-icon c8 fi-dropdown_item_icon"
-                          focusable="false"
-                          height="1em"
-                          viewBox="0 0 20 20"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            class="fi-icon-base-fill"
-                            d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
-                            fill="#222"
-                            fill-rule="evenodd"
-                          />
-                        </svg>
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-1"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Helmikuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-2"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Maaliskuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-3"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Huhtikuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-4"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Toukokuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-5"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Kesäkuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-6"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Heinäkuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-7"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Elokuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-8"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Syyskuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-9"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Lokakuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-10"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Marraskuu
-                      </li>
-                      <li
-                        aria-selected="false"
-                        class="c15 c16 fi-dropdown_item"
-                        id="10-11"
-                        role="option"
-                        tabindex="-1"
-                      >
-                        Joulukuu
-                      </li>
-                    </div>
-                  </ul>
-                </div>
-              </div>
             </div>
           </div>
         </span>
         <button
           aria-disabled="false"
           aria-label="Edellinen kuukausi Joulukuu"
-          class="c6 fi-button c17 fi-date-selectors_month-button fi-button--secondary-noborder"
+          class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
           tabindex="0"
           type="button"
         >
@@ -4792,7 +4274,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         <button
           aria-disabled="false"
           aria-label="Seuraava kuukausi Helmikuu"
-          class="c6 fi-button c17 fi-date-selectors_month-button fi-button--secondary-noborder"
+          class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
           tabindex="0"
           type="button"
         >
@@ -4815,7 +4297,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         </button>
       </div>
       <table
-        class="c18 fi-month-table"
+        class="c14 fi-month-table"
         role="presentation"
       >
         <thead>
@@ -4860,17 +4342,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
         <tbody>
           <tr>
             <td
-              class="c19 fi-month-day fi-month-day--disabled"
+              class="c15 fi-month-day fi-month-day--disabled"
             >
               30
             </td>
             <td
-              class="c19 fi-month-day fi-month-day--disabled"
+              class="c15 fi-month-day fi-month-day--disabled"
             >
               31
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-current="date"
@@ -4896,7 +4378,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4917,7 +4399,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4938,7 +4420,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4959,7 +4441,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4982,7 +4464,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5003,7 +4485,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5024,7 +4506,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5045,7 +4527,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5066,7 +4548,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5087,7 +4569,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5108,7 +4590,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5131,7 +4613,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5152,7 +4634,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5173,7 +4655,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5193,7 +4675,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5214,7 +4696,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5235,7 +4717,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5256,7 +4738,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5279,7 +4761,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5300,7 +4782,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5321,7 +4803,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5342,7 +4824,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5363,7 +4845,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5384,7 +4866,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5405,7 +4887,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5428,7 +4910,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5449,7 +4931,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5470,7 +4952,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5491,7 +4973,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5512,7 +4994,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5533,12 +5015,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c19 fi-month-day fi-month-day--disabled"
+              class="c15 fi-month-day fi-month-day--disabled"
             >
               1
             </td>
             <td
-              class="c19 fi-month-day fi-month-day--disabled"
+              class="c15 fi-month-day fi-month-day--disabled"
             >
               2
             </td>
@@ -5550,7 +5032,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
       >
         <button
           aria-disabled="false"
-          class="c6 fi-button c17 fi-date-picker_bottom-button"
+          class="c6 fi-button c13 fi-date-picker_bottom-button"
           tabindex="0"
           type="button"
         >
@@ -5558,7 +5040,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         </button>
         <button
           aria-disabled="false"
-          class="c6 fi-button c17 fi-date-picker_bottom-button fi-button--secondary"
+          class="c6 fi-button c13 fi-date-picker_bottom-button fi-button--secondary"
           tabindex="0"
           type="button"
         >
@@ -6930,7 +6412,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 class="c0 fi-dropdown_input-wrapper"
               >
                 <button
-                  aria-activedescendant="9-2020"
                   aria-expanded="false"
                   aria-haspopup="listbox"
                   aria-labelledby="9-displayValue 9-label"
@@ -6983,7 +6464,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 class="c0 fi-dropdown_input-wrapper"
               >
                 <button
-                  aria-activedescendant="10-0"
                   aria-expanded="false"
                   aria-haspopup="listbox"
                   aria-labelledby="10-displayValue 10-label"

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3544,7 +3544,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 .c12.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
   height: 100%;
-  display: block;
+  display: inline-block;
   line-height: 1.5;
   overflow: hidden;
 }
@@ -3613,7 +3613,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 }
 
 .c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
+  outline: 3px solid transparent;
   position: relative;
 }
 
@@ -4160,56 +4160,52 @@ exports[`snapshots match date input with datepicker with controlled input value 
           id="16"
         >
           <div
-            class="c0"
+            class="c3 c4 fi-label"
           >
-            <div
-              class="c3 c4 fi-label"
+            <label
+              class="c7 fi-visually-hidden"
+              id="16-label"
             >
-              <label
-                class="c7 fi-visually-hidden"
-                id="16-label"
-              >
-                Valitse vuosi
-              </label>
-            </div>
-            <div
-              class="c0 fi-dropdown_input-wrapper"
+              Valitse vuosi
+            </label>
+          </div>
+          <div
+            class="c0 fi-dropdown_input-wrapper"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="16-displayValue 16-label"
+              aria-owns="16-popover"
+              class="c6 fi-dropdown_button"
+              id="16_button"
+              tabindex="0"
+              type="button"
+              value="2020"
             >
-              <button
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-labelledby="16-displayValue 16-label"
-                aria-owns="16-popover"
-                class="c6 fi-dropdown_button"
-                id="16_button"
-                tabindex="0"
-                type="button"
-                value="2020"
-              >
-                <span
-                  class="c2 fi-dropdown_display-value"
-                >
-                  2020
-                </span>
-                <input
-                  class="c5"
-                  tabindex="-1"
-                  type="hidden"
-                  value="2020"
-                />
-              </button>
               <span
-                class="c2 c7 fi-visually-hidden"
-                id="16-displayValue"
+                class="c2 fi-dropdown_display-value"
               >
                 2020
               </span>
-              <span
-                aria-atomic="true"
-                aria-live="assertive"
-                class="c2 c9 fi-status-text"
+              <input
+                class="c5"
+                tabindex="-1"
+                type="hidden"
+                value="2020"
               />
-            </div>
+            </button>
+            <span
+              class="c2 c7 fi-visually-hidden"
+              id="16-displayValue"
+            >
+              2020
+            </span>
+            <span
+              aria-atomic="true"
+              aria-live="assertive"
+              class="c2 c9 fi-status-text"
+            />
           </div>
         </div>
         <div
@@ -4217,56 +4213,52 @@ exports[`snapshots match date input with datepicker with controlled input value 
           id="17"
         >
           <div
-            class="c0"
+            class="c3 c4 fi-label"
           >
-            <div
-              class="c3 c4 fi-label"
+            <label
+              class="c7 fi-visually-hidden"
+              id="17-label"
             >
-              <label
-                class="c7 fi-visually-hidden"
-                id="17-label"
-              >
-                Valitse kuukausi
-              </label>
-            </div>
-            <div
-              class="c0 fi-dropdown_input-wrapper"
+              Valitse kuukausi
+            </label>
+          </div>
+          <div
+            class="c0 fi-dropdown_input-wrapper"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby="17-displayValue 17-label"
+              aria-owns="17-popover"
+              class="c6 fi-dropdown_button"
+              id="17_button"
+              tabindex="0"
+              type="button"
+              value="0"
             >
-              <button
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-labelledby="17-displayValue 17-label"
-                aria-owns="17-popover"
-                class="c6 fi-dropdown_button"
-                id="17_button"
-                tabindex="0"
-                type="button"
-                value="0"
-              >
-                <span
-                  class="c2 fi-dropdown_display-value"
-                >
-                  Tammikuu
-                </span>
-                <input
-                  class="c5"
-                  tabindex="-1"
-                  type="hidden"
-                  value="0"
-                />
-              </button>
               <span
-                class="c2 c7 fi-visually-hidden"
-                id="17-displayValue"
+                class="c2 fi-dropdown_display-value"
               >
                 Tammikuu
               </span>
-              <span
-                aria-atomic="true"
-                aria-live="assertive"
-                class="c2 c9 fi-status-text"
+              <input
+                class="c5"
+                tabindex="-1"
+                type="hidden"
+                value="0"
               />
-            </div>
+            </button>
+            <span
+              class="c2 c7 fi-visually-hidden"
+              id="17-displayValue"
+            >
+              Tammikuu
+            </span>
+            <span
+              aria-atomic="true"
+              aria-live="assertive"
+              class="c2 c9 fi-status-text"
+            />
           </div>
         </div>
         <button
@@ -5804,7 +5796,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 .c12.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
   height: 100%;
-  display: block;
+  display: inline-block;
   line-height: 1.5;
   overflow: hidden;
 }
@@ -5873,7 +5865,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 }
 
 .c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
-  outline: 0;
+  outline: 3px solid transparent;
   position: relative;
 }
 
@@ -6429,56 +6421,52 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
             id="9"
           >
             <div
-              class="c0"
+              class="c3 c4 fi-label"
             >
-              <div
-                class="c3 c4 fi-label"
+              <label
+                class="c7 fi-visually-hidden"
+                id="9-label"
               >
-                <label
-                  class="c7 fi-visually-hidden"
-                  id="9-label"
-                >
-                  Valitse vuosi
-                </label>
-              </div>
-              <div
-                class="c0 fi-dropdown_input-wrapper"
+                Valitse vuosi
+              </label>
+            </div>
+            <div
+              class="c0 fi-dropdown_input-wrapper"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="9-displayValue 9-label"
+                aria-owns="9-popover"
+                class="c6 fi-dropdown_button"
+                id="9_button"
+                tabindex="0"
+                type="button"
+                value="2020"
               >
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="listbox"
-                  aria-labelledby="9-displayValue 9-label"
-                  aria-owns="9-popover"
-                  class="c6 fi-dropdown_button"
-                  id="9_button"
-                  tabindex="0"
-                  type="button"
-                  value="2020"
-                >
-                  <span
-                    class="c2 fi-dropdown_display-value"
-                  >
-                    2020
-                  </span>
-                  <input
-                    class="c5"
-                    tabindex="-1"
-                    type="hidden"
-                    value="2020"
-                  />
-                </button>
                 <span
-                  class="c2 c7 fi-visually-hidden"
-                  id="9-displayValue"
+                  class="c2 fi-dropdown_display-value"
                 >
                   2020
                 </span>
-                <span
-                  aria-atomic="true"
-                  aria-live="assertive"
-                  class="c2 c9 fi-status-text"
+                <input
+                  class="c5"
+                  tabindex="-1"
+                  type="hidden"
+                  value="2020"
                 />
-              </div>
+              </button>
+              <span
+                class="c2 c7 fi-visually-hidden"
+                id="9-displayValue"
+              >
+                2020
+              </span>
+              <span
+                aria-atomic="true"
+                aria-live="assertive"
+                class="c2 c9 fi-status-text"
+              />
             </div>
           </div>
           <div
@@ -6486,56 +6474,52 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
             id="10"
           >
             <div
-              class="c0"
+              class="c3 c4 fi-label"
             >
-              <div
-                class="c3 c4 fi-label"
+              <label
+                class="c7 fi-visually-hidden"
+                id="10-label"
               >
-                <label
-                  class="c7 fi-visually-hidden"
-                  id="10-label"
-                >
-                  Valitse kuukausi
-                </label>
-              </div>
-              <div
-                class="c0 fi-dropdown_input-wrapper"
+                Valitse kuukausi
+              </label>
+            </div>
+            <div
+              class="c0 fi-dropdown_input-wrapper"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-labelledby="10-displayValue 10-label"
+                aria-owns="10-popover"
+                class="c6 fi-dropdown_button"
+                id="10_button"
+                tabindex="0"
+                type="button"
+                value="0"
               >
-                <button
-                  aria-expanded="false"
-                  aria-haspopup="listbox"
-                  aria-labelledby="10-displayValue 10-label"
-                  aria-owns="10-popover"
-                  class="c6 fi-dropdown_button"
-                  id="10_button"
-                  tabindex="0"
-                  type="button"
-                  value="0"
-                >
-                  <span
-                    class="c2 fi-dropdown_display-value"
-                  >
-                    Tammikuu
-                  </span>
-                  <input
-                    class="c5"
-                    tabindex="-1"
-                    type="hidden"
-                    value="0"
-                  />
-                </button>
                 <span
-                  class="c2 c7 fi-visually-hidden"
-                  id="10-displayValue"
+                  class="c2 fi-dropdown_display-value"
                 >
                   Tammikuu
                 </span>
-                <span
-                  aria-atomic="true"
-                  aria-live="assertive"
-                  class="c2 c9 fi-status-text"
+                <input
+                  class="c5"
+                  tabindex="-1"
+                  type="hidden"
+                  value="0"
                 />
-              </div>
+              </button>
+              <span
+                class="c2 c7 fi-visually-hidden"
+                id="10-displayValue"
+              >
+                Tammikuu
+              </span>
+              <span
+                aria-atomic="true"
+                aria-live="assertive"
+                class="c2 c9 fi-status-text"
+              />
             </div>
           </div>
           <button

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -4180,7 +4180,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
               >
                 <span
                   class="c2"
-                  id="16-displayValue"
                 >
                   2020
                 </span>
@@ -4191,6 +4190,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   value="2020"
                 />
               </button>
+              <span
+                class="c2 c7 fi-visually-hidden"
+                id="16-displayValue"
+              >
+                2020
+              </span>
               <span
                 aria-atomic="true"
                 aria-live="assertive"
@@ -4232,7 +4237,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
               >
                 <span
                   class="c2"
-                  id="17-displayValue"
                 >
                   Tammikuu
                 </span>
@@ -4243,6 +4247,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   value="0"
                 />
               </button>
+              <span
+                class="c2 c7 fi-visually-hidden"
+                id="17-displayValue"
+              >
+                Tammikuu
+              </span>
               <span
                 aria-atomic="true"
                 aria-live="assertive"
@@ -6431,7 +6441,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 >
                   <span
                     class="c2"
-                    id="9-displayValue"
                   >
                     2020
                   </span>
@@ -6442,6 +6451,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     value="2020"
                   />
                 </button>
+                <span
+                  class="c2 c7 fi-visually-hidden"
+                  id="9-displayValue"
+                >
+                  2020
+                </span>
                 <span
                   aria-atomic="true"
                   aria-live="assertive"
@@ -6483,7 +6498,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 >
                   <span
                     class="c2"
-                    id="10-displayValue"
                   >
                     Tammikuu
                   </span>
@@ -6494,6 +6508,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     value="0"
                   />
                 </button>
+                <span
+                  class="c2 c7 fi-visually-hidden"
+                  id="10-displayValue"
+                >
+                  Tammikuu
+                </span>
                 <span
                   aria-atomic="true"
                   aria-live="assertive"

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -2964,6 +2964,31 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-sizing: border-box;
 }
 
+.c15 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: list-item;
+}
+
+.c15::before,
+.c15::after {
+  box-sizing: border-box;
+}
+
 .c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2993,6 +3018,37 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-sizing: border-box;
 }
 
+.c13 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c13::before,
+.c13::after {
+  box-sizing: border-box;
+}
+
 .c8 {
   vertical-align: baseline;
 }
@@ -3017,7 +3073,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: inherit;
 }
 
-.c13 {
+.c17 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -3044,12 +3100,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: pointer;
 }
 
-.c13:focus {
+.c17:focus {
   outline: none;
   position: relative;
 }
 
-.c13:focus::after {
+.c17:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3065,17 +3121,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c13:hover {
+.c17:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
 }
 
-.c13:active {
+.c17:active {
   background: hsl(212,63%,37%);
 }
 
-.c13.fi-button--disabled,
-.c13[disabled],
-.c13:disabled {
+.c17.fi-button--disabled,
+.c17[disabled],
+.c17:disabled {
   text-shadow: 0 1px 1px rgba(33,33,33,0.5);
   background: linear-gradient(0deg,hsl(202,7%,67%) 0%,hsl(202,7%,80%) 100%);
   -webkit-user-select: none;
@@ -3085,41 +3141,41 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: not-allowed;
 }
 
-.c13.fi-button--disabled::after {
+.c17.fi-button--disabled::after {
   border: none;
   box-shadow: none;
 }
 
-.c13.fi-button--fullwidth {
+.c17.fi-button--fullwidth {
   display: block;
   width: 100%;
 }
 
-.c13.fi-button--inverted {
+.c17.fi-button--inverted {
   background: none;
   background-color: hsl(212,63%,45%);
   border: 1px solid hsl(0,0%,100%);
   text-shadow: none;
 }
 
-.c13.fi-button--inverted:hover {
+.c17.fi-button--inverted:hover {
   background: linear-gradient(-180deg,hsla(0,0%,100%,0.1) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c13.fi-button--inverted:active {
+.c17.fi-button--inverted:active {
   background: none;
   background-color: hsl(212,63%,45%);
 }
 
-.c13.fi-button--inverted.fi-button--disabled,
-.c13.fi-button--inverted[disabled],
-.c13.fi-button--inverted:disabled {
+.c17.fi-button--inverted.fi-button--disabled,
+.c17.fi-button--inverted[disabled],
+.c17.fi-button--inverted:disabled {
   opacity: 0.41;
   background: none;
   background-color: none;
 }
 
-.c13.fi-button--secondary {
+.c17.fi-button--secondary {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -3127,18 +3183,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   text-shadow: none;
 }
 
-.c13.fi-button--secondary:hover {
+.c17.fi-button--secondary:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c13.fi-button--secondary:active {
+.c17.fi-button--secondary:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c13.fi-button--secondary.fi-button--disabled,
-.c13.fi-button--secondary[disabled],
-.c13.fi-button--secondary:disabled {
+.c17.fi-button--secondary.fi-button--disabled,
+.c17.fi-button--secondary[disabled],
+.c17.fi-button--secondary:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3146,7 +3202,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c13.fi-button--secondary-noborder {
+.c17.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -3156,18 +3212,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   background-color: transparent;
 }
 
-.c13.fi-button--secondary-noborder:hover {
+.c17.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c13.fi-button--secondary-noborder:active {
+.c17.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c13.fi-button--secondary-noborder.fi-button--disabled,
-.c13.fi-button--secondary-noborder[disabled],
-.c13.fi-button--secondary-noborder:disabled {
+.c17.fi-button--secondary-noborder.fi-button--disabled,
+.c17.fi-button--secondary-noborder[disabled],
+.c17.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3175,7 +3231,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c13.fi-button--link {
+.c17.fi-button--link {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -3186,18 +3242,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border: none;
 }
 
-.c13.fi-button--link:hover {
+.c17.fi-button--link:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c13.fi-button--link:active {
+.c17.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c13.fi-button--link.fi-button--disabled,
-.c13.fi-button--link[disabled],
-.c13.fi-button--link:disabled {
+.c17.fi-button--link.fi-button--disabled,
+.c17.fi-button--link[disabled],
+.c17.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3205,23 +3261,23 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c13.fi-button--link:hover {
+.c17.fi-button--link:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c13.fi-button--link:active {
+.c17.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c13.fi-button--link.fi-button--disabled,
-.c13.fi-button--link[disabled],
-.c13.fi-button--link:disabled {
+.c17.fi-button--link.fi-button--disabled,
+.c17.fi-button--link[disabled],
+.c17.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
 }
 
-.c13 > .fi-button_icon {
+.c17 > .fi-button_icon {
   width: 16px;
   height: 16px;
   margin-right: 8px;
@@ -3231,12 +3287,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   transform: translateY(-0.1em);
 }
 
-.c13 > .fi-button_icon.fi-button_icon--right {
+.c17 > .fi-button_icon.fi-button_icon--right {
   margin-right: 0;
   margin-left: 8px;
 }
 
-.c13.fi-button--disabled > .fi-button_icon {
+.c17.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
 
@@ -3252,40 +3308,40 @@ exports[`snapshots match date input with datepicker with controlled input value 
   overflow: hidden;
 }
 
-.c15.fi-month-day {
+.c19.fi-month-day {
   padding: 1px;
   text-align: center;
   min-width: 36px;
   height: 38px;
 }
 
-.c15.fi-month-day--disabled {
+.c19.fi-month-day--disabled {
   color: hsl(202,7%,67%);
 }
 
-.c15 .fi-month-day_current {
+.c19 .fi-month-day_current {
   margin: 0 6px;
   padding: 3px 0;
   border-bottom: 1px solid hsl(202,7%,67%);
   text-align: center;
 }
 
-.c15 .fi-month-day_button_current {
+.c19 .fi-month-day_button_current {
   margin: 0 6px;
   padding: 3px 0;
   border-bottom: 1px solid hsl(0,0%,13%);
   text-align: center;
 }
 
-.c15 .fi-month-day_button--disabled {
+.c19 .fi-month-day_button--disabled {
   color: hsl(202,7%,67%);
 }
 
-.c15 .fi-month-day_button--disabled .fi-month-day_button_current {
+.c19 .fi-month-day_button--disabled .fi-month-day_button_current {
   border-bottom: 1px solid hsl(202,7%,67%);
 }
 
-.c15 .fi-month-day_button {
+.c19 .fi-month-day_button {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3306,13 +3362,13 @@ exports[`snapshots match date input with datepicker with controlled input value 
   text-align: center;
 }
 
-.c15 .fi-month-day_button:focus {
+.c19 .fi-month-day_button:focus {
   box-shadow: none;
   position: relative;
   outline: 3px solid transparent;
 }
 
-.c15 .fi-month-day_button:focus:after {
+.c19 .fi-month-day_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3328,16 +3384,16 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c15 .fi-month-day_button:not(.fi-month-day_button--disabled):hover {
+.c19 .fi-month-day_button:not(.fi-month-day_button--disabled):hover {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c15 .fi-month-day_button:not(.fi-month-day_button--disabled):hover .fi-month-day_button_current {
+.c19 .fi-month-day_button:not(.fi-month-day_button--disabled):hover .fi-month-day_button_current {
   border-bottom: 1px solid hsl(0,0%,100%);
 }
 
-.c15 .fi-month-day_button--selected {
+.c19 .fi-month-day_button--selected {
   border: 1px solid hsl(212,63%,45%);
   background-color: hsl(212,63%,95%);
   -webkit-text-decoration: none;
@@ -3345,12 +3401,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   font-weight: 600;
 }
 
-.c15 .fi-month-day_button--selected:focus {
+.c19 .fi-month-day_button--selected:focus {
   box-shadow: none;
   position: relative;
 }
 
-.c15 .fi-month-day_button--selected:focus:after {
+.c19 .fi-month-day_button--selected:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3366,11 +3422,11 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c15 .fi-month-day_button--selected:hover {
+.c19 .fi-month-day_button--selected:hover {
   font-weight: 400;
 }
 
-.c14.fi-month-table {
+.c18.fi-month-table {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3388,7 +3444,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin-bottom: 10px;
 }
 
-.c14 .fi-month-table_thead-cell {
+.c18 .fi-month-table_thead-cell {
   padding: 1px;
   text-align: center;
   min-width: 36px;
@@ -3423,6 +3479,45 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c4.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
+}
+
+.c14 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  list-style-type: none;
+  box-sizing: content-box;
+  max-height: 265px;
+  background-color: hsl(0,0%,100%);
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+  border-color: hsl(201,7%,58%);
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  margin: 0;
+  padding: 4px 0 0 0;
+}
+
+.c14:focus {
+  outline: none;
+}
+
+.c14 .fi-select-item-list_content_wrapper {
+  display: block;
+  width: 100%;
+  max-height: inherit;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c9 {
@@ -3619,6 +3714,56 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
+}
+
+.c16.fi-dropdown_item {
+  color: hsl(0,0%,13%);
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+  line-height: 1.5;
+  padding: 8px;
+  border: 0;
+  position: relative;
+}
+
+.c16.fi-dropdown_item:focus {
+  outline: 0;
+}
+
+.c16.fi-dropdown_item:hover {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c16.fi-dropdown_item .fi-dropdown_item_icon {
+  position: absolute;
+  top: 14px;
+  right: 10px;
+  height: 12px;
+  width: 12px;
+}
+
+.c16.fi-dropdown_item--selected {
+  background-color: hsl(215,100%,95%);
+  color: hsl(0,0%,13%);
+}
+
+.c16.fi-dropdown_item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
+}
+
+.c16.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
+  background-color: hsl(0,0%,100%);
+  color: hsl(0,0%,13%);
+}
+
+.c16.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
+  background-color: hsl(212,63%,45%);
+  color: hsl(0,0%,100%);
 }
 
 .c11 .fi-date-selectors_container {
@@ -4193,6 +4338,232 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 aria-live="assertive"
                 class="c2 c9 fi-status-text"
               />
+              <div
+                role="presentation"
+                style="position: absolute; left: 0px; top: 0px; visibility: hidden; width: 0px;"
+                tabindex="-1"
+              >
+                <div
+                  class="c3"
+                >
+                  <ul
+                    class="c13 fi-select-item-list c14 fi-dropdown_item-list"
+                    id="9-popover"
+                    role="listbox"
+                    tabindex="0"
+                  >
+                    <div
+                      class="c3 fi-select-item-list_content_wrapper"
+                    >
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2010"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2010
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2011"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2011
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2012"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2012
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2013"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2013
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2014"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2014
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2015"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2015
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2016"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2016
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2017"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2017
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2018"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2018
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2019"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2019
+                      </li>
+                      <li
+                        aria-selected="true"
+                        class="c15 c16 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus fi-dropdown_item--selected"
+                        id="9-2020"
+                        role="option"
+                        tabindex="0"
+                      >
+                        2020
+                        <svg
+                          aria-hidden="true"
+                          class="fi-icon c8 fi-dropdown_item_icon"
+                          focusable="false"
+                          height="1em"
+                          viewBox="0 0 20 20"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            class="fi-icon-base-fill"
+                            d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
+                            fill="#222"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2021"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2021
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2022"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2022
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2023"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2023
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2024"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2024
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2025"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2025
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2026"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2026
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2027"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2027
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2028"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2028
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2029"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2029
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="9-2030"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        2030
+                      </li>
+                    </div>
+                  </ul>
+                </div>
+              </div>
             </div>
           </div>
         </span>
@@ -4246,13 +4617,158 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 aria-live="assertive"
                 class="c2 c9 fi-status-text"
               />
+              <div
+                role="presentation"
+                style="position: absolute; left: 0px; top: 0px; visibility: hidden; width: 0px;"
+                tabindex="-1"
+              >
+                <div
+                  class="c3"
+                >
+                  <ul
+                    class="c13 fi-select-item-list c14 fi-dropdown_item-list"
+                    id="10-popover"
+                    role="listbox"
+                    tabindex="0"
+                  >
+                    <div
+                      class="c3 fi-select-item-list_content_wrapper"
+                    >
+                      <li
+                        aria-selected="true"
+                        class="c15 c16 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus fi-dropdown_item--selected"
+                        id="10-0"
+                        role="option"
+                        tabindex="0"
+                      >
+                        Tammikuu
+                        <svg
+                          aria-hidden="true"
+                          class="fi-icon c8 fi-dropdown_item_icon"
+                          focusable="false"
+                          height="1em"
+                          viewBox="0 0 20 20"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            class="fi-icon-base-fill"
+                            d="M19.447 5.384L8 17.42a1.82 1.82 0 01-2.667 0L.552 12.394a2.059 2.059 0 010-2.805 1.822 1.822 0 012.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 012.666 0 2.053 2.053 0 010 2.803"
+                            fill="#222"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-1"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Helmikuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-2"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Maaliskuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-3"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Huhtikuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-4"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Toukokuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-5"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Kesäkuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-6"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Heinäkuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-7"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Elokuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-8"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Syyskuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-9"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Lokakuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-10"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Marraskuu
+                      </li>
+                      <li
+                        aria-selected="false"
+                        class="c15 c16 fi-dropdown_item"
+                        id="10-11"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        Joulukuu
+                      </li>
+                    </div>
+                  </ul>
+                </div>
+              </div>
             </div>
           </div>
         </span>
         <button
           aria-disabled="false"
           aria-label="Edellinen kuukausi Joulukuu"
-          class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
+          class="c6 fi-button c17 fi-date-selectors_month-button fi-button--secondary-noborder"
           tabindex="0"
           type="button"
         >
@@ -4276,7 +4792,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         <button
           aria-disabled="false"
           aria-label="Seuraava kuukausi Helmikuu"
-          class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
+          class="c6 fi-button c17 fi-date-selectors_month-button fi-button--secondary-noborder"
           tabindex="0"
           type="button"
         >
@@ -4299,7 +4815,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         </button>
       </div>
       <table
-        class="c14 fi-month-table"
+        class="c18 fi-month-table"
         role="presentation"
       >
         <thead>
@@ -4344,17 +4860,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
         <tbody>
           <tr>
             <td
-              class="c15 fi-month-day fi-month-day--disabled"
+              class="c19 fi-month-day fi-month-day--disabled"
             >
               30
             </td>
             <td
-              class="c15 fi-month-day fi-month-day--disabled"
+              class="c19 fi-month-day fi-month-day--disabled"
             >
               31
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-current="date"
@@ -4380,7 +4896,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4401,7 +4917,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4422,7 +4938,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4443,7 +4959,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4466,7 +4982,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4487,7 +5003,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4508,7 +5024,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4529,7 +5045,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4550,7 +5066,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4571,7 +5087,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4592,7 +5108,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4615,7 +5131,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4636,7 +5152,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4657,7 +5173,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4677,7 +5193,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4698,7 +5214,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4719,7 +5235,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4740,7 +5256,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4763,7 +5279,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4784,7 +5300,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4805,7 +5321,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4826,7 +5342,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4847,7 +5363,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4868,7 +5384,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4889,7 +5405,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4912,7 +5428,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4933,7 +5449,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4954,7 +5470,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4975,7 +5491,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4996,7 +5512,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day"
+              class="c19 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5017,12 +5533,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c15 fi-month-day fi-month-day--disabled"
+              class="c19 fi-month-day fi-month-day--disabled"
             >
               1
             </td>
             <td
-              class="c15 fi-month-day fi-month-day--disabled"
+              class="c19 fi-month-day fi-month-day--disabled"
             >
               2
             </td>
@@ -5034,7 +5550,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
       >
         <button
           aria-disabled="false"
-          class="c6 fi-button c13 fi-date-picker_bottom-button"
+          class="c6 fi-button c17 fi-date-picker_bottom-button"
           tabindex="0"
           type="button"
         >
@@ -5042,7 +5558,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         </button>
         <button
           aria-disabled="false"
-          class="c6 fi-button c13 fi-date-picker_bottom-button fi-button--secondary"
+          class="c6 fi-button c17 fi-date-picker_bottom-button fi-button--secondary"
           tabindex="0"
           type="button"
         >

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -4150,7 +4150,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
         <span
           class="c2 c12 fi-date-selectors_year-select fi-dropdown"
           id="16"
-          value="2020"
         >
           <div
             class="c0"
@@ -4177,6 +4176,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 id="16_button"
                 tabindex="0"
                 type="button"
+                value="2020"
               >
                 <span
                   class="c2"
@@ -4202,7 +4202,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
         <span
           class="c2 c12 fi-date-selectors_month-select fi-dropdown"
           id="17"
-          value="0"
         >
           <div
             class="c0"
@@ -4229,6 +4228,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 id="17_button"
                 tabindex="0"
                 type="button"
+                value="0"
               >
                 <span
                   class="c2"
@@ -6401,7 +6401,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
           <span
             class="c2 c12 fi-date-selectors_year-select fi-dropdown"
             id="9"
-            value="2020"
           >
             <div
               class="c0"
@@ -6428,6 +6427,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   id="9_button"
                   tabindex="0"
                   type="button"
+                  value="2020"
                 >
                   <span
                     class="c2"
@@ -6453,7 +6453,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
           <span
             class="c2 c12 fi-date-selectors_month-select fi-dropdown"
             id="10"
-            value="0"
           >
             <div
               class="c0"
@@ -6480,6 +6479,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   id="10_button"
                   tabindex="0"
                   type="button"
+                  value="0"
                 >
                   <span
                     class="c2"

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3541,6 +3541,14 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-width: 0 4px 6px 4px;
 }
 
+.c12.fi-dropdown .fi-dropdown_display-value {
+  width: 100%;
+  height: 100%;
+  display: block;
+  line-height: 1.5;
+  overflow: hidden;
+}
+
 .c12.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -4179,7 +4187,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 value="2020"
               >
                 <span
-                  class="c2"
+                  class="c2 fi-dropdown_display-value"
                 >
                   2020
                 </span>
@@ -4236,7 +4244,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 value="0"
               >
                 <span
-                  class="c2"
+                  class="c2 fi-dropdown_display-value"
                 >
                   Tammikuu
                 </span>
@@ -5793,6 +5801,14 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border-width: 0 4px 6px 4px;
 }
 
+.c12.fi-dropdown .fi-dropdown_display-value {
+  width: 100%;
+  height: 100%;
+  display: block;
+  line-height: 1.5;
+  overflow: hidden;
+}
+
 .c12.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -6440,7 +6456,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   value="2020"
                 >
                   <span
-                    class="c2"
+                    class="c2 fi-dropdown_display-value"
                   >
                     2020
                   </span>
@@ -6497,7 +6513,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   value="0"
                 >
                   <span
-                    class="c2"
+                    class="c2 fi-dropdown_display-value"
                   >
                     Tammikuu
                   </span>

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -4147,8 +4147,8 @@ exports[`snapshots match date input with datepicker with controlled input value 
       <div
         class="c0 c11 fi-date-selectors_container"
       >
-        <span
-          class="c2 c12 fi-date-selectors_year-select fi-dropdown"
+        <div
+          class="c0 c12 fi-date-selectors_year-select fi-dropdown"
           id="16"
         >
           <div
@@ -4203,9 +4203,9 @@ exports[`snapshots match date input with datepicker with controlled input value 
               />
             </div>
           </div>
-        </span>
-        <span
-          class="c2 c12 fi-date-selectors_month-select fi-dropdown"
+        </div>
+        <div
+          class="c0 c12 fi-date-selectors_month-select fi-dropdown"
           id="17"
         >
           <div
@@ -4260,7 +4260,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               />
             </div>
           </div>
-        </span>
+        </div>
         <button
           aria-disabled="false"
           aria-label="Edellinen kuukausi Joulukuu"
@@ -6408,8 +6408,8 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
         <div
           class="c0 c11 fi-date-selectors_container"
         >
-          <span
-            class="c2 c12 fi-date-selectors_year-select fi-dropdown"
+          <div
+            class="c0 c12 fi-date-selectors_year-select fi-dropdown"
             id="9"
           >
             <div
@@ -6464,9 +6464,9 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 />
               </div>
             </div>
-          </span>
-          <span
-            class="c2 c12 fi-date-selectors_month-select fi-dropdown"
+          </div>
+          <div
+            class="c0 c12 fi-date-selectors_month-select fi-dropdown"
             id="10"
           >
             <div
@@ -6521,7 +6521,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 />
               </div>
             </div>
-          </span>
+          </div>
           <button
             aria-disabled="false"
             aria-label="Edellinen kuukausi Joulukuu"

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3017,7 +3017,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: inherit;
 }
 
-.c14 {
+.c13 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -3044,12 +3044,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: pointer;
 }
 
-.c14:focus {
+.c13:focus {
   outline: none;
   position: relative;
 }
 
-.c14:focus::after {
+.c13:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3065,17 +3065,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c14:hover {
+.c13:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
 }
 
-.c14:active {
+.c13:active {
   background: hsl(212,63%,37%);
 }
 
-.c14.fi-button--disabled,
-.c14[disabled],
-.c14:disabled {
+.c13.fi-button--disabled,
+.c13[disabled],
+.c13:disabled {
   text-shadow: 0 1px 1px rgba(33,33,33,0.5);
   background: linear-gradient(0deg,hsl(202,7%,67%) 0%,hsl(202,7%,80%) 100%);
   -webkit-user-select: none;
@@ -3085,41 +3085,41 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: not-allowed;
 }
 
-.c14.fi-button--disabled::after {
+.c13.fi-button--disabled::after {
   border: none;
   box-shadow: none;
 }
 
-.c14.fi-button--fullwidth {
+.c13.fi-button--fullwidth {
   display: block;
   width: 100%;
 }
 
-.c14.fi-button--inverted {
+.c13.fi-button--inverted {
   background: none;
   background-color: hsl(212,63%,45%);
   border: 1px solid hsl(0,0%,100%);
   text-shadow: none;
 }
 
-.c14.fi-button--inverted:hover {
+.c13.fi-button--inverted:hover {
   background: linear-gradient(-180deg,hsla(0,0%,100%,0.1) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c14.fi-button--inverted:active {
+.c13.fi-button--inverted:active {
   background: none;
   background-color: hsl(212,63%,45%);
 }
 
-.c14.fi-button--inverted.fi-button--disabled,
-.c14.fi-button--inverted[disabled],
-.c14.fi-button--inverted:disabled {
+.c13.fi-button--inverted.fi-button--disabled,
+.c13.fi-button--inverted[disabled],
+.c13.fi-button--inverted:disabled {
   opacity: 0.41;
   background: none;
   background-color: none;
 }
 
-.c14.fi-button--secondary {
+.c13.fi-button--secondary {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -3127,18 +3127,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   text-shadow: none;
 }
 
-.c14.fi-button--secondary:hover {
+.c13.fi-button--secondary:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c14.fi-button--secondary:active {
+.c13.fi-button--secondary:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c14.fi-button--secondary.fi-button--disabled,
-.c14.fi-button--secondary[disabled],
-.c14.fi-button--secondary:disabled {
+.c13.fi-button--secondary.fi-button--disabled,
+.c13.fi-button--secondary[disabled],
+.c13.fi-button--secondary:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3146,7 +3146,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c14.fi-button--secondary-noborder {
+.c13.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -3156,18 +3156,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   background-color: transparent;
 }
 
-.c14.fi-button--secondary-noborder:hover {
+.c13.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c14.fi-button--secondary-noborder:active {
+.c13.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c14.fi-button--secondary-noborder.fi-button--disabled,
-.c14.fi-button--secondary-noborder[disabled],
-.c14.fi-button--secondary-noborder:disabled {
+.c13.fi-button--secondary-noborder.fi-button--disabled,
+.c13.fi-button--secondary-noborder[disabled],
+.c13.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3175,7 +3175,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c14.fi-button--link {
+.c13.fi-button--link {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -3186,18 +3186,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border: none;
 }
 
-.c14.fi-button--link:hover {
+.c13.fi-button--link:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c14.fi-button--link:active {
+.c13.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c14.fi-button--link.fi-button--disabled,
-.c14.fi-button--link[disabled],
-.c14.fi-button--link:disabled {
+.c13.fi-button--link.fi-button--disabled,
+.c13.fi-button--link[disabled],
+.c13.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3205,23 +3205,23 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c14.fi-button--link:hover {
+.c13.fi-button--link:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c14.fi-button--link:active {
+.c13.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c14.fi-button--link.fi-button--disabled,
-.c14.fi-button--link[disabled],
-.c14.fi-button--link:disabled {
+.c13.fi-button--link.fi-button--disabled,
+.c13.fi-button--link[disabled],
+.c13.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
 }
 
-.c14 > .fi-button_icon {
+.c13 > .fi-button_icon {
   width: 16px;
   height: 16px;
   margin-right: 8px;
@@ -3231,12 +3231,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   transform: translateY(-0.1em);
 }
 
-.c14 > .fi-button_icon.fi-button_icon--right {
+.c13 > .fi-button_icon.fi-button_icon--right {
   margin-right: 0;
   margin-left: 8px;
 }
 
-.c14.fi-button--disabled > .fi-button_icon {
+.c13.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
 
@@ -3252,40 +3252,40 @@ exports[`snapshots match date input with datepicker with controlled input value 
   overflow: hidden;
 }
 
-.c16.fi-month-day {
+.c15.fi-month-day {
   padding: 1px;
   text-align: center;
   min-width: 36px;
   height: 38px;
 }
 
-.c16.fi-month-day--disabled {
+.c15.fi-month-day--disabled {
   color: hsl(202,7%,67%);
 }
 
-.c16 .fi-month-day_current {
+.c15 .fi-month-day_current {
   margin: 0 6px;
   padding: 3px 0;
   border-bottom: 1px solid hsl(202,7%,67%);
   text-align: center;
 }
 
-.c16 .fi-month-day_button_current {
+.c15 .fi-month-day_button_current {
   margin: 0 6px;
   padding: 3px 0;
   border-bottom: 1px solid hsl(0,0%,13%);
   text-align: center;
 }
 
-.c16 .fi-month-day_button--disabled {
+.c15 .fi-month-day_button--disabled {
   color: hsl(202,7%,67%);
 }
 
-.c16 .fi-month-day_button--disabled .fi-month-day_button_current {
+.c15 .fi-month-day_button--disabled .fi-month-day_button_current {
   border-bottom: 1px solid hsl(202,7%,67%);
 }
 
-.c16 .fi-month-day_button {
+.c15 .fi-month-day_button {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3306,13 +3306,13 @@ exports[`snapshots match date input with datepicker with controlled input value 
   text-align: center;
 }
 
-.c16 .fi-month-day_button:focus {
+.c15 .fi-month-day_button:focus {
   box-shadow: none;
   position: relative;
   outline: 3px solid transparent;
 }
 
-.c16 .fi-month-day_button:focus:after {
+.c15 .fi-month-day_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3328,16 +3328,16 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c16 .fi-month-day_button:not(.fi-month-day_button--disabled):hover {
+.c15 .fi-month-day_button:not(.fi-month-day_button--disabled):hover {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c16 .fi-month-day_button:not(.fi-month-day_button--disabled):hover .fi-month-day_button_current {
+.c15 .fi-month-day_button:not(.fi-month-day_button--disabled):hover .fi-month-day_button_current {
   border-bottom: 1px solid hsl(0,0%,100%);
 }
 
-.c16 .fi-month-day_button--selected {
+.c15 .fi-month-day_button--selected {
   border: 1px solid hsl(212,63%,45%);
   background-color: hsl(212,63%,95%);
   -webkit-text-decoration: none;
@@ -3345,12 +3345,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   font-weight: 600;
 }
 
-.c16 .fi-month-day_button--selected:focus {
+.c15 .fi-month-day_button--selected:focus {
   box-shadow: none;
   position: relative;
 }
 
-.c16 .fi-month-day_button--selected:focus:after {
+.c15 .fi-month-day_button--selected:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3366,11 +3366,11 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c16 .fi-month-day_button--selected:hover {
+.c15 .fi-month-day_button--selected:hover {
   font-weight: 400;
 }
 
-.c15.fi-month-table {
+.c14.fi-month-table {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3388,7 +3388,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin-bottom: 10px;
 }
 
-.c15 .fi-month-table_thead-cell {
+.c14 .fi-month-table_thead-cell {
   padding: 1px;
   text-align: center;
   min-width: 36px;
@@ -3425,6 +3425,10 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin-left: 6px;
 }
 
+.c12 .fi-dropdown_item-list {
+  padding-top: 0;
+}
+
 .c12.fi-dropdown {
   display: inline-block;
 }
@@ -3433,7 +3437,11 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin-bottom: 10px;
 }
 
-.c12 [data-reach-listbox-button].fi-dropdown_button {
+.c12.fi-dropdown .fi-dropdown_input-wrapper {
+  height: 40px;
+}
+
+.c12.fi-dropdown .fi-dropdown_button {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -3458,7 +3466,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   display: inline-block;
   word-break: break-word;
   overflow-wrap: break-word;
-  min-height: 22px;
+  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201,7%,58%);
   text-align: left;
@@ -3466,14 +3474,38 @@ exports[`snapshots match date input with datepicker with controlled input value 
   background-color: hsl(0,0%,100%);
   box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
-.c12 [data-reach-listbox-button].fi-dropdown_button:focus {
+.c12.fi-dropdown .fi-dropdown_button:focus-visible {
+  outline: none;
+}
+
+.c12.fi-dropdown .fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(0,0%,13%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c12.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(0,0%,13%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
   outline: 0;
   position: relative;
 }
 
-.c12 [data-reach-listbox-button].fi-dropdown_button:focus:after {
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -3489,34 +3521,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c12 [data-reach-listbox-button].fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(201,7%,58%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c12 [data-reach-listbox-button].fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(201,7%,58%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c12 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  cursor: not-allowed;
-}
-
-.c12 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c12[data-reach-listbox-popover].fi-dropdown_popover {
+.c12.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -3537,66 +3542,31 @@ exports[`snapshots match date input with datepicker with controlled input value 
   overflow-x: hidden;
 }
 
-.c12[data-reach-listbox-popover].fi-dropdown_popover:focus-within {
+.c12.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
 }
 
-.c12.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-  background-color: hsl(0,0%,100%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
+.c12.fi-dropdown--disabled .fi-dropdown_input-wrapper {
+  cursor: not-allowed;
 }
 
-.c12.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
+.c12.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  pointer-events: none;
 }
 
-.c12 [data-reach-listbox-list] {
-  border: 0;
-  padding: 0;
-  margin: 0;
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: break-word;
+.c12.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
 }
 
-.c13[data-reach-listbox-option].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  cursor: pointer;
-  line-height: 1.5;
-  padding: 8px;
-  border: 0;
-}
-
-.c13[data-reach-listbox-option].fi-dropdown_item:focus {
-  outline: 0;
-}
-
-.c13[data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
-}
-
-.c13[data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
+.c12.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
 }
 
 .c11 .fi-date-selectors_container {
@@ -3612,7 +3582,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 }
 
 .c11 .fi-date-selectors_year-select .fi-dropdown_button {
-  min-width: 33px;
+  min-width: 60px;
 }
 
 .c11 .fi-date-selectors_month-select {
@@ -3621,7 +3591,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 }
 
 .c11 .fi-date-selectors_month-select .fi-dropdown_button {
-  min-width: 78px;
+  min-width: 125px;
 }
 
 .c11 .fi-date-selectors_month-button {
@@ -4167,250 +4137,23 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </label>
             </div>
             <div
-              data-reach-listbox-input=""
-              data-state="closed"
-              data-value="2020"
-              id="listbox-input--15"
+              class="c0 fi-dropdown_input-wrapper"
             >
               <span
+                aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-labelledby="16-label button--listbox-input--15"
-                class="fi-dropdown_button"
-                data-reach-listbox-button=""
-                id="button--listbox-input--15"
+                aria-owns="16-popover"
+                class="c2 fi-dropdown_button"
+                id="16_button"
                 role="button"
                 tabindex="0"
-              >
-                2020
-              </span>
-              <div
-                class="c12 fi-date-selectors_year-select fi-dropdown_popover"
-                data-reach-listbox-popover=""
-                hidden=""
+              />
+              <input
+                class="c5"
                 tabindex="-1"
-              >
-                <ul
-                  aria-activedescendant="option-2020--listbox-input--15"
-                  aria-labelledby="16-label"
-                  data-reach-listbox-list=""
-                  id="listbox--listbox-input--15"
-                  role="listbox"
-                  tabindex="-1"
-                >
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2010"
-                    data-reach-listbox-option=""
-                    data-value="2010"
-                    id="option-2010--listbox-input--15"
-                    role="option"
-                  >
-                    2010
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2011"
-                    data-reach-listbox-option=""
-                    data-value="2011"
-                    id="option-2011--listbox-input--15"
-                    role="option"
-                  >
-                    2011
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2012"
-                    data-reach-listbox-option=""
-                    data-value="2012"
-                    id="option-2012--listbox-input--15"
-                    role="option"
-                  >
-                    2012
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2013"
-                    data-reach-listbox-option=""
-                    data-value="2013"
-                    id="option-2013--listbox-input--15"
-                    role="option"
-                  >
-                    2013
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2014"
-                    data-reach-listbox-option=""
-                    data-value="2014"
-                    id="option-2014--listbox-input--15"
-                    role="option"
-                  >
-                    2014
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2015"
-                    data-reach-listbox-option=""
-                    data-value="2015"
-                    id="option-2015--listbox-input--15"
-                    role="option"
-                  >
-                    2015
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2016"
-                    data-reach-listbox-option=""
-                    data-value="2016"
-                    id="option-2016--listbox-input--15"
-                    role="option"
-                  >
-                    2016
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2017"
-                    data-reach-listbox-option=""
-                    data-value="2017"
-                    id="option-2017--listbox-input--15"
-                    role="option"
-                  >
-                    2017
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2018"
-                    data-reach-listbox-option=""
-                    data-value="2018"
-                    id="option-2018--listbox-input--15"
-                    role="option"
-                  >
-                    2018
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2019"
-                    data-reach-listbox-option=""
-                    data-value="2019"
-                    id="option-2019--listbox-input--15"
-                    role="option"
-                  >
-                    2019
-                  </li>
-                  <li
-                    aria-selected="true"
-                    class="c13 fi-dropdown_item"
-                    data-current-selected=""
-                    data-label="2020"
-                    data-reach-listbox-option=""
-                    data-value="2020"
-                    id="option-2020--listbox-input--15"
-                    role="option"
-                  >
-                    2020
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2021"
-                    data-reach-listbox-option=""
-                    data-value="2021"
-                    id="option-2021--listbox-input--15"
-                    role="option"
-                  >
-                    2021
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2022"
-                    data-reach-listbox-option=""
-                    data-value="2022"
-                    id="option-2022--listbox-input--15"
-                    role="option"
-                  >
-                    2022
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2023"
-                    data-reach-listbox-option=""
-                    data-value="2023"
-                    id="option-2023--listbox-input--15"
-                    role="option"
-                  >
-                    2023
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2024"
-                    data-reach-listbox-option=""
-                    data-value="2024"
-                    id="option-2024--listbox-input--15"
-                    role="option"
-                  >
-                    2024
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2025"
-                    data-reach-listbox-option=""
-                    data-value="2025"
-                    id="option-2025--listbox-input--15"
-                    role="option"
-                  >
-                    2025
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2026"
-                    data-reach-listbox-option=""
-                    data-value="2026"
-                    id="option-2026--listbox-input--15"
-                    role="option"
-                  >
-                    2026
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2027"
-                    data-reach-listbox-option=""
-                    data-value="2027"
-                    id="option-2027--listbox-input--15"
-                    role="option"
-                  >
-                    2027
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2028"
-                    data-reach-listbox-option=""
-                    data-value="2028"
-                    id="option-2028--listbox-input--15"
-                    role="option"
-                  >
-                    2028
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2029"
-                    data-reach-listbox-option=""
-                    data-value="2029"
-                    id="option-2029--listbox-input--15"
-                    role="option"
-                  >
-                    2029
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="2030"
-                    data-reach-listbox-option=""
-                    data-value="2030"
-                    id="option-2030--listbox-input--15"
-                    role="option"
-                  >
-                    2030
-                  </li>
-                </ul>
-              </div>
+                type="hidden"
+                value="2020"
+              />
             </div>
           </div>
         </span>
@@ -4433,167 +4176,30 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </label>
             </div>
             <div
-              data-reach-listbox-input=""
-              data-state="closed"
-              data-value="0"
-              id="listbox-input--16"
+              class="c0 fi-dropdown_input-wrapper"
             >
               <span
+                aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-labelledby="17-label button--listbox-input--16"
-                class="fi-dropdown_button"
-                data-reach-listbox-button=""
-                id="button--listbox-input--16"
+                aria-owns="17-popover"
+                class="c2 fi-dropdown_button"
+                id="17_button"
                 role="button"
                 tabindex="0"
-              >
-                Tammikuu
-              </span>
-              <div
-                class="c12 fi-date-selectors_month-select fi-dropdown_popover"
-                data-reach-listbox-popover=""
-                hidden=""
+              />
+              <input
+                class="c5"
                 tabindex="-1"
-              >
-                <ul
-                  aria-activedescendant="option-0--listbox-input--16"
-                  aria-labelledby="17-label"
-                  data-reach-listbox-list=""
-                  id="listbox--listbox-input--16"
-                  role="listbox"
-                  tabindex="-1"
-                >
-                  <li
-                    aria-selected="true"
-                    class="c13 fi-dropdown_item"
-                    data-current-selected=""
-                    data-label="Tammikuu"
-                    data-reach-listbox-option=""
-                    data-value="0"
-                    id="option-0--listbox-input--16"
-                    role="option"
-                  >
-                    Tammikuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Helmikuu"
-                    data-reach-listbox-option=""
-                    data-value="1"
-                    id="option-1--listbox-input--16"
-                    role="option"
-                  >
-                    Helmikuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Maaliskuu"
-                    data-reach-listbox-option=""
-                    data-value="2"
-                    id="option-2--listbox-input--16"
-                    role="option"
-                  >
-                    Maaliskuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Huhtikuu"
-                    data-reach-listbox-option=""
-                    data-value="3"
-                    id="option-3--listbox-input--16"
-                    role="option"
-                  >
-                    Huhtikuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Toukokuu"
-                    data-reach-listbox-option=""
-                    data-value="4"
-                    id="option-4--listbox-input--16"
-                    role="option"
-                  >
-                    Toukokuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Kesäkuu"
-                    data-reach-listbox-option=""
-                    data-value="5"
-                    id="option-5--listbox-input--16"
-                    role="option"
-                  >
-                    Kesäkuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Heinäkuu"
-                    data-reach-listbox-option=""
-                    data-value="6"
-                    id="option-6--listbox-input--16"
-                    role="option"
-                  >
-                    Heinäkuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Elokuu"
-                    data-reach-listbox-option=""
-                    data-value="7"
-                    id="option-7--listbox-input--16"
-                    role="option"
-                  >
-                    Elokuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Syyskuu"
-                    data-reach-listbox-option=""
-                    data-value="8"
-                    id="option-8--listbox-input--16"
-                    role="option"
-                  >
-                    Syyskuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Lokakuu"
-                    data-reach-listbox-option=""
-                    data-value="9"
-                    id="option-9--listbox-input--16"
-                    role="option"
-                  >
-                    Lokakuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Marraskuu"
-                    data-reach-listbox-option=""
-                    data-value="10"
-                    id="option-10--listbox-input--16"
-                    role="option"
-                  >
-                    Marraskuu
-                  </li>
-                  <li
-                    class="c13 fi-dropdown_item"
-                    data-label="Joulukuu"
-                    data-reach-listbox-option=""
-                    data-value="11"
-                    id="option-11--listbox-input--16"
-                    role="option"
-                  >
-                    Joulukuu
-                  </li>
-                </ul>
-              </div>
+                type="hidden"
+                value="0"
+              />
             </div>
           </div>
         </span>
         <button
           aria-disabled="false"
           aria-label="Edellinen kuukausi Joulukuu"
-          class="c6 fi-button c14 fi-date-selectors_month-button fi-button--secondary-noborder"
+          class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
           tabindex="0"
           type="button"
         >
@@ -4617,7 +4223,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         <button
           aria-disabled="false"
           aria-label="Seuraava kuukausi Helmikuu"
-          class="c6 fi-button c14 fi-date-selectors_month-button fi-button--secondary-noborder"
+          class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
           tabindex="0"
           type="button"
         >
@@ -4640,7 +4246,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         </button>
       </div>
       <table
-        class="c15 fi-month-table"
+        class="c14 fi-month-table"
         role="presentation"
       >
         <thead>
@@ -4685,17 +4291,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
         <tbody>
           <tr>
             <td
-              class="c16 fi-month-day fi-month-day--disabled"
+              class="c15 fi-month-day fi-month-day--disabled"
             >
               30
             </td>
             <td
-              class="c16 fi-month-day fi-month-day--disabled"
+              class="c15 fi-month-day fi-month-day--disabled"
             >
               31
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-current="date"
@@ -4721,7 +4327,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4742,7 +4348,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4763,7 +4369,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4784,7 +4390,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4807,7 +4413,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4828,7 +4434,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4849,7 +4455,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4870,7 +4476,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4891,7 +4497,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4912,7 +4518,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4933,7 +4539,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4956,7 +4562,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4977,7 +4583,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -4998,7 +4604,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5018,7 +4624,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5039,7 +4645,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5060,7 +4666,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5081,7 +4687,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5104,7 +4710,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5125,7 +4731,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5146,7 +4752,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5167,7 +4773,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5188,7 +4794,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5209,7 +4815,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5230,7 +4836,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5253,7 +4859,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           </tr>
           <tr>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5274,7 +4880,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5295,7 +4901,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5316,7 +4922,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5337,7 +4943,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day"
+              class="c15 fi-month-day"
             >
               <button
                 aria-disabled="false"
@@ -5358,12 +4964,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
               </button>
             </td>
             <td
-              class="c16 fi-month-day fi-month-day--disabled"
+              class="c15 fi-month-day fi-month-day--disabled"
             >
               1
             </td>
             <td
-              class="c16 fi-month-day fi-month-day--disabled"
+              class="c15 fi-month-day fi-month-day--disabled"
             >
               2
             </td>
@@ -5375,7 +4981,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
       >
         <button
           aria-disabled="false"
-          class="c6 fi-button c14 fi-date-picker_bottom-button"
+          class="c6 fi-button c13 fi-date-picker_bottom-button"
           tabindex="0"
           type="button"
         >
@@ -5383,7 +4989,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         </button>
         <button
           aria-disabled="false"
-          class="c6 fi-button c14 fi-date-picker_bottom-button fi-button--secondary"
+          class="c6 fi-button c13 fi-date-picker_bottom-button fi-button--secondary"
           tabindex="0"
           type="button"
         >
@@ -5598,7 +5204,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   cursor: inherit;
 }
 
-.c14 {
+.c13 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -5625,12 +5231,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   cursor: pointer;
 }
 
-.c14:focus {
+.c13:focus {
   outline: none;
   position: relative;
 }
 
-.c14:focus::after {
+.c13:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -5646,17 +5252,17 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   z-index: 9999;
 }
 
-.c14:hover {
+.c13:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
 }
 
-.c14:active {
+.c13:active {
   background: hsl(212,63%,37%);
 }
 
-.c14.fi-button--disabled,
-.c14[disabled],
-.c14:disabled {
+.c13.fi-button--disabled,
+.c13[disabled],
+.c13:disabled {
   text-shadow: 0 1px 1px rgba(33,33,33,0.5);
   background: linear-gradient(0deg,hsl(202,7%,67%) 0%,hsl(202,7%,80%) 100%);
   -webkit-user-select: none;
@@ -5666,41 +5272,41 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   cursor: not-allowed;
 }
 
-.c14.fi-button--disabled::after {
+.c13.fi-button--disabled::after {
   border: none;
   box-shadow: none;
 }
 
-.c14.fi-button--fullwidth {
+.c13.fi-button--fullwidth {
   display: block;
   width: 100%;
 }
 
-.c14.fi-button--inverted {
+.c13.fi-button--inverted {
   background: none;
   background-color: hsl(212,63%,45%);
   border: 1px solid hsl(0,0%,100%);
   text-shadow: none;
 }
 
-.c14.fi-button--inverted:hover {
+.c13.fi-button--inverted:hover {
   background: linear-gradient(-180deg,hsla(0,0%,100%,0.1) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c14.fi-button--inverted:active {
+.c13.fi-button--inverted:active {
   background: none;
   background-color: hsl(212,63%,45%);
 }
 
-.c14.fi-button--inverted.fi-button--disabled,
-.c14.fi-button--inverted[disabled],
-.c14.fi-button--inverted:disabled {
+.c13.fi-button--inverted.fi-button--disabled,
+.c13.fi-button--inverted[disabled],
+.c13.fi-button--inverted:disabled {
   opacity: 0.41;
   background: none;
   background-color: none;
 }
 
-.c14.fi-button--secondary {
+.c13.fi-button--secondary {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -5708,18 +5314,18 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   text-shadow: none;
 }
 
-.c14.fi-button--secondary:hover {
+.c13.fi-button--secondary:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c14.fi-button--secondary:active {
+.c13.fi-button--secondary:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c14.fi-button--secondary.fi-button--disabled,
-.c14.fi-button--secondary[disabled],
-.c14.fi-button--secondary:disabled {
+.c13.fi-button--secondary.fi-button--disabled,
+.c13.fi-button--secondary[disabled],
+.c13.fi-button--secondary:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -5727,7 +5333,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c14.fi-button--secondary-noborder {
+.c13.fi-button--secondary-noborder {
   color: hsl(212,63%,45%);
   background: none;
   background-color: hsl(0,0%,100%);
@@ -5737,18 +5343,18 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   background-color: transparent;
 }
 
-.c14.fi-button--secondary-noborder:hover {
+.c13.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c14.fi-button--secondary-noborder:active {
+.c13.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c14.fi-button--secondary-noborder.fi-button--disabled,
-.c14.fi-button--secondary-noborder[disabled],
-.c14.fi-button--secondary-noborder:disabled {
+.c13.fi-button--secondary-noborder.fi-button--disabled,
+.c13.fi-button--secondary-noborder[disabled],
+.c13.fi-button--secondary-noborder:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -5756,7 +5362,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c14.fi-button--link {
+.c13.fi-button--link {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -5767,18 +5373,18 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border: none;
 }
 
-.c14.fi-button--link:hover {
+.c13.fi-button--link:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c14.fi-button--link:active {
+.c13.fi-button--link:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c14.fi-button--link.fi-button--disabled,
-.c14.fi-button--link[disabled],
-.c14.fi-button--link:disabled {
+.c13.fi-button--link.fi-button--disabled,
+.c13.fi-button--link[disabled],
+.c13.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -5786,23 +5392,23 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c14.fi-button--link:hover {
+.c13.fi-button--link:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c14.fi-button--link:active {
+.c13.fi-button--link:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c14.fi-button--link.fi-button--disabled,
-.c14.fi-button--link[disabled],
-.c14.fi-button--link:disabled {
+.c13.fi-button--link.fi-button--disabled,
+.c13.fi-button--link[disabled],
+.c13.fi-button--link:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
 }
 
-.c14 > .fi-button_icon {
+.c13 > .fi-button_icon {
   width: 16px;
   height: 16px;
   margin-right: 8px;
@@ -5812,12 +5418,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   transform: translateY(-0.1em);
 }
 
-.c14 > .fi-button_icon.fi-button_icon--right {
+.c13 > .fi-button_icon.fi-button_icon--right {
   margin-right: 0;
   margin-left: 8px;
 }
 
-.c14.fi-button--disabled > .fi-button_icon {
+.c13.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
 
@@ -5833,40 +5439,40 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   overflow: hidden;
 }
 
-.c16.fi-month-day {
+.c15.fi-month-day {
   padding: 1px;
   text-align: center;
   min-width: 36px;
   height: 38px;
 }
 
-.c16.fi-month-day--disabled {
+.c15.fi-month-day--disabled {
   color: hsl(202,7%,67%);
 }
 
-.c16 .fi-month-day_current {
+.c15 .fi-month-day_current {
   margin: 0 6px;
   padding: 3px 0;
   border-bottom: 1px solid hsl(202,7%,67%);
   text-align: center;
 }
 
-.c16 .fi-month-day_button_current {
+.c15 .fi-month-day_button_current {
   margin: 0 6px;
   padding: 3px 0;
   border-bottom: 1px solid hsl(0,0%,13%);
   text-align: center;
 }
 
-.c16 .fi-month-day_button--disabled {
+.c15 .fi-month-day_button--disabled {
   color: hsl(202,7%,67%);
 }
 
-.c16 .fi-month-day_button--disabled .fi-month-day_button_current {
+.c15 .fi-month-day_button--disabled .fi-month-day_button_current {
   border-bottom: 1px solid hsl(202,7%,67%);
 }
 
-.c16 .fi-month-day_button {
+.c15 .fi-month-day_button {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -5887,13 +5493,13 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   text-align: center;
 }
 
-.c16 .fi-month-day_button:focus {
+.c15 .fi-month-day_button:focus {
   box-shadow: none;
   position: relative;
   outline: 3px solid transparent;
 }
 
-.c16 .fi-month-day_button:focus:after {
+.c15 .fi-month-day_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -5909,16 +5515,16 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   z-index: 9999;
 }
 
-.c16 .fi-month-day_button:not(.fi-month-day_button--disabled):hover {
+.c15 .fi-month-day_button:not(.fi-month-day_button--disabled):hover {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c16 .fi-month-day_button:not(.fi-month-day_button--disabled):hover .fi-month-day_button_current {
+.c15 .fi-month-day_button:not(.fi-month-day_button--disabled):hover .fi-month-day_button_current {
   border-bottom: 1px solid hsl(0,0%,100%);
 }
 
-.c16 .fi-month-day_button--selected {
+.c15 .fi-month-day_button--selected {
   border: 1px solid hsl(212,63%,45%);
   background-color: hsl(212,63%,95%);
   -webkit-text-decoration: none;
@@ -5926,12 +5532,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   font-weight: 600;
 }
 
-.c16 .fi-month-day_button--selected:focus {
+.c15 .fi-month-day_button--selected:focus {
   box-shadow: none;
   position: relative;
 }
 
-.c16 .fi-month-day_button--selected:focus:after {
+.c15 .fi-month-day_button--selected:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -5947,11 +5553,11 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   z-index: 9999;
 }
 
-.c16 .fi-month-day_button--selected:hover {
+.c15 .fi-month-day_button--selected:hover {
   font-weight: 400;
 }
 
-.c15.fi-month-table {
+.c14.fi-month-table {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -5969,7 +5575,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   margin-bottom: 10px;
 }
 
-.c15 .fi-month-table_thead-cell {
+.c14 .fi-month-table_thead-cell {
   padding: 1px;
   text-align: center;
   min-width: 36px;
@@ -6006,6 +5612,10 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   margin-left: 6px;
 }
 
+.c12 .fi-dropdown_item-list {
+  padding-top: 0;
+}
+
 .c12.fi-dropdown {
   display: inline-block;
 }
@@ -6014,7 +5624,11 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   margin-bottom: 10px;
 }
 
-.c12 [data-reach-listbox-button].fi-dropdown_button {
+.c12.fi-dropdown .fi-dropdown_input-wrapper {
+  height: 40px;
+}
+
+.c12.fi-dropdown .fi-dropdown_button {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -6039,7 +5653,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   display: inline-block;
   word-break: break-word;
   overflow-wrap: break-word;
-  min-height: 22px;
+  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201,7%,58%);
   text-align: left;
@@ -6047,14 +5661,38 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   background-color: hsl(0,0%,100%);
   box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
-.c12 [data-reach-listbox-button].fi-dropdown_button:focus {
+.c12.fi-dropdown .fi-dropdown_button:focus-visible {
+  outline: none;
+}
+
+.c12.fi-dropdown .fi-dropdown_button:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  margin-top: -3px;
+  border-style: solid;
+  border-color: hsl(0,0%,13%) transparent transparent transparent;
+  border-width: 6px 4px 0 4px;
+}
+
+.c12.fi-dropdown .fi-dropdown_button[aria-expanded='true']:before {
+  border-color: transparent transparent hsl(0,0%,13%) transparent;
+  border-width: 0 4px 6px 4px;
+}
+
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus {
   outline: 0;
   position: relative;
 }
 
-.c12 [data-reach-listbox-button].fi-dropdown_button:focus:after {
+.c12.fi-dropdown:not(.fi-dropdown--open) .fi-dropdown_button:focus:after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -6070,34 +5708,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   z-index: 9999;
 }
 
-.c12 [data-reach-listbox-button].fi-dropdown_button:before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  margin-top: -3px;
-  border-style: solid;
-  border-color: hsl(201,7%,58%) transparent transparent transparent;
-  border-width: 6px 4px 0 4px;
-}
-
-.c12 [data-reach-listbox-button].fi-dropdown_button[aria-expanded='true']:before {
-  border-color: transparent transparent hsl(201,7%,58%) transparent;
-  border-width: 0 4px 6px 4px;
-}
-
-.c12 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled {
-  background-color: hsl(202,7%,97%);
-  color: hsl(202,7%,67%);
-  opacity: 1;
-  cursor: not-allowed;
-}
-
-.c12 [data-reach-listbox-button].fi-dropdown_button.fi-dropdown--disabled:before {
-  border-color: hsl(202,7%,67%) transparent transparent transparent;
-}
-
-.c12[data-reach-listbox-popover].fi-dropdown_popover {
+.c12.fi-dropdown .fi-dropdown_popover {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -6118,66 +5729,31 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   overflow-x: hidden;
 }
 
-.c12[data-reach-listbox-popover].fi-dropdown_popover:focus-within {
+.c12.fi-dropdown .fi-dropdown_popover:focus-within {
   outline: 0;
   box-shadow: none;
 }
 
-.c12.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-  background-color: hsl(0,0%,100%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
+.c12.fi-dropdown--disabled .fi-dropdown_input-wrapper {
+  cursor: not-allowed;
 }
 
-.c12.fi-dropdown--noSelectedStyles [data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
+.c12.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button {
+  background-color: hsl(202,7%,97%);
+  color: hsl(202,7%,67%);
+  opacity: 1;
+  pointer-events: none;
 }
 
-.c12 [data-reach-listbox-list] {
-  border: 0;
-  padding: 0;
-  margin: 0;
-  white-space: normal;
-  word-break: break-word;
-  overflow-wrap: break-word;
+.c12.fi-dropdown--disabled .fi-dropdown_input-wrapper .fi-dropdown_button:before {
+  border-color: hsl(202,7%,67%) transparent transparent transparent;
 }
 
-.c13[data-reach-listbox-option].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-  cursor: pointer;
-  line-height: 1.5;
-  padding: 8px;
-  border: 0;
-}
-
-.c13[data-reach-listbox-option].fi-dropdown_item:focus {
-  outline: 0;
-}
-
-.c13[data-reach-listbox-option][data-current-selected].fi-dropdown_item {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
-}
-
-.c13[data-reach-listbox-option][data-current-nav].fi-dropdown_item {
-  color: hsl(0,0%,13%);
-  background-image: none;
-  background-color: hsl(212,63%,95%);
-  border: 0;
+.c12.fi-dropdown--open .fi-dropdown_button {
+  border-bottom: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  padding-bottom: 8px;
 }
 
 .c11 .fi-date-selectors_container {
@@ -6193,7 +5769,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 }
 
 .c11 .fi-date-selectors_year-select .fi-dropdown_button {
-  min-width: 33px;
+  min-width: 60px;
 }
 
 .c11 .fi-date-selectors_month-select {
@@ -6202,7 +5778,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 }
 
 .c11 .fi-date-selectors_month-select .fi-dropdown_button {
-  min-width: 78px;
+  min-width: 125px;
 }
 
 .c11 .fi-date-selectors_month-button {
@@ -6757,250 +6333,23 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </label>
               </div>
               <div
-                data-reach-listbox-input=""
-                data-state="closed"
-                data-value="2020"
-                id="listbox-input--1"
+                class="c0 fi-dropdown_input-wrapper"
               >
                 <span
+                  aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-labelledby="9-label button--listbox-input--1"
-                  class="fi-dropdown_button"
-                  data-reach-listbox-button=""
-                  id="button--listbox-input--1"
+                  aria-owns="9-popover"
+                  class="c2 fi-dropdown_button"
+                  id="9_button"
                   role="button"
                   tabindex="0"
-                >
-                  2020
-                </span>
-                <div
-                  class="c12 fi-date-selectors_year-select fi-dropdown_popover"
-                  data-reach-listbox-popover=""
-                  hidden=""
+                />
+                <input
+                  class="c5"
                   tabindex="-1"
-                >
-                  <ul
-                    aria-activedescendant="option-2020--listbox-input--1"
-                    aria-labelledby="9-label"
-                    data-reach-listbox-list=""
-                    id="listbox--listbox-input--1"
-                    role="listbox"
-                    tabindex="-1"
-                  >
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2010"
-                      data-reach-listbox-option=""
-                      data-value="2010"
-                      id="option-2010--listbox-input--1"
-                      role="option"
-                    >
-                      2010
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2011"
-                      data-reach-listbox-option=""
-                      data-value="2011"
-                      id="option-2011--listbox-input--1"
-                      role="option"
-                    >
-                      2011
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2012"
-                      data-reach-listbox-option=""
-                      data-value="2012"
-                      id="option-2012--listbox-input--1"
-                      role="option"
-                    >
-                      2012
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2013"
-                      data-reach-listbox-option=""
-                      data-value="2013"
-                      id="option-2013--listbox-input--1"
-                      role="option"
-                    >
-                      2013
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2014"
-                      data-reach-listbox-option=""
-                      data-value="2014"
-                      id="option-2014--listbox-input--1"
-                      role="option"
-                    >
-                      2014
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2015"
-                      data-reach-listbox-option=""
-                      data-value="2015"
-                      id="option-2015--listbox-input--1"
-                      role="option"
-                    >
-                      2015
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2016"
-                      data-reach-listbox-option=""
-                      data-value="2016"
-                      id="option-2016--listbox-input--1"
-                      role="option"
-                    >
-                      2016
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2017"
-                      data-reach-listbox-option=""
-                      data-value="2017"
-                      id="option-2017--listbox-input--1"
-                      role="option"
-                    >
-                      2017
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2018"
-                      data-reach-listbox-option=""
-                      data-value="2018"
-                      id="option-2018--listbox-input--1"
-                      role="option"
-                    >
-                      2018
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2019"
-                      data-reach-listbox-option=""
-                      data-value="2019"
-                      id="option-2019--listbox-input--1"
-                      role="option"
-                    >
-                      2019
-                    </li>
-                    <li
-                      aria-selected="true"
-                      class="c13 fi-dropdown_item"
-                      data-current-selected=""
-                      data-label="2020"
-                      data-reach-listbox-option=""
-                      data-value="2020"
-                      id="option-2020--listbox-input--1"
-                      role="option"
-                    >
-                      2020
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2021"
-                      data-reach-listbox-option=""
-                      data-value="2021"
-                      id="option-2021--listbox-input--1"
-                      role="option"
-                    >
-                      2021
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2022"
-                      data-reach-listbox-option=""
-                      data-value="2022"
-                      id="option-2022--listbox-input--1"
-                      role="option"
-                    >
-                      2022
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2023"
-                      data-reach-listbox-option=""
-                      data-value="2023"
-                      id="option-2023--listbox-input--1"
-                      role="option"
-                    >
-                      2023
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2024"
-                      data-reach-listbox-option=""
-                      data-value="2024"
-                      id="option-2024--listbox-input--1"
-                      role="option"
-                    >
-                      2024
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2025"
-                      data-reach-listbox-option=""
-                      data-value="2025"
-                      id="option-2025--listbox-input--1"
-                      role="option"
-                    >
-                      2025
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2026"
-                      data-reach-listbox-option=""
-                      data-value="2026"
-                      id="option-2026--listbox-input--1"
-                      role="option"
-                    >
-                      2026
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2027"
-                      data-reach-listbox-option=""
-                      data-value="2027"
-                      id="option-2027--listbox-input--1"
-                      role="option"
-                    >
-                      2027
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2028"
-                      data-reach-listbox-option=""
-                      data-value="2028"
-                      id="option-2028--listbox-input--1"
-                      role="option"
-                    >
-                      2028
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2029"
-                      data-reach-listbox-option=""
-                      data-value="2029"
-                      id="option-2029--listbox-input--1"
-                      role="option"
-                    >
-                      2029
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="2030"
-                      data-reach-listbox-option=""
-                      data-value="2030"
-                      id="option-2030--listbox-input--1"
-                      role="option"
-                    >
-                      2030
-                    </li>
-                  </ul>
-                </div>
+                  type="hidden"
+                  value="2020"
+                />
               </div>
             </div>
           </span>
@@ -7023,167 +6372,30 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </label>
               </div>
               <div
-                data-reach-listbox-input=""
-                data-state="closed"
-                data-value="0"
-                id="listbox-input--2"
+                class="c0 fi-dropdown_input-wrapper"
               >
                 <span
+                  aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-labelledby="10-label button--listbox-input--2"
-                  class="fi-dropdown_button"
-                  data-reach-listbox-button=""
-                  id="button--listbox-input--2"
+                  aria-owns="10-popover"
+                  class="c2 fi-dropdown_button"
+                  id="10_button"
                   role="button"
                   tabindex="0"
-                >
-                  Tammikuu
-                </span>
-                <div
-                  class="c12 fi-date-selectors_month-select fi-dropdown_popover"
-                  data-reach-listbox-popover=""
-                  hidden=""
+                />
+                <input
+                  class="c5"
                   tabindex="-1"
-                >
-                  <ul
-                    aria-activedescendant="option-0--listbox-input--2"
-                    aria-labelledby="10-label"
-                    data-reach-listbox-list=""
-                    id="listbox--listbox-input--2"
-                    role="listbox"
-                    tabindex="-1"
-                  >
-                    <li
-                      aria-selected="true"
-                      class="c13 fi-dropdown_item"
-                      data-current-selected=""
-                      data-label="Tammikuu"
-                      data-reach-listbox-option=""
-                      data-value="0"
-                      id="option-0--listbox-input--2"
-                      role="option"
-                    >
-                      Tammikuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Helmikuu"
-                      data-reach-listbox-option=""
-                      data-value="1"
-                      id="option-1--listbox-input--2"
-                      role="option"
-                    >
-                      Helmikuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Maaliskuu"
-                      data-reach-listbox-option=""
-                      data-value="2"
-                      id="option-2--listbox-input--2"
-                      role="option"
-                    >
-                      Maaliskuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Huhtikuu"
-                      data-reach-listbox-option=""
-                      data-value="3"
-                      id="option-3--listbox-input--2"
-                      role="option"
-                    >
-                      Huhtikuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Toukokuu"
-                      data-reach-listbox-option=""
-                      data-value="4"
-                      id="option-4--listbox-input--2"
-                      role="option"
-                    >
-                      Toukokuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Kesäkuu"
-                      data-reach-listbox-option=""
-                      data-value="5"
-                      id="option-5--listbox-input--2"
-                      role="option"
-                    >
-                      Kesäkuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Heinäkuu"
-                      data-reach-listbox-option=""
-                      data-value="6"
-                      id="option-6--listbox-input--2"
-                      role="option"
-                    >
-                      Heinäkuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Elokuu"
-                      data-reach-listbox-option=""
-                      data-value="7"
-                      id="option-7--listbox-input--2"
-                      role="option"
-                    >
-                      Elokuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Syyskuu"
-                      data-reach-listbox-option=""
-                      data-value="8"
-                      id="option-8--listbox-input--2"
-                      role="option"
-                    >
-                      Syyskuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Lokakuu"
-                      data-reach-listbox-option=""
-                      data-value="9"
-                      id="option-9--listbox-input--2"
-                      role="option"
-                    >
-                      Lokakuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Marraskuu"
-                      data-reach-listbox-option=""
-                      data-value="10"
-                      id="option-10--listbox-input--2"
-                      role="option"
-                    >
-                      Marraskuu
-                    </li>
-                    <li
-                      class="c13 fi-dropdown_item"
-                      data-label="Joulukuu"
-                      data-reach-listbox-option=""
-                      data-value="11"
-                      id="option-11--listbox-input--2"
-                      role="option"
-                    >
-                      Joulukuu
-                    </li>
-                  </ul>
-                </div>
+                  type="hidden"
+                  value="0"
+                />
               </div>
             </div>
           </span>
           <button
             aria-disabled="false"
             aria-label="Edellinen kuukausi Joulukuu"
-            class="c6 fi-button c14 fi-date-selectors_month-button fi-button--secondary-noborder"
+            class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
             tabindex="0"
             type="button"
           >
@@ -7207,7 +6419,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
           <button
             aria-disabled="false"
             aria-label="Seuraava kuukausi Helmikuu"
-            class="c6 fi-button c14 fi-date-selectors_month-button fi-button--secondary-noborder"
+            class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
             tabindex="0"
             type="button"
           >
@@ -7230,7 +6442,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
           </button>
         </div>
         <table
-          class="c15 fi-month-table"
+          class="c14 fi-month-table"
           role="presentation"
         >
           <thead>
@@ -7275,17 +6487,17 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
           <tbody>
             <tr>
               <td
-                class="c16 fi-month-day fi-month-day--disabled"
+                class="c15 fi-month-day fi-month-day--disabled"
               >
                 30
               </td>
               <td
-                class="c16 fi-month-day fi-month-day--disabled"
+                class="c15 fi-month-day fi-month-day--disabled"
               >
                 31
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-current="date"
@@ -7311,7 +6523,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7332,7 +6544,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7353,7 +6565,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7374,7 +6586,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7397,7 +6609,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
             </tr>
             <tr>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7418,7 +6630,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7439,7 +6651,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7460,7 +6672,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7481,7 +6693,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7502,7 +6714,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7523,7 +6735,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7546,7 +6758,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
             </tr>
             <tr>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7567,7 +6779,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7588,7 +6800,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7608,7 +6820,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7629,7 +6841,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7650,7 +6862,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7671,7 +6883,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7694,7 +6906,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
             </tr>
             <tr>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7715,7 +6927,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7736,7 +6948,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7757,7 +6969,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7778,7 +6990,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7799,7 +7011,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7820,7 +7032,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7843,7 +7055,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
             </tr>
             <tr>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7864,7 +7076,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7885,7 +7097,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7906,7 +7118,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7927,7 +7139,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day"
+                class="c15 fi-month-day"
               >
                 <button
                   aria-disabled="false"
@@ -7948,12 +7160,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 </button>
               </td>
               <td
-                class="c16 fi-month-day fi-month-day--disabled"
+                class="c15 fi-month-day fi-month-day--disabled"
               >
                 1
               </td>
               <td
-                class="c16 fi-month-day fi-month-day--disabled"
+                class="c15 fi-month-day fi-month-day--disabled"
               >
                 2
               </td>
@@ -7965,7 +7177,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
         >
           <button
             aria-disabled="false"
-            class="c6 fi-button c14 fi-date-picker_bottom-button fi-button--fullwidth"
+            class="c6 fi-button c13 fi-date-picker_bottom-button fi-button--fullwidth"
             tabindex="0"
             type="button"
           >
@@ -7973,7 +7185,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
           </button>
           <button
             aria-disabled="false"
-            class="c6 fi-button c14 fi-date-picker_bottom-button fi-button--secondary fi-button--fullwidth"
+            class="c6 fi-button c13 fi-date-picker_bottom-button fi-button--secondary fi-button--fullwidth"
             tabindex="0"
             type="button"
           >

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
@@ -55,6 +55,12 @@ class BaseSelectItemList extends Component<
     }
   }
 
+  componentDidMount() {
+    if (!!this.props.focusedDescendantId) {
+      this.scrollItemList(this.props.focusedDescendantId);
+    }
+  }
+
   private scrollItemList = (elementId: string) => {
     // 4px reduction to scroll position is required due to container padding.
     const wrapperOffsetPx = 4;

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
@@ -27,6 +27,8 @@ export interface SelectItemListProps {
   focusedDescendantId: string;
   /** onBlur event handler */
   onBlur?: (event: FocusEvent<Element>) => void;
+  /** onKeyDown event handler */
+  onKeyDown?: (event: React.KeyboardEvent<HTMLUListElement>) => void;
   /** Id needed for aria-owns and aria-controls */
   id: string;
 }
@@ -93,6 +95,7 @@ class BaseSelectItemList extends Component<
       forwardedRef,
       children,
       onBlur,
+      onKeyDown,
       id,
       focusedDescendantId,
       ...passProps
@@ -106,6 +109,8 @@ class BaseSelectItemList extends Component<
         {...passProps}
         role="listbox"
         onBlur={onBlur}
+        aria-activedescendant={focusedDescendantId}
+        onKeyDown={onKeyDown}
       >
         <HtmlDivWithRef
           forwardedRef={this.wrapperRef}

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1346,6 +1346,7 @@ exports[`has matching snapshot 1`] = `
       class="c3"
     >
       <ul
+        aria-activedescendant=""
         aria-multiselectable="true"
         class="c15 fi-select-item-list c16"
         id="3-popover"

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -70,11 +70,11 @@ const tools = [
 ];
 
 const defaultSelectedTool = {
-  name: 'Hammer',
-  price: 15,
+  name: 'Rake',
+  price: 50,
   tax: true,
-  labelText: 'Hammer',
-  uniqueItemId: 'h9823523'
+  labelText: 'Rake',
+  uniqueItemId: 'r09282626'
 };
 
 const [selectedValue, setSelectedValue] = React.useState(

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -951,6 +951,7 @@ exports[`has matching snapshot 1`] = `
       class="c3"
     >
       <ul
+        aria-activedescendant=""
         class="c14 fi-select-item-list c15"
         id="2-popover"
         role="listbox"

--- a/src/core/Popover/Popover.tsx
+++ b/src/core/Popover/Popover.tsx
@@ -21,6 +21,11 @@ export interface PopoverProps extends HtmlDivProps {
   allowFlip?: boolean;
   /** Event hanlder for clicks outside the popover element */
   onClickOutside?: (event: MouseEvent) => void;
+  /**
+   * Whether the popper element is rendered in a portal or not
+   * @default true
+   */
+  portal?: boolean;
 }
 
 const sameWidth: any = {
@@ -46,6 +51,7 @@ export const Popover = (props: PopoverProps) => {
     children,
     sourceRef,
     onClickOutside,
+    portal = true,
     ...passProps
   } = props;
 
@@ -91,25 +97,39 @@ export const Popover = (props: PopoverProps) => {
     setMountNode(window.document.body);
   });
 
-  if (!mountNode) {
+  if (portal && !mountNode) {
     return null;
   }
+  if (portal && mountNode) {
+    return (
+      <>
+        {ReactDOM.createPortal(
+          <div
+            className={'fi-portal'}
+            ref={setPopperElement}
+            style={{ ...styles.popper, ...portalStyleProps }}
+            tabIndex={-1}
+            role="presentation"
+          >
+            <HtmlDivWithRef forwardedRef={portalRef} {...passProps}>
+              {children}
+            </HtmlDivWithRef>
+          </div>,
+          mountNode,
+        )}
+      </>
+    );
+  }
   return (
-    <>
-      {ReactDOM.createPortal(
-        <div
-          className={'fi-portal'}
-          ref={setPopperElement}
-          style={{ ...styles.popper, ...portalStyleProps }}
-          tabIndex={-1}
-          role="presentation"
-        >
-          <HtmlDivWithRef forwardedRef={portalRef} {...passProps}>
-            {children}
-          </HtmlDivWithRef>
-        </div>,
-        mountNode,
-      )}
-    </>
+    <div
+      ref={setPopperElement}
+      style={{ ...styles.popper, ...portalStyleProps }}
+      tabIndex={-1}
+      role="presentation"
+    >
+      <HtmlDivWithRef forwardedRef={portalRef} {...passProps}>
+        {children}
+      </HtmlDivWithRef>
+    </div>
   );
 };

--- a/src/reset/HtmlButton/HtmlButton.tsx
+++ b/src/reset/HtmlButton/HtmlButton.tsx
@@ -12,7 +12,7 @@ export interface HtmlButtonProps
    */
   type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
   'data-testid'?: string;
-  forwardedRef?: React.RefObject<HTMLButtonElement>;
+  forwardedRef?: React.Ref<HTMLButtonElement>;
 }
 
 const buttonResets = css`

--- a/src/reset/HtmlLi/HtmlLi.tsx
+++ b/src/reset/HtmlLi/HtmlLi.tsx
@@ -5,6 +5,8 @@ import { asPropType } from '../../utils/typescript';
 
 export interface HtmlLiProps extends Omit<HTMLProps<HTMLLIElement>, 'as'> {
   as?: asPropType;
+  /** Ref for the input element */
+  forwardedRef?: React.Ref<HTMLLIElement>;
 }
 
 const liResets = css`
@@ -13,7 +15,9 @@ const liResets = css`
   display: list-item;
 `;
 
-const Li = (props: HtmlLiProps) => <li {...props} />;
+const Li = ({ forwardedRef, ...passProps }: HtmlLiProps) => (
+  <li ref={forwardedRef} {...passProps} />
+);
 
 export const HtmlLi = styled(Li)`
   ${liResets}

--- a/src/utils/common/common.ts
+++ b/src/utils/common/common.ts
@@ -67,10 +67,10 @@ export const getRecursiveChildText = (reactNode: ReactElement): any => {
   }
   if (typeof children === 'object') {
     // Found direct child
-    return getRecursiveChildText(reactNode.props.children);
+    return getRecursiveChildText(children);
   }
   if (typeof children === 'string' || typeof children === 'number') {
     // Found searchable string
-    return reactNode.props.children;
+    return children;
   }
 };

--- a/src/utils/common/common.ts
+++ b/src/utils/common/common.ts
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, Ref } from 'react';
+import React, { MutableRefObject, ReactElement, Ref } from 'react';
 import { getLogger } from '../../utils/log';
 
 export function windowAvailable() {
@@ -46,3 +46,31 @@ export const forkRefs =
       }
     });
   };
+
+export const getRecursiveChildText = (reactNode: ReactElement): any => {
+  const children = reactNode.props?.children || undefined;
+  if (Array.isArray(reactNode)) {
+    // Multiple children
+    const joinedNodes: Array<ReactElement | string> = [];
+    reactNode.forEach((node) => {
+      if (typeof node === 'object') {
+        joinedNodes.push(getRecursiveChildText(node));
+      } else if (typeof node === 'string') {
+        joinedNodes.push(node);
+      }
+    });
+    return joinedNodes.join(' ');
+  }
+  if (children === undefined) {
+    if (typeof reactNode === 'string') return reactNode;
+    return '';
+  }
+  if (typeof children === 'object') {
+    // Found direct child
+    return getRecursiveChildText(reactNode.props.children);
+  }
+  if (typeof children === 'string' || typeof children === 'number') {
+    // Found searchable string
+    return reactNode.props.children;
+  }
+};

--- a/src/utils/common/common.ts
+++ b/src/utils/common/common.ts
@@ -74,3 +74,15 @@ export const getRecursiveChildText = (reactNode: ReactElement): any => {
     return children;
   }
 };
+
+/**
+ * The following interface allows data-* attributes.
+ * The basic React.HTMLAttributes interface throws errors when trying to do something like
+ * <Component wrapperProps={{ 'data-testid': 'something' }}
+ * Solution copied from: https://github.com/microsoft/TypeScript/issues/28960
+ */
+type DataAttributeKey = `data-${string}`;
+export interface HTMLAttributesIncludingDataAttributes
+  extends React.HTMLAttributes<any> {
+  [dataAttribute: DataAttributeKey]: any;
+}

--- a/src/utils/common/common.ts
+++ b/src/utils/common/common.ts
@@ -79,10 +79,10 @@ export const getRecursiveChildText = (reactNode: ReactElement): any => {
  * The following interface allows data-* attributes.
  * The basic React.HTMLAttributes interface throws errors when trying to do something like
  * <Component wrapperProps={{ 'data-testid': 'something' }}
- * Solution copied from: https://github.com/microsoft/TypeScript/issues/28960
+ * Solution inspired by: https://github.com/microsoft/TypeScript/issues/28960
  */
 type DataAttributeKey = `data-${string}`;
-export interface HTMLAttributesIncludingDataAttributes
-  extends React.HTMLAttributes<any> {
+export interface HTMLAttributesIncludingDataAttributes<T>
+  extends React.HTMLAttributes<T> {
   [dataAttribute: DataAttributeKey]: any;
 }


### PR DESCRIPTION
## Description

This PR introduces a complete rewrite of the `<Dropdown>` component, implementing the component without ReachUI dependencies. 

The API has stayed as similar as possible, but some changes were inevitable. See release notes for changes and additions.

`<DateInput>` uses Dropdown, so some API related as well as minor visual changes had to be made there.  

## Motivation and Context

ReachUI has ceased development and it does not support React 18 anymore. We need to replace Reach stuff with our own code. 

## How Has This Been Tested?

Styleguidist on Mac Chrome, Safari, Firefox. VoiceOver on Mac. CRA with react 18

## Screenshots
![image](https://user-images.githubusercontent.com/17459942/223099011-0d6ebf55-de92-4676-b047-fb8310a56426.png)


## Release notes

### Dropdown
- **Breaking change**: Completely rewrite the component without using ReachUI dependency
    - Remove props `dropdownButtonProps` and `dropdownPopoverProps` (these were provided by Reach)
    - Change ref type from `HtmlDivElement` to `HtmlButtonElement`
    - Add boolean prop `portal` which defaults to true. Controls whether the popover is rendered in a React portal
    - Add props `status`, `statustext` and `hintText`. These are familiar from the library's other form components
    - Add `onBlur()` prop
    - Add boolean prop `fullWidth` which makes the component fill its parent horizontally
    - Add prop `wrapperProps` which accepts `React.HTMLAttributes` and is placed to the outermost div of the component
    - All other props (for example `data-testid`) are now placed to the component's interactive `<button>` element instead of the outermost div
    - Adjust the component's visual appearance so that it is in line with `<SingleSelect>` and `<MultiSelect>`
