### PR TITLE
[Feature] Add border to Alert

### DIFF
--- a/src/core/Alert/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert/Alert.baseStyles.ts
@@ -7,6 +7,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     ${element(theme)}
     ${font(theme)('bodyTextSmall')}
     width: 100%;
+    border: 1px solid;
 
     & .fi-alert_style-wrapper {
       display: flex;
@@ -77,6 +78,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     /** Status variant styles */
     &.fi-alert--neutral {
       background-color: ${theme.colors.accentSecondaryLight1};
+      border-color: ${theme.colors.accentSecondary};
       & .fi-alert_style-wrapper {
         & .fi-alert_icon--neutral {
           & .fi-icon-base-fill {
@@ -88,6 +90,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &.fi-alert--error {
       background-color: ${theme.colors.alertLight1};
+      border-color: ${theme.colors.alertBase};
       & .fi-alert_style-wrapper {
         & .fi-alert_icon--error {
           & .fi-icon-base-fill {
@@ -99,6 +102,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &.fi-alert--warning {
       background-color: ${theme.colors.warningLight1};
+      border-color: ${theme.colors.accentBase};
       & .fi-alert_style-wrapper {
         & .fi-alert_icon--warning {
           & .fi-icon-base-fill {

--- a/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
@@ -152,6 +152,7 @@ exports[`props children should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   width: 100%;
+  border: 1px solid;
 }
 
 .c1.fi-alert .fi-alert_style-wrapper {
@@ -274,6 +275,7 @@ exports[`props children should match snapshot 1`] = `
 
 .c1.fi-alert.fi-alert--neutral {
   background-color: hsl(196,77%,97%);
+  border-color: hsl(196,77%,44%);
 }
 
 .c1.fi-alert.fi-alert--neutral .fi-alert_style-wrapper .fi-alert_icon--neutral .fi-icon-base-fill {
@@ -282,6 +284,7 @@ exports[`props children should match snapshot 1`] = `
 
 .c1.fi-alert.fi-alert--error {
   background-color: hsl(0,59%,96%);
+  border-color: hsl(3,59%,48%);
 }
 
 .c1.fi-alert.fi-alert--error .fi-alert_style-wrapper .fi-alert_icon--error .fi-icon-base-fill {
@@ -290,6 +293,7 @@ exports[`props children should match snapshot 1`] = `
 
 .c1.fi-alert.fi-alert--warning {
   background-color: hsl(42,100%,94%);
+  border-color: hsl(23,82%,51%);
 }
 
 .c1.fi-alert.fi-alert--warning .fi-alert_style-wrapper .fi-alert_icon--warning .fi-icon-base-fill {

--- a/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/Alert/InlineAlert/InlineAlert.baseStyles.ts
@@ -8,8 +8,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     ${font(theme)('bodyTextSmall')}
     width: 100%;
     padding: 5px 0px 4px 0px;
+    border: 1px solid;
     border-left-width: 4px;
-    border-left-style: solid;
 
     & .fi-inline-alert_style-wrapper {
       display: flex;
@@ -45,7 +45,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &.fi-inline-alert--neutral {
       background-color: ${theme.colors.accentSecondaryLight1};
-      border-left-color: ${theme.colors.accentSecondary};
+      border-color: ${theme.colors.accentSecondary};
 
       & .fi-inline-alert_text-content-wrapper {
         padding-left: ${theme.spacing.m};
@@ -54,7 +54,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &.fi-inline-alert--error {
       background-color: ${theme.colors.alertLight1};
-      border-left-color: ${theme.colors.alertBase};
+      border-color: ${theme.colors.alertBase};
 
       & .fi-inline-alert_icon--error {
         & .fi-icon-base-fill {
@@ -65,7 +65,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &.fi-inline-alert--warning {
       background-color: ${theme.colors.warningLight1};
-      border-left-color: ${theme.colors.accentBase};
+      border-color: ${theme.colors.accentBase};
 
       & .fi-inline-alert_icon--warning {
         & .fi-icon-base-fill {

--- a/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
+++ b/src/core/Alert/InlineAlert/__snapshots__/InlineAlert.test.tsx.snap
@@ -76,8 +76,8 @@ exports[`children should match snapshot 1`] = `
   font-weight: 400;
   width: 100%;
   padding: 5px 0px 4px 0px;
+  border: 1px solid;
   border-left-width: 4px;
-  border-left-style: solid;
 }
 
 .c1.fi-inline-alert .fi-inline-alert_style-wrapper {
@@ -149,7 +149,7 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-inline-alert.fi-inline-alert--neutral {
   background-color: hsl(196,77%,97%);
-  border-left-color: hsl(196,77%,44%);
+  border-color: hsl(196,77%,44%);
 }
 
 .c1.fi-inline-alert.fi-inline-alert--neutral .fi-inline-alert_text-content-wrapper {
@@ -158,7 +158,7 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-inline-alert.fi-inline-alert--error {
   background-color: hsl(0,59%,96%);
-  border-left-color: hsl(3,59%,48%);
+  border-color: hsl(3,59%,48%);
 }
 
 .c1.fi-inline-alert.fi-inline-alert--error .fi-inline-alert_icon--error .fi-icon-base-fill {
@@ -167,7 +167,7 @@ exports[`children should match snapshot 1`] = `
 
 .c1.fi-inline-alert.fi-inline-alert--warning {
   background-color: hsl(42,100%,94%);
-  border-left-color: hsl(23,82%,51%);
+  border-color: hsl(23,82%,51%);
 }
 
 .c1.fi-inline-alert.fi-inline-alert--warning .fi-inline-alert_icon--warning .fi-icon-base-fill {


### PR DESCRIPTION
## Description

This PR adds a 1px visual border to `<Alert>` and `<InlineAlert>` in accordance with the recent changes in Figma styleguide.

## Motivation and Context

Make the alert component pop out more from its background

## Screenshots

<img width="471" alt="image" src="https://user-images.githubusercontent.com/17459942/226103427-dd7194ab-bce9-4b06-9810-c8f042661e0f.png">
<img width="468" alt="image" src="https://user-images.githubusercontent.com/17459942/226103433-da531e53-f9a1-4eea-8318-b29eaa277d85.png">


## Release notes

### Alert & InlineAlert
* Add 1px border
