### PR TITLE
[Breaking change] wrapperProps typing

### DIFF
--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -14,10 +14,11 @@ import { AutoId } from '../../utils/AutoId/AutoId';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
+import { getLogger } from '../../../utils/log';
+import { HTMLAttributesIncludingDataAttributes } from '../../../utils/common/common';
 import {
   HtmlInputProps,
   HtmlDiv,
-  HtmlDivProps,
   HtmlSpan,
   HtmlInput,
   HtmlButton,
@@ -47,7 +48,6 @@ import {
   lastDayOfMonth,
   cellDateAriaLabel,
 } from './dateUtils';
-import { getLogger } from '../../../utils/log';
 
 const baseClassName = 'fi-date-input';
 export const dateInputClassNames = {
@@ -158,7 +158,10 @@ export interface DateInputProps
   /** DateInput container div class name for custom styling. */
   className?: string;
   /** DateInput wrapping div element props */
-  wrapperProps?: Omit<HtmlDivProps, 'className'>;
+  wrapperProps?: Omit<
+    HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
+    'className'
+  >;
   /** Disable input usage */
   disabled?: boolean;
   /** Callback fired when input is clicked. */

--- a/src/core/Form/Label/Label.tsx
+++ b/src/core/Form/Label/Label.tsx
@@ -12,13 +12,9 @@ import { default as styled } from 'styled-components';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { baseStyles } from './Label.baseStyles';
 import { asPropType } from '../../../utils/typescript';
+import { HTMLAttributesIncludingDataAttributes } from '../../../utils/common/common';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
-import {
-  HtmlSpan,
-  HtmlSpanProps,
-  HtmlDivProps,
-  HtmlDivWithRef,
-} from '../../../reset';
+import { HtmlSpan, HtmlSpanProps, HtmlDivWithRef } from '../../../reset';
 import { TooltipProps } from '../../Tooltip/Tooltip';
 
 export type LabelMode = 'hidden' | 'visible';
@@ -39,7 +35,10 @@ export interface LabelProps extends Omit<HtmlSpanProps, 'as'> {
    */
   labelMode?: LabelMode;
   /** Props for label wrapper element */
-  wrapperProps?: Omit<HtmlDivProps, 'as' | 'className'>;
+  wrapperProps?: Omit<
+    HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
+    'as' | 'className'
+  >;
   /** Render the wrapping element as another element
    *
    * @default 'label'

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -11,13 +11,13 @@ import classnames from 'classnames';
 import { AutoId } from '../../utils/AutoId/AutoId';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { getConditionalAriaProp } from '../../../utils/aria';
+import { HTMLAttributesIncludingDataAttributes } from '../../../utils/common/common';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import {
   HtmlInput,
   HtmlInputProps,
   HtmlSpan,
   HtmlDiv,
-  HtmlDivProps,
   HtmlButton,
   HtmlButtonProps,
 } from '../../../reset';
@@ -48,7 +48,10 @@ export interface SearchInputProps
   /** SearchInput container div class name for custom styling. */
   className?: string;
   /** SearchInput wrapping div element props */
-  wrapperProps?: Omit<HtmlDivProps, 'className'>;
+  wrapperProps?: Omit<
+    HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
+    'className'
+  >;
   /** Label text */
   labelText: ReactNode;
   /** Hide or show label. Label element is always present, but can be visually hidden.

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -12,13 +12,8 @@ import { AutoId } from '../../utils/AutoId/AutoId';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
-import {
-  HtmlInputProps,
-  HtmlDiv,
-  HtmlDivProps,
-  HtmlSpan,
-  HtmlInput,
-} from '../../../reset';
+import { HTMLAttributesIncludingDataAttributes } from '../../../utils/common/common';
+import { HtmlInputProps, HtmlDiv, HtmlSpan, HtmlInput } from '../../../reset';
 import { Icon, IconProps, BaseIconKeys } from '../../Icon/Icon';
 import { Label, LabelMode } from '../Label/Label';
 import { StatusText } from '../StatusText/StatusText';
@@ -49,7 +44,10 @@ export interface TextInputProps
   /** TextInput container div class name for custom styling. */
   className?: string;
   /** TextInput wrapping div element props */
-  wrapperProps?: Omit<HtmlDivProps, 'className'>;
+  wrapperProps?: Omit<
+    HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
+    'className'
+  >;
   /** Disable input usage */
   disabled?: boolean;
   /** Event handler to execute when clicked */


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

PR fixes typing of wrapperProps in DateInput and TextInput components. 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Fix allows users to add data-attributes in wrapperProps.

## How Has This Been Tested?
 
CRA with TypeScript

## Screenshots (if appropriate):

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### Label, SearchInput, TextInput
- **Breaking change:** `wrapperProps` prop typing is changed to include also data-attributes