### PR TITLE
[Fix] Safari margin issue with CheckboxGroup and RadiobuttonGroup

### DIFF
--- a/src/core/Form/Checkbox/CheckboxGroup.baseStyles.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.baseStyles.tsx
@@ -5,11 +5,15 @@ import { element } from '../../theme/reset';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${element(theme)}
 
-  & .fi-checkbox-group_label--visible {
+  & .fi-checkbox-group_legend {
     margin-bottom: 10px;
+
+    .fi-hint-text {
+      margin-bottom: 0;
+    }
   }
 
-  & .fi-checkbox-group_legend .fi-hint-text {
+  & .fi-checkbox-group_label--with-margin {
     margin-bottom: 10px;
   }
 

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -21,7 +21,7 @@ import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 const baseClassName = 'fi-checkbox-group';
 const checkboxGroupClassNames = {
   legend: `${baseClassName}_legend`,
-  labelIsVisible: `${baseClassName}_label--visible`,
+  labelWithMargin: `${baseClassName}_label--with-margin`,
   container: `${baseClassName}_container`,
   statusTextHasContent: `${baseClassName}_statusText--has-content`,
 };
@@ -105,8 +105,7 @@ class BaseCheckboxGroup extends Component<
               labelMode={labelMode}
               optionalText={optionalText}
               className={classnames({
-                [checkboxGroupClassNames.labelIsVisible]:
-                  labelMode !== 'hidden',
+                [checkboxGroupClassNames.labelWithMargin]: groupHintText,
               })}
               tooltipComponent={tooltipComponent}
             >

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -257,11 +257,15 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c1 .fi-checkbox-group_label--visible {
+.c1 .fi-checkbox-group_legend {
   margin-bottom: 10px;
 }
 
 .c1 .fi-checkbox-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
+.c1 .fi-checkbox-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -425,7 +429,7 @@ exports[`default, with only required props should match snapshot 1`] = `
         class="c3 fi-checkbox-group_legend"
       >
         <div
-          class="c0 c4 fi-checkbox-group_label--visible fi-label"
+          class="c0 c4 fi-label"
         >
           <label
             class="c5 fi-label_label-span"

--- a/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
@@ -7,16 +7,20 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')}
 
   &.fi-radio-button-group {
+    & .fi-radio-button-group_legend {
+      margin-bottom: 10px;
+
+      .fi-hint-text {
+        margin-bottom: 0;
+      }
+    }
+
     & .fi-radio-button-group_label {
       display: block;
       ${theme.typography.bodySemiBoldSmall};
     }
 
-    & .fi-radio-button-group_label--visible {
-      margin-bottom: 10px;
-    }
-
-    & .fi-radio-button-group_legend .fi-hint-text {
+    & .fi-radio-button-group_label--with-margin {
       margin-bottom: 10px;
     }
 

--- a/src/core/Form/RadioButton/RadioButtonGroup.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.tsx
@@ -17,7 +17,7 @@ import classnames from 'classnames';
 const baseClassName = 'fi-radio-button-group';
 const radioButtonGroupClassNames = {
   legend: `${baseClassName}_legend`,
-  labelIsVisible: `${baseClassName}_label--visible`,
+  labelWithMargin: `${baseClassName}_label--with-margin`,
   container: `${baseClassName}_container`,
 };
 
@@ -126,8 +126,7 @@ class BaseRadioButtonGroup extends Component<
               labelMode={labelMode}
               optionalText={optionalText}
               className={classnames({
-                [radioButtonGroupClassNames.labelIsVisible]:
-                  labelMode !== 'hidden',
+                [radioButtonGroupClassNames.labelWithMargin]: groupHintText,
               })}
               tooltipComponent={tooltipComponent}
             >

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -259,6 +259,14 @@ exports[`default, with only required props should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-radio-button-group .fi-radio-button-group_legend {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_label {
   display: block;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -267,11 +275,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+.c1.fi-radio-button-group .fi-radio-button-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -441,7 +445,7 @@ exports[`default, with only required props should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-label"
         >
           <label
             class="c5 fi-label_label-span"
@@ -863,6 +867,14 @@ exports[`props className should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-radio-button-group .fi-radio-button-group_legend {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_label {
   display: block;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -871,11 +883,7 @@ exports[`props className should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+.c1.fi-radio-button-group .fi-radio-button-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -1045,7 +1053,7 @@ exports[`props className should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-label"
         >
           <label
             class="c5 fi-label_label-span"
@@ -1467,6 +1475,14 @@ exports[`props defaultValue should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-radio-button-group .fi-radio-button-group_legend {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_label {
   display: block;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -1475,11 +1491,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+.c1.fi-radio-button-group .fi-radio-button-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -1649,7 +1661,7 @@ exports[`props defaultValue should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-label"
         >
           <label
             class="c5 fi-label_label-span"
@@ -2093,6 +2105,14 @@ exports[`props hintText should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-radio-button-group .fi-radio-button-group_legend {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_label {
   display: block;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -2101,11 +2121,7 @@ exports[`props hintText should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+.c1.fi-radio-button-group .fi-radio-button-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -2275,7 +2291,7 @@ exports[`props hintText should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-radio-button-group_label--with-margin fi-label"
         >
           <label
             class="c5 fi-label_label-span"
@@ -2702,6 +2718,14 @@ exports[`props id should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-radio-button-group .fi-radio-button-group_legend {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_label {
   display: block;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -2710,11 +2734,7 @@ exports[`props id should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+.c1.fi-radio-button-group .fi-radio-button-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -2884,7 +2904,7 @@ exports[`props id should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-label"
         >
           <label
             class="c5 fi-label_label-span"
@@ -3306,6 +3326,14 @@ exports[`props label should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-radio-button-group .fi-radio-button-group_legend {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_label {
   display: block;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -3314,11 +3342,7 @@ exports[`props label should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+.c1.fi-radio-button-group .fi-radio-button-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -3488,7 +3512,7 @@ exports[`props label should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-label"
         >
           <label
             class="c5 fi-label_label-span"
@@ -3922,6 +3946,14 @@ exports[`props labelMode should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-radio-button-group .fi-radio-button-group_legend {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_label {
   display: block;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -3930,11 +3962,7 @@ exports[`props labelMode should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+.c1.fi-radio-button-group .fi-radio-button-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -4526,6 +4554,14 @@ exports[`props name should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-radio-button-group .fi-radio-button-group_legend {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_label {
   display: block;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -4534,11 +4570,7 @@ exports[`props name should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+.c1.fi-radio-button-group .fi-radio-button-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -4708,7 +4740,7 @@ exports[`props name should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-label"
         >
           <label
             class="c5 fi-label_label-span"
@@ -5130,6 +5162,14 @@ exports[`props value should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1.fi-radio-button-group .fi-radio-button-group_legend {
+  margin-bottom: 10px;
+}
+
+.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+  margin-bottom: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_label {
   display: block;
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
@@ -5138,11 +5178,7 @@ exports[`props value should match snapshot 1`] = `
   font-weight: 600;
 }
 
-.c1.fi-radio-button-group .fi-radio-button-group_label--visible {
-  margin-bottom: 10px;
-}
-
-.c1.fi-radio-button-group .fi-radio-button-group_legend .fi-hint-text {
+.c1.fi-radio-button-group .fi-radio-button-group_label--with-margin {
   margin-bottom: 10px;
 }
 
@@ -5313,7 +5349,7 @@ exports[`props value should match snapshot 1`] = `
         class="c3 fi-radio-button-group_legend"
       >
         <div
-          class="c0 c4 fi-radio-button-group_label--visible fi-label"
+          class="c0 c4 fi-label"
         >
           <label
             class="c5 fi-label_label-span"


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description


Fix for margin issues on CheckboxGroup and RadiobuttonGroup.

Reason for this bug is probably that `<legend>` contains `<div>` (that has `<span>` children) element which is against [html specifications](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend)  "Permitted content | Phrasing content and headings (h1–h6 elements)." and Safari messes up the bottom margin of that inner `span`.
Issue is somewhat isolated in this example https://codepen.io/riippi/pen/xxJbYYP  (try with Safari and compare to other browsers).

Removing that div+span structure is currently not feasible so in this PR the margin is removed from span. Instead it's added to div element in question when hintText is present. 

Solution here is a bit complicated and pure CSS fix would be "ideal", but this was the only way to get it working.

## Related Issue

https://jira.dvv.fi/browse/SFIDS-669

## Motivation and Context

Fixes margin issues in Safari so that the components look same in all browsers


## How Has This Been Tested?
Safari + Styleguidist, Firefox, Chrome


## Screenshots (if appropriate):

#### Before:
![Screenshot 2023-03-24 at 9 49 41](https://user-images.githubusercontent.com/14258876/227459582-d4620cc7-e261-4995-9b78-657ebe463ee9.png)
![Screenshot 2023-03-24 at 9 49 49](https://user-images.githubusercontent.com/14258876/227459585-b0b4ebe5-7748-4f9a-b9c5-de3b4d908319.png)
#### After:
![Screenshot 2023-03-24 at 9 51 49](https://user-images.githubusercontent.com/14258876/227459587-dca70fc2-c3c1-43da-b3c1-a8dfcc185ed5.png)
![Screenshot 2023-03-24 at 9 51 55](https://user-images.githubusercontent.com/14258876/227459588-dc7c11a8-de88-452b-9216-672bd78516d0.png)


## Release notes

### CheckboxGroup
* Fix missing margin of the hintText on Safari
### RadioButtonGroup
* Fix missing margin of the hintText on Safari

