### PR TITLE
[Feature] Expander facelift

### DIFF
--- a/src/core/Expander/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander/Expander.baseStyles.tsx
@@ -8,8 +8,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   background-color: ${theme.colors.whiteBase};
   position: relative;
   padding: 0;
+  border: 1px solid ${theme.colors.highlightBase};
   border-radius: ${theme.radiuses.basic};
-  box-shadow: ${theme.shadows.panelShadow};
   width: 100%;
   max-width: 100%;
 

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -159,8 +159,8 @@ exports[`Basic expander shoud match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   position: relative;
   padding: 0;
+  border: 1px solid hsl(212,63%,45%);
   border-radius: 2px;
-  box-shadow: 0 1px 2px 0 hsla(0,0%,13%,0.14),0 1px 5px 0 hsla(0,0%,13%,0.12);
   width: 100%;
   max-width: 100%;
 }
@@ -225,7 +225,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
 }
 
 .c7.fi-expander_content--open:not(.fi-expander_content--no-padding) {
-  padding-top: 0;
+  padding-top: 10px;
   padding-right: 20px;
   padding-bottom: 20px;
   padding-left: 20px;
@@ -265,7 +265,11 @@ exports[`Basic expander shoud match snapshot 1`] = `
   border-radius: inherit;
 }
 
-.c3.fi-expander_title-button {
+.c3:hover {
+  background: linear-gradient(0deg,hsl(215,100%,95%),hsl(215,100%,97%));
+}
+
+.c3 .fi-expander_title-button {
   display: block;
 }
 

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -196,9 +196,6 @@ exports[`Basic expander shoud match snapshot 1`] = `
   height: 0;
   overflow: hidden;
   word-break: break-word;
-  -webkit-transform: scaleY(0);
-  -ms-transform: scaleY(0);
-  transform: scaleY(0);
   -webkit-transform-origin: top;
   -ms-transform-origin: top;
   transform-origin: top;

--- a/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
@@ -13,7 +13,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   height: 0;
   overflow: hidden;
   word-break: break-word;
-  transform: scaleY(0);
   transform-origin: top;
   transition: all ${`${theme.transitions.basicTime}
         ${theme.transitions.basicTimingFunction}`};

--- a/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
@@ -35,7 +35,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     animation: fi-expander_content-anim ${theme.transitions.basicTime}
       ${theme.transitions.basicTimingFunction} 1 forwards;
     &:not(.fi-expander_content--no-padding) {
-      ${padding(theme)('0', 'm', 'm', 'm')}
+      ${padding(theme)('xs', 'm', 'm', 'm')}
     }
   }
   @keyframes fi-expander_content-anim {

--- a/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
+++ b/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
 }
 
 .c1.fi-expander_content--open:not(.fi-expander_content--no-padding) {
-  padding-top: 0;
+  padding-top: 10px;
   padding-right: 20px;
   padding-bottom: 20px;
   padding-left: 20px;

--- a/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
+++ b/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
@@ -52,9 +52,6 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
   height: 0;
   overflow: hidden;
   word-break: break-word;
-  -webkit-transform: scaleY(0);
-  -ms-transform: scaleY(0);
-  transform: scaleY(0);
   -webkit-transform-origin: top;
   -ms-transform-origin: top;
   transform-origin: top;

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -17,33 +17,19 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-expander {
       margin-top: 0;
       margin-bottom: 0;
-      border-radius: 0;
-      border-top: 1px solid ${theme.colors.depthLight1};
-      transition: margin ${`${theme.transitions.basicTime}
-        ${theme.transitions.basicTimingFunction}`};
-
-      & > {
-        border-radius: 0;
-      }
-      &:first-child {
+      &:not(:first-of-type) {
         border-top: none;
-        border-radius: ${theme.radiuses.basic} ${theme.radiuses.basic} 0 0;
-      }
-      &:last-child {
-        /* stylelint-disable */
-        /* prettier-ignore */
-        border-radius: 0 0 ${theme.radiuses.basic} ${theme.radiuses.basic};
       }
       &.fi-expander--open {
-        border-top: none;
+        border-top: 1px solid ${theme.colors.highlightBase};
+        & + .fi-expander {
+          border-top: 1px solid ${theme.colors.highlightBase};
+        }
         &:not(:first-of-type) {
           margin-top: ${theme.spacing.insetXl};
         }
         &:not(:last-of-type) {
           margin-bottom: ${theme.spacing.insetXl};
-        }
-        & + .fi-expander {
-          border-top: none;
         }
       }
     }

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -17,11 +17,27 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-expander {
       margin-top: 0;
       margin-bottom: 0;
-      &:not(:first-of-type) {
+      border-radius: 0;
+      transition: margin ${`${theme.transitions.basicTime}
+        ${theme.transitions.basicTimingFunction}`};
+
+      & > {
+        border-radius: 0;
+      }
+      &:first-child {
+        border-radius: ${theme.radiuses.basic} ${theme.radiuses.basic} 0 0;
+      }
+      &:last-child {
+        border-bottom-left-radius: ${theme.radiuses.basic};
+        border-bottom-right-radius: ${theme.radiuses.basic};
+      }
+      &:not(:first-child) {
         border-top: none;
       }
+
       &.fi-expander--open {
         border-top: 1px solid ${theme.colors.highlightBase};
+        border-radius: ${theme.radiuses.basic};
         & + .fi-expander {
           border-top: 1px solid ${theme.colors.highlightBase};
         }

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -179,7 +179,6 @@ exports[`Basic expander group should match snapshot 1`] = `
   margin-top: 0;
   margin-bottom: 0;
   border-radius: 0;
-  border-top: 1px solid hsl(202,7%,80%);
   -webkit-transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
   transition: margin 50ms cubic-bezier(0.28,0.84,0.42,1);
 }
@@ -189,16 +188,25 @@ exports[`Basic expander group should match snapshot 1`] = `
 }
 
 .c1 > .fi-expander-group_expanders .fi-expander:first-child {
-  border-top: none;
   border-radius: 2px 2px 0 0;
 }
 
 .c1 > .fi-expander-group_expanders .fi-expander:last-child {
-  border-radius: 0 0 2px 2px;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+}
+
+.c1 > .fi-expander-group_expanders .fi-expander:not(:first-child) {
+  border-top: none;
 }
 
 .c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open {
-  border-top: none;
+  border-top: 1px solid hsl(212,63%,45%);
+  border-radius: 2px;
+}
+
+.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open + .fi-expander {
+  border-top: 1px solid hsl(212,63%,45%);
 }
 
 .c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:first-of-type) {
@@ -207,10 +215,6 @@ exports[`Basic expander group should match snapshot 1`] = `
 
 .c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open:not(:last-of-type) {
   margin-bottom: 16px;
-}
-
-.c1 > .fi-expander-group_expanders .fi-expander.fi-expander--open + .fi-expander {
-  border-top: none;
 }
 
 .c1 > .fi-expander-group_all-button {
@@ -290,8 +294,8 @@ exports[`Basic expander group should match snapshot 1`] = `
   background-color: hsl(0,0%,100%);
   position: relative;
   padding: 0;
+  border: 1px solid hsl(212,63%,45%);
   border-radius: 2px;
-  box-shadow: 0 1px 2px 0 hsla(0,0%,13%,0.14),0 1px 5px 0 hsla(0,0%,13%,0.12);
   width: 100%;
   max-width: 100%;
 }
@@ -356,7 +360,7 @@ exports[`Basic expander group should match snapshot 1`] = `
 }
 
 .c9.fi-expander_content--open:not(.fi-expander_content--no-padding) {
-  padding-top: 0;
+  padding-top: 10px;
   padding-right: 20px;
   padding-bottom: 20px;
   padding-left: 20px;
@@ -396,7 +400,11 @@ exports[`Basic expander group should match snapshot 1`] = `
   border-radius: inherit;
 }
 
-.c7.fi-expander_title-button {
+.c7:hover {
+  background: linear-gradient(0deg,hsl(215,100%,95%),hsl(215,100%,97%));
+}
+
+.c7 .fi-expander_title-button {
   display: block;
 }
 

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -331,9 +331,6 @@ exports[`Basic expander group should match snapshot 1`] = `
   height: 0;
   overflow: hidden;
   word-break: break-word;
-  -webkit-transform: scaleY(0);
-  -ms-transform: scaleY(0);
-  transform: scaleY(0);
   -webkit-transform-origin: top;
   -ms-transform-origin: top;
   transform-origin: top;

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
@@ -27,7 +27,7 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
 
   & .fi-expander_title-content {
     display: inline-block;
-    padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
+    padding: 17px ${theme.spacing.m} 16px ${theme.spacing.m};
   }
 
   & .fi-expander_title-button {
@@ -37,8 +37,9 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
     display: flex;
     justify-content: center;
     position: relative;
-    align-items: center;
-    width: 60px;
+    align-items: flex-start;
+    flex: 0 0 60px;
+    padding-top: ${theme.spacing.m};
 
     &:focus {
       outline: 0;

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
@@ -12,12 +12,12 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
   min-height: 60px;
   background-color: ${theme.colors.highlightLight4};
   border-radius: inherit;
-  padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
   white-space: break-word;
   word-wrap: break-word;
 
   &.fi-expander_title {
-    display: block;
+    display: flex;
+    justify-content: space-between;
   }
   &.fi-expander_title--open {
     background-color: ${theme.colors.whiteBase};
@@ -27,20 +27,18 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
 
   & .fi-expander_title-content {
     display: inline-block;
+    padding: 17px ${theme.spacing.xxxl} 16px ${theme.spacing.m};
   }
 
   & .fi-expander_title-button {
     ${button(theme)}
     ${font(theme)('bodySemiBold')}
     color: ${theme.colors.highlightBase};
-    display: inline-block;
-    position: absolute;
-    right: 0;
-    top: 0;
-    width: 44px;
-    height: 44px;
-    padding: 12px;
-    margin: 13px;
+    display: flex;
+    justify-content: center;
+    position: relative;
+    align-items: center;
+    width: 60px;
 
     &:focus {
       outline: 0;
@@ -52,6 +50,11 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
         ${theme.focuses.absoluteFocus}
       }
     }
+
+    &:hover {
+      background: ${theme.gradients.depthSecondaryToDepthSecondaryDark1};
+    }
+
     ${theme.focuses.noMouseFocus}
     & * {
       cursor: pointer;

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -169,13 +169,19 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   min-height: 60px;
   background-color: hsl(212,63%,98%);
   border-radius: inherit;
-  padding: 17px 60px 16px 20px;
   white-space: break-word;
   word-wrap: break-word;
 }
 
 .c1.fi-expander_title {
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
 .c1.fi-expander_title--open {
@@ -186,6 +192,7 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
 
 .c1 .fi-expander_title-content {
   display: inline-block;
+  padding: 17px 20px 16px 20px;
 }
 
 .c1 .fi-expander_title-button {
@@ -219,14 +226,23 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 600;
   color: hsl(212,63%,45%);
-  display: inline-block;
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 44px;
-  height: 44px;
-  padding: 12px;
-  margin: 13px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  position: relative;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-flex: 0 0 60px;
+  -ms-flex: 0 0 60px;
+  flex: 0 0 60px;
+  padding-top: 20px;
 }
 
 .c1 .fi-expander_title-button:focus {
@@ -251,6 +267,10 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
+}
+
+.c1 .fi-expander_title-button:hover {
+  background: linear-gradient(0deg,hsl(215,100%,95%),hsl(215,100%,97%));
 }
 
 .c1 .fi-expander_title-button:not(:focus-visible) {

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
@@ -12,7 +12,11 @@ export const expanderTitleButtonBaseStyles = (theme: SuomifiTheme) => css`
   background-color: ${theme.colors.highlightLight4};
   border-radius: inherit;
 
-  &.fi-expander_title-button {
+  &:hover {
+    background: ${theme.gradients.depthSecondaryToDepthSecondaryDark1};
+  }
+
+  & .fi-expander_title-button {
     display: block;
   }
   &.fi-expander_title-button--open {
@@ -41,6 +45,7 @@ export const expanderTitleButtonBaseStyles = (theme: SuomifiTheme) => css`
         ${theme.focuses.absoluteFocus}
       }
     }
+
     ${theme.focuses.noMouseFocus}
     & * {
       cursor: pointer;

--- a/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
@@ -146,7 +146,11 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
   border-radius: inherit;
 }
 
-.c1.fi-expander_title-button {
+.c1:hover {
+  background: linear-gradient(0deg,hsl(215,100%,95%),hsl(215,100%,97%));
+}
+
+.c1 .fi-expander_title-button {
   display: block;
 }
 


### PR DESCRIPTION
## Description

This PR contains a visual update for the `<Expander>` component. Biggest changes concern the open/close button, which is now implemented using flexbox instead of absolute positioning. 

Also removed this CSS line from ExpanderContent: `transform: scaleY(0)`. The same rule is already applied in the `fi-expander_content-anim` animation, and removing it from ExpanderContent's default state seemed to fix a Safari print bug described here: https://jira.dvv.fi/browse/SFIDS-673

## Motivation and Context

Expander's appearance was updated in Figma in order to better pop out from backgrounds and provide visual clues regarding click targets (hover styles)

## How Has This Been Tested?

Styleguidist, Chrome, Safari

## Screenshots:

<img width="457" alt="Screenshot 2023-03-30 at 14 16 00" src="https://user-images.githubusercontent.com/17459942/228819611-da597889-c51a-471c-98b3-b965a3de19c3.png">


## Release notes

### Expander & ExpanderGroup
* Update visual style: Remove shadows, add border, add hover styles
