### PR TITLE
[Fix] Expander border disappears when scaled

### DIFF
--- a/src/core/Expander/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander/Expander.baseStyles.tsx
@@ -20,4 +20,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     background-color: ${theme.colors.highlightLight4};
     opacity: 0;
   }
+
+  &.fi-expander--open {
+    border-bottom: none;
+  }
 `;

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -174,6 +174,10 @@ exports[`Basic expander shoud match snapshot 1`] = `
   opacity: 0;
 }
 
+.c1.fi-expander--open {
+  border-bottom: none;
+}
+
 .c7 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -215,6 +219,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
 .c7.fi-expander_content--open {
   visibility: visible;
   height: auto;
+  border-bottom: 1px solid hsl(212,63%,45%);
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -220,6 +220,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
   visibility: visible;
   height: auto;
   border-bottom: 1px solid hsl(212,63%,45%);
+  border-top: 1px solid transparent;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;

--- a/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
@@ -28,6 +28,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-expander_content--open {
     visibility: visible;
     height: auto;
+    /* Add border-bottom to this class and remove it from parent element to prevent
+    a scaling bug, where border-bottom sometimes disappears with Firefox */
+    border-bottom: 1px solid ${theme.colors.highlightBase};
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     /* This is very robust - cannot animate dynamic height with height-definition */

--- a/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
+++ b/src/core/Expander/ExpanderContent/ExpanderContent.baseStyles.tsx
@@ -31,6 +31,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     /* Add border-bottom to this class and remove it from parent element to prevent
     a scaling bug, where border-bottom sometimes disappears with Firefox */
     border-bottom: 1px solid ${theme.colors.highlightBase};
+    /* Add border-top to prevent Safari/iOS browsers rendering subpixel top border */
+    border-top: 1px solid transparent;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     /* This is very robust - cannot animate dynamic height with height-definition */

--- a/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
+++ b/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
@@ -71,6 +71,7 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
 .c1.fi-expander_content--open {
   visibility: visible;
   height: auto;
+  border-bottom: 1px solid hsl(212,63%,45%);
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;

--- a/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
+++ b/src/core/Expander/ExpanderContent/__snapshots__/ExpanderContent.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`Basic ExpanderContent shoud match snapshot 1`] = `
   visibility: visible;
   height: auto;
   border-bottom: 1px solid hsl(212,63%,45%);
+  border-top: 1px solid transparent;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -309,6 +309,10 @@ exports[`Basic expander group should match snapshot 1`] = `
   opacity: 0;
 }
 
+.c6.fi-expander--open {
+  border-bottom: none;
+}
+
 .c9 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -350,6 +354,7 @@ exports[`Basic expander group should match snapshot 1`] = `
 .c9.fi-expander_content--open {
   visibility: visible;
   height: auto;
+  border-bottom: 1px solid hsl(212,63%,45%);
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -355,6 +355,7 @@ exports[`Basic expander group should match snapshot 1`] = `
   visibility: visible;
   height: auto;
   border-bottom: 1px solid hsl(212,63%,45%);
+  border-top: 1px solid transparent;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   -webkit-animation: fi-expander_content-anim 50ms cubic-bezier(0.28,0.84,0.42,1) 1 forwards;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

With Firefox, expander's bottom border disapperas. Safari/iOS browsers on the other hand add an additional border.


<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Motivation and Context

Border disappearing seems to be a scaling issue with Firefox.
Border appearing seems to be a scaling issue with Safari and iOS browsers.
<img width="640" alt="borders" src="https://user-images.githubusercontent.com/14312917/231150717-d1914541-ab30-4524-9776-1cfaf04af5b9.PNG">


## How Has This Been Tested?

Styleguidist with Firefox, Chrome, Edge, and Safari, iOS with Safari and Chrome.


## Release notes

None (fixes issue in new UI #704)
