### PR TITLE
[Fix] Remove Confirm button from DateInput

### DIFF
--- a/src/core/Form/DateInput/DateInput.test.tsx
+++ b/src/core/Form/DateInput/DateInput.test.tsx
@@ -150,7 +150,7 @@ describe('callbacks', () => {
 
     it('calls onChange when date is selected', () => {
       const mockOnChange = jest.fn();
-      const { getByRole, getByText, getAllByText } = render(
+      const { getByRole, getAllByText } = render(
         <DateInput
           labelText="Date"
           datePickerEnabled
@@ -162,10 +162,6 @@ describe('callbacks', () => {
         'button',
       ) as HTMLButtonElement;
       fireEvent.click(dateButton);
-      const confirmButton = getByText('Valitse').closest(
-        'button',
-      ) as HTMLButtonElement;
-      fireEvent.click(confirmButton);
       expect(mockOnChange).toBeCalledWith({
         value: '1.1.2020',
         date: new Date(2020, 0, 1),
@@ -493,10 +489,6 @@ describe('props', () => {
       fireEvent.click(getByRole('button'));
       const dateButton = getByText('16').closest('button') as HTMLButtonElement;
       fireEvent.click(dateButton);
-      const confirmButton = getByText('Valitse').closest(
-        'button',
-      ) as HTMLButtonElement;
-      fireEvent.click(confirmButton);
       expect(getByRole('textbox')).toHaveValue('2020-1-16');
     });
   });

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -16,13 +16,7 @@ import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
 import { HTMLAttributesIncludingDataAttributes } from '../../../utils/common/common';
-import {
-  HtmlInputProps,
-  HtmlDiv,
-  HtmlSpan,
-  HtmlInput,
-  HtmlButton,
-} from '../../../reset';
+import { HtmlInputProps, HtmlDiv, HtmlInput, HtmlButton } from '../../../reset';
 import { DatePicker } from './DatePicker/DatePicker';
 import { Label, LabelMode } from '../Label/Label';
 import { StatusText } from '../StatusText/StatusText';
@@ -349,7 +343,7 @@ const BaseDateInput = (props: DateInputProps) => {
         [dateInputClassNames.hasPicker]: datePickerEnabled,
       })}
     >
-      <HtmlSpan className={dateInputClassNames.styleWrapper}>
+      <HtmlDiv className={dateInputClassNames.styleWrapper}>
         <Label
           htmlFor={id}
           labelMode={labelMode}
@@ -441,7 +435,7 @@ const BaseDateInput = (props: DateInputProps) => {
         >
           {statusText}
         </StatusText>
-      </HtmlSpan>
+      </HtmlDiv>
     </HtmlDiv>
   );
 };

--- a/src/core/Form/DateInput/DatePicker/DatePicker.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.baseStyles.tsx
@@ -13,7 +13,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   & .fi-date-picker_bottom-container {
     display: flex;
-    gap: ${theme.spacing.xs};
+    justify-content: flex-end;
   }
 
   & .fi-date-picker_application {
@@ -39,10 +39,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     .fi-date-picker_application {
       padding-top: ${theme.spacing.xs};
       padding-bottom: ${theme.spacing.xl};
-    }
-
-    .fi-date-picker_bottom-container {
-      flex-direction: column;
     }
   }
 
@@ -117,9 +113,5 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   & .fi-date-picker_popper-arrow[data-popper-placement^='top-end']::before {
     border-bottom: 1px solid ${theme.colors.blackLight1};
     border-right: 1px solid ${theme.colors.blackLight1};
-  }
-
-  & .fi-date-picker_bottom-button {
-    flex: 1;
   }
 `;

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -13,7 +13,6 @@ import { Button } from '../../../Button/Button';
 import { MonthTable } from './MonthTable/MonthTable';
 import { DateSelectors } from './DateSelectors/DateSelectors';
 import {
-  cellDateAriaLabel,
   dayIsAfter,
   dayIsBefore,
   moveDays,
@@ -38,7 +37,6 @@ export const datePickerClassNames = {
   slideIndicatorWrapper: `${baseClassName}_slide-indicator-wrapper`,
   application: `${baseClassName}_application`,
   bottomContainer: `${baseClassName}_bottom-container`,
-  bottomButton: `${baseClassName}_bottom-button`,
   popperArrow: `${baseClassName}_popper-arrow`,
 };
 
@@ -100,7 +98,6 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   const yearSelectRef = useRef<HTMLButtonElement>(null);
   const monthSelectRef = useRef<HTMLButtonElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const dayButtonRef = useRef<HTMLButtonElement>(null);
 
   useEnhancedEffect(() => {
@@ -343,11 +340,6 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
       monthSelectRef.current.getAttribute('data-state') === 'expanded') ||
     false;
 
-  const handleConfirm = (): void => {
-    handleClose(true);
-    onChange(focusableDate);
-  };
-
   const handleClose = (focus: boolean = false): void => {
     setSelectedDate(null);
     setFocusedDate(null);
@@ -359,9 +351,9 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   };
 
   const handleDateSelect = (date: Date): void => {
+    handleClose(true);
+    onChange(date);
     setFocusableDate(date);
-    setSelectedDate(date);
-    confirmButtonRef.current?.focus();
   };
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -461,28 +453,9 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
       />
       <HtmlDiv className={datePickerClassNames.bottomContainer}>
         <Button
-          aria-disabled={selectedDate === null}
-          onClick={() => handleConfirm()}
-          forwardedRef={confirmButtonRef}
-          className={datePickerClassNames.bottomButton}
-          fullWidth={smallScreen}
-          aria-label={
-            selectedDate
-              ? `${texts.selectButtonText} ${cellDateAriaLabel(
-                  selectedDate,
-                  texts,
-                )}`
-              : ''
-          }
-        >
-          {texts.selectButtonText}
-        </Button>
-        <Button
-          variant="secondary"
+          variant="secondaryNoBorder"
           onClick={() => handleClose(true)}
           forwardedRef={closeButtonRef}
-          className={datePickerClassNames.bottomButton}
-          fullWidth={smallScreen}
         >
           {texts.closeButtonText}
         </Button>

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -13,6 +13,7 @@ import { Button } from '../../../Button/Button';
 import { MonthTable } from './MonthTable/MonthTable';
 import { DateSelectors } from './DateSelectors/DateSelectors';
 import {
+  cellDateAriaLabel,
   dayIsAfter,
   dayIsBefore,
   moveDays,
@@ -98,6 +99,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   const smallScreenAppRef = useRef<HTMLDivElement>(null);
   const yearSelectRef = useRef<HTMLButtonElement>(null);
   const monthSelectRef = useRef<HTMLButtonElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const dayButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -217,7 +219,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
     if (event.key === 'Tab') {
       // Trap focus to dialog
       const firstElement = yearSelectRef.current;
-      const lastElement = confirmButtonRef?.current;
+      const lastElement = closeButtonRef?.current;
       if (event.shiftKey && document.activeElement === firstElement) {
         event.preventDefault();
         lastElement?.focus();
@@ -359,6 +361,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   const handleDateSelect = (date: Date): void => {
     setFocusableDate(date);
     setSelectedDate(date);
+    confirmButtonRef.current?.focus();
   };
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -458,17 +461,26 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
       />
       <HtmlDiv className={datePickerClassNames.bottomContainer}>
         <Button
-          disabled={selectedDate === null}
+          aria-disabled={selectedDate === null}
           onClick={() => handleConfirm()}
+          forwardedRef={confirmButtonRef}
           className={datePickerClassNames.bottomButton}
           fullWidth={smallScreen}
+          aria-label={
+            selectedDate
+              ? `${texts.selectButtonText} ${cellDateAriaLabel(
+                  selectedDate,
+                  texts,
+                )}`
+              : ''
+          }
         >
           {texts.selectButtonText}
         </Button>
         <Button
           variant="secondary"
           onClick={() => handleClose(true)}
-          forwardedRef={confirmButtonRef}
+          forwardedRef={closeButtonRef}
           className={datePickerClassNames.bottomButton}
           fullWidth={smallScreen}
         >

--- a/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
@@ -6,8 +6,10 @@ export const baseStyles = (
   yearSelectWidth: number,
   monthSelectWidth: number,
 ) => css`
-  & .fi-date-selectors_container {
+  &.fi-date-selectors_container {
     display: flex;
+    flex-wrap: wrap;
+    row-gap: ${theme.spacing.xs};
   }
 
   & .fi-date-selectors_year-select {
@@ -19,11 +21,16 @@ export const baseStyles = (
   }
 
   & .fi-date-selectors_month-select {
-    margin-right: ${theme.spacing.xs};
+    margin-right: ${theme.spacing.xxs};
     width: ${monthSelectWidth}px;
     .fi-dropdown_button {
       min-width: 145px;
     }
+  }
+
+  & .fi-date-selectors_buttons {
+    display: flex;
+    flex-wrap: nowrap;
   }
 
   & .fi-date-selectors_month-button {

--- a/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.tsx
+++ b/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.tsx
@@ -25,6 +25,7 @@ export const selectorsClassNames = {
   container: `${baseClassName}_container`,
   yearSelect: `${baseClassName}_year-select`,
   monthSelect: `${baseClassName}_month-select`,
+  buttons: `${baseClassName}_buttons`,
   monthButton: `${baseClassName}_month-button`,
   monthButtonIcon: `${baseClassName}_month-button_icon`,
 };
@@ -144,30 +145,32 @@ export const BaseDateSelectors = (props: DateSelectorsProps) => {
           ),
         )}
       </Dropdown>
-      <Button
-        onClick={() => handlePrevMonthButton()}
-        variant="secondaryNoBorder"
-        aria-label={getPrevMonthButtonLabel()}
-        className={selectorsClassNames.monthButton}
-        disabled={monthIsSame(focusableDate, minDate)}
-      >
-        <Icon
-          icon="chevronLeft"
-          className={selectorsClassNames.monthButtonIcon}
-        />
-      </Button>
-      <Button
-        onClick={() => handleNextMonthButton()}
-        variant="secondaryNoBorder"
-        aria-label={getNextMonthButtonLabel()}
-        className={selectorsClassNames.monthButton}
-        disabled={monthIsSame(focusableDate, maxDate)}
-      >
-        <Icon
-          icon="chevronRight"
-          className={selectorsClassNames.monthButtonIcon}
-        />
-      </Button>
+      <HtmlDiv className={selectorsClassNames.buttons}>
+        <Button
+          onClick={() => handlePrevMonthButton()}
+          variant="secondaryNoBorder"
+          aria-label={getPrevMonthButtonLabel()}
+          className={selectorsClassNames.monthButton}
+          disabled={monthIsSame(focusableDate, minDate)}
+        >
+          <Icon
+            icon="chevronLeft"
+            className={selectorsClassNames.monthButtonIcon}
+          />
+        </Button>
+        <Button
+          onClick={() => handleNextMonthButton()}
+          variant="secondaryNoBorder"
+          aria-label={getNextMonthButtonLabel()}
+          className={selectorsClassNames.monthButton}
+          disabled={monthIsSame(focusableDate, maxDate)}
+        >
+          <Icon
+            icon="chevronRight"
+            className={selectorsClassNames.monthButtonIcon}
+          />
+        </Button>
+      </HtmlDiv>
     </HtmlDiv>
   );
 };

--- a/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.tsx
+++ b/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.tsx
@@ -147,7 +147,7 @@ export const BaseDateSelectors = (props: DateSelectorsProps) => {
       </Dropdown>
       <HtmlDiv className={selectorsClassNames.buttons}>
         <Button
-          onClick={() => handlePrevMonthButton()}
+          onClick={handlePrevMonthButton}
           variant="secondaryNoBorder"
           aria-label={getPrevMonthButtonLabel()}
           className={selectorsClassNames.monthButton}
@@ -159,7 +159,7 @@ export const BaseDateSelectors = (props: DateSelectorsProps) => {
           />
         </Button>
         <Button
-          onClick={() => handleNextMonthButton()}
+          onClick={handleNextMonthButton}
           variant="secondaryNoBorder"
           aria-label={getNextMonthButtonLabel()}
           className={selectorsClassNames.monthButton}

--- a/src/core/Form/DateInput/DatePicker/MonthDay/MonthDay.tsx
+++ b/src/core/Form/DateInput/DatePicker/MonthDay/MonthDay.tsx
@@ -67,18 +67,10 @@ export const BaseMonthDay = (props: MonthDayProps) => {
   const isDisabledDate = (): boolean =>
     shouldDisableDate ? shouldDisableDate(date.date) : false;
 
-  const buttonText = (): string => {
-    const text = cellDateAriaLabel(date.date, texts);
-    if (isSelectedDate()) {
-      return `${texts.selectedDateLabel}, ${text}`;
-    }
-    return text;
-  };
-
   const cellDateElements = (
     <>
       <span aria-hidden>{date.number}</span>
-      <VisuallyHidden>{buttonText()}</VisuallyHidden>
+      <VisuallyHidden>{cellDateAriaLabel(date.date, texts)}</VisuallyHidden>
     </>
   );
 

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3633,11 +3633,15 @@ exports[`snapshots match date input with datepicker with controlled input value 
   z-index: 9999;
 }
 
-.c11 .fi-date-selectors_container {
+.c11.fi-date-selectors_container {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 10px;
 }
 
 .c11 .fi-date-selectors_year-select {
@@ -3650,12 +3654,22 @@ exports[`snapshots match date input with datepicker with controlled input value 
 }
 
 .c11 .fi-date-selectors_month-select {
-  margin-right: 10px;
+  margin-right: 5px;
   width: 0px;
 }
 
 .c11 .fi-date-selectors_month-select .fi-dropdown_button {
   min-width: 145px;
+}
+
+.c11 .fi-date-selectors_buttons {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
 }
 
 .c11 .fi-date-selectors_month-button {
@@ -4261,54 +4275,58 @@ exports[`snapshots match date input with datepicker with controlled input value 
             />
           </div>
         </div>
-        <button
-          aria-disabled="false"
-          aria-label="Edellinen kuukausi Joulukuu"
-          class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
-          tabindex="0"
-          type="button"
+        <div
+          class="c0 fi-date-selectors_buttons"
         >
-          <svg
-            aria-hidden="true"
-            class="fi-icon c8 fi-date-selectors_month-button_icon"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
+          <button
+            aria-disabled="false"
+            aria-label="Edellinen kuukausi Joulukuu"
+            class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
+            tabindex="0"
+            type="button"
           >
-            <path
-              class="fi-icon-base-fill"
-              d="M8.41 12.61a1.298 1.298 0 01-.41-.943c0-.342.137-.683.41-.943l5.6-5.333a1.448 1.448 0 011.98 0 1.287 1.287 0 010 1.885l-4.61 4.39 4.61 4.391a1.287 1.287 0 010 1.885 1.448 1.448 0 01-1.98 0l-5.6-5.333z"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </button>
-        <button
-          aria-disabled="false"
-          aria-label="Seuraava kuukausi Helmikuu"
-          class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
-          tabindex="0"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="fi-icon c8 fi-date-selectors_month-button_icon"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
+            <svg
+              aria-hidden="true"
+              class="fi-icon c8 fi-date-selectors_month-button_icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="fi-icon-base-fill"
+                d="M8.41 12.61a1.298 1.298 0 01-.41-.943c0-.342.137-.683.41-.943l5.6-5.333a1.448 1.448 0 011.98 0 1.287 1.287 0 010 1.885l-4.61 4.39 4.61 4.391a1.287 1.287 0 010 1.885 1.448 1.448 0 01-1.98 0l-5.6-5.333z"
+                fill="#222"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <button
+            aria-disabled="false"
+            aria-label="Seuraava kuukausi Helmikuu"
+            class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
+            tabindex="0"
+            type="button"
           >
-            <path
-              class="fi-icon-base-fill"
-              d="M15.61 11.01c.26.273.39.632.39.99s-.13.717-.39.99l-5.334 5.6a1.287 1.287 0 01-1.885 0 1.448 1.448 0 010-1.98l4.39-4.61-4.39-4.61a1.448 1.448 0 010-1.98 1.287 1.287 0 011.885 0l5.333 5.6z"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </button>
+            <svg
+              aria-hidden="true"
+              class="fi-icon c8 fi-date-selectors_month-button_icon"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="fi-icon-base-fill"
+                d="M15.61 11.01c.26.273.39.632.39.99s-.13.717-.39.99l-5.334 5.6a1.287 1.287 0 01-1.885 0 1.448 1.448 0 010-1.98l4.39-4.61-4.39-4.61a1.448 1.448 0 010-1.98 1.287 1.287 0 011.885 0l5.333 5.6z"
+                fill="#222"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
       <table
         class="c14 fi-month-table"
@@ -5885,11 +5903,15 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   z-index: 9999;
 }
 
-.c11 .fi-date-selectors_container {
+.c11.fi-date-selectors_container {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  row-gap: 10px;
 }
 
 .c11 .fi-date-selectors_year-select {
@@ -5902,12 +5924,22 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 }
 
 .c11 .fi-date-selectors_month-select {
-  margin-right: 10px;
+  margin-right: 5px;
   width: 0px;
 }
 
 .c11 .fi-date-selectors_month-select .fi-dropdown_button {
   min-width: 145px;
+}
+
+.c11 .fi-date-selectors_buttons {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
 }
 
 .c11 .fi-date-selectors_month-button {
@@ -6522,54 +6554,58 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               />
             </div>
           </div>
-          <button
-            aria-disabled="false"
-            aria-label="Edellinen kuukausi Joulukuu"
-            class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
-            tabindex="0"
-            type="button"
+          <div
+            class="c0 fi-date-selectors_buttons"
           >
-            <svg
-              aria-hidden="true"
-              class="fi-icon c8 fi-date-selectors_month-button_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-disabled="false"
+              aria-label="Edellinen kuukausi Joulukuu"
+              class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
+              tabindex="0"
+              type="button"
             >
-              <path
-                class="fi-icon-base-fill"
-                d="M8.41 12.61a1.298 1.298 0 01-.41-.943c0-.342.137-.683.41-.943l5.6-5.333a1.448 1.448 0 011.98 0 1.287 1.287 0 010 1.885l-4.61 4.39 4.61 4.391a1.287 1.287 0 010 1.885 1.448 1.448 0 01-1.98 0l-5.6-5.333z"
-                fill="#222"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </button>
-          <button
-            aria-disabled="false"
-            aria-label="Seuraava kuukausi Helmikuu"
-            class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
-            tabindex="0"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="fi-icon c8 fi-date-selectors_month-button_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+              <svg
+                aria-hidden="true"
+                class="fi-icon c8 fi-date-selectors_month-button_icon"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M8.41 12.61a1.298 1.298 0 01-.41-.943c0-.342.137-.683.41-.943l5.6-5.333a1.448 1.448 0 011.98 0 1.287 1.287 0 010 1.885l-4.61 4.39 4.61 4.391a1.287 1.287 0 010 1.885 1.448 1.448 0 01-1.98 0l-5.6-5.333z"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </button>
+            <button
+              aria-disabled="false"
+              aria-label="Seuraava kuukausi Helmikuu"
+              class="c6 fi-button c13 fi-date-selectors_month-button fi-button--secondary-noborder"
+              tabindex="0"
+              type="button"
             >
-              <path
-                class="fi-icon-base-fill"
-                d="M15.61 11.01c.26.273.39.632.39.99s-.13.717-.39.99l-5.334 5.6a1.287 1.287 0 01-1.885 0 1.448 1.448 0 010-1.98l4.39-4.61-4.39-4.61a1.448 1.448 0 010-1.98 1.287 1.287 0 011.885 0l5.333 5.6z"
-                fill="#222"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </button>
+              <svg
+                aria-hidden="true"
+                class="fi-icon c8 fi-date-selectors_month-button_icon"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M15.61 11.01c.26.273.39.632.39.99s-.13.717-.39.99l-5.334 5.6a1.287 1.287 0 01-1.885 0 1.448 1.448 0 010-1.98l4.39-4.61-4.39-4.61a1.448 1.448 0 010-1.98 1.287 1.287 0 011.885 0l5.333 5.6z"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
         <table
           class="c14 fi-month-table"

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -4702,7 +4702,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 <span
                   class="c2 c7 fi-visually-hidden"
                 >
-                  Valittu päivä, 15 keskiviikko Tammikuu 2020
+                  15 keskiviikko Tammikuu 2020
                 </span>
               </button>
             </td>
@@ -5064,6 +5064,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
       >
         <button
           aria-disabled="false"
+          aria-label="Valitse 15 keskiviikko Tammikuu 2020"
           class="c6 fi-button c13 fi-date-picker_bottom-button"
           tabindex="0"
           type="button"
@@ -6981,7 +6982,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   <span
                     class="c2 c7 fi-visually-hidden"
                   >
-                    Valittu päivä, 15 keskiviikko Tammikuu 2020
+                    15 keskiviikko Tammikuu 2020
                   </span>
                 </button>
               </td>
@@ -7343,6 +7344,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
         >
           <button
             aria-disabled="false"
+            aria-label="Valitse 15 keskiviikko Tammikuu 2020"
             class="c6 fi-button c13 fi-date-picker_bottom-button fi-button--fullwidth"
             tabindex="0"
             type="button"

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3710,7 +3710,10 @@ exports[`snapshots match date input with datepicker with controlled input value 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 10px;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
 }
 
 .c10 .fi-date-picker_application {
@@ -3751,12 +3754,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
 .c10.fi-date-picker--small-screen .fi-date-picker_application {
   padding-top: 10px;
   padding-bottom: 30px;
-}
-
-.c10.fi-date-picker--small-screen .fi-date-picker_bottom-container {
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c10.fi-date-picker--hidden {
@@ -3837,12 +3834,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
 .c10 .fi-date-picker_popper-arrow[data-popper-placement^='top-end']::before {
   border-bottom: 1px solid hsl(0,0%,58%);
   border-right: 1px solid hsl(0,0%,58%);
-}
-
-.c10 .fi-date-picker_bottom-button {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .c1 {
@@ -5064,16 +5055,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
       >
         <button
           aria-disabled="false"
-          aria-label="Valitse 15 keskiviikko Tammikuu 2020"
-          class="c6 fi-button c13 fi-date-picker_bottom-button"
-          tabindex="0"
-          type="button"
-        >
-          Valitse
-        </button>
-        <button
-          aria-disabled="false"
-          class="c6 fi-button c13 fi-date-picker_bottom-button fi-button--secondary"
+          class="c6 fi-button c13 fi-button--secondary-noborder"
           tabindex="0"
           type="button"
         >
@@ -5981,7 +5963,10 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 10px;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
 }
 
 .c10 .fi-date-picker_application {
@@ -6022,12 +6007,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 .c10.fi-date-picker--small-screen .fi-date-picker_application {
   padding-top: 10px;
   padding-bottom: 30px;
-}
-
-.c10.fi-date-picker--small-screen .fi-date-picker_bottom-container {
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
 }
 
 .c10.fi-date-picker--hidden {
@@ -6108,12 +6087,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 .c10 .fi-date-picker_popper-arrow[data-popper-placement^='top-end']::before {
   border-bottom: 1px solid hsl(0,0%,58%);
   border-right: 1px solid hsl(0,0%,58%);
-}
-
-.c10 .fi-date-picker_bottom-button {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .c1 {
@@ -7344,16 +7317,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
         >
           <button
             aria-disabled="false"
-            aria-label="Valitse 15 keskiviikko Tammikuu 2020"
-            class="c6 fi-button c13 fi-date-picker_bottom-button fi-button--fullwidth"
-            tabindex="0"
-            type="button"
-          >
-            Valitse
-          </button>
-          <button
-            aria-disabled="false"
-            class="c6 fi-button c13 fi-date-picker_bottom-button fi-button--secondary fi-button--fullwidth"
+            class="c6 fi-button c13 fi-button--secondary-noborder"
             tabindex="0"
             type="button"
           >

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`snapshots match date input error status with statustext 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -54,8 +54,8 @@ exports[`snapshots match date input error status with statustext 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -92,7 +92,7 @@ exports[`snapshots match date input error status with statustext 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -116,12 +116,12 @@ exports[`snapshots match date input error status with statustext 1`] = `
   white-space: normal;
 }
 
-.c2::before,
-.c2::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -140,14 +140,14 @@ exports[`snapshots match date input error status with statustext 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -421,14 +421,14 @@ exports[`snapshots match date input error status with statustext 1`] = `
     <div
       class="c0 fi-date-input c1 fi-date-input--error"
     >
-      <span
-        class="c2 fi-date-input_wrapper"
+      <div
+        class="c0 fi-date-input_wrapper"
       >
         <div
-          class="c3 c4 fi-date-input_label--visible fi-label"
+          class="c2 c3 fi-date-input_label--visible fi-label"
         >
           <label
-            class="c2 fi-label_label-span"
+            class="c4 fi-label_label-span"
             for="7"
           >
             Date
@@ -454,12 +454,12 @@ exports[`snapshots match date input error status with statustext 1`] = `
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c2 c6 fi-date-input_statusText--has-content fi-status-text fi-status-text--error"
+          class="c4 c6 fi-date-input_statusText--has-content fi-status-text fi-status-text--error"
           id="7-statusText"
         >
           Error
         </span>
-      </span>
+      </div>
     </div>
   </div>
 </body>
@@ -495,7 +495,7 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -519,12 +519,12 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
-.c6 {
+.c5 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -547,17 +547,17 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
   max-width: 100%;
 }
 
-.c6::-webkit-input-placeholder {
+.c5::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c6::before,
-.c6::after {
+.c5::before,
+.c5::after {
   box-sizing: border-box;
 }
 
-.c2 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -581,12 +581,12 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
   white-space: normal;
 }
 
-.c2::before,
-.c2::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
-.c5 {
+.c4 {
   position: absolute;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -598,7 +598,7 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
   overflow: hidden;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -617,14 +617,14 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -898,14 +898,14 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
     <div
       class="c0 fi-date-input c1"
     >
-      <span
-        class="c2 fi-date-input_wrapper"
+      <div
+        class="c0 fi-date-input_wrapper"
       >
         <div
-          class="c3 c4 fi-label"
+          class="c2 c3 fi-label"
         >
           <label
-            class="c5 fi-visually-hidden"
+            class="c4 fi-visually-hidden"
             for="3"
           >
             Date
@@ -919,7 +919,7 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
           >
             <input
               autocomplete="off"
-              class="c6 fi-date-input_input"
+              class="c5 fi-date-input_input"
               id="3"
               placeholder="DateInput"
               type="text"
@@ -930,10 +930,10 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c2 c7 fi-status-text"
+          class="c6 c7 fi-status-text"
           id="3-statusText"
         />
-      </span>
+      </div>
     </div>
   </div>
 </body>
@@ -969,7 +969,7 @@ exports[`snapshots match date input hint text 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -993,8 +993,8 @@ exports[`snapshots match date input hint text 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -1031,7 +1031,7 @@ exports[`snapshots match date input hint text 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1055,12 +1055,12 @@ exports[`snapshots match date input hint text 1`] = `
   white-space: normal;
 }
 
-.c2::before,
-.c2::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1079,14 +1079,14 @@ exports[`snapshots match date input hint text 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -1381,21 +1381,21 @@ exports[`snapshots match date input hint text 1`] = `
     <div
       class="c0 fi-date-input c1"
     >
-      <span
-        class="c2 fi-date-input_wrapper"
+      <div
+        class="c0 fi-date-input_wrapper"
       >
         <div
-          class="c3 c4 fi-date-input_label--visible fi-label"
+          class="c2 c3 fi-date-input_label--visible fi-label"
         >
           <label
-            class="c2 fi-label_label-span"
+            class="c4 fi-label_label-span"
             for="4"
           >
             Date
           </label>
         </div>
         <span
-          class="c2 c5 fi-hint-text"
+          class="c4 c5 fi-hint-text"
           id="4-hintText"
         >
           User format D.M.YYYY
@@ -1419,10 +1419,10 @@ exports[`snapshots match date input hint text 1`] = `
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c2 c7 fi-status-text"
+          class="c4 c7 fi-status-text"
           id="4-statusText"
         />
-      </span>
+      </div>
     </div>
   </div>
 </body>
@@ -1458,7 +1458,7 @@ exports[`snapshots match date input minimal implementation 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1482,8 +1482,8 @@ exports[`snapshots match date input minimal implementation 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -1520,7 +1520,7 @@ exports[`snapshots match date input minimal implementation 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1544,12 +1544,12 @@ exports[`snapshots match date input minimal implementation 1`] = `
   white-space: normal;
 }
 
-.c2::before,
-.c2::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1568,14 +1568,14 @@ exports[`snapshots match date input minimal implementation 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -1849,14 +1849,14 @@ exports[`snapshots match date input minimal implementation 1`] = `
     <div
       class="c0 fi-date-input c1"
     >
-      <span
-        class="c2 fi-date-input_wrapper"
+      <div
+        class="c0 fi-date-input_wrapper"
       >
         <div
-          class="c3 c4 fi-date-input_label--visible fi-label"
+          class="c2 c3 fi-date-input_label--visible fi-label"
         >
           <label
-            class="c2 fi-label_label-span"
+            class="c4 fi-label_label-span"
             for="1"
           >
             Date
@@ -1880,10 +1880,10 @@ exports[`snapshots match date input minimal implementation 1`] = `
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c2 c6 fi-status-text"
+          class="c4 c6 fi-status-text"
           id="1-statusText"
         />
-      </span>
+      </div>
     </div>
   </div>
 </body>
@@ -1919,7 +1919,7 @@ exports[`snapshots match date input optional text 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1943,8 +1943,8 @@ exports[`snapshots match date input optional text 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -1981,7 +1981,7 @@ exports[`snapshots match date input optional text 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2005,12 +2005,12 @@ exports[`snapshots match date input optional text 1`] = `
   white-space: normal;
 }
 
-.c2::before,
-.c2::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2029,14 +2029,14 @@ exports[`snapshots match date input optional text 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -2310,19 +2310,19 @@ exports[`snapshots match date input optional text 1`] = `
     <div
       class="c0 fi-date-input c1"
     >
-      <span
-        class="c2 fi-date-input_wrapper"
+      <div
+        class="c0 fi-date-input_wrapper"
       >
         <div
-          class="c3 c4 fi-date-input_label--visible fi-label"
+          class="c2 c3 fi-date-input_label--visible fi-label"
         >
           <label
-            class="c2 fi-label_label-span"
+            class="c4 fi-label_label-span"
             for="5"
           >
             Date
             <span
-              class="c2 fi-label_optional-text"
+              class="c4 fi-label_optional-text"
             >
                (optional)
             </span>
@@ -2346,10 +2346,10 @@ exports[`snapshots match date input optional text 1`] = `
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c2 c6 fi-status-text"
+          class="c4 c6 fi-status-text"
           id="5-statusText"
         />
-      </span>
+      </div>
     </div>
   </div>
 </body>
@@ -2385,7 +2385,7 @@ exports[`snapshots match date input success status with statustext 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2409,8 +2409,8 @@ exports[`snapshots match date input success status with statustext 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -2447,7 +2447,7 @@ exports[`snapshots match date input success status with statustext 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2471,12 +2471,12 @@ exports[`snapshots match date input success status with statustext 1`] = `
   white-space: normal;
 }
 
-.c2::before,
-.c2::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2495,14 +2495,14 @@ exports[`snapshots match date input success status with statustext 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -2776,14 +2776,14 @@ exports[`snapshots match date input success status with statustext 1`] = `
     <div
       class="c0 fi-date-input c1 fi-date-input--success"
     >
-      <span
-        class="c2 fi-date-input_wrapper"
+      <div
+        class="c0 fi-date-input_wrapper"
       >
         <div
-          class="c3 c4 fi-date-input_label--visible fi-label"
+          class="c2 c3 fi-date-input_label--visible fi-label"
         >
           <label
-            class="c2 fi-label_label-span"
+            class="c4 fi-label_label-span"
             for="6"
           >
             Date
@@ -2808,12 +2808,12 @@ exports[`snapshots match date input success status with statustext 1`] = `
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c2 c6 fi-date-input_statusText--has-content fi-status-text"
+          class="c4 c6 fi-date-input_statusText--has-content fi-status-text"
           id="6-statusText"
         >
           Success
         </span>
-      </span>
+      </div>
     </div>
   </div>
 </body>
@@ -2902,7 +2902,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2926,8 +2926,8 @@ exports[`snapshots match date input with datepicker with controlled input value 
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -2964,7 +2964,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2988,8 +2988,8 @@ exports[`snapshots match date input with datepicker with controlled input value 
   white-space: normal;
 }
 
-.c2::before,
-.c2::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
@@ -3395,7 +3395,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   height: 38px;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -3414,14 +3414,14 @@ exports[`snapshots match date input with datepicker with controlled input value 
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -4088,14 +4088,14 @@ exports[`snapshots match date input with datepicker with controlled input value 
     <div
       class="c0 fi-date-input c1 fi-date-input--has-picker"
     >
-      <span
-        class="c2 fi-date-input_wrapper"
+      <div
+        class="c0 fi-date-input_wrapper"
       >
         <div
-          class="c3 c4 fi-date-input_label--visible fi-label"
+          class="c2 c3 fi-date-input_label--visible fi-label"
         >
           <label
-            class="c2 fi-label_label-span"
+            class="c4 fi-label_label-span"
             for="15"
           >
             Date
@@ -4124,7 +4124,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               type="button"
             >
               <span
-                class="c2 c7 fi-visually-hidden"
+                class="c4 c7 fi-visually-hidden"
               >
                 Valitse päivämäärä, Valittu päivä 15 keskiviikko Tammikuu 2020
               </span>
@@ -4150,15 +4150,15 @@ exports[`snapshots match date input with datepicker with controlled input value 
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c2 c9 fi-status-text"
+          class="c4 c9 fi-status-text"
           id="15-statusText"
         />
-      </span>
+      </div>
     </div>
   </div>
   <div
     aria-hidden="false"
-    class="c3 c10 fi-date-picker"
+    class="c2 c10 fi-date-picker"
     role="dialog"
     style="position: fixed; left: 0px; top: 0px;"
   >
@@ -4174,7 +4174,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           id="16"
         >
           <div
-            class="c3 c4 fi-label"
+            class="c2 c3 fi-label"
           >
             <label
               class="c7 fi-visually-hidden"
@@ -4198,7 +4198,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               value="2020"
             >
               <span
-                class="c2 fi-dropdown_display-value"
+                class="c4 fi-dropdown_display-value"
               >
                 2020
               </span>
@@ -4210,7 +4210,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               />
             </button>
             <span
-              class="c2 c7 fi-visually-hidden"
+              class="c4 c7 fi-visually-hidden"
               id="16-displayValue"
             >
               2020
@@ -4218,7 +4218,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             <span
               aria-atomic="true"
               aria-live="assertive"
-              class="c2 c9 fi-status-text"
+              class="c4 c9 fi-status-text"
             />
           </div>
         </div>
@@ -4227,7 +4227,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           id="17"
         >
           <div
-            class="c3 c4 fi-label"
+            class="c2 c3 fi-label"
           >
             <label
               class="c7 fi-visually-hidden"
@@ -4251,7 +4251,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               value="0"
             >
               <span
-                class="c2 fi-dropdown_display-value"
+                class="c4 fi-dropdown_display-value"
               >
                 Tammikuu
               </span>
@@ -4263,7 +4263,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               />
             </button>
             <span
-              class="c2 c7 fi-visually-hidden"
+              class="c4 c7 fi-visually-hidden"
               id="17-displayValue"
             >
               Tammikuu
@@ -4271,7 +4271,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             <span
               aria-atomic="true"
               aria-live="assertive"
-              class="c2 c9 fi-status-text"
+              class="c4 c9 fi-status-text"
             />
           </div>
         </div>
@@ -4402,7 +4402,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                     1
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     1 keskiviikko Tammikuu 2020
                   </span>
@@ -4424,7 +4424,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   2
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   2 torstai Tammikuu 2020
                 </span>
@@ -4445,7 +4445,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   3
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   3 perjantai Tammikuu 2020
                 </span>
@@ -4466,7 +4466,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   4
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   4 lauantai Tammikuu 2020
                 </span>
@@ -4487,7 +4487,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   5
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   5 sunnuntai Tammikuu 2020
                 </span>
@@ -4510,7 +4510,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   6
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   6 maanantai Tammikuu 2020
                 </span>
@@ -4531,7 +4531,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   7
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   7 tiistai Tammikuu 2020
                 </span>
@@ -4552,7 +4552,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   8
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   8 keskiviikko Tammikuu 2020
                 </span>
@@ -4573,7 +4573,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   9
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   9 torstai Tammikuu 2020
                 </span>
@@ -4594,7 +4594,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   10
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   10 perjantai Tammikuu 2020
                 </span>
@@ -4615,7 +4615,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   11
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   11 lauantai Tammikuu 2020
                 </span>
@@ -4636,7 +4636,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   12
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   12 sunnuntai Tammikuu 2020
                 </span>
@@ -4659,7 +4659,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   13
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   13 maanantai Tammikuu 2020
                 </span>
@@ -4680,7 +4680,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   14
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   14 tiistai Tammikuu 2020
                 </span>
@@ -4700,7 +4700,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   15
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   15 keskiviikko Tammikuu 2020
                 </span>
@@ -4721,7 +4721,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   16
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   16 torstai Tammikuu 2020
                 </span>
@@ -4742,7 +4742,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   17
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   17 perjantai Tammikuu 2020
                 </span>
@@ -4763,7 +4763,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   18
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   18 lauantai Tammikuu 2020
                 </span>
@@ -4784,7 +4784,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   19
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   19 sunnuntai Tammikuu 2020
                 </span>
@@ -4807,7 +4807,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   20
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   20 maanantai Tammikuu 2020
                 </span>
@@ -4828,7 +4828,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   21
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   21 tiistai Tammikuu 2020
                 </span>
@@ -4849,7 +4849,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   22
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   22 keskiviikko Tammikuu 2020
                 </span>
@@ -4870,7 +4870,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   23
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   23 torstai Tammikuu 2020
                 </span>
@@ -4891,7 +4891,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   24
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   24 perjantai Tammikuu 2020
                 </span>
@@ -4912,7 +4912,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   25
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   25 lauantai Tammikuu 2020
                 </span>
@@ -4933,7 +4933,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   26
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   26 sunnuntai Tammikuu 2020
                 </span>
@@ -4956,7 +4956,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   27
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   27 maanantai Tammikuu 2020
                 </span>
@@ -4977,7 +4977,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   28
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   28 tiistai Tammikuu 2020
                 </span>
@@ -4998,7 +4998,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   29
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   29 keskiviikko Tammikuu 2020
                 </span>
@@ -5019,7 +5019,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   30
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   30 torstai Tammikuu 2020
                 </span>
@@ -5040,7 +5040,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   31
                 </span>
                 <span
-                  class="c2 c7 fi-visually-hidden"
+                  class="c4 c7 fi-visually-hidden"
                 >
                   31 perjantai Tammikuu 2020
                 </span>
@@ -5173,7 +5173,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c2 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -5197,8 +5197,8 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   white-space: normal;
 }
 
-.c3::before,
-.c3::after {
+.c2::before,
+.c2::after {
   box-sizing: border-box;
 }
 
@@ -5235,7 +5235,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -5259,8 +5259,8 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   white-space: normal;
 }
 
-.c2::before,
-.c2::after {
+.c4::before,
+.c4::after {
   box-sizing: border-box;
 }
 
@@ -5666,7 +5666,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   height: 38px;
 }
 
-.c4.fi-label .fi-label_label-span {
+.c3.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -5685,14 +5685,14 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+.c3.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c4.fi-label .fi-label_label-span .fi-tooltip {
+.c3.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
@@ -6359,14 +6359,14 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
     <div
       class="c0 fi-date-input c1 fi-date-input--has-picker"
     >
-      <span
-        class="c2 fi-date-input_wrapper"
+      <div
+        class="c0 fi-date-input_wrapper"
       >
         <div
-          class="c3 c4 fi-date-input_label--visible fi-label"
+          class="c2 c3 fi-date-input_label--visible fi-label"
         >
           <label
-            class="c2 fi-label_label-span"
+            class="c4 fi-label_label-span"
             for="8"
           >
             Date
@@ -6395,7 +6395,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               type="button"
             >
               <span
-                class="c2 c7 fi-visually-hidden"
+                class="c4 c7 fi-visually-hidden"
               >
                 Valitse päivämäärä, Valittu päivä 15 keskiviikko Tammikuu 2020
               </span>
@@ -6421,10 +6421,10 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
         <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c2 c9 fi-status-text"
+          class="c4 c9 fi-status-text"
           id="8-statusText"
         />
-      </span>
+      </div>
     </div>
   </div>
   <div
@@ -6432,11 +6432,11 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
     class="c0 c10 fi-date-picker fi-date-picker--small-screen"
   >
     <div
-      class="c3 fi-date-picker_small-screen-container"
+      class="c2 fi-date-picker_small-screen-container"
       role="dialog"
     >
       <div
-        class="c3 fi-date-picker_slide-indicator-wrapper"
+        class="c2 fi-date-picker_slide-indicator-wrapper"
       >
         <div
           class="fi-date-picker_slide-indicator"
@@ -6454,7 +6454,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
             id="9"
           >
             <div
-              class="c3 c4 fi-label"
+              class="c2 c3 fi-label"
             >
               <label
                 class="c7 fi-visually-hidden"
@@ -6478,7 +6478,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 value="2020"
               >
                 <span
-                  class="c2 fi-dropdown_display-value"
+                  class="c4 fi-dropdown_display-value"
                 >
                   2020
                 </span>
@@ -6490,7 +6490,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 />
               </button>
               <span
-                class="c2 c7 fi-visually-hidden"
+                class="c4 c7 fi-visually-hidden"
                 id="9-displayValue"
               >
                 2020
@@ -6498,7 +6498,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               <span
                 aria-atomic="true"
                 aria-live="assertive"
-                class="c2 c9 fi-status-text"
+                class="c4 c9 fi-status-text"
               />
             </div>
           </div>
@@ -6507,7 +6507,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
             id="10"
           >
             <div
-              class="c3 c4 fi-label"
+              class="c2 c3 fi-label"
             >
               <label
                 class="c7 fi-visually-hidden"
@@ -6531,7 +6531,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 value="0"
               >
                 <span
-                  class="c2 fi-dropdown_display-value"
+                  class="c4 fi-dropdown_display-value"
                 >
                   Tammikuu
                 </span>
@@ -6543,7 +6543,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 />
               </button>
               <span
-                class="c2 c7 fi-visually-hidden"
+                class="c4 c7 fi-visually-hidden"
                 id="10-displayValue"
               >
                 Tammikuu
@@ -6551,7 +6551,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               <span
                 aria-atomic="true"
                 aria-live="assertive"
-                class="c2 c9 fi-status-text"
+                class="c4 c9 fi-status-text"
               />
             </div>
           </div>
@@ -6682,7 +6682,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                       1
                     </span>
                     <span
-                      class="c2 c7 fi-visually-hidden"
+                      class="c4 c7 fi-visually-hidden"
                     >
                       1 keskiviikko Tammikuu 2020
                     </span>
@@ -6704,7 +6704,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     2
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     2 torstai Tammikuu 2020
                   </span>
@@ -6725,7 +6725,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     3
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     3 perjantai Tammikuu 2020
                   </span>
@@ -6746,7 +6746,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     4
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     4 lauantai Tammikuu 2020
                   </span>
@@ -6767,7 +6767,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     5
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     5 sunnuntai Tammikuu 2020
                   </span>
@@ -6790,7 +6790,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     6
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     6 maanantai Tammikuu 2020
                   </span>
@@ -6811,7 +6811,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     7
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     7 tiistai Tammikuu 2020
                   </span>
@@ -6832,7 +6832,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     8
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     8 keskiviikko Tammikuu 2020
                   </span>
@@ -6853,7 +6853,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     9
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     9 torstai Tammikuu 2020
                   </span>
@@ -6874,7 +6874,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     10
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     10 perjantai Tammikuu 2020
                   </span>
@@ -6895,7 +6895,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     11
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     11 lauantai Tammikuu 2020
                   </span>
@@ -6916,7 +6916,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     12
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     12 sunnuntai Tammikuu 2020
                   </span>
@@ -6939,7 +6939,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     13
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     13 maanantai Tammikuu 2020
                   </span>
@@ -6960,7 +6960,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     14
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     14 tiistai Tammikuu 2020
                   </span>
@@ -6980,7 +6980,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     15
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     15 keskiviikko Tammikuu 2020
                   </span>
@@ -7001,7 +7001,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     16
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     16 torstai Tammikuu 2020
                   </span>
@@ -7022,7 +7022,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     17
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     17 perjantai Tammikuu 2020
                   </span>
@@ -7043,7 +7043,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     18
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     18 lauantai Tammikuu 2020
                   </span>
@@ -7064,7 +7064,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     19
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     19 sunnuntai Tammikuu 2020
                   </span>
@@ -7087,7 +7087,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     20
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     20 maanantai Tammikuu 2020
                   </span>
@@ -7108,7 +7108,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     21
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     21 tiistai Tammikuu 2020
                   </span>
@@ -7129,7 +7129,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     22
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     22 keskiviikko Tammikuu 2020
                   </span>
@@ -7150,7 +7150,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     23
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     23 torstai Tammikuu 2020
                   </span>
@@ -7171,7 +7171,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     24
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     24 perjantai Tammikuu 2020
                   </span>
@@ -7192,7 +7192,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     25
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     25 lauantai Tammikuu 2020
                   </span>
@@ -7213,7 +7213,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     26
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     26 sunnuntai Tammikuu 2020
                   </span>
@@ -7236,7 +7236,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     27
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     27 maanantai Tammikuu 2020
                   </span>
@@ -7257,7 +7257,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     28
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     28 tiistai Tammikuu 2020
                   </span>
@@ -7278,7 +7278,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     29
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     29 keskiviikko Tammikuu 2020
                   </span>
@@ -7299,7 +7299,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     30
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     30 torstai Tammikuu 2020
                   </span>
@@ -7320,7 +7320,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     31
                   </span>
                   <span
-                    class="c2 c7 fi-visually-hidden"
+                    class="c4 c7 fi-visually-hidden"
                   >
                     31 perjantai Tammikuu 2020
                   </span>


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Based on accessibility review, removed confirm feature. Close button styles were also updated to be less dominant.


## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Datepicker has better usability, especially with screen readers, without separate confirm button.

## How Has This Been Tested?

Windows NVDA Edge, Chrome, Firefox
iOS VoiceOver Safari, Chrome
Mac VoiceOver (with BrowserStack) Safari, Chrome
Android (with BrowsersStack) Chrome

## Screenshots (if appropriate):
<img width="280" alt="datepicker" src="https://user-images.githubusercontent.com/14312917/231755274-c8fa8523-9e03-4982-9905-781292fe3048.png">

<img width="287" alt="smallScreen" src="https://user-images.githubusercontent.com/14312917/231755286-66ecfef6-62ab-46e0-9010-d93e9328298d.PNG">
