### PR TITLE
Remove smaller margin from non-scrollable modal

### DIFF
--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -568,10 +568,6 @@ exports[`Basic modal should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c4.fi-modal_title--no-scroll {
-  margin-bottom: 10px;
-}
-
 .c4.fi-modal_title--small-screen {
   margin-bottom: 20px;
 }

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -515,10 +515,6 @@ exports[`Basic ModalContent should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c4.fi-modal_title--no-scroll {
-  margin-bottom: 10px;
-}
-
 .c4.fi-modal_title--small-screen {
   margin-bottom: 20px;
 }

--- a/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
+++ b/src/core/Modal/ModalTitle/ModalTitle.baseStyles.tsx
@@ -21,10 +21,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     margin-bottom: ${theme.spacing.m};
 
-    &--no-scroll {
-      margin-bottom: ${theme.spacing.xs};
-    }
-
     &--small-screen {
       margin-bottom: ${theme.spacing.m};
     }

--- a/src/core/Modal/ModalTitle/ModalTitle.tsx
+++ b/src/core/Modal/ModalTitle/ModalTitle.tsx
@@ -27,7 +27,6 @@ interface InternalModalTitleProps extends ModalTitleProps, SuomifiThemeProp {
 const titleClassName = `${baseClassName}_title`;
 const titleClassNames = {
   smallScreen: `${titleClassName}--smallScreen`,
-  noScroll: `${titleClassName}--no-scroll`,
   focusWrapper: `${titleClassName}_focus-wrapper`,
 };
 
@@ -54,7 +53,6 @@ class BaseModalTitle extends Component<InternalModalTitleProps> {
       <HtmlSpan
         className={classnames(className, titleClassName, {
           [titleClassNames.smallScreen]: modalVariant === 'smallScreen',
-          [titleClassNames.noScroll]: scrollable === false,
         })}
       >
         <Heading


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

PR unifies modal heading styles in scrollable and non-scrollable modal.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Margins under heading have been slightly different height. Margin is unified for more uniform design.

## How Has This Been Tested?

Styleguidist

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### Modal

- **Breaking change:** Removed class `.fi-modal_title--no-scroll` from non-scrollable dialog