### PR TITLE
[Fix] DateInput button text from VisuallyHidden to aria-label

### DIFF
--- a/src/core/Form/DateInput/DateInput.test.tsx
+++ b/src/core/Form/DateInput/DateInput.test.tsx
@@ -421,7 +421,10 @@ describe('props', () => {
       );
       fireEvent.click(getByRole('button'));
       const dateButton = getByText('15').closest('button');
-      expect(dateButton).toHaveTextContent('15 maanantai Kesäkuu 2015');
+      expect(dateButton).toHaveAttribute(
+        'aria-label',
+        '15 maanantai Kesäkuu 2015',
+      );
     });
 
     it('has focus', () => {
@@ -475,7 +478,10 @@ describe('props', () => {
       const dateButton = baseElement.querySelector(
         '.fi-month-day_button--selected',
       );
-      expect(dateButton).toHaveTextContent('15 lauantai Elokuu 2020');
+      expect(dateButton).toHaveAttribute(
+        'aria-label',
+        '15 lauantai Elokuu 2020',
+      );
     });
 
     it('formats selected date to input field', () => {
@@ -680,7 +686,10 @@ describe('props', () => {
         const dateButton = getByText('15').closest(
           'button',
         ) as HTMLButtonElement;
-        expect(dateButton).toHaveTextContent('15 keskiviikko Tammikuu 2020');
+        expect(dateButton).toHaveAttribute(
+          'aria-label',
+          '15 keskiviikko Tammikuu 2020',
+        );
         expect(dateButton).toHaveFocus();
       });
     });
@@ -710,7 +719,10 @@ describe('props', () => {
       const dateButton = baseElement.querySelector(
         '.fi-month-day_button--selected',
       );
-      expect(dateButton).toHaveTextContent('1 perjantai Toukokuu 2020');
+      expect(dateButton).toHaveAttribute(
+        'aria-label',
+        '1 perjantai Toukokuu 2020',
+      );
     });
 
     it('has user given value focused in calendar', () => {
@@ -721,7 +733,10 @@ describe('props', () => {
       const dateButton = baseElement.querySelector(
         '.fi-month-day_button--selected',
       );
-      expect(dateButton).toHaveTextContent('1 perjantai Toukokuu 2020');
+      expect(dateButton).toHaveAttribute(
+        'aria-label',
+        '1 perjantai Toukokuu 2020',
+      );
       expect(dateButton).toHaveFocus();
     });
   });
@@ -769,7 +784,10 @@ describe('props', () => {
         const dateButton = baseElement.querySelector(
           '.fi-month-day_button--selected',
         );
-        expect(dateButton).toHaveTextContent('31 perjantai Tammikuu 2020');
+        expect(dateButton).toHaveAttribute(
+          'aria-label',
+          '31 perjantai Tammikuu 2020',
+        );
       });
 
       it('has user given defaultValue focused in calendar', () => {
@@ -784,7 +802,10 @@ describe('props', () => {
         const dateButton = baseElement.querySelector(
           '.fi-month-day_button--selected',
         );
-        expect(dateButton).toHaveTextContent('31 perjantai Tammikuu 2020');
+        expect(dateButton).toHaveAttribute(
+          'aria-label',
+          '31 perjantai Tammikuu 2020',
+        );
         expect(dateButton).toHaveFocus();
       });
     });

--- a/src/core/Form/DateInput/DatePicker/MonthDay/MonthDay.tsx
+++ b/src/core/Form/DateInput/DatePicker/MonthDay/MonthDay.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { VisuallyHidden } from '../../../../VisuallyHidden/VisuallyHidden';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../../theme';
 import { HtmlButton, HtmlDiv } from '../../../../../reset';
 import { InternalDatePickerTextProps } from '../../datePickerTexts';
@@ -64,15 +63,8 @@ export const BaseMonthDay = (props: MonthDayProps) => {
 
   const isFocusableDate = (): boolean => daysMatch(focusableDate, date.date);
 
-  const isDisabledDate = (): boolean =>
+  const isDisabledByFn = (): boolean =>
     shouldDisableDate ? shouldDisableDate(date.date) : false;
-
-  const cellDateElements = (
-    <>
-      <span aria-hidden>{date.number}</span>
-      <VisuallyHidden>{cellDateAriaLabel(date.date, texts)}</VisuallyHidden>
-    </>
-  );
 
   return (
     <td
@@ -91,15 +83,16 @@ export const BaseMonthDay = (props: MonthDayProps) => {
         )
       ) : (
         <HtmlButton
-          onClick={() => (isDisabledDate() ? undefined : onSelect(date.date))}
+          onClick={() => (isDisabledByFn() ? undefined : onSelect(date.date))}
           onKeyDown={onKeyDown}
           tabIndex={isFocusableDate() ? undefined : -1}
           forwardedRef={isFocusedDate() ? dayButtonRef : undefined}
           aria-current={date.current ? 'date' : undefined}
-          aria-disabled={isDisabledDate()}
+          aria-disabled={isDisabledByFn()}
+          aria-label={cellDateAriaLabel(date.date, texts)}
           className={classnames(monthDayClassNames.button, {
             [monthDayClassNames.buttonSelected]: isSelectedDate(),
-            [monthDayClassNames.buttonDisabled]: isDisabledDate(),
+            [monthDayClassNames.buttonDisabled]: isDisabledByFn(),
           })}
         >
           {date.current ? (
@@ -108,10 +101,10 @@ export const BaseMonthDay = (props: MonthDayProps) => {
                 [monthDayClassNames.buttonCurrent]: date.current,
               })}
             >
-              {cellDateElements}
+              <span aria-hidden>{date.number}</span>
             </HtmlDiv>
           ) : (
-            cellDateElements
+            <span aria-hidden>{date.number}</span>
           )}
         </HtmlButton>
       )}

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3240,18 +3240,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
   cursor: not-allowed;
 }
 
-.c7 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-}
-
 .c15.fi-month-day {
   padding: 1px;
   text-align: center;
@@ -3393,6 +3381,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   text-align: center;
   min-width: 36px;
   height: 38px;
+}
+
+.c7 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
 }
 
 .c3.fi-label .fi-label_label-span {
@@ -4380,6 +4380,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               <button
                 aria-current="date"
                 aria-disabled="false"
+                aria-label="1 keskiviikko Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4392,11 +4393,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   >
                     1
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    1 keskiviikko Tammikuu 2020
-                  </span>
                 </div>
               </button>
             </td>
@@ -4405,6 +4401,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="2 torstai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4414,11 +4411,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   2
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  2 torstai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4426,6 +4418,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="3 perjantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4435,11 +4428,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   3
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  3 perjantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4447,6 +4435,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="4 lauantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4456,11 +4445,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   4
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  4 lauantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4468,6 +4452,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="5 sunnuntai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4477,11 +4462,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   5
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  5 sunnuntai Tammikuu 2020
-                </span>
               </button>
             </td>
           </tr>
@@ -4491,6 +4471,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="6 maanantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4500,11 +4481,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   6
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  6 maanantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4512,6 +4488,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="7 tiistai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4521,11 +4498,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   7
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  7 tiistai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4533,6 +4505,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="8 keskiviikko Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4542,11 +4515,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   8
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  8 keskiviikko Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4554,6 +4522,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="9 torstai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4563,11 +4532,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   9
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  9 torstai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4575,6 +4539,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="10 perjantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4584,11 +4549,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   10
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  10 perjantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4596,6 +4556,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="11 lauantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4605,11 +4566,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   11
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  11 lauantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4617,6 +4573,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="12 sunnuntai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4626,11 +4583,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   12
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  12 sunnuntai Tammikuu 2020
-                </span>
               </button>
             </td>
           </tr>
@@ -4640,6 +4592,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="13 maanantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4649,11 +4602,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   13
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  13 maanantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4661,6 +4609,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="14 tiistai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4670,11 +4619,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   14
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  14 tiistai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4682,6 +4626,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="15 keskiviikko Tammikuu 2020"
                 class="c6 fi-month-day_button fi-month-day_button--selected"
                 type="button"
               >
@@ -4690,11 +4635,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   15
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  15 keskiviikko Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4702,6 +4642,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="16 torstai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4711,11 +4652,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   16
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  16 torstai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4723,6 +4659,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="17 perjantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4732,11 +4669,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   17
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  17 perjantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4744,6 +4676,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="18 lauantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4753,11 +4686,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   18
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  18 lauantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4765,6 +4693,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="19 sunnuntai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4774,11 +4703,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   19
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  19 sunnuntai Tammikuu 2020
-                </span>
               </button>
             </td>
           </tr>
@@ -4788,6 +4712,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="20 maanantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4797,11 +4722,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   20
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  20 maanantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4809,6 +4729,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="21 tiistai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4818,11 +4739,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   21
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  21 tiistai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4830,6 +4746,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="22 keskiviikko Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4839,11 +4756,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   22
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  22 keskiviikko Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4851,6 +4763,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="23 torstai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4860,11 +4773,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   23
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  23 torstai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4872,6 +4780,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="24 perjantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4881,11 +4790,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   24
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  24 perjantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4893,6 +4797,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="25 lauantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4902,11 +4807,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   25
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  25 lauantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4914,6 +4814,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="26 sunnuntai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4922,11 +4823,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   aria-hidden="true"
                 >
                   26
-                </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  26 sunnuntai Tammikuu 2020
                 </span>
               </button>
             </td>
@@ -4937,6 +4833,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="27 maanantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4946,11 +4843,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   27
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  27 maanantai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4958,6 +4850,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="28 tiistai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4967,11 +4860,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   28
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  28 tiistai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -4979,6 +4867,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="29 keskiviikko Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -4988,11 +4877,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   29
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  29 keskiviikko Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -5000,6 +4884,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="30 torstai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -5009,11 +4894,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 >
                   30
                 </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  30 torstai Tammikuu 2020
-                </span>
               </button>
             </td>
             <td
@@ -5021,6 +4901,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <button
                 aria-disabled="false"
+                aria-label="31 perjantai Tammikuu 2020"
                 class="c6 fi-month-day_button"
                 tabindex="-1"
                 type="button"
@@ -5029,11 +4910,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                   aria-hidden="true"
                 >
                   31
-                </span>
-                <span
-                  class="c4 c7 fi-visually-hidden"
-                >
-                  31 perjantai Tammikuu 2020
                 </span>
               </button>
             </td>
@@ -5493,18 +5369,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   cursor: not-allowed;
 }
 
-.c7 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
-}
-
 .c15.fi-month-day {
   padding: 1px;
   text-align: center;
@@ -5646,6 +5510,18 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   text-align: center;
   min-width: 36px;
   height: 38px;
+}
+
+.c7 {
+  position: absolute;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
 }
 
 .c3.fi-label .fi-label_label-span {
@@ -6642,6 +6518,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 <button
                   aria-current="date"
                   aria-disabled="false"
+                  aria-label="1 keskiviikko Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6654,11 +6531,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     >
                       1
                     </span>
-                    <span
-                      class="c4 c7 fi-visually-hidden"
-                    >
-                      1 keskiviikko Tammikuu 2020
-                    </span>
                   </div>
                 </button>
               </td>
@@ -6667,6 +6539,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="2 torstai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6676,11 +6549,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     2
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    2 torstai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6688,6 +6556,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="3 perjantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6697,11 +6566,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     3
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    3 perjantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6709,6 +6573,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="4 lauantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6718,11 +6583,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     4
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    4 lauantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6730,6 +6590,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="5 sunnuntai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6739,11 +6600,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     5
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    5 sunnuntai Tammikuu 2020
-                  </span>
                 </button>
               </td>
             </tr>
@@ -6753,6 +6609,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="6 maanantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6762,11 +6619,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     6
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    6 maanantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6774,6 +6626,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="7 tiistai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6783,11 +6636,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     7
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    7 tiistai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6795,6 +6643,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="8 keskiviikko Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6804,11 +6653,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     8
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    8 keskiviikko Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6816,6 +6660,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="9 torstai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6825,11 +6670,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     9
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    9 torstai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6837,6 +6677,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="10 perjantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6846,11 +6687,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     10
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    10 perjantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6858,6 +6694,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="11 lauantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6867,11 +6704,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     11
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    11 lauantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6879,6 +6711,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="12 sunnuntai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6888,11 +6721,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     12
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    12 sunnuntai Tammikuu 2020
-                  </span>
                 </button>
               </td>
             </tr>
@@ -6902,6 +6730,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="13 maanantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6911,11 +6740,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     13
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    13 maanantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6923,6 +6747,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="14 tiistai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6932,11 +6757,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     14
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    14 tiistai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6944,6 +6764,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="15 keskiviikko Tammikuu 2020"
                   class="c6 fi-month-day_button fi-month-day_button--selected"
                   type="button"
                 >
@@ -6952,11 +6773,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     15
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    15 keskiviikko Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6964,6 +6780,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="16 torstai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6973,11 +6790,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     16
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    16 torstai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -6985,6 +6797,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="17 perjantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -6994,11 +6807,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     17
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    17 perjantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7006,6 +6814,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="18 lauantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7015,11 +6824,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     18
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    18 lauantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7027,6 +6831,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="19 sunnuntai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7036,11 +6841,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     19
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    19 sunnuntai Tammikuu 2020
-                  </span>
                 </button>
               </td>
             </tr>
@@ -7050,6 +6850,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="20 maanantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7059,11 +6860,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     20
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    20 maanantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7071,6 +6867,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="21 tiistai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7080,11 +6877,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     21
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    21 tiistai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7092,6 +6884,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="22 keskiviikko Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7101,11 +6894,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     22
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    22 keskiviikko Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7113,6 +6901,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="23 torstai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7122,11 +6911,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     23
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    23 torstai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7134,6 +6918,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="24 perjantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7143,11 +6928,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     24
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    24 perjantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7155,6 +6935,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="25 lauantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7164,11 +6945,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     25
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    25 lauantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7176,6 +6952,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="26 sunnuntai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7184,11 +6961,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     aria-hidden="true"
                   >
                     26
-                  </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    26 sunnuntai Tammikuu 2020
                   </span>
                 </button>
               </td>
@@ -7199,6 +6971,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="27 maanantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7208,11 +6981,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     27
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    27 maanantai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7220,6 +6988,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="28 tiistai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7229,11 +6998,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     28
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    28 tiistai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7241,6 +7005,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="29 keskiviikko Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7250,11 +7015,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     29
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    29 keskiviikko Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7262,6 +7022,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="30 torstai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7271,11 +7032,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   >
                     30
                   </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    30 torstai Tammikuu 2020
-                  </span>
                 </button>
               </td>
               <td
@@ -7283,6 +7039,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <button
                   aria-disabled="false"
+                  aria-label="31 perjantai Tammikuu 2020"
                   class="c6 fi-month-day_button"
                   tabindex="-1"
                   type="button"
@@ -7291,11 +7048,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                     aria-hidden="true"
                   >
                     31
-                  </span>
-                  <span
-                    class="c4 c7 fi-visually-hidden"
-                  >
-                    31 perjantai Tammikuu 2020
                   </span>
                 </button>
               </td>


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

PR changes date to aria-label and improves naming for dates disabled by shouldDisableDate prop.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Removes VisuallyHidden component dependency as unnecessary.

## How Has This Been Tested?

Windows NVDA Chrome, Edge, Firefox
iOS VoiceOver Safari, Chrome
Mac VoiceOver Safari, Chrome
Android TalkBack
