### PR TITLE
[Fix] Dropdown itemlist adjustments

### DIFF
--- a/src/core/Dropdown/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown/Dropdown.md
@@ -5,6 +5,18 @@ import { Dropdown, DropdownItem } from 'suomifi-ui-components';
 const [selectedValue, setSelectedValue] = React.useState(null);
 const [status, setStatus] = React.useState('default');
 
+const createItems = () => {
+  const items = [];
+  for (let i = 1; i < 251; i++) {
+    items.push(
+      <DropdownItem value={`item-value-${i}`} key={`key-${i}`}>
+        {`Dropdown item ${i}`}
+      </DropdownItem>
+    );
+  }
+  return items;
+};
+
 <Dropdown
   name="dropdown_example_1"
   labelText="Dropdown label"
@@ -24,51 +36,7 @@ const [status, setStatus] = React.useState('default');
   statusText={status === 'error' ? 'You must select a value.' : ''}
   visualPlaceholder="Select a value"
 >
-  <DropdownItem value={'dropdown-item-1'}>
-    Dropdown Item 1
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-2'}>
-    Dropdown Item 2
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-3'}>
-    Dropdown Item 3
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-4'}>
-    Dropdown Item 4
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-5'}>
-    Dropdown Item 5
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-6'}>
-    Dropdown Item 6
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-7'}>
-    Dropdown Item 7
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-8'}>
-    Dropdown Item 8
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-9'}>
-    Dropdown Item 9
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-10'}>
-    Dropdown Item 10
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-11'}>
-    Dropdown Item 11
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-12'}>
-    Dropdown Item 12
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-13'}>
-    Dropdown Item 13
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-14'}>
-    Dropdown Item 14
-  </DropdownItem>
-  <DropdownItem value={'dropdown-item-15'}>
-    Dropdown Item 15
-  </DropdownItem>
+  {createItems()}
 </Dropdown>;
 ```
 

--- a/src/core/Dropdown/Dropdown/Dropdown.md
+++ b/src/core/Dropdown/Dropdown/Dropdown.md
@@ -5,18 +5,6 @@ import { Dropdown, DropdownItem } from 'suomifi-ui-components';
 const [selectedValue, setSelectedValue] = React.useState(null);
 const [status, setStatus] = React.useState('default');
 
-const createItems = () => {
-  const items = [];
-  for (let i = 1; i < 251; i++) {
-    items.push(
-      <DropdownItem value={`item-value-${i}`} key={`key-${i}`}>
-        {`Dropdown item ${i}`}
-      </DropdownItem>
-    );
-  }
-  return items;
-};
-
 <Dropdown
   name="dropdown_example_1"
   labelText="Dropdown label"
@@ -36,7 +24,51 @@ const createItems = () => {
   statusText={status === 'error' ? 'You must select a value.' : ''}
   visualPlaceholder="Select a value"
 >
-  {createItems()}
+  <DropdownItem value={'dropdown-item-1'}>
+    Dropdown Item 1
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-2'}>
+    Dropdown Item 2
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-3'}>
+    Dropdown Item 3
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-4'}>
+    Dropdown Item 4
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-5'}>
+    Dropdown Item 5
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-6'}>
+    Dropdown Item 6
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-7'}>
+    Dropdown Item 7
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-8'}>
+    Dropdown Item 8
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-9'}>
+    Dropdown Item 9
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-10'}>
+    Dropdown Item 10
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-11'}>
+    Dropdown Item 11
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-12'}>
+    Dropdown Item 12
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-13'}>
+    Dropdown Item 13
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-14'}>
+    Dropdown Item 14
+  </DropdownItem>
+  <DropdownItem value={'dropdown-item-15'}>
+    Dropdown Item 15
+  </DropdownItem>
 </Dropdown>;
 ```
 

--- a/src/core/Dropdown/DropdownItem/DropdownItem.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.tsx
@@ -88,6 +88,9 @@ const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
           consumer.onItemTabPress();
         }
       }}
+      onMouseOver={() => {
+        consumer.onItemMouseOver(value);
+      }}
       {...passProps}
     >
       {children}

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
@@ -31,6 +31,8 @@ export interface SelectItemListProps {
   onKeyDown?: (event: React.KeyboardEvent<HTMLUListElement>) => void;
   /** Id needed for aria-owns and aria-controls */
   id: string;
+  /** Prevents scrollItemList() function from running */
+  preventScrolling?: boolean;
 }
 
 interface InnerRef {
@@ -51,14 +53,15 @@ class BaseSelectItemList extends Component<
   ) {
     if (
       this.props.focusedDescendantId !== prevProps.focusedDescendantId &&
-      !!this.props.focusedDescendantId
+      !!this.props.focusedDescendantId &&
+      !this.props.preventScrolling
     ) {
       this.scrollItemList(this.props.focusedDescendantId);
     }
   }
 
   componentDidMount() {
-    if (!!this.props.focusedDescendantId) {
+    if (!!this.props.focusedDescendantId && !this.props.preventScrolling) {
       this.scrollItemList(this.props.focusedDescendantId);
     }
   }
@@ -98,6 +101,7 @@ class BaseSelectItemList extends Component<
       onKeyDown,
       id,
       focusedDescendantId,
+      preventScrolling,
       ...passProps
     } = this.props;
     return (


### PR DESCRIPTION
## Description

This PR adjusts how Dropdown item list works with mouse and keyboard combo. Previously, mouse hover did not move the actual focus but rather just applied a similar looking style. Now it actually changes the focus(). So using a mouse in the item list is basically the same as navigating through it with a keyboard. This ensures there is only one "active" item in the list at all times (as opposed to the keyboard navigation having its own and another one with a mouse hover)

Also made a small adjustment to `<SelectItemList>` so that the scrolling function is not used when hovering with a mouse.

## Motivation and Context

Prevent multiple "active" looking elements from existing in the Dropdown item list.

## How Has This Been Tested?

MacOS Chrome and Safari VoiceOver
iOS Safari VoiceOver
Windows Chrome Firefox Edge NVDA

## Release notes

### Dropdown
* Fix and issue with multiple "active" looking items appearing in the list. Keyboard and mouse navigation now use the same logic
