### PR TITLE
[Fix] Dropdown unmounted

### DIFF
--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -191,6 +191,8 @@ class BaseDropdown extends Component<DropdownProps> {
 
   popoverRef: React.RefObject<HTMLUListElement>;
 
+  isMounted: boolean;
+
   constructor(props: DropdownProps) {
     super(props);
     this.buttonRef = React.createRef();
@@ -235,6 +237,14 @@ class BaseDropdown extends Component<DropdownProps> {
     }
   }
 
+  componentDidMount(): void {
+    this.isMounted = true;
+  }
+
+  componentWillUnmount(): void {
+    this.isMounted = false;
+  }
+
   private isOutsideClick(event: MouseEvent) {
     return (
       !!this.buttonRef &&
@@ -256,10 +266,13 @@ class BaseDropdown extends Component<DropdownProps> {
       ariaExpanded: false,
     });
     setTimeout(() => {
-      // NVDA with Firefox requires small timeout before focus to read updated value
-      this.buttonRef.current?.focus();
-      // Set showPopover separately to prevent NVDA focus from going to body
-      this.setState({ showPopover: false });
+      // Check mounted status to prevent setting state on an unmounted component
+      if (this.isMounted) {
+        // NVDA with Firefox requires small timeout before focus to read updated value
+        this.buttonRef.current?.focus();
+        // Set showPopover separately to prevent NVDA focus from going to body
+        this.setState({ showPopover: false });
+      }
     }, 10);
   }
 

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -191,7 +191,7 @@ class BaseDropdown extends Component<DropdownProps> {
 
   popoverRef: React.RefObject<HTMLUListElement>;
 
-  isMounted: boolean;
+  componentIsMounted: boolean;
 
   constructor(props: DropdownProps) {
     super(props);
@@ -238,11 +238,11 @@ class BaseDropdown extends Component<DropdownProps> {
   }
 
   componentDidMount(): void {
-    this.isMounted = true;
+    this.componentIsMounted = true;
   }
 
   componentWillUnmount(): void {
-    this.isMounted = false;
+    this.componentIsMounted = false;
   }
 
   private isOutsideClick(event: MouseEvent) {
@@ -267,7 +267,7 @@ class BaseDropdown extends Component<DropdownProps> {
     });
     setTimeout(() => {
       // Check mounted status to prevent setting state on an unmounted component
-      if (this.isMounted) {
+      if (this.componentIsMounted) {
         // NVDA with Firefox requires small timeout before focus to read updated value
         this.buttonRef.current?.focus();
         // Set showPopover separately to prevent NVDA focus from going to body


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

PR introduces a fix to the below mentioned issue. Created a `componentIsMounted` variable which is checked before updating state inside a timeout

## Related Issue

https://github.com/vrk-kpa/suomifi-ui-components/issues/720

## How Has This Been Tested?
Jest tests, where the error also occured

## Release notes

### Dropdown
* Fix an issue where setState was sometimes called when the component was unmounted (https://github.com/vrk-kpa/suomifi-ui-components/issues/720)
