### PR TITLE
[Fix] Support nested array children in Dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/core/Dropdown/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.test.tsx
@@ -20,6 +20,21 @@ const TestDropdown = (props: DropdownProps, testId?: string) => (
   </Dropdown>
 );
 
+const TestNestedDropdown = (props: DropdownProps, testId?: string) => (
+  <Dropdown {...props} wrapperProps={{ 'data-testid': testId || '' }}>
+    {[1, 2, 3].map((item) => (
+      <DropdownItem
+        value={`dropdown-item-${item}`}
+        disabled={item === 3}
+        key={item}
+      >
+        {`Dropdown Item ${item}`}
+      </DropdownItem>
+    ))}
+    <DropdownItem value="All">All</DropdownItem>
+  </Dropdown>
+);
+
 describe('Basic dropdown', () => {
   const BasicDropdown = TestDropdown(dropdownProps, 'dropdown-test-id');
 
@@ -167,7 +182,56 @@ describe('Dropdown with additional aria-label', () => {
   });
 });
 
-describe('DropdownOption', () => {
+describe('Children', () => {
+  it('should select nested item when item is clicked', async () => {
+    const NestedDropdown = TestNestedDropdown({
+      labelText: 'Dropdown',
+    });
+    const { getByRole, getAllByRole } = render(NestedDropdown);
+    const menuButton = getByRole('button') as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(menuButton);
+    });
+    const option = getAllByRole('option')[0];
+    await act(async () => {
+      fireEvent.click(option);
+    });
+    expect(menuButton).toHaveTextContent('Dropdown Item 1');
+  });
+
+  it('should not select disabled nested item when item is clicked', async () => {
+    const NestedDropdown = TestNestedDropdown({
+      labelText: 'Dropdown',
+      visualPlaceholder: 'Select',
+    });
+    const { getByRole, getAllByRole } = render(NestedDropdown);
+    const menuButton = getByRole('button') as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(menuButton);
+    });
+    const option = getAllByRole('option')[2];
+    await act(async () => {
+      fireEvent.click(option);
+    });
+    expect(menuButton).toHaveTextContent('Select');
+  });
+
+  it('should select item when item is clicked', async () => {
+    const NestedDropdown = TestNestedDropdown({ labelText: 'Dropdown' });
+    const { getByRole, getAllByRole } = render(NestedDropdown);
+    const menuButton = getByRole('button') as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(menuButton);
+    });
+    const option = getAllByRole('option')[3];
+    await act(async () => {
+      fireEvent.click(option);
+    });
+    expect(menuButton).toHaveTextContent('All');
+  });
+});
+
+describe('DropdownItem', () => {
   it('should be selected when item is clicked', async () => {
     const BasicDropdown = TestDropdown({ labelText: 'Dropdown' });
     const { getByRole, getAllByRole } = render(BasicDropdown);

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -132,7 +132,9 @@ export interface DropdownProps extends StatusTextCommonProps {
   disabled?: boolean;
   /** DropdownItems */
   children?:
-    | Array<ReactElement<DropdownItemProps>>
+    | Array<
+        ReactElement<DropdownItemProps> | Array<ReactElement<DropdownItemProps>>
+      >
     | ReactElement<DropdownItemProps>;
   /** Callback that fires when the dropdown value changes. */
   onChange?(value: string): void;
@@ -218,15 +220,20 @@ class BaseDropdown extends Component<DropdownProps> {
   static getSelectedValueNode(
     selectedValue: string | undefined,
     children:
-      | Array<ReactElement<DropdownItemProps>>
+      | Array<
+          | ReactElement<DropdownItemProps>
+          | Array<ReactElement<DropdownItemProps>>
+        >
       | ReactElement<DropdownItemProps>
       | undefined,
   ): ReactNode | undefined {
     if (selectedValue === undefined || children === undefined) return undefined;
 
     if (Array.isArray(children)) {
-      for (let index = 0; index < children.length; index += 1) {
-        const element = children[index];
+      const flatChildren = children.flat();
+      for (let index = 0; index < flatChildren.length; index += 1) {
+        const element = flatChildren[index];
+
         if (element.props.value === selectedValue) {
           return element.props.children;
         }
@@ -303,12 +310,13 @@ class BaseDropdown extends Component<DropdownProps> {
     this.setState({ preventListScrolling: false });
 
     const { focusedDescendantId, ariaExpanded, showPopover } = this.state;
-    const popoverItems = Array.isArray(this.props.children)
+    const items = Array.isArray(this.props.children)
       ? this.props.children
       : this.props.children !== undefined
       ? [this.props.children]
       : undefined;
-    if (!popoverItems) return;
+    if (!items) return;
+    const popoverItems: Array<ReactElement<DropdownItemProps>> = items.flat();
     const index = !!focusedDescendantId
       ? popoverItems.findIndex(
           (item) => item?.props.value === focusedDescendantId,
@@ -416,6 +424,11 @@ class BaseDropdown extends Component<DropdownProps> {
   private getFirstItemValue() {
     if (Array.isArray(this.props.children)) {
       const element = this.props.children[0];
+
+      if (Array.isArray(element)) {
+        return element[0].props.value;
+      }
+
       return element.props.value;
     }
     if (!!this.props.children) {

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -19,7 +19,6 @@ import { SelectItemList } from '../../Form/Select/BaseSelect/SelectItemList/Sele
 import { HintText } from '../../Form/HintText/HintText';
 import { StatusText } from '../../Form/StatusText/StatusText';
 import { StatusTextCommonProps } from '../../Form/types';
-import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 
 const baseClassName = 'fi-dropdown';
 
@@ -577,7 +576,10 @@ class BaseDropdown extends Component<DropdownProps> {
             onBlur={this.handleOnBlur}
             {...passProps}
           >
-            <HtmlSpan className={dropdownClassNames.displayValue}>
+            <HtmlSpan
+              className={dropdownClassNames.displayValue}
+              id={displayValueId}
+            >
               {dropdownDisplayValue}
             </HtmlSpan>
             <HtmlInput
@@ -587,10 +589,6 @@ class BaseDropdown extends Component<DropdownProps> {
               value={selectedValue || ''}
             />
           </HtmlButton>
-          {/* NVDA, Chrome does not read displayValue, if within HtmlButton */}
-          <VisuallyHidden id={displayValueId}>
-            {dropdownDisplayValue}
-          </VisuallyHidden>
           <StatusText
             id={statusTextId}
             className={classnames({

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c11 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -165,8 +165,8 @@ exports[`Basic dropdown should match snapshot 1`] = `
   display: list-item;
 }
 
-.c11::before,
-.c11::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -199,7 +199,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -225,21 +225,9 @@ exports[`Basic dropdown should match snapshot 1`] = `
   padding-left: 40px;
 }
 
-.c9::before,
-.c9::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
-}
-
-.c7 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
 }
 
 .c3.fi-label .fi-label_label-span {
@@ -272,7 +260,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   margin-left: 6px;
 }
 
-.c10 {
+.c9 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -299,11 +287,11 @@ exports[`Basic dropdown should match snapshot 1`] = `
   padding: 4px 0 0 0;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
 }
 
-.c10 .fi-select-item-list_content_wrapper {
+.c9 .fi-select-item-list_content_wrapper {
   display: block;
   width: 100%;
   max-height: inherit;
@@ -311,7 +299,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   overflow-x: hidden;
 }
 
-.c8 {
+.c7 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -330,11 +318,11 @@ exports[`Basic dropdown should match snapshot 1`] = `
   line-height: 20px;
 }
 
-.c8.fi-status-text {
+.c7.fi-status-text {
   display: block;
 }
 
-.c8.fi-status-text.fi-status-text--error {
+.c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
 }
 
@@ -519,7 +507,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c12.fi-dropdown_item {
+.c11.fi-dropdown_item {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -532,16 +520,16 @@ exports[`Basic dropdown should match snapshot 1`] = `
   position: relative;
 }
 
-.c12.fi-dropdown_item:focus {
+.c11.fi-dropdown_item:focus {
   outline: 0;
 }
 
-.c12.fi-dropdown_item:hover {
+.c11.fi-dropdown_item:hover {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c12.fi-dropdown_item .fi-dropdown_item_icon {
+.c11.fi-dropdown_item .fi-dropdown_item_icon {
   position: absolute;
   top: 14px;
   right: 10px;
@@ -549,38 +537,38 @@ exports[`Basic dropdown should match snapshot 1`] = `
   width: 12px;
 }
 
-.c12.fi-dropdown_item--selected {
+.c11.fi-dropdown_item--selected {
   background-color: hsl(215,100%,95%);
   color: hsl(0,0%,13%);
 }
 
-.c12.fi-dropdown_item--hasKeyboardFocus {
+.c11.fi-dropdown_item--hasKeyboardFocus {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
+.c11.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
   background-color: hsl(0,0%,100%);
   color: hsl(0,0%,13%);
 }
 
-.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
+.c11.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c12.fi-dropdown_item--disabled {
+.c11.fi-dropdown_item--disabled {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c12.fi-dropdown_item--disabled:hover {
+.c11.fi-dropdown_item--disabled:hover {
   color: hsl(202,7%,67%);
 }
 
 @media (forced-colors:active) {
-  .c12.fi-dropdown_item--hasKeyboardFocus,
-  .c12.fi-dropdown_item:hover {
+  .c11.fi-dropdown_item--hasKeyboardFocus,
+  .c11.fi-dropdown_item:hover {
     background-color: Highlight;
   }
 }
@@ -617,6 +605,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
         >
           <span
             class="c4 fi-dropdown_display-value"
+            id="test-id-displayValue"
           >
             Dropdown
           </span>
@@ -629,15 +618,9 @@ exports[`Basic dropdown should match snapshot 1`] = `
           />
         </button>
         <span
-          class="c4 c7 fi-visually-hidden"
-          id="test-id-displayValue"
-        >
-          Dropdown
-        </span>
-        <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c4 c8 fi-status-text"
+          class="c4 c7 fi-status-text"
         />
       </div>
     </div>
@@ -653,7 +636,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
     >
       <ul
         aria-activedescendant="test-id-item-1"
-        class="c9 fi-select-item-list c10 fi-dropdown_item-list"
+        class="c8 fi-select-item-list c9 fi-dropdown_item-list"
         id="test-id-popover"
         role="listbox"
         tabindex="0"
@@ -664,7 +647,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
           <li
             aria-disabled="false"
             aria-selected="false"
-            class="c11 c12 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
+            class="c10 c11 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
             id="test-id-item-1"
             role="option"
             tabindex="0"
@@ -674,7 +657,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
           <li
             aria-disabled="false"
             aria-selected="false"
-            class="c11 c12 fi-dropdown_item"
+            class="c10 c11 fi-dropdown_item"
             id="test-id-item-2"
             role="option"
             tabindex="-1"
@@ -833,7 +816,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c11 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -853,8 +836,8 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   display: list-item;
 }
 
-.c11::before,
-.c11::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -887,7 +870,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -913,21 +896,9 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   padding-left: 40px;
 }
 
-.c9::before,
-.c9::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
-}
-
-.c7 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
 }
 
 .c3.fi-label .fi-label_label-span {
@@ -960,7 +931,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   margin-left: 6px;
 }
 
-.c10 {
+.c9 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -987,11 +958,11 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   padding: 4px 0 0 0;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
 }
 
-.c10 .fi-select-item-list_content_wrapper {
+.c9 .fi-select-item-list_content_wrapper {
   display: block;
   width: 100%;
   max-height: inherit;
@@ -999,7 +970,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   overflow-x: hidden;
 }
 
-.c8 {
+.c7 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1018,11 +989,11 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   line-height: 20px;
 }
 
-.c8.fi-status-text {
+.c7.fi-status-text {
   display: block;
 }
 
-.c8.fi-status-text.fi-status-text--error {
+.c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
 }
 
@@ -1207,31 +1178,31 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c13 {
+.c12 {
   vertical-align: baseline;
 }
 
-.c13.fi-icon {
+.c12.fi-icon {
   display: inline-block;
 }
 
-.c13 .fi-icon-base-fill {
+.c12 .fi-icon-base-fill {
   fill: currentColor;
 }
 
-.c13 .fi-icon-base-stroke {
+.c12 .fi-icon-base-stroke {
   stroke: currentColor;
 }
 
-.c13.fi-icon--cursor-pointer {
+.c12.fi-icon--cursor-pointer {
   cursor: pointer;
 }
 
-.c13.fi-icon--cursor-pointer * {
+.c12.fi-icon--cursor-pointer * {
   cursor: inherit;
 }
 
-.c12.fi-dropdown_item {
+.c11.fi-dropdown_item {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -1244,16 +1215,16 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   position: relative;
 }
 
-.c12.fi-dropdown_item:focus {
+.c11.fi-dropdown_item:focus {
   outline: 0;
 }
 
-.c12.fi-dropdown_item:hover {
+.c11.fi-dropdown_item:hover {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c12.fi-dropdown_item .fi-dropdown_item_icon {
+.c11.fi-dropdown_item .fi-dropdown_item_icon {
   position: absolute;
   top: 14px;
   right: 10px;
@@ -1261,38 +1232,38 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   width: 12px;
 }
 
-.c12.fi-dropdown_item--selected {
+.c11.fi-dropdown_item--selected {
   background-color: hsl(215,100%,95%);
   color: hsl(0,0%,13%);
 }
 
-.c12.fi-dropdown_item--hasKeyboardFocus {
+.c11.fi-dropdown_item--hasKeyboardFocus {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
+.c11.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
   background-color: hsl(0,0%,100%);
   color: hsl(0,0%,13%);
 }
 
-.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
+.c11.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c12.fi-dropdown_item--disabled {
+.c11.fi-dropdown_item--disabled {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c12.fi-dropdown_item--disabled:hover {
+.c11.fi-dropdown_item--disabled:hover {
   color: hsl(202,7%,67%);
 }
 
 @media (forced-colors:active) {
-  .c12.fi-dropdown_item--hasKeyboardFocus,
-  .c12.fi-dropdown_item:hover {
+  .c11.fi-dropdown_item--hasKeyboardFocus,
+  .c11.fi-dropdown_item:hover {
     background-color: Highlight;
   }
 }
@@ -1330,6 +1301,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
         >
           <span
             class="c4 fi-dropdown_display-value"
+            id="test-id-displayValue"
           >
             Item 2
           </span>
@@ -1342,15 +1314,9 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           />
         </button>
         <span
-          class="c4 c7 fi-visually-hidden"
-          id="test-id-displayValue"
-        >
-          Item 2
-        </span>
-        <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c4 c8 fi-status-text"
+          class="c4 c7 fi-status-text"
         />
       </div>
     </div>
@@ -1366,7 +1332,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
     >
       <ul
         aria-activedescendant="test-id-item-2"
-        class="c9 fi-select-item-list c10 fi-dropdown_item-list"
+        class="c8 fi-select-item-list c9 fi-dropdown_item-list"
         id="test-id-popover"
         role="listbox"
         tabindex="0"
@@ -1377,7 +1343,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           <li
             aria-disabled="false"
             aria-selected="false"
-            class="c11 c12 fi-dropdown_item"
+            class="c10 c11 fi-dropdown_item"
             id="test-id-item-1"
             role="option"
             tabindex="-1"
@@ -1387,7 +1353,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           <li
             aria-disabled="false"
             aria-selected="true"
-            class="c11 c12 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus fi-dropdown_item--selected"
+            class="c10 c11 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus fi-dropdown_item--selected"
             id="test-id-item-2"
             role="option"
             tabindex="0"
@@ -1395,7 +1361,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
             Item 2
             <svg
               aria-hidden="true"
-              class="fi-icon c13 fi-dropdown_item_icon"
+              class="fi-icon c12 fi-dropdown_item_icon"
               focusable="false"
               height="1em"
               viewBox="0 0 20 20"
@@ -1562,7 +1528,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c11 {
+.c10 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1582,8 +1548,8 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   display: list-item;
 }
 
-.c11::before,
-.c11::after {
+.c10::before,
+.c10::after {
   box-sizing: border-box;
 }
 
@@ -1616,7 +1582,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c9 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1642,21 +1608,9 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   padding-left: 40px;
 }
 
-.c9::before,
-.c9::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
-}
-
-.c7 {
-  position: absolute;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-  overflow: hidden;
 }
 
 .c3.fi-label .fi-label_label-span {
@@ -1689,7 +1643,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   margin-left: 6px;
 }
 
-.c10 {
+.c9 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1716,11 +1670,11 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   padding: 4px 0 0 0;
 }
 
-.c10:focus {
+.c9:focus {
   outline: none;
 }
 
-.c10 .fi-select-item-list_content_wrapper {
+.c9 .fi-select-item-list_content_wrapper {
   display: block;
   width: 100%;
   max-height: inherit;
@@ -1728,7 +1682,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   overflow-x: hidden;
 }
 
-.c8 {
+.c7 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1747,11 +1701,11 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   line-height: 20px;
 }
 
-.c8.fi-status-text {
+.c7.fi-status-text {
   display: block;
 }
 
-.c8.fi-status-text.fi-status-text--error {
+.c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,48%);
 }
 
@@ -1936,7 +1890,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   z-index: 9999;
 }
 
-.c12.fi-dropdown_item {
+.c11.fi-dropdown_item {
   color: hsl(0,0%,13%);
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
@@ -1949,16 +1903,16 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   position: relative;
 }
 
-.c12.fi-dropdown_item:focus {
+.c11.fi-dropdown_item:focus {
   outline: 0;
 }
 
-.c12.fi-dropdown_item:hover {
+.c11.fi-dropdown_item:hover {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c12.fi-dropdown_item .fi-dropdown_item_icon {
+.c11.fi-dropdown_item .fi-dropdown_item_icon {
   position: absolute;
   top: 14px;
   right: 10px;
@@ -1966,38 +1920,38 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   width: 12px;
 }
 
-.c12.fi-dropdown_item--selected {
+.c11.fi-dropdown_item--selected {
   background-color: hsl(215,100%,95%);
   color: hsl(0,0%,13%);
 }
 
-.c12.fi-dropdown_item--hasKeyboardFocus {
+.c11.fi-dropdown_item--hasKeyboardFocus {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
+.c11.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected {
   background-color: hsl(0,0%,100%);
   color: hsl(0,0%,13%);
 }
 
-.c12.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
+.c11.fi-dropdown_item--noSelectedStyles.fi-dropdown_item--selected.fi-dropdown_item--hasKeyboardFocus {
   background-color: hsl(212,63%,45%);
   color: hsl(0,0%,100%);
 }
 
-.c12.fi-dropdown_item--disabled {
+.c11.fi-dropdown_item--disabled {
   color: hsl(202,7%,67%);
   cursor: not-allowed;
 }
 
-.c12.fi-dropdown_item--disabled:hover {
+.c11.fi-dropdown_item--disabled:hover {
   color: hsl(202,7%,67%);
 }
 
 @media (forced-colors:active) {
-  .c12.fi-dropdown_item--hasKeyboardFocus,
-  .c12.fi-dropdown_item:hover {
+  .c11.fi-dropdown_item--hasKeyboardFocus,
+  .c11.fi-dropdown_item:hover {
     background-color: Highlight;
   }
 }
@@ -2034,6 +1988,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
         >
           <span
             class="c4 fi-dropdown_display-value"
+            id="test-id-displayValue"
           >
             Dropdown
           </span>
@@ -2046,15 +2001,9 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           />
         </button>
         <span
-          class="c4 c7 fi-visually-hidden"
-          id="test-id-displayValue"
-        >
-          Dropdown
-        </span>
-        <span
           aria-atomic="true"
           aria-live="assertive"
-          class="c4 c8 fi-status-text"
+          class="c4 c7 fi-status-text"
         />
       </div>
     </div>
@@ -2070,7 +2019,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
     >
       <ul
         aria-activedescendant="test-id-item-1"
-        class="c9 fi-select-item-list c10 fi-dropdown_item-list"
+        class="c8 fi-select-item-list c9 fi-dropdown_item-list"
         id="test-id-popover"
         role="listbox"
         tabindex="0"
@@ -2081,7 +2030,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           <li
             aria-disabled="false"
             aria-selected="false"
-            class="c11 c12 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
+            class="c10 c11 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
             id="test-id-item-1"
             role="option"
             tabindex="0"
@@ -2091,7 +2040,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           <li
             aria-disabled="false"
             aria-selected="false"
-            class="c11 c12 fi-dropdown_item"
+            class="c10 c11 fi-dropdown_item"
             id="test-id-item-2"
             role="option"
             tabindex="-1"
@@ -2561,6 +2510,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
         >
           <span
             class="c6 fi-dropdown_display-value"
+            id="test-id-displayValue"
           >
             Dropdown
           </span>
@@ -2572,12 +2522,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
             value=""
           />
         </button>
-        <span
-          class="c6 c4 fi-visually-hidden"
-          id="test-id-displayValue"
-        >
-          Dropdown
-        </span>
         <span
           aria-atomic="true"
           aria-live="assertive"

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -4190,6 +4190,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <span
                 class="c4 fi-dropdown_display-value"
+                id="16-displayValue"
               >
                 2020
               </span>
@@ -4200,12 +4201,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 value="2020"
               />
             </button>
-            <span
-              class="c4 c7 fi-visually-hidden"
-              id="16-displayValue"
-            >
-              2020
-            </span>
             <span
               aria-atomic="true"
               aria-live="assertive"
@@ -4243,6 +4238,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             >
               <span
                 class="c4 fi-dropdown_display-value"
+                id="17-displayValue"
               >
                 Tammikuu
               </span>
@@ -4253,12 +4249,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 value="0"
               />
             </button>
-            <span
-              class="c4 c7 fi-visually-hidden"
-              id="17-displayValue"
-            >
-              Tammikuu
-            </span>
             <span
               aria-atomic="true"
               aria-live="assertive"
@@ -6328,6 +6318,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <span
                   class="c4 fi-dropdown_display-value"
+                  id="9-displayValue"
                 >
                   2020
                 </span>
@@ -6338,12 +6329,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   value="2020"
                 />
               </button>
-              <span
-                class="c4 c7 fi-visually-hidden"
-                id="9-displayValue"
-              >
-                2020
-              </span>
               <span
                 aria-atomic="true"
                 aria-live="assertive"
@@ -6381,6 +6366,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               >
                 <span
                   class="c4 fi-dropdown_display-value"
+                  id="10-displayValue"
                 >
                   Tammikuu
                 </span>
@@ -6391,12 +6377,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   value="0"
                 />
               </button>
-              <span
-                class="c4 c7 fi-visually-hidden"
-                id="10-displayValue"
-              >
-                Tammikuu
-              </span>
               <span
                 aria-atomic="true"
                 aria-live="assertive"

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
@@ -22,7 +22,7 @@ export interface SelectItemListProps {
   /** SelectItemList container div class name for custom styling. */
   className?: string;
   /** List items */
-  children: ReactElement | Array<ReactElement>;
+  children: ReactElement | Array<ReactElement | Array<ReactElement>>;
   /** Id for the currently focused list item for styles and scrolling */
   focusedDescendantId: string;
   /** onBlur event handler */


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
PR adds support to giving nested array children in Dropdown.

```
<Dropdown ...>
  {['Item 1', 'Item 2', 'Item 3'].map((item) => (
    <DropdownItem value={`dropdown-item-${item}`}>
      {item}
    </DropdownItem>
  ))}
  <DropdownItem value="Static">Static</DropdownItem>
</Dropdown>
```

PR removes old NVDA fix that was needed for v10.0.0-beta.1 but not as of v10.0.0.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Giving a nested array as children was supported by previous Dropdown version and is a common pattern.

Old fix for NVDA with` <VisuallyHidden> `text causes confusion with mobile screen readers, that can navigate to the hidden text.

## How Has This Been Tested?

Windows: Firefox, Chrome, Edge (NVDA)
iOS: Chrome, Safari (VoiceOver)
Android: Chrome (TalkBack)
Mac: Chrome, Safari (VoiceOver)

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
