### PR TITLE
[Breaking change] Rename button's link variant to secondaryLight

### DIFF
--- a/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
@@ -401,7 +401,7 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link {
+.c3.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -412,18 +412,18 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   border: none;
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -431,17 +431,17 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -1167,7 +1167,7 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link {
+.c3.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -1178,18 +1178,18 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   border: none;
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1197,17 +1197,17 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -1933,7 +1933,7 @@ exports[`No borders variant should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link {
+.c3.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -1944,18 +1944,18 @@ exports[`No borders variant should match snapshot 1`] = `
   border: none;
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1963,17 +1963,17 @@ exports[`No borders variant should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -2700,7 +2700,7 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link {
+.c3.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -2711,18 +2711,18 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   border: none;
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -2730,17 +2730,17 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -3467,7 +3467,7 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link {
+.c3.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -3478,18 +3478,18 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   border: none;
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3497,17 +3497,17 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c3.fi-button--link:hover {
+.c3.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c3.fi-button--link:active {
+.c3.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c3.fi-button--link.fi-button--disabled,
-.c3.fi-button--link[disabled],
-.c3.fi-button--link:disabled {
+.c3.fi-button--secondary-light.fi-button--disabled,
+.c3.fi-button--secondary-light[disabled],
+.c3.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -70,8 +70,8 @@ const secondaryNoBorderStyles = (theme: SuomifiTheme) => css`
   }
 `;
 
-const linkStyles = (theme: SuomifiTheme) => css`
-  &.fi-button--link {
+const secondaryLightStyles = (theme: SuomifiTheme) => css`
+  &.fi-button--secondary-light {
     color: ${theme.colors.highlightBase};
     ${secondary(theme)}
     background: ${theme.gradients.depthSecondaryToDepthSecondaryDark1};
@@ -147,7 +147,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   ${invertedStyles(theme)}
   ${secondaryStyles(theme)}
   ${secondaryNoBorderStyles(theme)}
-  ${linkStyles(theme)}
+
+  ${secondaryLightStyles(theme)}
   
   & > .fi-button_icon > .fi-icon {
     width: 16px;

--- a/src/core/Button/Button.md
+++ b/src/core/Button/Button.md
@@ -115,10 +115,10 @@ import { Button } from 'suomifi-ui-components';
 import { IconLogin } from 'suomifi-icons';
 
 <>
-  <Button variant="link">Link Button</Button>
+  <Button variant="secondaryLight">Light secondary button</Button>
 
-  <Button variant="link" disabled icon={<IconLogin />}>
-    Link Button disabled icon="login"
+  <Button variant="secondaryLight" disabled icon={<IconLogin />}>
+    Light secondary Button disabled icon="login"
   </Button>
 </>;
 ```

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -75,7 +75,9 @@ describe('Button variant', () => {
   });
 
   it('link match snapshot', () => {
-    const { container } = render(<Button variant="link">Link button</Button>);
+    const { container } = render(
+      <Button variant="secondaryLight">Secondary light button</Button>,
+    );
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -10,13 +10,13 @@ export type ButtonVariant =
   | 'inverted'
   | 'secondary'
   | 'secondaryNoBorder'
-  | 'link';
+  | 'secondaryLight';
 
 export interface ButtonProps
   extends Omit<HtmlButtonProps, 'aria-disabled' | 'onClick'> {
   /**
    * Variant for Button
-   * 'default' | 'inverted' | 'secondary' | 'secondaryNoBorder' | 'link'
+   * 'default' | 'inverted' | 'secondary' | 'secondaryNoBorder' | 'secondaryLight'
    * @default default
    */
   variant?: ButtonVariant;
@@ -92,7 +92,7 @@ class BaseButton extends Component<ButtonProps> {
           [`${baseClassName}--secondary`]: variant === 'secondary',
           [`${baseClassName}--secondary-noborder`]:
             variant === 'secondaryNoBorder',
-          [`${baseClassName}--link`]: variant === 'link',
+          [`${baseClassName}--secondary-light`]: variant === 'secondaryLight',
           [fullWidthClassName]: fullWidth,
         })}
       >
@@ -113,7 +113,6 @@ const StyledButton = styled(
 )`
   ${({ theme }) => baseStyles(theme)}
 `;
-
 /**
  * <i class="semantics" />
  * Use for inside Application onClick events.<br />

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -243,7 +243,7 @@ exports[`Button variant default should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link {
+.c1.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -254,18 +254,18 @@ exports[`Button variant default should match snapshot 1`] = `
   border: none;
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -273,17 +273,17 @@ exports[`Button variant default should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -567,7 +567,7 @@ exports[`Button variant inverted should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link {
+.c1.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -578,18 +578,18 @@ exports[`Button variant inverted should match snapshot 1`] = `
   border: none;
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -597,17 +597,17 @@ exports[`Button variant inverted should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -891,7 +891,7 @@ exports[`Button variant link match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link {
+.c1.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -902,18 +902,18 @@ exports[`Button variant link match snapshot 1`] = `
   border: none;
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -921,17 +921,17 @@ exports[`Button variant link match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -958,14 +958,14 @@ exports[`Button variant link match snapshot 1`] = `
 
 <button
   aria-disabled="false"
-  class="c0 fi-button c1 fi-button--link"
+  class="c0 fi-button c1 fi-button--secondary-light"
   tabindex="0"
   type="button"
 >
   <span
     class="c2 fi-button_icon"
   />
-  Link button
+  Secondary light button
   <span
     class="c2 fi-button_icon fi-button_icon--right"
   />
@@ -1215,7 +1215,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link {
+.c1.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -1226,18 +1226,18 @@ exports[`Button variant secondary should match snapshot 1`] = `
   border: none;
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1245,17 +1245,17 @@ exports[`Button variant secondary should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -1539,7 +1539,7 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link {
+.c1.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -1550,18 +1550,18 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
   border: none;
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1569,17 +1569,17 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c1.fi-button--link:hover {
+.c1.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c1.fi-button--link:active {
+.c1.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c1.fi-button--link.fi-button--disabled,
-.c1.fi-button--link[disabled],
-.c1.fi-button--link:disabled {
+.c1.fi-button--secondary-light.fi-button--disabled,
+.c1.fi-button--secondary-light[disabled],
+.c1.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3231,7 +3231,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c13.fi-button--link {
+.c13.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -3242,18 +3242,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border: none;
 }
 
-.c13.fi-button--link:hover {
+.c13.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c13.fi-button--link:active {
+.c13.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c13.fi-button--link.fi-button--disabled,
-.c13.fi-button--link[disabled],
-.c13.fi-button--link:disabled {
+.c13.fi-button--secondary-light.fi-button--disabled,
+.c13.fi-button--secondary-light[disabled],
+.c13.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -3261,17 +3261,17 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border-color: hsl(202,7%,67%);
 }
 
-.c13.fi-button--link:hover {
+.c13.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c13.fi-button--link:active {
+.c13.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c13.fi-button--link.fi-button--disabled,
-.c13.fi-button--link[disabled],
-.c13.fi-button--link:disabled {
+.c13.fi-button--secondary-light.fi-button--disabled,
+.c13.fi-button--secondary-light[disabled],
+.c13.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -5419,7 +5419,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c13.fi-button--link {
+.c13.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -5430,18 +5430,18 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border: none;
 }
 
-.c13.fi-button--link:hover {
+.c13.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c13.fi-button--link:active {
+.c13.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c13.fi-button--link.fi-button--disabled,
-.c13.fi-button--link[disabled],
-.c13.fi-button--link:disabled {
+.c13.fi-button--secondary-light.fi-button--disabled,
+.c13.fi-button--secondary-light[disabled],
+.c13.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -5449,17 +5449,17 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c13.fi-button--link:hover {
+.c13.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c13.fi-button--link:active {
+.c13.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c13.fi-button--link.fi-button--disabled,
-.c13.fi-button--link[disabled],
-.c13.fi-button--link:disabled {
+.c13.fi-button--secondary-light.fi-button--disabled,
+.c13.fi-button--secondary-light[disabled],
+.c13.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1018,7 +1018,7 @@ exports[`has matching snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c15.fi-button--link {
+.c15.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -1029,18 +1029,18 @@ exports[`has matching snapshot 1`] = `
   border: none;
 }
 
-.c15.fi-button--link:hover {
+.c15.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c15.fi-button--link:active {
+.c15.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c15.fi-button--link.fi-button--disabled,
-.c15.fi-button--link[disabled],
-.c15.fi-button--link:disabled {
+.c15.fi-button--secondary-light.fi-button--disabled,
+.c15.fi-button--secondary-light[disabled],
+.c15.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -1048,17 +1048,17 @@ exports[`has matching snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c15.fi-button--link:hover {
+.c15.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c15.fi-button--link:active {
+.c15.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c15.fi-button--link.fi-button--disabled,
-.c15.fi-button--link[disabled],
-.c15.fi-button--link:disabled {
+.c15.fi-button--secondary-light.fi-button--disabled,
+.c15.fi-button--secondary-light[disabled],
+.c15.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);
@@ -1399,7 +1399,7 @@ exports[`has matching snapshot 1`] = `
         </div>
         <button
           aria-disabled="false"
-          class="c7 fi-button c15 fi-multiselect_removeAllButton fi-button--link"
+          class="c7 fi-button c15 fi-multiselect_removeAllButton fi-button--secondary-light"
           tabindex="0"
           type="button"
         >

--- a/src/core/Form/Select/MultiSelect/MultiSelectRemoveAllButton/MultiSelectRemoveAllButton.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelectRemoveAllButton/MultiSelectRemoveAllButton.tsx
@@ -35,7 +35,7 @@ export const MultiSelectRemoveAllButton = <T extends MultiSelectData>(
   return showRemoveAllButton ? (
     <Button
       className={className}
-      variant="link"
+      variant="secondaryLight"
       icon={<IconRemove />}
       onClick={onClick}
       {...passProps}

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -777,7 +777,7 @@ exports[`Basic modal should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c9.fi-button--link {
+.c9.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -788,18 +788,18 @@ exports[`Basic modal should match snapshot 1`] = `
   border: none;
 }
 
-.c9.fi-button--link:hover {
+.c9.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c9.fi-button--link:active {
+.c9.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c9.fi-button--link.fi-button--disabled,
-.c9.fi-button--link[disabled],
-.c9.fi-button--link:disabled {
+.c9.fi-button--secondary-light.fi-button--disabled,
+.c9.fi-button--secondary-light[disabled],
+.c9.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -807,17 +807,17 @@ exports[`Basic modal should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c9.fi-button--link:hover {
+.c9.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c9.fi-button--link:active {
+.c9.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c9.fi-button--link.fi-button--disabled,
-.c9.fi-button--link[disabled],
-.c9.fi-button--link:disabled {
+.c9.fi-button--secondary-light.fi-button--disabled,
+.c9.fi-button--secondary-light[disabled],
+.c9.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -405,7 +405,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c4.fi-button--link {
+.c4.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -416,18 +416,18 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   border: none;
 }
 
-.c4.fi-button--link:hover {
+.c4.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c4.fi-button--link:active {
+.c4.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c4.fi-button--link.fi-button--disabled,
-.c4.fi-button--link[disabled],
-.c4.fi-button--link:disabled {
+.c4.fi-button--secondary-light.fi-button--disabled,
+.c4.fi-button--secondary-light[disabled],
+.c4.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -435,17 +435,17 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c4.fi-button--link:hover {
+.c4.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c4.fi-button--link:active {
+.c4.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c4.fi-button--link.fi-button--disabled,
-.c4.fi-button--link[disabled],
-.c4.fi-button--link:disabled {
+.c4.fi-button--secondary-light.fi-button--disabled,
+.c4.fi-button--secondary-light[disabled],
+.c4.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -731,7 +731,7 @@ exports[`snapshot should have matching default structure 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c6.fi-button--link {
+.c6.fi-button--secondary-light {
   color: hsl(212,63%,45%);
   color: hsl(212,63%,45%);
   background: none;
@@ -742,18 +742,18 @@ exports[`snapshot should have matching default structure 1`] = `
   border: none;
 }
 
-.c6.fi-button--link:hover {
+.c6.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg,hsl(202,7%,93%) 0%,hsla(0,0%,100%,0) 100%);
 }
 
-.c6.fi-button--link:active {
+.c6.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202,7%,93%);
 }
 
-.c6.fi-button--link.fi-button--disabled,
-.c6.fi-button--link[disabled],
-.c6.fi-button--link:disabled {
+.c6.fi-button--secondary-light.fi-button--disabled,
+.c6.fi-button--secondary-light[disabled],
+.c6.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   text-shadow: none;
   background: none;
@@ -761,17 +761,17 @@ exports[`snapshot should have matching default structure 1`] = `
   border-color: hsl(202,7%,67%);
 }
 
-.c6.fi-button--link:hover {
+.c6.fi-button--secondary-light:hover {
   background: linear-gradient(0deg,hsl(215,100%,97%),hsl(212,63%,98%));
 }
 
-.c6.fi-button--link:active {
+.c6.fi-button--secondary-light:active {
   background: linear-gradient(0deg,hsl(202,7%,93%),hsl(202,7%,97%));
 }
 
-.c6.fi-button--link.fi-button--disabled,
-.c6.fi-button--link[disabled],
-.c6.fi-button--link:disabled {
+.c6.fi-button--secondary-light.fi-button--disabled,
+.c6.fi-button--secondary-light[disabled],
+.c6.fi-button--secondary-light:disabled {
   color: hsl(202,7%,67%);
   background: none;
   background-color: hsl(202,7%,97%);


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

PR changes Button component's variant options. Option "link" is renamed to "secondaryLight" to remove ambiguity about element's semantics. (Element is still a button with the "link" variant, and not a link.)

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->

Closes #729

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Variant naming is misleading, since variant only affects the appearance of the element. Link variant still renders a button.

## How Has This Been Tested?

With Styleguidist (Windows, Firefox)

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### Button
- **Breaking change:** Rename variant `link` to `secondaryLight`
