### PR TITLE
[Fix] Improve support for Windows High contrast Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "react-modal": "3.15.1",
     "react-popper": "2.3.0",
     "react-svg": "15.1.3",
-    "suomifi-design-tokens": "5.0.0",
+    "suomifi-design-tokens": "5.1.0",
     "suomifi-icons": "7.0.0"
   },
   "peerDependencies": {

--- a/src/core/Alert/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert/Alert.baseStyles.ts
@@ -38,7 +38,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
         &:focus-visible {
           position: relative;
-          outline: 3px solid transparent; /* For high contrast mode */
+          ${theme.focuses.highContrastFocus} /* For high contrast mode */
 
           &:after {
             ${theme.focuses.absoluteFocus}

--- a/src/core/Alert/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert/Alert.baseStyles.ts
@@ -37,8 +37,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         white-space: nowrap;
 
         &:focus-visible {
-          outline: 0;
           position: relative;
+          outline: 3px solid transparent; /* For high contrast mode */
 
           &:after {
             ${theme.focuses.absoluteFocus}

--- a/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/Alert/__snapshots__/Alert.test.tsx.snap
@@ -227,8 +227,8 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-alert .fi-alert_style-wrapper .fi-alert_close-button:focus-visible {
-  outline: 0;
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-alert .fi-alert_style-wrapper .fi-alert_close-button:focus-visible:after {

--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -221,6 +221,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-link:hover,

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -109,6 +109,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   &:focus {
     position: relative;
+    ${theme.focuses.highContrastFocus} /* For high contrast mode */
 
     &::after {
       ${theme.focuses.absoluteFocus}

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -105,9 +105,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   text-align: center;
   text-shadow: ${theme.shadows.invertTextShadow};
   cursor: pointer;
+  border: 1px solid transparent; /* For high contrast mode */
 
   &:focus {
-    outline: none;
     position: relative;
 
     &::after {
@@ -117,6 +117,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   &:hover {
     background: ${theme.gradients.highlightLight1ToHighlightBase};
+    outline: 2px solid transparent; /* For high contrast mode */
   }
 
   &:active {

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -108,10 +108,10 @@ exports[`Button variant default should match snapshot 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c1:focus {
-  outline: none;
   position: relative;
 }
 
@@ -133,6 +133,7 @@ exports[`Button variant default should match snapshot 1`] = `
 
 .c1:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c1:active {
@@ -430,10 +431,10 @@ exports[`Button variant inverted should match snapshot 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c1:focus {
-  outline: none;
   position: relative;
 }
 
@@ -455,6 +456,7 @@ exports[`Button variant inverted should match snapshot 1`] = `
 
 .c1:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c1:active {
@@ -752,10 +754,10 @@ exports[`Button variant link match snapshot 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c1:focus {
-  outline: none;
   position: relative;
 }
 
@@ -777,6 +779,7 @@ exports[`Button variant link match snapshot 1`] = `
 
 .c1:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c1:active {
@@ -1074,10 +1077,10 @@ exports[`Button variant secondary should match snapshot 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c1:focus {
-  outline: none;
   position: relative;
 }
 
@@ -1099,6 +1102,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
 
 .c1:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c1:active {
@@ -1396,10 +1400,10 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c1:focus {
-  outline: none;
   position: relative;
 }
 
@@ -1421,6 +1425,7 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
 
 .c1:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c1:active {

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -113,6 +113,7 @@ exports[`Button variant default should match snapshot 1`] = `
 
 .c1:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1:focus::after {
@@ -436,6 +437,7 @@ exports[`Button variant inverted should match snapshot 1`] = `
 
 .c1:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1:focus::after {
@@ -759,6 +761,7 @@ exports[`Button variant link match snapshot 1`] = `
 
 .c1:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1:focus::after {
@@ -1082,6 +1085,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
 
 .c1:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1:focus::after {
@@ -1405,6 +1409,7 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
 
 .c1:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1:focus::after {

--- a/src/core/Chip/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip/Chip.baseStyles.tsx
@@ -13,6 +13,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &:active {
       background: ${theme.colors.highlightDark1};
     }
+    &:focus {
+      outline: 3px solid transparent; /* For high contrast mode */
+    }
   }
 
   &.fi-chip--removable {

--- a/src/core/Chip/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip/Chip.baseStyles.tsx
@@ -14,7 +14,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       background: ${theme.colors.highlightDark1};
     }
     &:focus {
-      outline: 3px solid transparent; /* For high contrast mode */
+      ${theme.focuses.highContrastFocus}
     }
   }
 

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -160,6 +160,10 @@ exports[`children should match snapshot 1`] = `
   background: hsl(212,63%,37%);
 }
 
+.c1.fi-chip--button:focus {
+  outline: 3px solid transparent;
+}
+
 .c1.fi-chip--removable {
   padding-top: 2px;
   padding-right: 22px;
@@ -363,6 +367,10 @@ exports[`classnames should match snapshot 1`] = `
   background: hsl(212,63%,37%);
 }
 
+.c1.fi-chip--button:focus {
+  outline: 3px solid transparent;
+}
+
 .c1.fi-chip--removable {
   padding-top: 2px;
   padding-right: 22px;
@@ -560,6 +568,10 @@ exports[`disabled should match snapshot 1`] = `
 
 .c1.fi-chip--button:active {
   background: hsl(212,63%,37%);
+}
+
+.c1.fi-chip--button:focus {
+  outline: 3px solid transparent;
 }
 
 .c1.fi-chip--removable {

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -144,7 +144,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &:not(.fi-dropdown--open) {
       .fi-dropdown_button {
         &:focus {
-          outline: 3px solid transparent;
+          ${theme.focuses.highContrastFocus}
           position: relative;
 
           &:after {

--- a/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
+++ b/src/core/Expander/Expander/__snapshots__/Expander.test.tsx.snap
@@ -325,7 +325,7 @@ exports[`Basic expander shoud match snapshot 1`] = `
 }
 
 .c3 .fi-expander_title-button_button:focus-within {
-  outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c3 .fi-expander_title-button_button:focus-within:after {

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -65,7 +65,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     cursor: pointer;
 
     &:focus {
-      outline: 3px solid transparent; /* For high contrast mode */
+      ${theme.focuses.highContrastFocus}
       position: relative;
 
       &:after {

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -65,7 +65,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     cursor: pointer;
 
     &:focus {
-      outline: 0;
+      outline: 3px solid transparent; /* For high contrast mode */
       position: relative;
 
       &:after {

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`Basic expander group should match snapshot 1`] = `
 }
 
 .c1 > .fi-expander-group_all-button:focus {
-  outline: 0;
+  outline: 3px solid transparent;
   position: relative;
 }
 
@@ -460,7 +460,7 @@ exports[`Basic expander group should match snapshot 1`] = `
 }
 
 .c7 .fi-expander_title-button_button:focus-within {
-  outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c7 .fi-expander_title-button_button:focus-within:after {

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
@@ -46,7 +46,7 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
     }
 
     &:focus-within {
-      outline: 3px solid transparent; /* For high contrast mode */
+      ${theme.focuses.highContrastFocus}
       &:after {
         ${theme.focuses.absoluteFocus}
       }

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.baseStyles.tsx
@@ -46,7 +46,7 @@ export const expanderTitleBaseStyles = (theme: SuomifiTheme) => css`
     }
 
     &:focus-within {
-      outline: 0;
+      outline: 3px solid transparent; /* For high contrast mode */
       &:after {
         ${theme.focuses.absoluteFocus}
       }

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -250,7 +250,7 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
 }
 
 .c1 .fi-expander_title-button:focus-within {
-  outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-expander_title-button:focus-within:after {

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
@@ -40,7 +40,7 @@ export const expanderTitleButtonBaseStyles = (theme: SuomifiTheme) => css`
     }
 
     &:focus-within {
-      outline: 0;
+      outline: 3px solid transparent; /* For high contrast mode */
       &:after {
         ${theme.focuses.absoluteFocus}
       }

--- a/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
+++ b/src/core/Expander/ExpanderTitleButton/ExpanderTitleButton.baseStyles.tsx
@@ -40,7 +40,7 @@ export const expanderTitleButtonBaseStyles = (theme: SuomifiTheme) => css`
     }
 
     &:focus-within {
-      outline: 3px solid transparent; /* For high contrast mode */
+      ${theme.focuses.highContrastFocus}
       &:after {
         ${theme.focuses.absoluteFocus}
       }

--- a/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitleButton/__snapshots__/ExpanderTitleButton.test.tsx.snap
@@ -203,7 +203,7 @@ exports[`Basic ExpanderTitleButton shoud match snapshot 1`] = `
 }
 
 .c1 .fi-expander_title-button_button:focus-within {
-  outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-expander_title-button_button:focus-within:after {

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -119,6 +119,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-checkbox_label {
       &::before {
         ${theme.focuses.boxShadowFocus}
+        outline: 2px solid transparent; /* For high contrast mode */
       }
     }
   }

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -194,6 +194,7 @@ exports[`props children has matching snapshot 1`] = `
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 2px solid transparent;
 }
 
 .c1 .fi-checkbox_input {

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -332,6 +332,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 2px solid transparent;
 }
 
 .c7 .fi-checkbox_input {

--- a/src/core/Form/DateInput/DateInput.baseStyles.tsx
+++ b/src/core/Form/DateInput/DateInput.baseStyles.tsx
@@ -86,7 +86,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     border: 1px solid ${theme.colors.highlightBase};
     border-radius: ${theme.radiuses.basic};
     &:focus {
-      outline: 3px solid transparent;
+      ${theme.focuses.highContrastFocus}
     }
   }
 

--- a/src/core/Form/DateInput/DateInput.baseStyles.tsx
+++ b/src/core/Form/DateInput/DateInput.baseStyles.tsx
@@ -32,6 +32,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &:focus-within {
       position: relative;
+      ${theme.focuses.highContrastFocus}
 
       &::after {
         ${theme.focuses.absoluteFocus}

--- a/src/core/Form/DateInput/DatePicker/MonthDay/MonthDay.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/MonthDay/MonthDay.baseStyles.tsx
@@ -47,7 +47,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &:focus {
       box-shadow: none;
       position: relative;
-      outline: 3px solid transparent;
+      ${theme.focuses.highContrastFocus}
 
       &:after {
         ${theme.focuses.absoluteFocus}

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3095,6 +3095,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c13:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c13:focus::after {
@@ -5281,6 +5282,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 
 .c13:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c13:focus::after {

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -233,6 +233,7 @@ exports[`snapshots match date input error status with statustext 1`] = `
 
 .c1 .fi-date-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-date-input_input-element-container:focus-within::after {
@@ -710,6 +711,7 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
 
 .c1 .fi-date-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-date-input_input-element-container:focus-within::after {
@@ -1193,6 +1195,7 @@ exports[`snapshots match date input hint text 1`] = `
 
 .c1 .fi-date-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-date-input_input-element-container:focus-within::after {
@@ -1661,6 +1664,7 @@ exports[`snapshots match date input minimal implementation 1`] = `
 
 .c1 .fi-date-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-date-input_input-element-container:focus-within::after {
@@ -2122,6 +2126,7 @@ exports[`snapshots match date input optional text 1`] = `
 
 .c1 .fi-date-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-date-input_input-element-container:focus-within::after {
@@ -2588,6 +2593,7 @@ exports[`snapshots match date input success status with statustext 1`] = `
 
 .c1 .fi-date-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-date-input_input-element-container:focus-within::after {
@@ -3941,6 +3947,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c1 .fi-date-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-date-input_input-element-container:focus-within::after {
@@ -6128,6 +6135,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 
 .c1 .fi-date-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-date-input_input-element-container:focus-within::after {

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3090,10 +3090,10 @@ exports[`snapshots match date input with datepicker with controlled input value 
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c13:focus {
-  outline: none;
   position: relative;
 }
 
@@ -3115,6 +3115,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c13:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c13:active {
@@ -5275,10 +5276,10 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c13:focus {
-  outline: none;
   position: relative;
 }
 
@@ -5300,6 +5301,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 
 .c13:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c13:active {

--- a/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
+++ b/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
@@ -10,7 +10,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   justify-content: center;
   align-items: center;
   &:focus {
-    outline: 3px solid transparent; /* For high contrast mode */
+    ${theme.focuses.highContrastFocus}
     &:after {
       ${theme.focuses.absoluteFocus}
     }

--- a/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
+++ b/src/core/Form/InputClearButton/InputClearButton.baseStyles.ts
@@ -10,7 +10,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   justify-content: center;
   align-items: center;
   &:focus {
-    outline: none;
+    outline: 3px solid transparent; /* For high contrast mode */
     &:after {
       ${theme.focuses.absoluteFocus}
     }

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -107,10 +107,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         }
       }
       &:focus {
-        outline: 0;
         + .fi-radio-button_icon_wrapper {
           ${theme.focuses.boxShadowFocus}
           border-radius: 50%;
+          outline: 3px solid transparent; /* For high contrast mode */
         }
       }
       &:focus:not(:focus-visible) {

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -110,7 +110,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         + .fi-radio-button_icon_wrapper {
           ${theme.focuses.boxShadowFocus}
           border-radius: 50%;
-          outline: 3px solid transparent; /* For high contrast mode */
+          ${theme.focuses.highContrastFocus}
         }
       }
       &:focus:not(:focus-visible) {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -201,15 +201,12 @@ exports[`children should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -515,15 +512,12 @@ exports[`className should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -829,15 +823,12 @@ exports[`disabled should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -1165,15 +1156,12 @@ exports[`hintText should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -1486,15 +1474,12 @@ exports[`id should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -1800,15 +1785,12 @@ exports[`name should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -2115,15 +2097,12 @@ exports[`value should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -2429,15 +2408,12 @@ exports[`variant should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -371,15 +371,12 @@ exports[`default, with only required props should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -979,15 +976,12 @@ exports[`props className should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -1587,15 +1581,12 @@ exports[`props defaultValue should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -2217,15 +2208,12 @@ exports[`props hintText should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c8.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c8.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -2830,15 +2818,12 @@ exports[`props id should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -3438,15 +3423,12 @@ exports[`props label should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -4058,15 +4040,12 @@ exports[`props labelMode should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -4666,15 +4645,12 @@ exports[`props name should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -5274,15 +5250,12 @@ exports[`props value should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus {
-  outline: 0;
-}
-
 .c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
   border-radius: 50%;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -33,7 +33,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       &:focus-within {
         position: relative;
         box-shadow: ${theme.shadows.actionElementBoxShadow};
-        outline: 3px solid transparent; /* For high contrast mode */
+        ${theme.focuses.highContrastFocus}
         &:after {
           ${theme.focuses.absoluteFocus}
           top: -3px;
@@ -108,7 +108,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         overflow: hidden;
 
         &:focus {
-          outline: 3px solid transparent; /* For high contrast mode */
+          ${theme.focuses.highContrastFocus}
         }
         &-icon {
           width: 12px;
@@ -176,7 +176,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
           ${theme.focuses.absoluteFocus}
         }
 
-        outline: 3px solid transparent; /* For high contrast mode */
+        ${theme.focuses.highContrastFocus}/* For high contrast mode */
       }
       &:hover {
         background: ${theme.gradients.highlightLight1ToHighlightBase};

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -33,6 +33,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       &:focus-within {
         position: relative;
         box-shadow: ${theme.shadows.actionElementBoxShadow};
+        outline: 3px solid transparent; /* For high contrast mode */
         &:after {
           ${theme.focuses.absoluteFocus}
           top: -3px;
@@ -105,6 +106,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         padding: 0;
         border: 0;
         overflow: hidden;
+
+        &:focus {
+          outline: 3px solid transparent; /* For high contrast mode */
+        }
         &-icon {
           width: 12px;
           height: 12px;
@@ -160,10 +165,18 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     & .fi-search-input_button-search {
       background: ${theme.gradients.highlightBaseToHighlightDark1};
+
+      /* Support for high contrast mode */
+      @media (forced-colors: active) {
+        background-color: Highlight;
+      }
+
       &:focus {
         &:after {
           ${theme.focuses.absoluteFocus}
         }
+
+        outline: 3px solid transparent; /* For high contrast mode */
       }
       &:hover {
         background: ${theme.gradients.highlightLight1ToHighlightBase};

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -168,7 +168,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
       /* Support for high contrast mode */
       @media (forced-colors: active) {
-        background-color: Highlight;
+        border: solid 1px ButtonBorder;
       }
 
       &:focus {
@@ -186,6 +186,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
       & .fi-search-input_button-search-icon .fi-icon-base-fill {
         fill: ${theme.colors.whiteBase};
+
+        @media (forced-colors: active) {
+          fill: ButtonText;
+        }
       }
     }
     & .fi-search-input_button-clear {

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -652,7 +652,13 @@ exports[`snapshot should have matching default structure 1`] = `
 
 @media (forced-colors:active) {
   .c1.fi-search-input--not-empty .fi-search-input_button-search {
-    background-color: Highlight;
+    border: solid 1px ButtonBorder;
+  }
+}
+
+@media (forced-colors:active) {
+  .c1.fi-search-input--not-empty .fi-search-input_button-search .fi-search-input_button-search-icon .fi-icon-base-fill {
+    fill: ButtonText;
   }
 }
 

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -308,7 +308,7 @@ exports[`snapshot should have matching default structure 1`] = `
 }
 
 .c7:focus {
-  outline: none;
+  outline: 3px solid transparent;
 }
 
 .c7:focus:after {
@@ -412,6 +412,7 @@ exports[`snapshot should have matching default structure 1`] = `
 .c1 .fi-search-input_input-element-container:focus-within {
   position: relative;
   box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-search-input_input-element-container:focus-within:after {
@@ -549,6 +550,10 @@ exports[`snapshot should have matching default structure 1`] = `
   overflow: hidden;
 }
 
+.c1 .fi-search-input_button-clear:focus {
+  outline: 3px solid transparent;
+}
+
 .c1 .fi-search-input_button-clear-icon {
   width: 12px;
   height: 12px;
@@ -604,6 +609,10 @@ exports[`snapshot should have matching default structure 1`] = `
   background: linear-gradient(0deg,hsl(212,63%,37%) 0%,hsl(212,63%,45%) 100%);
 }
 
+.c1.fi-search-input--not-empty .fi-search-input_button-search:focus {
+  outline: 3px solid transparent;
+}
+
 .c1.fi-search-input--not-empty .fi-search-input_button-search:focus:after {
   content: '';
   position: absolute;
@@ -639,6 +648,12 @@ exports[`snapshot should have matching default structure 1`] = `
   height: 20px;
   width: 20px;
   margin: 10px;
+}
+
+@media (forced-colors:active) {
+  .c1.fi-search-input--not-empty .fi-search-input_button-search {
+    background-color: Highlight;
+  }
 }
 
 <div

--- a/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
@@ -37,6 +37,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       background-color: ${theme.colors.highlightBase};
       color: ${theme.colors.whiteBase};
 
+      @media (forced-colors: active) {
+        background-color: Highlight;
+      }
+
       & .fi-select-item--query_highlight {
         color: ${theme.colors.whiteBase};
         background-color: ${theme.colors.highlightBase};
@@ -47,14 +51,27 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       color: ${theme.colors.depthBase};
       cursor: not-allowed;
 
+      @media (forced-colors: active) {
+        color: GrayText; /* Support for high contrast mode */
+      }
+
       & .fi-select-item--query_highlight {
         color: ${theme.colors.depthBase};
+        @media (forced-colors: active) {
+          color: GrayText;
+        }
       }
 
       &.fi-select-item:hover {
         color: ${theme.colors.depthBase};
+        @media (forced-colors: active) {
+          color: GrayText;
+        }
         & .fi-select-item--query_highlight {
           color: ${theme.colors.depthBase};
+          @media (forced-colors: active) {
+            color: GrayText;
+          }
         }
       }
     }
@@ -65,6 +82,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       /* stylelint-disable no-descending-specificity */
       & .fi-select-item--query_highlight {
         color: ${theme.colors.whiteBase};
+      }
+
+      @media (forced-colors: active) {
+        background-color: Highlight;
       }
     }
   }

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -888,6 +888,7 @@ exports[`has matching snapshot 1`] = `
 
 .c15:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c15:focus::after {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -796,6 +796,10 @@ exports[`has matching snapshot 1`] = `
   background: hsl(212,63%,37%);
 }
 
+.c13.fi-chip--button:focus {
+  outline: 3px solid transparent;
+}
+
 .c13.fi-chip--removable {
   padding-top: 2px;
   padding-right: 22px;
@@ -879,10 +883,10 @@ exports[`has matching snapshot 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c15:focus {
-  outline: none;
   position: relative;
 }
 
@@ -904,6 +908,7 @@ exports[`has matching snapshot 1`] = `
 
 .c15:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c15:active {
@@ -1158,6 +1163,42 @@ exports[`has matching snapshot 1`] = `
 
 .c1 .fi-multiselect_removeAllButton {
   margin-top: 10px;
+}
+
+@media (forced-colors:active) {
+  .c20.fi-select-item--hasKeyboardFocus {
+    background-color: Highlight;
+  }
+}
+
+@media (forced-colors:active) {
+  .c20.fi-select-item--disabled {
+    color: GrayText;
+  }
+}
+
+@media (forced-colors:active) {
+  .c20.fi-select-item--disabled .fi-select-item--query_highlight {
+    color: GrayText;
+  }
+}
+
+@media (forced-colors:active) {
+  .c20.fi-select-item--disabled.fi-select-item:hover {
+    color: GrayText;
+  }
+}
+
+@media (forced-colors:active) {
+  .c20.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
+    color: GrayText;
+  }
+}
+
+@media (forced-colors:active) {
+  .c20.fi-select-item:hover {
+    background-color: Highlight;
+  }
 }
 
 <body>

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -853,37 +853,37 @@ exports[`has matching snapshot 1`] = `
 }
 
 @media (forced-colors:active) {
-  .c17.fi-select-item--hasKeyboardFocus {
+  .c18.fi-select-item--hasKeyboardFocus {
     background-color: Highlight;
   }
 }
 
 @media (forced-colors:active) {
-  .c17.fi-select-item--disabled {
+  .c18.fi-select-item--disabled {
     color: GrayText;
   }
 }
 
 @media (forced-colors:active) {
-  .c17.fi-select-item--disabled .fi-select-item--query_highlight {
+  .c18.fi-select-item--disabled .fi-select-item--query_highlight {
     color: GrayText;
   }
 }
 
 @media (forced-colors:active) {
-  .c17.fi-select-item--disabled.fi-select-item:hover {
+  .c18.fi-select-item--disabled.fi-select-item:hover {
     color: GrayText;
   }
 }
 
 @media (forced-colors:active) {
-  .c17.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
+  .c18.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
     color: GrayText;
   }
 }
 
 @media (forced-colors:active) {
-  .c17.fi-select-item:hover {
+  .c18.fi-select-item:hover {
     background-color: Highlight;
   }
 }

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -605,7 +605,7 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c9:focus {
-  outline: none;
+  outline: 3px solid transparent;
 }
 
 .c9:focus:after {
@@ -850,6 +850,42 @@ exports[`has matching snapshot 1`] = `
   border-bottom: 0;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
+}
+
+@media (forced-colors:active) {
+  .c17.fi-select-item--hasKeyboardFocus {
+    background-color: Highlight;
+  }
+}
+
+@media (forced-colors:active) {
+  .c17.fi-select-item--disabled {
+    color: GrayText;
+  }
+}
+
+@media (forced-colors:active) {
+  .c17.fi-select-item--disabled .fi-select-item--query_highlight {
+    color: GrayText;
+  }
+}
+
+@media (forced-colors:active) {
+  .c17.fi-select-item--disabled.fi-select-item:hover {
+    color: GrayText;
+  }
+}
+
+@media (forced-colors:active) {
+  .c17.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
+    color: GrayText;
+  }
+}
+
+@media (forced-colors:active) {
+  .c17.fi-select-item:hover {
+    background-color: Highlight;
+  }
 }
 
 <body>

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -29,7 +29,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &:focus-within {
       position: relative;
-      outline: 3px solid transparent; /* For high contrast mode */
+      ${theme.focuses.highContrastFocus}
 
       &::after {
         ${theme.focuses.absoluteFocus}

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -29,6 +29,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &:focus-within {
       position: relative;
+      outline: 3px solid transparent; /* For high contrast mode */
 
       &::after {
         ${theme.focuses.absoluteFocus}

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -225,6 +225,7 @@ exports[`snapshots match error status with statustext 1`] = `
 
 .c1 .fi-text-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-text-input_input-element-container:focus-within::after {
@@ -629,6 +630,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 
 .c1 .fi-text-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-text-input_input-element-container:focus-within::after {
@@ -1018,6 +1020,7 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c1 .fi-text-input_input-element-container:focus-within {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-text-input_input-element-container:focus-within::after {

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -19,7 +19,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-textarea_textarea-element-container {
       margin-top: ${theme.spacing.insetL};
       &:focus-within {
-        outline: 3px solid transparent; /* For high contrast mode */
+        ${theme.focuses.highContrastFocus} /* For high contrast mode */
         position: relative;
 
         &::after {

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -19,7 +19,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-textarea_textarea-element-container {
       margin-top: ${theme.spacing.insetL};
       &:focus-within {
-        outline: none;
+        outline: 3px solid transparent; /* For high contrast mode */
         position: relative;
 
         &::after {

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
 }
 
 .c1.fi-textarea .fi-textarea_textarea-element-container:focus-within {
-  outline: none;
+  outline: 3px solid transparent;
   position: relative;
 }
 

--- a/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
@@ -17,7 +17,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         &:after {
           ${theme.focuses.absoluteFocus}
           ${focusOverrides}
-          outline: 3px solid transparent; /* For high contrast mode */
+          ${theme.focuses.highContrastFocus} /* For high contrast mode */
         }
       }
     }

--- a/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
@@ -17,6 +17,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         &:after {
           ${theme.focuses.absoluteFocus}
           ${focusOverrides}
+          outline: 3px solid transparent; /* For high contrast mode */
         }
       }
     }

--- a/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -312,6 +312,7 @@ exports[`Basic ToggleButton should match snapshot 1`] = `
   border-radius: 14px;
   right: -4px;
   left: -4px;
+  outline: 3px solid transparent;
 }
 
 <span

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
@@ -17,7 +17,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         &:after {
           ${theme.focuses.absoluteFocus}
           ${focusOverrides}
-          outline: 3px solid transparent; /* For high contrast mode */
+            ${theme.focuses.highContrastFocus} /* For high contrast mode */
         }
       }
     }

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
@@ -17,6 +17,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         &:after {
           ${theme.focuses.absoluteFocus}
           ${focusOverrides}
+          outline: 3px solid transparent; /* For high contrast mode */
         }
       }
     }

--- a/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
@@ -313,6 +313,7 @@ exports[`Basic ToggleInput should match snapshot 1`] = `
   border-radius: 14px;
   right: -4px;
   left: -4px;
+  outline: 3px solid transparent;
 }
 
 .c1 .fi-toggle_input-element {

--- a/src/core/Link/BaseLink/BaseLink.baseStyles.ts
+++ b/src/core/Link/BaseLink/BaseLink.baseStyles.ts
@@ -18,6 +18,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &:focus {
       ${theme.focuses.boxShadowFocus}
+      outline: 3px solid transparent;
     }
 
     &:hover,

--- a/src/core/Link/BaseLink/BaseLink.baseStyles.ts
+++ b/src/core/Link/BaseLink/BaseLink.baseStyles.ts
@@ -18,7 +18,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &:focus {
       ${theme.focuses.boxShadowFocus}
-      outline: 3px solid transparent;
+      ${theme.focuses.highContrastFocus}
     }
 
     &:hover,

--- a/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
+++ b/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
@@ -143,6 +143,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-link:hover,

--- a/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-link:hover,

--- a/src/core/Link/RouterLink/RouterLink.baseStyles.ts
+++ b/src/core/Link/RouterLink/RouterLink.baseStyles.ts
@@ -18,6 +18,7 @@ export const RouterLinkStyles = (theme: SuomifiTheme) => css`
 
     &:focus {
       ${theme.focuses.boxShadowFocus}
+      outline: 3px solid transparent; /* For high contrast mode */
     }
 
     &:hover,

--- a/src/core/Link/RouterLink/RouterLink.baseStyles.ts
+++ b/src/core/Link/RouterLink/RouterLink.baseStyles.ts
@@ -18,7 +18,7 @@ export const RouterLinkStyles = (theme: SuomifiTheme) => css`
 
     &:focus {
       ${theme.focuses.boxShadowFocus}
-      outline: 3px solid transparent; /* For high contrast mode */
+      ${theme.focuses.highContrastFocus} /* For high contrast mode */
     }
 
     &:hover,

--- a/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
+++ b/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-link--router:hover,

--- a/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
+++ b/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`should match snapshot 1`] = `
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-link:hover,
@@ -146,6 +147,7 @@ exports[`should match snapshot 1`] = `
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c2.fi-link:hover,

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -647,6 +647,7 @@ exports[`Basic modal should match snapshot 1`] = `
 
 .c9:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c9:focus::after {

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -642,10 +642,10 @@ exports[`Basic modal should match snapshot 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c9:focus {
-  outline: none;
   position: relative;
 }
 
@@ -667,6 +667,7 @@ exports[`Basic modal should match snapshot 1`] = `
 
 .c9:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c9:active {

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -270,10 +270,10 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c4:focus {
-  outline: none;
   position: relative;
 }
 
@@ -295,6 +295,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 
 .c4:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c4:active {

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -275,6 +275,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 
 .c4:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c4:focus::after {

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -28,7 +28,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         }
 
         &:focus {
-          outline: 0;
+          outline: 3px solid transparent; /* For high contrast mode */
           &:after {
             ${theme.focuses.absoluteFocus}
           }

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -28,7 +28,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         }
 
         &:focus {
-          outline: 3px solid transparent; /* For high contrast mode */
+          ${theme.focuses.highContrastFocus} /* For high contrast mode */
           &:after {
             ${theme.focuses.absoluteFocus}
           }

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -252,7 +252,7 @@ exports[`should match snapshot 1`] = `
 }
 
 .c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button:focus {
-  outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-service-navigation--small-screen .fi-service-navigation_expand-button:focus:after {
@@ -348,10 +348,10 @@ exports[`should match snapshot 1`] = `
 }
 
 .c5.fi-service-navigation-item .fi-link--router:focus {
-  outline: 0;
   border: none;
   box-shadow: none;
   color: hsl(0,0%,13%);
+  outline: 3px solid transparent;
 }
 
 .c5.fi-service-navigation-item .fi-link--router:hover,
@@ -492,6 +492,7 @@ exports[`should match snapshot 1`] = `
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c10.fi-link:hover,
@@ -566,6 +567,7 @@ exports[`should match snapshot 1`] = `
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c7.fi-link--router:hover,

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -39,10 +39,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       border: none;
 
       &:focus {
-        outline: 0;
         border: none;
         box-shadow: none;
         color: ${theme.colors.blackBase};
+        outline: 3px solid transparent; /* For high contrast mode */
       }
 
       &:hover,

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -42,7 +42,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         border: none;
         box-shadow: none;
         color: ${theme.colors.blackBase};
-        outline: 3px solid transparent; /* For high contrast mode */
+        ${theme.focuses.highContrastFocus}/* For high contrast mode */
       }
 
       &:hover,

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -384,7 +384,7 @@ exports[`calling render with the same component on the same container does not r
 
 .c7.fi-side-navigation-item:focus,
 .c7.fi-side-navigation-item:focus-within {
-  outline: 0;
+  outline: none;
   box-shadow: none;
   border: none;
 }
@@ -420,7 +420,7 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c7.fi-side-navigation-item .fi-link--router:focus-visible {
-  outline: 0;
+  outline: 3px solid transparent;
   position: relative;
   box-shadow: none;
 }
@@ -611,6 +611,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c11.fi-link:hover,
@@ -685,6 +686,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c9.fi-link--router:hover,

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -16,7 +16,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &:focus,
     &:focus-within {
-      outline: 0;
+      outline: none;
       box-shadow: none;
       border: none;
     }
@@ -44,7 +44,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
 
       &:focus-visible {
-        outline: 0;
+        outline: 3px solid transparent; /* For high contrast mode */
         position: relative;
         box-shadow: none;
 

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -44,7 +44,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
 
       &:focus-visible {
-        outline: 3px solid transparent; /* For high contrast mode */
+        ${theme.focuses.highContrastFocus} /* For high contrast mode */
         position: relative;
         box-shadow: none;
 

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -339,6 +339,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper {
@@ -787,6 +788,7 @@ exports[`calling render with the same component on the same container does not r
   border-radius: 2px;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c8.fi-link--router:hover,

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -31,7 +31,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &:focus-within {
       ${theme.focuses.boxShadowFocus}
-      outline: 3px solid transparent; /* Support for high contrast mode */
+      ${theme.focuses.highContrastFocus} /* Support for high contrast mode */
     }
 
     .fi-wizard-navigation-item_inner-wrapper {

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -31,6 +31,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &:focus-within {
       ${theme.focuses.boxShadowFocus}
+      outline: 3px solid transparent; /* Support for high contrast mode */
     }
 
     .fi-wizard-navigation-item_inner-wrapper {

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -85,7 +85,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
         &:after {
           ${theme.focuses.absoluteFocus}
-          outline: 3px solid transparent; /* For high contrast mode */
+          ${theme.focuses.highContrastFocus} /* For high contrast mode */
         }
       }
       &:active {

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -10,6 +10,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   border-radius: 4px;
   padding-bottom: 10px;
 
+  @media (forced-colors: active) {
+    border: solid 1px ButtonBorder; /* For high contrast mode */
+  }
+
   &.fi-notification {
     background-color: ${theme.colors.whiteBase};
     display: flex;
@@ -81,6 +85,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
         &:after {
           ${theme.focuses.absoluteFocus}
+          outline: 3px solid transparent; /* For high contrast mode */
         }
       }
       &:active {

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -619,6 +619,7 @@ exports[`props children should match snapshot 1`] = `
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
+  outline: 3px solid transparent;
 }
 
 .c1.fi-notification .fi-notification_close-button:active {
@@ -687,6 +688,12 @@ exports[`props children should match snapshot 1`] = `
   width: 100%;
   margin-top: 15px;
   margin-right: 0;
+}
+
+@media (forced-colors:active) {
+  .c1 {
+    border: solid 1px ButtonBorder;
+  }
 }
 
 <div>

--- a/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
+++ b/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
@@ -32,7 +32,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       &:focus-within {
         position: relative;
         box-shadow: ${theme.shadows.actionElementBoxShadow};
-        outline: 3px solid transparent; /* For hight contrast mode */
+        ${theme.focuses.highContrastFocus} /* For hight contrast mode */
 
         &:after {
           ${theme.focuses.absoluteFocus}
@@ -127,7 +127,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       &:focus {
         &:after {
           ${theme.focuses.absoluteFocus}
-          outline: 3px solid transparent; /* For hight contrast mode */
+          ${theme.focuses.highContrastFocus} /* For hight contrast mode */
         }
       }
       &:hover {

--- a/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
+++ b/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
@@ -32,6 +32,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       &:focus-within {
         position: relative;
         box-shadow: ${theme.shadows.actionElementBoxShadow};
+        outline: 3px solid transparent; /* For hight contrast mode */
+
         &:after {
           ${theme.focuses.absoluteFocus}
           top: -3px;
@@ -116,9 +118,16 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       cursor: pointer;
       pointer-events: all;
       background: ${theme.gradients.highlightBaseToHighlightDark1};
+
+      /* Support for high contrast mode */
+      @media (forced-colors: active) {
+        background-color: Highlight;
+      }
+
       &:focus {
         &:after {
           ${theme.focuses.absoluteFocus}
+          outline: 3px solid transparent; /* For hight contrast mode */
         }
       }
       &:hover {

--- a/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
+++ b/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
@@ -119,9 +119,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       pointer-events: all;
       background: ${theme.gradients.highlightBaseToHighlightDark1};
 
-      /* Support for high contrast mode */
       @media (forced-colors: active) {
-        background-color: Highlight;
+        border: solid 1px ButtonBorder;
       }
 
       &:focus {
@@ -138,6 +137,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
       & .fi-page-input_button-icon .fi-icon-base-fill {
         fill: ${theme.colors.whiteBase};
+
+        @media (forced-colors: active) {
+          fill: ButtonText;
+        }
       }
     }
   }

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -399,6 +399,7 @@ exports[`snapshot should have matching default structure 1`] = `
 .c9 .fi-page-input_input-element-container:focus-within {
   position: relative;
   box-shadow: 0 1px 2px 0 hsla(214,100%,24%,0.1) inset;
+  outline: 3px solid transparent;
 }
 
 .c9 .fi-page-input_input-element-container:focus-within:after {
@@ -555,6 +556,7 @@ exports[`snapshot should have matching default structure 1`] = `
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
+  outline: 3px solid transparent;
 }
 
 .c9.fi-page-input--not-empty .fi-page-input_button:hover {
@@ -594,10 +596,10 @@ exports[`snapshot should have matching default structure 1`] = `
   text-align: center;
   text-shadow: 0 1px 1px hsla(214,100%,24%,0.5);
   cursor: pointer;
+  border: 1px solid transparent;
 }
 
 .c6:focus {
-  outline: none;
   position: relative;
 }
 
@@ -619,6 +621,7 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c6:hover {
   background: linear-gradient(0deg,hsl(212,63%,45%) 0%,hsl(212,63%,49%) 100%);
+  outline: 2px solid transparent;
 }
 
 .c6:active {
@@ -894,6 +897,12 @@ exports[`snapshot should have matching default structure 1`] = `
   min-width: 100%;
   margin-left: 0;
   margin-right: 0;
+}
+
+@media (forced-colors:active) {
+  .c8.fi-page-input--not-empty .fi-page-input_button {
+    background-color: Highlight;
+  }
 }
 
 <nav

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -900,7 +900,7 @@ exports[`snapshot should have matching default structure 1`] = `
 }
 
 @media (forced-colors:active) {
-  .c8.fi-page-input--not-empty .fi-page-input_button {
+  .c9.fi-page-input--not-empty .fi-page-input_button {
     background-color: Highlight;
   }
 }

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -601,6 +601,7 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c6:focus {
   position: relative;
+  outline: 3px solid transparent;
 }
 
 .c6:focus::after {
@@ -901,7 +902,13 @@ exports[`snapshot should have matching default structure 1`] = `
 
 @media (forced-colors:active) {
   .c9.fi-page-input--not-empty .fi-page-input_button {
-    background-color: Highlight;
+    border: solid 1px ButtonBorder;
+  }
+}
+
+@media (forced-colors:active) {
+  .c9.fi-page-input--not-empty .fi-page-input_button .fi-page-input_button-icon .fi-icon-base-fill {
+    fill: ButtonText;
   }
 }
 

--- a/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
+++ b/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
@@ -61,7 +61,7 @@ export const baseStyles = (arrowOffsetPx: number, theme: SuomifiTheme) => css`
         background: ${theme.gradients.whiteBaseToDepthLight1};
       }
       &:focus-visible {
-        outline: 3px solid transparent; /* For hight contrast mode */
+        ${theme.focuses.highContrastFocus} /* For hight contrast mode */
         &:after {
           ${theme.focuses.absoluteFocus}
         }

--- a/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
+++ b/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
@@ -61,7 +61,7 @@ export const baseStyles = (arrowOffsetPx: number, theme: SuomifiTheme) => css`
         background: ${theme.gradients.whiteBaseToDepthLight1};
       }
       &:focus-visible {
-        outline: 0;
+        outline: 3px solid transparent; /* For hight contrast mode */
         &:after {
           ${theme.focuses.absoluteFocus}
         }

--- a/src/core/Tooltip/TooltipToggleButton/TooltipToggleButton.baseStyles.tsx
+++ b/src/core/Tooltip/TooltipToggleButton/TooltipToggleButton.baseStyles.tsx
@@ -9,7 +9,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   vertical-align: middle;
 
   &:focus-visible {
-    outline: 3px solid transparent; /* For hight contrast mode */
+    ${theme.focuses.highContrastFocus} /* For hight contrast mode */
     position: relative;
     &:after {
       ${theme.focuses.absoluteFocus}

--- a/src/core/Tooltip/TooltipToggleButton/TooltipToggleButton.baseStyles.tsx
+++ b/src/core/Tooltip/TooltipToggleButton/TooltipToggleButton.baseStyles.tsx
@@ -9,7 +9,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   vertical-align: middle;
 
   &:focus-visible {
-    outline: 0;
+    outline: 3px solid transparent; /* For hight contrast mode */
     position: relative;
     &:after {
       ${theme.focuses.absoluteFocus}

--- a/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`Basic tooltip should match snapshot 1`] = `
 }
 
 .c4.fi-tooltip_content .fi-tooltip_close-button:focus-visible {
-  outline: 0;
+  outline: 3px solid transparent;
 }
 
 .c4.fi-tooltip_content .fi-tooltip_close-button:focus-visible:after {
@@ -244,7 +244,7 @@ exports[`Basic tooltip should match snapshot 1`] = `
 }
 
 .c1:focus-visible {
-  outline: 0;
+  outline: 3px solid transparent;
   position: relative;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12223,10 +12223,10 @@ stylelint@14.9.1:
     v8-compile-cache "^2.3.0"
     write-file-atomic "^4.0.1"
 
-suomifi-design-tokens@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-5.0.0.tgz#773de7faeb3136387587bbc3151e65b6201a77ad"
-  integrity sha512-hdDFKkiXNV0n1WvozR3ELTmMUoRaG8Wn6Jsg2SM5HzhwDx5MyBbDuuYGujuepCCsI6bp1P9c6TIb22H6w1/szA==
+suomifi-design-tokens@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-5.1.0.tgz#8ce5748c5f91c3177335f11773364c2255720b6e"
+  integrity sha512-SUiIMXpDoNql1TO0QRR03EQnNsSBAGYLCWtkNEcRbWXSSTEiQtXL/pAitpXn1G+XZoWsCp3gjmVXUBC+v3RreA==
 
 suomifi-icons@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
Improve / add support for Windows High Contrast Mode (HCM).

Modified components:
Alert, button, Chip, Dropdown, Expander, ExpanderGroup, Checkbox, CheckboxGroup, DateInput, RadioButton, SearchInput, MultiSelect, SingleSelect, TextInput, TextArea, Toggle, Link, SkipLink, RouterLink, Modal, ServiceNavigation, SideNavigation, WizardNavigation, Notification, Pagination, Tooltip

## Related Issue

[Closes #SFIDS-664](https://jira.dvv.fi/browse/SFIDS-664)

## Motivation and Context
Many components did not have any indication of focus on HCM. Also some buttons and borders were invisible.



## How Has This Been Tested?
Mac + Chrome + dev tools high contrast mode + styleguidist

## Screenshots 
![Screenshot 2023-06-12 at 12 07 06](https://github.com/vrk-kpa/suomifi-ui-components/assets/14258876/e9428c7d-8af8-49be-925f-6c4aece63b59)


## Release notes

* Improve support for Windows High Contrast Mode
