### PR TITLE
[Bugfix] LinkList ariaDescribedBy prop handling

### DIFF
--- a/src/core/Link/LinkList/LinkList.tsx
+++ b/src/core/Link/LinkList/LinkList.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { LinkListStyles } from './LinkList.baseStyles';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlUlProps, HtmlUlWithRef } from '../../../reset';
+import { getConditionalAriaProp } from '../../../utils/aria';
 
 const LinkListClassName = 'fi-link-list';
 const SmallScreenClassName = 'fi-link-list--small';
@@ -23,6 +24,7 @@ const StyledLinkList = styled(
     theme,
     children,
     smallScreen,
+    ariaDescribedBy,
     forwardedRef,
     ...passProps
   }: LinkListProps & SuomifiThemeProp) => (
@@ -32,6 +34,7 @@ const StyledLinkList = styled(
       className={classnames(className, LinkListClassName, {
         [SmallScreenClassName]: smallScreen,
       })}
+      {...getConditionalAriaProp('aria-describedby', [ariaDescribedBy])}
     >
       {children}
     </HtmlUlWithRef>

--- a/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
+++ b/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`Simple link list with one item should match snapshot 1`] = `
       Heading
     </h1>
     <ul
-      ariadescribedby="a"
+      aria-describedby="a"
       class="c0 c1 fi-link-list"
     >
       <li


### PR DESCRIPTION
## Description
`ariaDescribedBy` prop accidentally went unhandled in the LinkList component. This PR fixes it so that it's implemented in the component properly.

## Motivation and Context
Previously the prop simply passed to the DOM without any handling causing an error to show up in console.

## How Has This Been Tested?
Tested locally in styleguidist on Chrome. The prop is now handled correctly.

## Screenshots (if appropriate):
Before: 
![image](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/24834403-99b1-48fb-b6ec-c3bef3836bc6)

After: 
![image](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/52fc4d19-02ff-4440-8d0d-094bfb3cec16)

