### PR TITLE
[Fix] Styleguidist introduction revamp

### DIFF
--- a/.styleguidist/foundations.md
+++ b/.styleguidist/foundations.md
@@ -1,0 +1,3 @@
+Suomi.fi Design System foundations contains basic information and technical documentation for the general styles, colors, theming and usage of the design system.
+
+For installation instructions and general overview see the [Introduction](./#/Introduction).

--- a/.styleguidist/icon.md
+++ b/.styleguidist/icon.md
@@ -1,1 +1,1 @@
-This component has been removed since library version 11.0.0. See documentation for [Icons](./#/Introduction/Icons).
+This component has been removed since library version 11.0.0. See documentation for [Icons](./#/Foundations/Icons).

--- a/.styleguidist/introduction.md
+++ b/.styleguidist/introduction.md
@@ -1,9 +1,54 @@
-**For latest documentation refer to [https://github.com/vrk-kpa/suomifi-ui-components](https://github.com/vrk-kpa/suomifi-ui-components#readme)**
+Suomi.fi UI Components is a part of [Suomi.fi Design System](https://designsystem.suomi.fi) and is maintained and built by the Digital and population data services agency of Finland.
+
+## ✨ Features
+
+- Accessibility WCAG 2.1 level AA
+- React-components with TypeScript support
+- Suomi.fi brand styles
+- Highly customizable (CSS, CSS-in-JS)
+
+Works with [React >= 16.8.0](https://github.com/facebook/react) (React 18 supported) and [Styled Components >= 5.2.1](https://github.com/styled-components/styled-components). Supports [TypeScript](https://github.com/Microsoft/TypeScript). CJS and ESM builds provided via the npm package.
+
+### Supported browser and screenreader combinations
+
+| Operating system | Browsers              | Screen reader |
+| ---------------- | --------------------- | ------------- |
+| macOS            | Safari, Chrome, Edge  | VoiceOver     |
+| Windows          | Chrome, Firefox, Edge | NVDA          |
+| iOS              | Safari                | VoiceOver     |
+| Android          | Chrome                | TalkBack      |
 
 ## 📦 Install
 
 ```bash
 yarn add suomifi-ui-components
+```
+
+Include **required** fonts as best suited for your project. You can, for example, use the following import with your global css.
+
+```css
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600&display=swap');
+```
+
+### Peer dependencies
+
+You should also install the following peer dependencies.
+
+- [React](https://www.npmjs.com/package/react) version >=16.8.0 and related dependencies and typings.
+- [styled-components](https://www.npmjs.com/package/styled-components) version >=5.2.1 and related dependencies and typings.
+
+- The aim is to keep dependencies up to date and use the latest available versions. We encourage you to use the latest available versions of peer dependencies.
+
+```bash
+yarn add styled-components
+```
+
+- If using TypeScript, version 3.8 or above is required.
+
+- In case TypeScript is used and skipLibCheck compiler option is set to false, also typings for [react](https://www.npmjs.com/package/@types/react), [react-dom](https://www.npmjs.com/package/@types/react-dom), [styled-components](https://www.npmjs.com/package/@types/styled-components/) and [warning](https://www.npmjs.com/package/@types/warning) are required.
+
+```bash
+yarn add @types/styled-components @types/warning
 ```
 
 ## 🔨 Usage
@@ -42,4 +87,4 @@ styled(Button)...
 }
 ```
 
-Don't use ~~!important~~, if really really needed - for specificity hack you can define styles using classNames multiple times `.fi-button.button--custom.button--custom {...}`
+Don't use ~~!important~~. if really really needed - for specificity hack you can define styles using classNames multiple times `.fi-button.button--custom.button--custom {...}`

--- a/.styleguidist/introduction.md
+++ b/.styleguidist/introduction.md
@@ -60,11 +60,11 @@ import { Button } from 'suomifi-ui-components';
 
 ### 🌊 `Component variants`
 
-Components have variant-property for different versions of the current component.
+Components have a `variant` property for different versions of the component.
 
 ```jsx static
 import { Button } from 'suomifi-ui-components';
-<Button variant="secondary">This is seconday button</Button>;
+<Button variant="secondary">This is a seconday button</Button>;
 ```
 
 ### ⛱ Extending styles

--- a/.styleguidist/introduction.md
+++ b/.styleguidist/introduction.md
@@ -20,6 +20,8 @@ Works with [React >= 16.8.0](https://github.com/facebook/react) (React 18 suppor
 
 ## 📦 Install
 
+To install the component library
+
 ```bash
 yarn add suomifi-ui-components
 ```

--- a/.styleguidist/introduction.md
+++ b/.styleguidist/introduction.md
@@ -1,4 +1,4 @@
-Suomi.fi UI Components is a part of [Suomi.fi Design System](https://designsystem.suomi.fi) and is maintained and built by the Digital and population data services agency of Finland.
+**Suomi.fi UI Components is a part of [Suomi.fi Design System](https://designsystem.suomi.fi) and is maintained and built by the Digital and population data services agency of Finland.**
 
 ## ✨ Features
 
@@ -45,17 +45,17 @@ yarn add styled-components
 
 - If using TypeScript, version 3.8 or above is required.
 
-- In case TypeScript is used and skipLibCheck compiler option is set to false, also typings for [react](https://www.npmjs.com/package/@types/react), [react-dom](https://www.npmjs.com/package/@types/react-dom), [styled-components](https://www.npmjs.com/package/@types/styled-components/) and [warning](https://www.npmjs.com/package/@types/warning) are required.
+- In case TypeScript is used and skipLibCheck compiler option is set to false, also add typings for [styled-components](https://www.npmjs.com/package/@types/styled-components/) as well as [react](https://www.npmjs.com/package/@types/react) and [react-dom](https://www.npmjs.com/package/@types/react-dom) as required by the React version used.
 
 ```bash
-yarn add @types/styled-components @types/warning
+yarn add @types/styled-components @types/react @types/react-dom
 ```
 
 ## 🔨 Usage
 
 ```jsx static
 import { Button } from 'suomifi-ui-components';
-ReactDOM.render(<Button />, mountNode);
+<Button>Suomi.fi button</Button>;
 ```
 
 ### 🌊 `Component variants`
@@ -87,4 +87,4 @@ styled(Button)...
 }
 ```
 
-Don't use ~~!important~~. if really really needed - for specificity hack you can define styles using classNames multiple times `.fi-button.button--custom.button--custom {...}`
+Don't use `!important`. If really, really needed you can define styles using classNames multiple times `.fi-button.button--custom.button--custom {...}` for a specificity hack.

--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -60,6 +60,12 @@ module.exports = {
     {
       name: 'Introduction',
       content: './.styleguidist/introduction.md',
+      sections: [() => {}],
+      sectiondepth: 0,
+    },
+    {
+      name: 'Foundations',
+      content: './.styleguidist/foundations.md',
       sections: [
         {
           name: 'Colors',
@@ -106,6 +112,8 @@ module.exports = {
       name: 'Versions',
       content: './.styleguidist/versions.md',
       sections: getVersions(),
+      sectiondepth: 1,
+      expand: false,
     },
     {
       name: 'Components',

--- a/.styleguidist/theme.md
+++ b/.styleguidist/theme.md
@@ -5,3 +5,32 @@ SuomifiTheme provides all shared styles for the suomifi-ui-components library. T
 The theme consists of Colors, Spacing, Typography, Gradients, Focus, Radius, Shadows, Transitions, Z-indexes and Raw design token values. Most of the default values for the theme are based on the [design tokens](https://github.com/vrk-kpa/suomifi-design-tokens).
 
 The theme can be customized by wrapping the target components to a SuomifiThemeProvider and providing customized theme for the provider.
+
+```js
+import {
+  SuomifiThemeProvider,
+  Chip,
+  Button
+} from 'suomifi-ui-components';
+
+const customTheme = {
+  gradients: {
+    highlightBaseToHighlightDark1:
+      'linear-gradient(to right, orange, red);',
+    highlightLight1ToHighlightBase:
+      'linear-gradient(to left, orange, red);'
+  },
+  colors: {
+    highlightBase: 'hotpink',
+    highlightLight1: 'orange',
+    highlightDark1: 'orange'
+  }
+};
+
+<SuomifiThemeProvider theme={customTheme}>
+  <Chip removable actionLabel="Custom styled Chip">
+    Custom color chip
+  </Chip>
+  <Button>Custom themed button</Button>
+</SuomifiThemeProvider>;
+```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Suomi.fi-styleguide in React components. [Living styleguide](https://vrk-kpa.git
 - Suomi.fi brand styles
 - Highly customizable (CSS, CSS-in-JS)
 
-Works with [React >= 16.8.0](https://github.com/facebook/react) and [Styled Components >= 5.2.1](https://github.com/styled-components/styled-components). Supports [TypeScript](https://github.com/Microsoft/TypeScript). CJS and ESM builds provided via the npm package.
+Works with [React >= 16.8.0](https://github.com/facebook/react) (React 18 supported) and [Styled Components >= 5.2.1](https://github.com/styled-components/styled-components). Supports [TypeScript](https://github.com/Microsoft/TypeScript). CJS and ESM builds provided via the npm package.
 
 ### Supported browser and screenreader combinations
 
@@ -24,7 +24,7 @@ Works with [React >= 16.8.0](https://github.com/facebook/react) and [Styled Comp
 
 ## 📦 Install
 
-To install the component library itself
+To install the component library itself:
 
 ```bash
 yarn add suomifi-ui-components
@@ -53,26 +53,26 @@ yarn add styled-components
 
 - If using TypeScript, version 3.8 or above is required.
 
-- In case TypeScript is used and skipLibCheck compiler option is set to false, also typings for [react](https://www.npmjs.com/package/@types/react), [react-dom](https://www.npmjs.com/package/@types/react-dom), [styled-components](https://www.npmjs.com/package/@types/styled-components/) and [warning](https://www.npmjs.com/package/@types/warning) are required.
+- In case TypeScript is used and skipLibCheck compiler option is set to false, also add typings for [styled-components](https://www.npmjs.com/package/@types/styled-components/) as well as [react](https://www.npmjs.com/package/@types/react) and [react-dom](https://www.npmjs.com/package/@types/react-dom) as required by the React version used.
 
 ```bash
-yarn add @types/styled-components @types/warning
+yarn add @types/styled-components @types/react @types/react-dom
 ```
 
 ## 🔨 Usage
 
 ```jsx
 import { Button } from 'suomifi-ui-components';
-ReactDOM.render(<Button />, mountNode);
+<Button>Suomi.fi button</Button>;
 ```
 
-### 🌊 Component variants
+### 🌊 `Component variants`
 
-Components have variant-property for different versions of the current component.
+Components have a `variant` property for different versions of the component.
 
 ```jsx
 import { Button } from 'suomifi-ui-components';
-<Button variant="secondary">This is a secondary button</Button>;
+<Button variant="secondary">This is a seconday button</Button>;
 ```
 
 ### ⛱ Extending styles
@@ -95,7 +95,7 @@ styled(Button)...
 }
 ```
 
-Don't use ~~!important~~, if really really needed - for specificity hack you can define styles using classNames multiple times `.fi-button.button--custom.button--custom {...}`
+Don't use `!important`. If really, really needed you can define styles using classNames multiple times `.fi-button.button--custom.button--custom {...}` for a specificity hack.
 
 ## 🔮 FAQ
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Works with [React >= 16.8.0](https://github.com/facebook/react) (React 18 suppor
 
 ## 📦 Install
 
-To install the component library itself:
+To install the component library
 
 ```bash
 yarn add suomifi-ui-components


### PR DESCRIPTION
## Description
This PR updates the styleguidist menu structure as well as adds and updates some information on the pages.
* Added introduction page with similar content to README.md
* Moved current introduction subpages under `Foundations`

## Motivation and Context
Styleguidist was lacking some basic level technical information and was in need of a restructure in terms of the menu.

## How Has This Been Tested?
By running styleguidist locally on chrome.

## Release notes
### General
* Update styleguidist menu structure and add general library usage documentation to styleguidist
