### PR TITLE
[Feature] SingleSelect/MultiSelect: Additional props for data-attributes

### DIFF
--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -763,3 +763,50 @@ describe('forward ref', () => {
     expect(ref.current?.tagName).toBe('INPUT');
   });
 });
+
+describe('listProps', () => {
+  it('adds data-test-id to unordered list element', () => {
+    const { getByRole } = render(
+      <MultiSelect
+        labelText="Test"
+        items={[]}
+        noItemsText="No items"
+        ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
+        listProps={{
+          'data-test-id': 'custom-attr',
+        }}
+      />,
+    );
+    const input = getByRole('textbox');
+    fireEvent.focus(input);
+    const menu = getByRole('listbox');
+    expect(menu).toHaveAttribute('data-test-id', 'custom-attr');
+  });
+});
+
+describe('listItemProps', () => {
+  it('adds data-test-id to unordered list element', () => {
+    const { getByRole } = render(
+      <MultiSelect
+        labelText="Test"
+        items={[
+          {
+            labelText: 'Apple',
+            uniqueItemId: 'cde456',
+            listItemProps: { 'data-test-id': 'apple' },
+          },
+        ]}
+        noItemsText="No items"
+        ariaSelectedAmountText=""
+        ariaOptionsAvailableText=""
+        ariaOptionChipRemovedText=""
+      />,
+    );
+    const input = getByRole('textbox');
+    fireEvent.focus(input);
+    const option = getByRole('option');
+    expect(option).toHaveAttribute('data-test-id', 'apple');
+  });
+});

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../../theme';
 import { HtmlDiv } from '../../../../../reset';
 import { getOwnerDocument } from '../../../../../utils/common';
+import { HTMLAttributesIncludingDataAttributes } from '../../../../../utils/common/common';
 import { AutoId } from '../../../../utils/AutoId/AutoId';
 import { Debounce } from '../../../../utils/Debounce/Debounce';
 import { Popover } from '../../../../Popover/Popover';
@@ -39,6 +40,8 @@ export interface MultiSelectData {
   disabled?: boolean;
   /** Unique id to identify the item */
   uniqueItemId: string;
+  /** Props to pass to select item's list element, for example data-attributes */
+  listItemProps?: HTMLAttributesIncludingDataAttributes<HTMLLIElement>;
 }
 
 interface CheckedProp {
@@ -113,7 +116,17 @@ type LoadingProps =
 interface InternalMultiSelectProps<T extends MultiSelectData> {
   /** MultiSelect container div class name for custom styling. */
   className?: string;
-  /** Items for the MultiSelect */
+  /** Items for the MultiSelect
+   * <pre>
+   * MultiSelectData {
+   *    labelText: string;
+   *    uniqueItemId: string;
+   *    disabled?: boolean;
+   *    chipText? string;
+   *    listItemProps?: HTMLAttributesIncludingDataAttributes&lt;HTMLLIElement&gt;;
+   * }
+   * </pre>
+   */
   items: Array<T & MultiSelectData>;
   /**
    * Unique id
@@ -163,6 +176,8 @@ interface InternalMultiSelectProps<T extends MultiSelectData> {
   tooltipComponent?: ReactElement;
   /** Ref object to be passed to the input element. Alternative to React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLInputElement>;
+  /** Props to pass to unordered list element, for example data-attributes */
+  listProps?: HTMLAttributesIncludingDataAttributes<HTMLUListElement>;
 }
 
 type AllowItemAdditionProps =
@@ -619,6 +634,7 @@ class BaseMultiSelect<T> extends Component<
       tooltipComponent,
       items, // Only destructured away so they don't end up in the DOM
       forwardedRef, // Only destructured away so it doesn't end up in the DOM
+      listProps,
       ...passProps
     } = this.props;
 
@@ -735,6 +751,7 @@ class BaseMultiSelect<T> extends Component<
                   ref={this.popoverListRef}
                   focusedDescendantId={ariaActiveDescendant}
                   aria-multiselectable="true"
+                  {...listProps}
                 >
                   <HtmlDiv>
                     {!loading &&
@@ -753,6 +770,7 @@ class BaseMultiSelect<T> extends Component<
                               this.handleItemSelection(item);
                             }}
                             hightlightQuery={this.filterInputRef.current?.value}
+                            {...item.listItemProps}
                           >
                             {item.labelText}
                           </SelectItem>

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -543,3 +543,50 @@ describe('forward ref', () => {
     expect(ref.current?.value).toBe('Hammer');
   });
 });
+
+describe('listProps', () => {
+  it('adds data-test-id to unordered list element', async () => {
+    const { getByRole } = render(
+      <SingleSelect
+        labelText="Test"
+        clearButtonLabel="Clear selection"
+        items={tools}
+        noItemsText="No items"
+        ariaOptionsAvailableText="Options available"
+        listProps={{
+          'data-test-id': 'custom-data-attr',
+        }}
+      />,
+    );
+    const input = getByRole('textbox');
+    fireEvent.focus(input);
+    const menu = getByRole('listbox');
+    expect(menu).toHaveAttribute('data-test-id', 'custom-data-attr');
+  });
+});
+
+describe('listItemProps', () => {
+  it('adds data-test-id to list item element', async () => {
+    const { getByRole } = render(
+      <SingleSelect
+        labelText="Test"
+        clearButtonLabel="Clear selection"
+        items={[
+          {
+            labelText: 'Abc',
+            uniqueItemId: 'abc123',
+            listItemProps: {
+              'data-test-id': 'abc',
+            },
+          },
+        ]}
+        noItemsText="No items"
+        ariaOptionsAvailableText="Options available"
+      />,
+    );
+    const input = getByRole('textbox');
+    fireEvent.focus(input);
+    const option = getByRole('option');
+    expect(option).toHaveAttribute('data-test-id', 'abc');
+  });
+});

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -3,6 +3,7 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv } from '../../../../reset';
 import { getOwnerDocument, escapeStringRegexp } from '../../../../utils/common';
+import { HTMLAttributesIncludingDataAttributes } from '../../../../utils/common/common';
 import { AutoId } from '../../../utils/AutoId/AutoId';
 import { Debounce } from '../../../utils/Debounce/Debounce';
 import { Popover } from '../../../Popover/Popover';
@@ -34,6 +35,8 @@ export interface SingleSelectData {
   disabled?: boolean;
   /** Unique id to identify the item */
   uniqueItemId: string;
+  /** Props to pass to select item's list element, for example data-attributes */
+  listItemProps?: HTMLAttributesIncludingDataAttributes<HTMLLIElement>;
 }
 
 export type SingleSelectStatus = FilterInputStatus & {};
@@ -58,7 +61,16 @@ type AriaOptionsAvailableProps =
 export interface InternalSingleSelectProps<T extends SingleSelectData> {
   /** SingleSelect container div class name for custom styling. */
   className?: string;
-  /** Items for the SingleSelect */
+  /** Items for the SingleSelect
+   * <pre>
+   * SingleSelectData {
+   *    labelText: string;
+   *    uniqueItemId: string;
+   *    disabled?: boolean;
+   *    listItemProps?: HTMLAttributesIncludingDataAttributes&lt;HTMLLIElement&gt;;
+   * }
+   * </pre>
+   */
   items: Array<T & SingleSelectData>;
   /**
    * Unique id
@@ -102,6 +114,8 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
   tooltipComponent?: ReactElement;
   /** Ref is forwarded to the input element. Alternative for React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLInputElement>;
+  /** Props to pass to unordered list element, for example data-attributes */
+  listProps?: HTMLAttributesIncludingDataAttributes<HTMLUListElement>;
 }
 
 type LoadingProps =
@@ -501,6 +515,7 @@ class BaseSingleSelect<T> extends Component<
       tooltipComponent,
       items, // Only destructured away so they don't end up in the DOM
       forwardedRef, // Only destructured away so it doesn't end up in the DOM
+      listProps,
       ...passProps
     } = this.props;
 
@@ -631,6 +646,7 @@ class BaseSingleSelect<T> extends Component<
               id={popoverItemListId}
               ref={this.popoverListRef}
               focusedDescendantId={ariaActiveDescendant}
+              {...listProps}
             >
               <HtmlDiv>
                 {popoverItems.length > 0 &&
@@ -655,6 +671,7 @@ class BaseSingleSelect<T> extends Component<
                         hightlightQuery={
                           filterMode ? this.filterInputRef.current?.value : ''
                         }
+                        {...item.listItemProps}
                       >
                         {item.labelText}
                       </SelectItem>


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

PR adds new props to SingleSelect and MultiSelect for passing custom data-attributes to elements that are rendered in portal.

## Motivation and Context

SingleSelect and MultiSelect render displayed menu in portal that is appended to the bottom of body element. Option to add
custom data-attributes enables targeting menu and menu items in tests.

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Component tests, Styleguidist testing, CRA application

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### SingleSelect
- Add optional property `listProps` for passing data-attributes to unordered list element
- Add optional property `listItemProps` for passing data-attributes to list items

### MultiSelect
- Add optional property `listProps` for passing data-attributes to unordered list element
- Add optional property `listItemProps` for passing data-attributes to list items