### PR TITLE
[Fix] CharacterCounter component tests

### DIFF
--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent } from '@testing-library/react';
 import { axeTest } from '../../../utils/test';
 
 import { TextInput } from './TextInput';
@@ -306,6 +306,14 @@ describe('props', () => {
 });
 
 describe('Character counter', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   it('should display correct character count', () => {
     const { container, getByTestId } = render(
       <TextInput
@@ -340,7 +348,6 @@ describe('Character counter', () => {
   });
 
   it('should have correct screen reader status text', () => {
-    jest.useFakeTimers();
     const { container, getByTestId } = render(
       <TextInput
         labelText="label"
@@ -370,7 +377,9 @@ describe('Character counter', () => {
       container.getElementsByClassName('fi-status-text')[0].firstChild,
     ).toHaveTextContent('');
 
-    jest.advanceTimersByTime(2000);
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
 
     expect(
       container.getElementsByClassName('fi-status-text')[0].firstChild,

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -129,6 +129,15 @@ const BaseTextInput = (props: characterCounterProps & TextInputProps) => {
     typeof setTimeout
   > | null>(null);
 
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+    return () => {
+      setIsMounted(false);
+    };
+  }, []);
+
   const {
     className,
     labelText,
@@ -178,11 +187,13 @@ const BaseTextInput = (props: characterCounterProps & TextInputProps) => {
       const charCountInInput = event.target.value.length;
       setCharCount(charCountInInput);
       const newTypingTimer = setTimeout(() => {
-        setCharacterCounterAriaText(
-          charCountInInput <= characterLimit
-            ? ariaCharactersRemainingText(characterLimit - charCountInInput)
-            : ariaCharactersExceededText(charCountInInput - characterLimit),
-        );
+        if (isMounted) {
+          setCharacterCounterAriaText(
+            charCountInInput <= characterLimit
+              ? ariaCharactersRemainingText(characterLimit - charCountInInput)
+              : ariaCharactersExceededText(charCountInInput - characterLimit),
+          );
+        }
       }, 1500);
       setTypingTimer(newTypingTimer);
     }

--- a/src/core/Form/Textarea/Textarea.test.tsx
+++ b/src/core/Form/Textarea/Textarea.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { axeTest } from '../../../utils/test';
 
 import { Textarea } from './Textarea';
@@ -290,6 +290,14 @@ describe('props', () => {
   });
 
   describe('Character counter', () => {
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
     it('should display character count', () => {
       const { container, getByRole } = render(
         <Textarea
@@ -324,7 +332,6 @@ describe('props', () => {
     });
 
     it('should have correct screen reader status text', () => {
-      jest.useFakeTimers();
       const { container, getByTestId } = render(
         <Textarea
           labelText="label"
@@ -345,6 +352,7 @@ describe('props', () => {
       ).toHaveTextContent('');
 
       const textInput = getByTestId('cc-textarea') as HTMLTextAreaElement;
+
       fireEvent.change(textInput, {
         target: { value: 'Lorem ipsum dolor sit amet' },
       });
@@ -354,7 +362,9 @@ describe('props', () => {
         container.getElementsByClassName('fi-status-text')[0].firstChild,
       ).toHaveTextContent('');
 
-      jest.advanceTimersByTime(2000);
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
 
       expect(
         container.getElementsByClassName('fi-status-text')[0].firstChild,

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -156,6 +156,15 @@ const BaseTextarea = (props: TextareaProps) => {
     typeof setTimeout
   > | null>(null);
 
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+    return () => {
+      setIsMounted(false);
+    };
+  }, []);
+
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const onClickProps = !!disabled ? {} : { onMouseDown: onClick };
@@ -180,11 +189,13 @@ const BaseTextarea = (props: TextareaProps) => {
       const charCountInInput = event.target.value.length;
       setCharCount(charCountInInput);
       const newTypingTimer = setTimeout(() => {
-        setCharacterCounterAriaText(
-          charCountInInput <= characterLimit
-            ? ariaCharactersRemainingText(characterLimit - charCountInInput)
-            : ariaCharactersExceededText(charCountInInput - characterLimit),
-        );
+        if (isMounted) {
+          setCharacterCounterAriaText(
+            charCountInInput <= characterLimit
+              ? ariaCharactersRemainingText(characterLimit - charCountInInput)
+              : ariaCharactersExceededText(charCountInInput - characterLimit),
+          );
+        }
       }, 1500);
       setTypingTimer(newTypingTimer);
     }


### PR DESCRIPTION

## Description

This PR fixes issues regarding character counter tests in Textarea and TextInput. Character counter uses a timeout, and we wanted to use Jest fake timers to control the passage of time more accurately in the tests. Furthermore, this PR adds mounted checks to timeout to avoid the `Warning: Can't perform a React state update on an unmounted component` error. 

## Motivation and Context

Error free tests

## How Has This Been Tested?

Running tests locally

## Release notes

None needed
