### PR TITLE
[Hotfix]: Update icons to 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -168,7 +168,7 @@
     "react-popper": "2.3.0",
     "react-svg": "15.1.3",
     "suomifi-design-tokens": "5.0.0",
-    "suomifi-icons": "7.0.0"
+    "suomifi-icons": "7.0.1"
   },
   "peerDependencies": {
     "@types/styled-components": ">=5.1.9",

--- a/src/docs/Icons/Icons.tsx
+++ b/src/docs/Icons/Icons.tsx
@@ -10,10 +10,10 @@ import {
 import clipboardCopy from 'clipboard-copy';
 import { suomifiDesignTokens } from 'suomifi-design-tokens';
 
-const baseIconKeys = baseIcons as string[];
-const illustrativeIconKeys = illustrativeIcons as string[];
-const doctypeIconKeys = doctypeIcons as string[];
-const logoIconKeys = logoIcons as string[];
+const baseIconKeys = baseIcons;
+const illustrativeIconKeys = illustrativeIcons;
+const doctypeIconKeys = doctypeIcons;
+const logoIconKeys = logoIcons;
 
 const IconWrapper = styled.figure`
   display: inline-block;
@@ -46,7 +46,7 @@ const iconStyles = {
 
 const getStyledIcon = (icon: string) => {
   const iconName = `Icon${icon}`;
-  const Icon = allIcons[iconName as keyof typeof allIcons];
+  const Icon: any = allIcons[iconName as keyof typeof allIcons];
   return styled(() => <Icon {...iconProps(iconName)} />)({
     ...iconStyles,
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12228,10 +12228,10 @@ suomifi-design-tokens@5.0.0:
   resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-5.0.0.tgz#773de7faeb3136387587bbc3151e65b6201a77ad"
   integrity sha512-hdDFKkiXNV0n1WvozR3ELTmMUoRaG8Wn6Jsg2SM5HzhwDx5MyBbDuuYGujuepCCsI6bp1P9c6TIb22H6w1/szA==
 
-suomifi-icons@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-7.0.0.tgz#c91d565187198e6f023fdc26112cb812244d15ea"
-  integrity sha512-EENcA1r3rjVmpZHw/QKGrHlxG7a1E/DkZ77hdpl7sEgaXCqFMyCzwORlf6oWJ8jU6EyW67FyPB7HyK8WhXgU+g==
+suomifi-icons@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-7.0.1.tgz#3b957a90d4f342237f04a8a9e3de9cdea703a462"
+  integrity sha512-0C9dYWedltuzO7C6e0zlRBWPdDElexyOrp2pMLmvPvsz+JQ/uMfCi+BErOpD9oIwZq3npgtHfTa6cRWUgk/gyA==
   dependencies:
     classnames "^2.3.1"
 


### PR DESCRIPTION
## Description

PR updates suomifi-icons version to 7.0.1. This version contains a critical bugfix regarding icons Typescript build. 

## Related Issue

https://github.com/vrk-kpa/suomifi-icons/issues/83

## How Has This Been Tested?
Styleguidist build, CRA

## Release notes
- Update `suomifi-icons` to 7.0.1
