### PR TITLE
[Fix] Breadcrumb example aria-label

### DIFF
--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.md
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.md
@@ -1,7 +1,9 @@
+Breadcrumb component is used to let the user know their current location in the service. Use an aria-label which describes this function.
+
 ```jsx
 import { Breadcrumb, BreadcrumbLink } from 'suomifi-ui-components';
 
-<Breadcrumb aria-label="breadcrumb">
+<Breadcrumb aria-label="Your current location">
   <BreadcrumbLink href="/">Frontpage</BreadcrumbLink>
   <BreadcrumbLink href="/sub">Sub page</BreadcrumbLink>
   <BreadcrumbLink current>Sub sub page</BreadcrumbLink>

--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.tsx
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.tsx
@@ -43,7 +43,7 @@ const StyledBreadcrumb = styled(BaseBreadcrumb)`
 
 /**
  * <i class="semantics" />
- * Used for navigation path
+ * Indicator for the user's current location in the service.
  */
 const Breadcrumb = (props: BreadcrumbProps) => {
   const { 'aria-label': ariaLabel, ...passProps } = props;


### PR DESCRIPTION
## Description
This PR adds a more descriptive aria-label to Breadcrumb component example, along with a small description of the component.

## Related Issue
Closes #728 

## Motivation and Context
Examples should show correct usage

## How Has This Been Tested?
By running locally in styleguidist on chrome

## Release notes
### Breadcrumb
- Improve documentation
