### PR TITLE
[Fix]: DateInput ref

### DIFF
--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -16,7 +16,10 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
-import { HTMLAttributesIncludingDataAttributes } from '../../../utils/common/common';
+import {
+  HTMLAttributesIncludingDataAttributes,
+  forkRefs,
+} from '../../../utils/common/common';
 import { HtmlInputProps, HtmlDiv, HtmlInput, HtmlButton } from '../../../reset';
 import { DatePicker } from './DatePicker/DatePicker';
 import { Label, LabelMode } from '../Label/Label';
@@ -245,6 +248,9 @@ const BaseDateInput = (props: DateInputProps) => {
     datePickerDefaultTexts.fi,
   );
 
+  // Remove the possibility to have undefined forwardedRef as a parameter for forkRefs
+  const definedRef = forwardedRef || null;
+
   useEffect(() => {
     if (defaultValue) {
       setInputValue(String(defaultValue));
@@ -366,7 +372,7 @@ const BaseDateInput = (props: DateInputProps) => {
                   value={'value' in props ? value : inputValue}
                   id={id}
                   className={dateInputClassNames.inputElement}
-                  forwardedRef={inputRef}
+                  forwardedRef={forkRefs(inputRef, definedRef)}
                   placeholder={visualPlaceholder}
                   aria-invalid={status === 'error' ? true : undefined}
                   {...getConditionalAriaProp('aria-describedby', [


### PR DESCRIPTION
## Description

There was a bug in `<DateInput>` ref. User given ref was never actually set to the input, because there was an internal ref taking its place.

The implementation now uses our custom `forkRefs` utility to set both refs to the input.

## How Has This Been Tested?

Styleguidist, running Jest tests.

## Release notes

### DateInput
* Fix ref
