### PR TITLE
Update suomifi-icons dependency to 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "react-modal": "3.16.1",
     "react-popper": "2.3.0",
     "suomifi-design-tokens": "5.1.0",
-    "suomifi-icons": "7.0.1"
+    "suomifi-icons": "7.1.0"
   },
   "peerDependencies": {
     "@types/styled-components": ">=5.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9545,7 +9545,6 @@ string-natural-compare@^3.0.1:
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  name string-width
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9642,7 +9641,6 @@ stringify-object@^3.2.0:
     is-regexp "^1.0.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9817,10 +9815,10 @@ suomifi-design-tokens@5.1.0:
   resolved "https://registry.yarnpkg.com/suomifi-design-tokens/-/suomifi-design-tokens-5.1.0.tgz#8ce5748c5f91c3177335f11773364c2255720b6e"
   integrity sha512-SUiIMXpDoNql1TO0QRR03EQnNsSBAGYLCWtkNEcRbWXSSTEiQtXL/pAitpXn1G+XZoWsCp3gjmVXUBC+v3RreA==
 
-suomifi-icons@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-7.0.1.tgz#3b957a90d4f342237f04a8a9e3de9cdea703a462"
-  integrity sha512-0C9dYWedltuzO7C6e0zlRBWPdDElexyOrp2pMLmvPvsz+JQ/uMfCi+BErOpD9oIwZq3npgtHfTa6cRWUgk/gyA==
+suomifi-icons@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/suomifi-icons/-/suomifi-icons-7.1.0.tgz#e8922a19821426f52f9e50ace15aab19adee016a"
+  integrity sha512-HCkX2EdsA84V+/yFQWarBnP0k1jjkM0eofZONobG7wU3oVYI6ZP8W+DMoIsXceitqdECKPg55j8DmG2cRiQuqw==
   dependencies:
     classnames "^2.3.1"
 
@@ -10666,7 +10664,6 @@ word-wrap@~1.2.3:
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description
This PR updates `suomifi-icons` dependency to version 7.1.0. The new version brings three new icons requested by the designers:
- Bold
- Italics
- Quotes

## Motivation and Context
Since icons can be used via ui-components as well, it should have all the latest icons available.

## How Has This Been Tested?
Tested by running locally on styleguidist on chrome and checking that all new icons appear and work correctly.

## Release notes
### Dependencies
- Update suomifi-icons to 7.1.0
  - This makes Bold, Italics and Quotes icons available via ui-components as well
