### PR TITLE
[Fix] Breadcrumb underline

### DIFF
--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -312,8 +312,39 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
+.c5.fi-breadcrumb-link .fi-breadcrumb-link_link:hover,
+.c5.fi-breadcrumb-link .fi-breadcrumb-link_link:active {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5.fi-breadcrumb-link .fi-breadcrumb-link_link--initial-underline {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5.fi-breadcrumb-link .fi-breadcrumb-link_link--initial-underline:focus,
+.c5.fi-breadcrumb-link .fi-breadcrumb-link_link--initial-underline:focus-within {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5.fi-breadcrumb-link .fi-breadcrumb-link_link--initial-underline:hover,
+.c5.fi-breadcrumb-link .fi-breadcrumb-link_link--initial-underline:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .c5.fi-breadcrumb-link .fi-breadcrumb-link_link--current {
   color: hsl(202,7%,40%);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c5.fi-breadcrumb-link .fi-breadcrumb-link_link--current:hover,
+.c5.fi-breadcrumb-link .fi-breadcrumb-link_link--current:active {
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .c5.fi-breadcrumb-link .fi-breadcrumb-link_icon {

--- a/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.baseStyles.ts
+++ b/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.baseStyles.ts
@@ -9,10 +9,37 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   )};
   &.fi-breadcrumb-link {
     display: inline-block;
+
     & .fi-breadcrumb-link_link {
       ${font(theme)('bodyTextSmall')}
+
+      &:hover,
+      &:active {
+        text-decoration: underline;
+      }
+
+      &--initial-underline {
+        text-decoration: underline;
+
+        &:focus,
+        &:focus-within {
+          text-decoration: underline;
+        }
+
+        &:hover,
+        &:active {
+          text-decoration: none;
+        }
+      }
+
       &--current {
         color: ${theme.colors.depthDark1};
+        text-decoration: none;
+
+        &:hover,
+        &:active {
+          text-decoration: none;
+        }
       }
     }
 

--- a/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.tsx
+++ b/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.tsx
@@ -11,6 +11,7 @@ const baseClassName = 'fi-breadcrumb-link';
 const breadcrumbClassNames = {
   link: `${baseClassName}_link`,
   current: `${baseClassName}_link--current`,
+  linkUnderline: `${baseClassName}_link--initial-underline`,
   icon: `${baseClassName}_icon`,
 };
 
@@ -27,6 +28,7 @@ const BaseBreadcrumbLink = (props: BreadcrumbLinkProps & SuomifiThemeProp) => {
     children,
     className,
     theme,
+    underline = 'hover',
     href = '',
     ...passProps
   } = props;
@@ -36,7 +38,9 @@ const BaseBreadcrumbLink = (props: BreadcrumbLinkProps & SuomifiThemeProp) => {
         <>
           <Link
             {...passProps}
-            className={breadcrumbClassNames.link}
+            className={classnames(breadcrumbClassNames.link, {
+              [breadcrumbClassNames.linkUnderline]: underline === 'initial',
+            })}
             href={href}
           >
             {children}


### PR DESCRIPTION
## Description

PR makes the `<BreadcrumbLink>` component follow the `underline` prop, same as all other link components. 

The breadcrumb link did not have any underlining previously. 

## Motivation and Context

`<BreadcrumbLink>` should work with the `underline` prop since it is part of the component's API (via BaseLinkProps)

## How Has This Been Tested?

Styleguidist

## Release notes

### Breadcrumb
- Fix `underline` prop behavior
