### PR TITLE
[Fix] SingleSelect to update when items array is changed

### DIFF
--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -590,3 +590,50 @@ describe('listItemProps', () => {
     expect(option).toHaveAttribute('data-test-id', 'abc');
   });
 });
+
+describe('External update to item array', () => {
+  const ModalWithSiblings = () => {
+    const planets: SingleSelectData[] = [
+      { labelText: 'Mercury', uniqueItemId: 'Me' },
+      { labelText: 'Venus', uniqueItemId: 'Ve' },
+      { labelText: 'Earth', uniqueItemId: 'Ea' },
+      { labelText: 'Mars', uniqueItemId: 'Ma' },
+    ];
+
+    const [stateItems, setStateItems] = React.useState(planets);
+
+    return (
+      <div>
+        <button
+          data-testid="changeState"
+          onClick={() => {
+            const tempPlanets = [...stateItems];
+            tempPlanets[0] = { labelText: 'Moon', uniqueItemId: 'Me' };
+            setStateItems(tempPlanets);
+          }}
+        />
+
+        <SingleSelect
+          labelText="Test"
+          clearButtonLabel="Clear selection"
+          items={stateItems}
+          defaultSelectedItem={stateItems[0]}
+          noItemsText="No items"
+          ariaOptionsAvailableText="Options available"
+        />
+      </div>
+    );
+  };
+
+  it('updated item array should be visible in input', async () => {
+    const { getByRole, getByTestId } = render(<ModalWithSiblings />);
+    const input = getByRole('textbox');
+    expect(input).toHaveDisplayValue('Mercury');
+
+    const button = getByTestId('changeState');
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(input).toHaveDisplayValue('Moon');
+  });
+});

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -225,10 +225,18 @@ class BaseSingleSelect<T> extends Component<
 
     if (selectedItemChanged || propItems !== prevState.initialItems) {
       const resolvedSelectedItem =
-        'selectedItem' in nextProps ? selectedItem : prevState.selectedItem;
+        'selectedItem' in nextProps
+          ? selectedItem
+          : propItems.find(
+              (item) =>
+                item.uniqueItemId === prevState.selectedItem?.uniqueItemId,
+            );
       const resolvedInputValue = selectedItemChanged
         ? selectedItem?.labelText || ''
-        : prevState.filterInputValue;
+        : propItems.find(
+            (item) =>
+              item.uniqueItemId === prevState.selectedItem?.uniqueItemId,
+          )?.labelText || '';
 
       return {
         selectedItem: resolvedSelectedItem,


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Currently if the selected object in SingleSelect is updated elsewhere so that the label value is changed, the new value is updated to the popover list, but not in the input.
This PR fixes it so that the input value is also updated.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, please link to the issue here: -->
https://jira.dvv.fi/browse/SFIDS-852


## Motivation and Context

This issue came from a project using SingleSelect in a form where some other input changes the item array.

## How Has This Been Tested?
Styleguidist. New unit test. 

There is a branch `fix/singleselect-modify-selected-test`  that has an styleguidist example demoing this fix. It's identical to this PR except the .md file.

## Release notes

### SingleSelect
- Fix input to show updated value when item array is changed

