### PR TITLE
[Breaking change] Combine expander button aria labels

### DIFF
--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -434,7 +434,7 @@ const [expanderThreeOpen, setExpanderThreeOpen] = useState(true);
 
 If you need to have interactive elements in the Expander title, use `<ExpanderTitle>` instead of `<ExpanderTitleButton>`.
 
-ExpanderTitle creates a smaller toggle button to the right side of the Expander. For screen readers, it is recommended to provide a descriptive label for the button using `toggleButtonAriaText`. State is communicated to assistive technology using `aria-expanded`. Point `toggleButtonAriaDescribedBy` to the ID of interactive element to provide additional context for assistive technology.
+ExpanderTitle creates a smaller toggle button to the right side of the Expander. For screen readers, it is recommended to provide a descriptive label for the button using `toggleButtonAriaText`. State is communicated to assistive technology using `aria-expanded`. Point `toggleButtonAriaDescribedBy` to the ID of interactive element to provide additional context for assistive technology. Screenreader reads `toggleButtonAriaText` and `toggleButtonAriaDescribedBy` together.
 
 ```jsx
 import {

--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -434,7 +434,7 @@ const [expanderThreeOpen, setExpanderThreeOpen] = useState(true);
 
 If you need to have interactive elements in the Expander title, use `<ExpanderTitle>` instead of `<ExpanderTitleButton>`.
 
-ExpanderTitle creates a smaller toggle button to the right side of the Expander. Generally `ariaOpenText`/`ariaCloseText` props should have the same value, because state is already communicated to assistive technology using `aria-expanded`. Point `toggleButtonAriaDescribedBy` to the ID of interactive element to provide additional context for assistive technology.
+ExpanderTitle creates a smaller toggle button to the right side of the Expander. For screen readers, it is recommended to provide a descriptive label for the button using `ariaToggleButtonText`. State is communicated to assistive technology using `aria-expanded`. Point `toggleButtonAriaDescribedBy` to the ID of interactive element to provide additional context for assistive technology.
 
 ```jsx
 import {
@@ -447,8 +447,7 @@ import {
 
 <Expander>
   <ExpanderTitle
-    ariaOpenText="Additional information"
-    ariaCloseText="Additional information"
+    ariaToggleButtonText="Additional information"
     toggleButtonAriaDescribedBy="checkbox-id"
   >
     <Checkbox id="checkbox-id">Guardianship</Checkbox>

--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -434,7 +434,7 @@ const [expanderThreeOpen, setExpanderThreeOpen] = useState(true);
 
 If you need to have interactive elements in the Expander title, use `<ExpanderTitle>` instead of `<ExpanderTitleButton>`.
 
-ExpanderTitle creates a smaller toggle button to the right side of the Expander. For screen readers, it is recommended to provide a descriptive label for the button using `ariaToggleButtonText`. State is communicated to assistive technology using `aria-expanded`. Point `toggleButtonAriaDescribedBy` to the ID of interactive element to provide additional context for assistive technology.
+ExpanderTitle creates a smaller toggle button to the right side of the Expander. For screen readers, it is recommended to provide a descriptive label for the button using `toggleButtonAriaText`. State is communicated to assistive technology using `aria-expanded`. Point `toggleButtonAriaDescribedBy` to the ID of interactive element to provide additional context for assistive technology.
 
 ```jsx
 import {
@@ -447,7 +447,7 @@ import {
 
 <Expander>
   <ExpanderTitle
-    ariaToggleButtonText="Additional information"
+    toggleButtonAriaText="Additional information"
     toggleButtonAriaDescribedBy="checkbox-id"
   >
     <Checkbox id="checkbox-id">Guardianship</Checkbox>

--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -434,7 +434,7 @@ const [expanderThreeOpen, setExpanderThreeOpen] = useState(true);
 
 If you need to have interactive elements in the Expander title, use `<ExpanderTitle>` instead of `<ExpanderTitleButton>`.
 
-ExpanderTitle creates a smaller toggle button to the right side of the Expander. For screen readers, it is recommended to provide a descriptive label for the button using `toggleButtonAriaText`. State is communicated to assistive technology using `aria-expanded`. Point `toggleButtonAriaDescribedBy` to the ID of interactive element to provide additional context for assistive technology. Screenreader reads `toggleButtonAriaText` and `toggleButtonAriaDescribedBy` together.
+ExpanderTitle creates a smaller toggle button to the right side of the Expander. For screen readers, it is recommended to provide a descriptive label for the button using `toggleButtonAriaLabel`. State is communicated to assistive technology using `aria-expanded`. Point `toggleButtonAriaDescribedBy` to the ID of interactive element to provide additional context for assistive technology. Screenreader reads `toggleButtonAriaLabel` and `toggleButtonAriaDescribedBy` together.
 
 ```jsx
 import {
@@ -447,7 +447,7 @@ import {
 
 <Expander>
   <ExpanderTitle
-    toggleButtonAriaText="Additional information"
+    toggleButtonAriaLabel="Additional information"
     toggleButtonAriaDescribedBy="checkbox-id"
   >
     <Checkbox id="checkbox-id">Guardianship</Checkbox>

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
@@ -50,7 +50,7 @@ describe('Basic ExpanderTitle', () => {
     <ExpanderTitle
       {...{ 'data-testid': 'expander-title' }}
       {...props}
-      ariaToggleButtonText="toggle"
+      toggleButtonAriaText="toggle"
       toggleButtonAriaDescribedBy="title-id"
     >
       {props?.children ? (
@@ -93,7 +93,7 @@ describe('Basic ExpanderTitle', () => {
 describe('Aria attributes', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
     <ExpanderTitle
-      ariaToggleButtonText="toggle"
+      toggleButtonAriaText="toggle"
       toggleButtonAriaDescribedBy="title-id"
       {...{ 'data-testid': 'expander-title' }}
       {...props}
@@ -130,7 +130,7 @@ describe('Custom id', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
     <ExpanderTitle
       {...props}
-      ariaToggleButtonText="toggle"
+      toggleButtonAriaText="toggle"
       toggleButtonAriaDescribedBy="title-id"
     >
       {props?.children ? (
@@ -160,7 +160,7 @@ describe('Provider open property', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
     <ExpanderTitle
       {...{ 'data-testid': 'expander-open-by-default-title' }}
-      ariaToggleButtonText="toggle"
+      toggleButtonAriaText="toggle"
       toggleButtonAriaDescribedBy="title-id"
       {...props}
     >

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
@@ -50,7 +50,7 @@ describe('Basic ExpanderTitle', () => {
     <ExpanderTitle
       {...{ 'data-testid': 'expander-title' }}
       {...props}
-      toggleButtonAriaText="toggle"
+      toggleButtonAriaLabel="toggle"
       toggleButtonAriaDescribedBy="title-id"
     >
       {props?.children ? (
@@ -93,7 +93,7 @@ describe('Basic ExpanderTitle', () => {
 describe('Aria attributes', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
     <ExpanderTitle
-      toggleButtonAriaText="toggle"
+      toggleButtonAriaLabel="toggle"
       toggleButtonAriaDescribedBy="title-id"
       {...{ 'data-testid': 'expander-title' }}
       {...props}
@@ -130,7 +130,7 @@ describe('Custom id', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
     <ExpanderTitle
       {...props}
-      toggleButtonAriaText="toggle"
+      toggleButtonAriaLabel="toggle"
       toggleButtonAriaDescribedBy="title-id"
     >
       {props?.children ? (
@@ -160,7 +160,7 @@ describe('Provider open property', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
     <ExpanderTitle
       {...{ 'data-testid': 'expander-open-by-default-title' }}
-      toggleButtonAriaText="toggle"
+      toggleButtonAriaLabel="toggle"
       toggleButtonAriaDescribedBy="title-id"
       {...props}
     >

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.test.tsx
@@ -50,8 +50,7 @@ describe('Basic ExpanderTitle', () => {
     <ExpanderTitle
       {...{ 'data-testid': 'expander-title' }}
       {...props}
-      ariaOpenText="open expander"
-      ariaCloseText="close expander"
+      ariaToggleButtonText="toggle"
       toggleButtonAriaDescribedBy="title-id"
     >
       {props?.children ? (
@@ -67,14 +66,14 @@ describe('Basic ExpanderTitle', () => {
       providerProps,
     });
     expect(getByTestId('expander-title').textContent).toBe(
-      'Expander title buttonopen expander',
+      'Expander title buttontoggle',
     );
     // re-render the same component with different props
     rerender(TestExpanderWithProps({ children: 'Expander title button two' }), {
       providerProps: { ...providerProps },
     });
     expect(getByTestId('expander-title').textContent).toBe(
-      'Expander title button twoopen expander',
+      'Expander title button twotoggle',
     );
   });
 
@@ -94,8 +93,7 @@ describe('Basic ExpanderTitle', () => {
 describe('Aria attributes', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
     <ExpanderTitle
-      ariaCloseText="click to close expander"
-      ariaOpenText="click to open expander"
+      ariaToggleButtonText="toggle"
       toggleButtonAriaDescribedBy="title-id"
       {...{ 'data-testid': 'expander-title' }}
       {...props}
@@ -116,7 +114,7 @@ describe('Aria attributes', () => {
       },
     );
     expect(getByRole('button')).toHaveAttribute('aria-describedby', 'title-id');
-    expect(getByText('click to open expander')).toBeTruthy();
+    expect(getByText('toggle')).toBeTruthy();
     const adjustedProviderProps = {
       ...providerProps,
       open: true,
@@ -124,7 +122,7 @@ describe('Aria attributes', () => {
     rerender(TestExpanderWithProps(), {
       providerProps: adjustedProviderProps,
     });
-    expect(getByText('click to close expander')).toBeTruthy();
+    expect(getByText('toggle')).toBeTruthy();
   });
 });
 
@@ -132,8 +130,7 @@ describe('Custom id', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
     <ExpanderTitle
       {...props}
-      ariaCloseText="click to close expander"
-      ariaOpenText="click to open expander"
+      ariaToggleButtonText="toggle"
       toggleButtonAriaDescribedBy="title-id"
     >
       {props?.children ? (
@@ -163,8 +160,7 @@ describe('Provider open property', () => {
   const TestExpanderWithProps = (props?: ExpanderTitleProps) => (
     <ExpanderTitle
       {...{ 'data-testid': 'expander-open-by-default-title' }}
-      ariaCloseText="click to close expander"
-      ariaOpenText="click to open expander"
+      ariaToggleButtonText="toggle"
       toggleButtonAriaDescribedBy="title-id"
       {...props}
     >

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -27,7 +27,7 @@ export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'className'> {
   /** Title for Expander */
   children?: ReactNode;
   /** Screen reader action label for expander toggle button. E.g. "Additional information". */
-  ariaToggleButtonText: string;
+  toggleButtonAriaText: string;
   /** Expander title id for screen reader reference in expander toggle button. */
   toggleButtonAriaDescribedBy: string;
   /** Properties for title open/close toggle button */
@@ -50,7 +50,7 @@ interface InternalExpanderTitleProps
 class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
   render() {
     const {
-      ariaToggleButtonText,
+      toggleButtonAriaText,
       children,
       className,
       theme,
@@ -78,7 +78,7 @@ class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
           aria-controls={consumer.contentId}
           aria-describedby={toggleButtonAriaDescribedBy}
         >
-          <VisuallyHidden>{ariaToggleButtonText}</VisuallyHidden>
+          <VisuallyHidden>{toggleButtonAriaText}</VisuallyHidden>
           <IconChevronDown
             className={classnames(iconClassName, {
               [iconOpenClassName]: consumer.open,

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -26,9 +26,10 @@ export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'className'> {
   className?: string;
   /** Title for Expander */
   children?: ReactNode;
-  /** Screen reader action label for expander toggle button. E.g. "Additional information". */
+  /** Screen reader action label for expander toggle button. E.g. "Additional information".
+   * Will be read along with `toggleButtonAriaDescribedBy`. */
   toggleButtonAriaText: string;
-  /** Expander title id for screen reader reference in expander toggle button. */
+  /** Expander title id for screen reader reference in expander toggle button.  Will be read along with `toggleButtonAriaText`. */
   toggleButtonAriaDescribedBy: string;
   /** Properties for title open/close toggle button */
   toggleButtonProps?: Omit<

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -28,8 +28,8 @@ export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'className'> {
   children?: ReactNode;
   /** Screen reader action label for expander toggle button. E.g. "Additional information".
    * Will be read along with `toggleButtonAriaDescribedBy`. */
-  toggleButtonAriaText: string;
-  /** Expander title id for screen reader reference in expander toggle button.  Will be read along with `toggleButtonAriaText`. */
+  toggleButtonAriaLabel: string;
+  /** Expander title id for screen reader reference in expander toggle button.  Will be read along with `toggleButtonAriaLabel`. */
   toggleButtonAriaDescribedBy: string;
   /** Properties for title open/close toggle button */
   toggleButtonProps?: Omit<
@@ -51,7 +51,7 @@ interface InternalExpanderTitleProps
 class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
   render() {
     const {
-      toggleButtonAriaText,
+      toggleButtonAriaLabel,
       children,
       className,
       theme,
@@ -79,7 +79,7 @@ class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
           aria-controls={consumer.contentId}
           aria-describedby={toggleButtonAriaDescribedBy}
         >
-          <VisuallyHidden>{toggleButtonAriaText}</VisuallyHidden>
+          <VisuallyHidden>{toggleButtonAriaLabel}</VisuallyHidden>
           <IconChevronDown
             className={classnames(iconClassName, {
               [iconOpenClassName]: consumer.open,

--- a/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
+++ b/src/core/Expander/ExpanderTitle/ExpanderTitle.tsx
@@ -26,10 +26,8 @@ export interface ExpanderTitleProps extends Omit<HtmlDivProps, 'className'> {
   className?: string;
   /** Title for Expander */
   children?: ReactNode;
-  /** Screen reader action label for collapsed expander toggle button. E.g. "Additional information". */
-  ariaOpenText: string;
-  /** Screen reader action label for expanded expander toggle button. Should usually be the same as `ariaOpenText` */
-  ariaCloseText: string;
+  /** Screen reader action label for expander toggle button. E.g. "Additional information". */
+  ariaToggleButtonText: string;
   /** Expander title id for screen reader reference in expander toggle button. */
   toggleButtonAriaDescribedBy: string;
   /** Properties for title open/close toggle button */
@@ -52,8 +50,7 @@ interface InternalExpanderTitleProps
 class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
   render() {
     const {
-      ariaCloseText,
-      ariaOpenText,
+      ariaToggleButtonText,
       children,
       className,
       theme,
@@ -81,9 +78,7 @@ class BaseExpanderTitle extends Component<InternalExpanderTitleProps> {
           aria-controls={consumer.contentId}
           aria-describedby={toggleButtonAriaDescribedBy}
         >
-          <VisuallyHidden>
-            {!!consumer.open ? ariaCloseText : ariaOpenText}
-          </VisuallyHidden>
+          <VisuallyHidden>{ariaToggleButtonText}</VisuallyHidden>
           <IconChevronDown
             className={classnames(iconClassName, {
               [iconOpenClassName]: consumer.open,

--- a/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
+++ b/src/core/Expander/ExpanderTitle/__snapshots__/ExpanderTitle.test.tsx.snap
@@ -329,7 +329,7 @@ exports[`Basic ExpanderTitle shoud match snapshot 1`] = `
     <span
       class="c2 c4 fi-visually-hidden"
     >
-      open expander
+      toggle
     </span>
     <svg
       aria-hidden="true"


### PR DESCRIPTION
## Description

Combine ariaOpenText and ariaCloseText to toggleButtonAriaLabel. This makes the button behaviour less complicated for screen readers. The opened state is already indicated programmatically.
This makes Expander behaviour uniform between different variants.


## Related Issue

https://jira.dvv.fi/browse/SFIDS-857

## Motivation and Context
This makes the button behaviour less complicated for screen readers as the button text doesn't change on the fly.

## How Has This Been Tested?
Voiceover Chrome + Safari.

## Release notes
### ExpanderTitle
- **Breaking change:** Combine `ariaOpenText` and `ariaCloseText` props to `toggleButtonAriaLabel`
