### PR TITLE
[Fix] ExpanderGroup conditional props

### DIFF
--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -15,24 +15,16 @@ const baseClassName = 'fi-expander-group';
 const openClassName = `${baseClassName}--open`;
 const expandersContainerClassName = `${baseClassName}_expanders`;
 const openAllButtonClassName = `${baseClassName}_all-button`;
-export interface ExpanderGroupProps extends MarginProps {
+
+interface PartialExpanderGroupProps extends MarginProps {
   /** Expanders (and optionally other ReactNodes) */
   children: ReactNode;
-  /** 'Open all' button text */
-  openAllText: string;
-  /** 'Close all' button text */
-  closeAllText: string;
   /** 'Open all' button text for screen readers, hides `OpenAllText` for screen readers if provided */
   ariaOpenAllText?: string;
   /** 'Close all' button text for screen readers, hides `CloseAllText` for screen readers if provided */
   ariaCloseAllText?: string;
   /** CSS class for custom styles */
   className?: string;
-  /**
-   * Shows Open/Close all button
-   * @default true
-   */
-  showToggleAllButton?: boolean;
   /** Props passed to the Open/Close all button */
   toggleAllButtonProps?: Omit<
     HtmlButtonProps,
@@ -46,6 +38,32 @@ export interface ExpanderGroupProps extends MarginProps {
   /** Ref is forwarded to the Open/Close all button element. Alternative for React `ref` attribute. */
   forwardedRef?: React.Ref<HTMLButtonElement>;
 }
+
+type ToggleAllProps =
+  | {
+      /** 'Open all' button text */
+      openAllText?: string;
+      /** 'Close all' button text */
+      closeAllText?: string;
+      /**
+       * Shows Open/Close all button
+       * @default true
+       */
+      showToggleAllButton?: false | never;
+    }
+  | {
+      /** 'Open all' button text. Required when `showToggleAllButton` is true. */
+      openAllText: string;
+      /** 'Close all' button text. Required when `showToggleAllButton` is true. */
+      closeAllText: string;
+      /**
+       * Shows Open/Close all button
+       * @default true
+       */
+      showToggleAllButton: true;
+    };
+
+export type ExpanderGroupProps = PartialExpanderGroupProps & ToggleAllProps;
 
 interface ExpanderOpenStates {
   [key: string]: boolean;

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -41,14 +41,8 @@ interface PartialExpanderGroupProps extends MarginProps {
 
 type ToggleAllProps =
   | {
-      /** 'Open all' button text */
       openAllText?: string;
-      /** 'Close all' button text */
       closeAllText?: string;
-      /**
-       * Shows Open/Close all button
-       * @default true
-       */
       showToggleAllButton?: false | never;
     }
   | {


### PR DESCRIPTION

## Description
Make the props conditional so that `openAllText` and `closeAllText` become optional when `showToggleAllButton` is set to false.

## Related Issue
https://jira.dvv.fi/browse/SFIDS-882


## Motivation and Context

ExpanderGroup had `openAllText` and `closeAllText` as mandatory props even when `showToggleAllButton` is set to false. This PR makes it more user friendly for developers.

## How Has This Been Tested?
Styleguidist

## Release notes

### ExpanderGroup
- `openAllText` and `closeAllText` are optional when `showToggleAllButton` is set to false
