### PR TITLE
[Fix] Html in ActionMenu divider

### DIFF
--- a/src/core/ActionMenu/ActionMenuDivider/ActionMenuDivider.tsx
+++ b/src/core/ActionMenu/ActionMenuDivider/ActionMenuDivider.tsx
@@ -18,7 +18,7 @@ const BaseActionMenuDivider = ({
   ...passProps
 }: ActionMenuDividerProps) => (
   <HtmlDiv
-    aria-hidden="true"
+    role="presentation"
     className={classnames(className, baseClassName)}
     {...passProps}
   >

--- a/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
@@ -736,8 +736,8 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
             Item 2
           </button>
           <div
-            aria-hidden="true"
             class="c0 c9 fi-action-menu-divider"
+            role="presentation"
           >
             <div
               class="c0 fi-action-menu-divider_line"
@@ -1502,8 +1502,8 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
             Item 2
           </button>
           <div
-            aria-hidden="true"
             class="c0 c9 fi-action-menu-divider"
+            role="presentation"
           >
             <div
               class="c0 fi-action-menu-divider_line"
@@ -2269,8 +2269,8 @@ exports[`No borders variant should match snapshot 1`] = `
             Item 2
           </button>
           <div
-            aria-hidden="true"
             class="c0 c9 fi-action-menu-divider"
+            role="presentation"
           >
             <div
               class="c0 fi-action-menu-divider_line"
@@ -3035,8 +3035,8 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
             Item 2
           </button>
           <div
-            aria-hidden="true"
             class="c0 c9 fi-action-menu-divider"
+            role="presentation"
           >
             <div
               class="c0 fi-action-menu-divider_line"
@@ -3802,8 +3802,8 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
             Item 2
           </button>
           <div
-            aria-hidden="true"
             class="c0 c9 fi-action-menu-divider"
+            role="presentation"
           >
             <div
               class="c0 fi-action-menu-divider_line"


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description
This was reported by Daniel. The divider in ActionMenu is not proper html as it has div inside the menu. It was also suggested not to use aria-hidden on divider so that also screen readers could "see" it.
Solutions that made it visible for screen readers didn't work as they expected some functionality from the divider that is not relevant to our use case. 
But this PR would fix the Html so that it's according to the rules. 


## Related Issue
https://jira.dvv.fi/browse/SFIDS-859

## Motivation and Context

Fixes the Html so it's according to the rules. Practical effect is minimal if any, but 

## How Has This Been Tested?
Mac chrome +  safari with voiceover.  Windows Chrome + NVDA. Android talkback.
Didn't notice any difference.

## Screenshots (if appropriate):

## Release notes
### ActionMenuDivider
- Improved Html

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->
