### PR TITLE
[Fix] LanguageMenu popover width

### DIFF
--- a/src/core/LanguageMenu/LanguageMenuPopover/LanguageMenuPopover.tsx
+++ b/src/core/LanguageMenu/LanguageMenuPopover/LanguageMenuPopover.tsx
@@ -59,21 +59,7 @@ const defaultProviderValue: LanguageMenuProviderState = {
 const { Provider: LanguageMenuProvider, Consumer: LanguageMenuConsumer } =
   React.createContext(defaultProviderValue);
 
-/* From Popover.tsx */
-const sameWidth: any = {
-  name: 'sameWidth',
-  enabled: true,
-  phase: 'beforeWrite',
-  requires: ['computeStyles'],
-  /* eslint-disable no-param-reassign */
-  fn({ state }: { state: any }) {
-    state.styles.popper.width = `${state.rects.reference.width}px`;
-  },
-  effect({ state }: { state: any }) {
-    state.elements.popper.style.width = `${state.elements.reference.offsetWidth}px`;
-  },
-};
-
+/* eslint-disable no-param-reassign */
 const scrollItemList = (
   elementId: string,
   wrapperRef: React.RefObject<HTMLDivElement>,
@@ -246,7 +232,6 @@ export const BaseLanguageMenuPopover = (
         padding: 5,
       },
     },
-    sameWidth,
   ];
 
   const { styles, attributes } = usePopper(

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -391,7 +391,7 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
       </button>
       <div
         class="c4 c5 fi-language-menu-popover fi-language-menu-popover--hidden"
-        style="position: fixed; left: 0px; top: 0px; width: 0px;"
+        style="position: fixed; left: 0px; top: 0px;"
       >
         <div
           class="c4 fi-language-menu-popover_list"
@@ -833,7 +833,7 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
       </button>
       <div
         class="c4 c5 fi-language-menu-popover"
-        style="position: fixed; left: 0px; top: 0px; width: 0px; right: 0px; transform: translate(0px, 15px);"
+        style="position: fixed; left: 0px; top: 0px; right: 0px; transform: translate(0px, 15px);"
       >
         <div
           class="c4 fi-language-menu-popover_list"


### PR DESCRIPTION
## Description

This PR makes the LanguageMenu component's widths behave as thus
- The menu button will have a dynamic width based on the text in the button (`buttonText`) prop
- The popover will always have the width of the widest item in the list. Previously, the popover used to be the same width as the menu button

## Motivation and Context

It was reported to us by users that the current behavior of the component is not optimal

## How Has This Been Tested?

Styleguidist

## Screenshots
Before: 
<img width="244" alt="image" src="https://github.com/vrk-kpa/suomifi-ui-components/assets/17459942/e69a5861-e557-4d79-92bc-904f9fd312f8">

After:
<img width="295" alt="image" src="https://github.com/vrk-kpa/suomifi-ui-components/assets/17459942/ac80a569-157e-48f4-b458-7faf25f5fd80">

## Release notes

### LanguageMenu
- Change the popover width to match the width of the widest element in the list
