### PR TITLE
[Hotfix] LinkListItem icon rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/core/Link/LinkListItem/LinkListItem.tsx
+++ b/src/core/Link/LinkListItem/LinkListItem.tsx
@@ -39,7 +39,7 @@ const StyledLinkListItem = styled(
     <HtmlLi {...passProps} className={classnames(baseClassName, className)}>
       <HtmlSpan className={listLinkClassNames.icon}>
         {!!icon ? (
-          { icon }
+          icon
         ) : (
           <IconChevronRight color={theme.colors.highlightBase} />
         )}


### PR DESCRIPTION
## Description

PR includes a hotfix to `<LinkListItem>` component. Its `icon` prop was not rendered correctly and caused a fatal error when trying to use it. 

```
Error: Objects are not valid as a React child (found: object with keys {icon}). If you meant to render a collection of children, use an array instead.
```

Also raised version to 12.0.1 in anticipation of a hotfix release.

## How Has This Been Tested?

Styleguidist, where the error could also be replicated

## Release notes

### LinkListItem
* Fix `icon` prop rendering
