### PR TITLE
[Fix] brandBase color docs

### DIFF
--- a/src/docs/Colors/Colors.tsx
+++ b/src/docs/Colors/Colors.tsx
@@ -122,6 +122,10 @@ const StyledFigure = styled.figure`
 
 const ColorFigure = (props: ColorProps & SuomifiThemeProp) => {
   const { color, keyName } = props;
+  // Brand color is hardcoded in these docs due to HSL conversion producing
+  // a hex which differs slightly from the value DVV defined as
+  // their brand color initially. It is reasonable to display the original value
+  // #003479 to avoid confusion.
   const hslaAsHex = keyName !== 'brandBase' ? hslaToHex(color) : '#003479';
 
   return (

--- a/src/docs/Colors/Colors.tsx
+++ b/src/docs/Colors/Colors.tsx
@@ -122,7 +122,7 @@ const StyledFigure = styled.figure`
 
 const ColorFigure = (props: ColorProps & SuomifiThemeProp) => {
   const { color, keyName } = props;
-  const hslaAsHex = hslaToHex(color);
+  const hslaAsHex = keyName !== 'brandBase' ? hslaToHex(color) : '#003479';
 
   return (
     <StyledFigure


### PR DESCRIPTION
## Description

This PR hardcodes the brandBase color hex value as #003479 in colors documentation. Due to HSL conversion, it has been previously shown as #00357a.

This same thing has already been implemented to DS-site. 

## Motivation and Context

In the beginning of time, the brand blue color of DVV was determined to be hex #003479. This color as HSL is 214.21, 100%, 23.73% (according to MacOS Chrome)

Suomifi-tokens uses HSL values for colors and when the brand color was added there it was rounded to 214, 100%, 24%

Now when this HSL is turned back to hex it's not #003479 anymore but rather #00357a. This has caused some confusion and we figured it's just easiest to display the original hex value. 

## Release notes

None needed? Silent change
