### PR TITLE
[Hotfix] Alert and InlineAlert refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/core/Alert/Alert.tsx
+++ b/src/core/Alert/Alert.tsx
@@ -55,6 +55,7 @@ class BaseAlert extends Component<AlertProps> {
       closeText,
       onCloseButtonClick,
       smallScreen,
+      forwardedRef,
       closeButtonProps = {},
       ...passProps
     } = this.props;
@@ -73,6 +74,7 @@ class BaseAlert extends Component<AlertProps> {
           [`${baseClassName}--${status}`]: !!status,
           [alertClassNames.smallScreen]: !!smallScreen,
         })}
+        ref={forwardedRef}
       >
         <HtmlDiv className={alertClassNames.styleWrapper}>
           {status === 'warning' && (

--- a/src/core/InlineAlert/InlineAlert.tsx
+++ b/src/core/InlineAlert/InlineAlert.tsx
@@ -47,6 +47,7 @@ class BaseInlineAlert extends Component<InlineAlertProps> {
       children,
       smallScreen,
       id,
+      forwardedRef,
       ...passProps
     } = this.props;
 
@@ -58,6 +59,7 @@ class BaseInlineAlert extends Component<InlineAlertProps> {
           [`${baseClassName}--${status}`]: !!status,
           [inlineAlertClassNames.smallScreen]: !!smallScreen,
         })}
+        ref={forwardedRef}
       >
         <HtmlDiv className={inlineAlertClassNames.styleWrapper}>
           {status === 'warning' && (


### PR DESCRIPTION
## Description
Alert and InlineAlert `forwardedRef` props weren't correctly implemented and would in some cases show in the DOM and cause warnings. This PR fixes the issue. 

## Motivation and Context
These were issues reported by developers using the library.

## How Has This Been Tested?
By checking ref functionality in styleguidist on Chrome.

## Release notes
### Alert, InlineAlert
* Fix ref/forwardedRef functionality
