### PR TITLE
[Fix] Expander and WizardNavigation example accessibility

### DIFF
--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -130,9 +130,9 @@ import {
 
 <ExpanderGroup
   openAllText="Open all"
-  ariaOpenAllText="Open all expanders"
+  ariaOpenAllText="Open all sections"
   closeAllText="Close all"
-  ariaCloseAllText="Close all expanders"
+  ariaCloseAllText="Close all sections"
 >
   <Expander>
     <ExpanderTitleButton>
@@ -231,9 +231,9 @@ import {
 
 <ExpanderGroup
   openAllText="Open all"
-  ariaOpenAllText="Open all expanders"
+  ariaOpenAllText="Open all sections"
   closeAllText="Close all"
-  ariaCloseAllText="Close all expanders"
+  ariaCloseAllText="Close all sections"
   showToggleAllButton={false}
 >
   <Expander>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
@@ -42,11 +42,11 @@ const Comp = (props) => {
 };
 
 <div style={{ width: '350px' }}>
-  <WizardNavigation heading="Steps" aria-label="Main">
+  <WizardNavigation heading="Steps" aria-label="Steps">
     <WizardNavigationItem status="completed">
       <RouterLink
         href="https://suomi.fi"
-        aria-label="Step 1 - Parties. This step is completed"
+        aria-label="1. Parties. This step is completed"
       >
         1. Parties
       </RouterLink>
@@ -93,7 +93,7 @@ const Comp = (props) => {
 <div style={{ width: '300px' }}>
   <WizardNavigation
     heading="Steps"
-    aria-label="Main"
+    aria-label="Steps"
     variant="smallScreen"
     initiallyExpanded={false}
   >


### PR DESCRIPTION
## Description and Release notes

- Change all "expanders" to "sections" in ariaOpenAllText and ariaCloseAllText in Expander example code. 
- Use the same text in `aria-label` as in `heading` in WizardNavigation. 

## Motivation and Context

Improves accessibility when example code is used as-is. However, in the case of the WizardNavigation component, ideally there should be no need for an aria-label at all, unless it is desired to have a different text from the one visually shown.