### PR TITLE
[Fix] Modal fullscreen padding

### DIFF
--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -270,9 +270,9 @@ exports[`Basic modal should match snapshot 1`] = `
 
 .c2.fi-modal_content--small-screen {
   padding-top: 20px;
-  padding-left: 20px;
+  padding-left: 15px;
   padding-bottom: 50px;
-  padding-right: 20px;
+  padding-right: 15px;
 }
 
 .c6 {
@@ -606,9 +606,9 @@ exports[`Basic modal should match snapshot 1`] = `
 }
 
 .c7.fi-modal_footer--small-screen .fi-modal_footer_content {
-  padding-right: 5px;
+  padding-right: 0;
   padding-bottom: 15px;
-  padding-left: 20px;
+  padding-left: 15px;
 }
 
 .c7.fi-modal_footer--small-screen .fi-modal_footer_content > * {

--- a/src/core/Modal/ModalContent/ModalContent.baseStyles.tsx
+++ b/src/core/Modal/ModalContent/ModalContent.baseStyles.tsx
@@ -20,9 +20,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &--small-screen {
       padding-top: ${theme.spacing.m};
-      padding-left: ${theme.spacing.m};
+      padding-left: ${theme.spacing.s};
       padding-bottom: 50px;
-      padding-right: ${theme.spacing.m};
+      padding-right: ${theme.spacing.s};
     }
   }
 `;

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -217,9 +217,9 @@ exports[`Basic ModalContent should match snapshot 1`] = `
 
 .c2.fi-modal_content--small-screen {
   padding-top: 20px;
-  padding-left: 20px;
+  padding-left: 15px;
   padding-bottom: 50px;
-  padding-right: 20px;
+  padding-right: 15px;
 }
 
 .c6 {

--- a/src/core/Modal/ModalFooter/ModalFooter.baseStyles.tsx
+++ b/src/core/Modal/ModalFooter/ModalFooter.baseStyles.tsx
@@ -35,9 +35,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     &--small-screen {
       & .fi-modal_footer_content {
-        padding-right: ${theme.spacing.xxs};
+        padding-right: 0;
         padding-bottom: ${theme.spacing.s};
-        padding-left: ${theme.spacing.m};
+        padding-left: ${theme.spacing.s};
         & > * {
           display: block;
           width: calc(100% - ${theme.spacing.s});

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -234,9 +234,9 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
 }
 
 .c2.fi-modal_footer--small-screen .fi-modal_footer_content {
-  padding-right: 5px;
+  padding-right: 0;
   padding-bottom: 15px;
-  padding-left: 20px;
+  padding-left: 15px;
 }
 
 .c2.fi-modal_footer--small-screen .fi-modal_footer_content > * {


### PR DESCRIPTION
## Description
This PR adjusts Modal component paddings in the `smallScreen` variant of the component according to [the updated design](https://www.figma.com/file/uBoVvfv64yvn1kDiaEJpdk/Suomi.fi---Components?node-id=1603%3A22957&mode=dev)

## Motivation and Context
This saves some space on smaller screens where the margins were slightly too big previously.

## How Has This Been Tested?
Tested by running locally on styleguidist on chrome and comparing the implementation with the design.

## Release notes
### Modal
- **Breaking change:**  Decrease padding of `smallScreen` variant
