### PR TITLE
[Fix] TimeInput: Remove wrapperProps in favor of style

### DIFF
--- a/src/core/Form/TimeInput/TimeInput.test.tsx
+++ b/src/core/Form/TimeInput/TimeInput.test.tsx
@@ -93,11 +93,7 @@ describe('props', () => {
 
     it('should have margin prop overwritten from wrapperProps', () => {
       const { container } = render(
-        <TimeInput
-          labelText=""
-          margin="xs"
-          wrapperProps={{ style: { margin: 2 } }}
-        />,
+        <TimeInput labelText="" margin="xs" style={{ margin: 2 }} />,
       );
       expect(container.firstChild).toHaveAttribute('style', 'margin: 2px;');
     });

--- a/src/core/Form/TimeInput/TimeInput.tsx
+++ b/src/core/Form/TimeInput/TimeInput.tsx
@@ -12,11 +12,7 @@ import { AutoId } from '../../utils/AutoId/AutoId';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
-import {
-  HTMLAttributesIncludingDataAttributes,
-  autocompleteTimeString,
-  forkRefs,
-} from '../../../utils/common/common';
+import { autocompleteTimeString, forkRefs } from '../../../utils/common/common';
 import {
   spacingStyles,
   separateMarginProps,
@@ -48,11 +44,6 @@ export interface TimeInputProps
     Omit<HtmlInputProps, 'type' | 'onChange' | 'onBlur' | 'defaultValue'> {
   /** CSS class for custom styles */
   className?: string;
-  /** Props passed to the outermost div element of the component */
-  wrapperProps?: Omit<
-    HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
-    'className'
-  >;
   /** Disables the input */
   disabled?: boolean;
   /** Callback fired on input click */
@@ -111,7 +102,7 @@ const BaseTimeInput = (props: TimeInputProps) => {
     visualPlaceholder,
     onChange: propOnChange,
     onBlur: propOnBlur,
-    wrapperProps,
+    style,
     optionalText,
     status,
     statusText,
@@ -153,13 +144,12 @@ const BaseTimeInput = (props: TimeInputProps) => {
   const statusTextId = `${id}-statusText`;
   return (
     <HtmlDiv
-      {...wrapperProps}
       className={classnames(baseClassName, className, {
         [timeInputClassNames.disabled]: !!passProps.disabled,
         [timeInputClassNames.error]: status === 'error',
         [timeInputClassNames.success]: status === 'success',
       })}
-      style={{ ...marginStyle, ...wrapperProps?.style }}
+      style={{ ...marginStyle, ...style }}
     >
       <HtmlSpan className={timeInputClassNames.styleWrapper}>
         <Label


### PR DESCRIPTION
## Description

This PR removes `wrapperProps` from TimeInput and places the generic `style` prop to the outer div element

## Motivation and Context

Other components in the library already follow this pattern

## How Has This Been Tested?

Unit test and Styleguidist

## Release notes

### TimeInput
- Remove `wrapperProps` and place the generic `style` attribute to the outermost div element of the component
