### PR TITLE
[Feature] LanguageMenu buttonText type

### DIFF
--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useRef,
   ReactElement,
+  ReactNode,
 } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
@@ -41,8 +42,8 @@ export type MenuContent =
   | ReactElement<LanguageMenuItemProps>;
 
 export interface LanguageMenuProps extends MarginProps, HtmlButtonProps {
-  /** Text content for the menu button */
-  buttonText: string;
+  /** Content for the menu button. Should indicate the currently selected language */
+  buttonText: ReactNode;
   /**
    * LanguageMenu should have a descriptive aria-label. Aria-label should also inform what language is selected.
    * For example "Select language, selected language: English". Aria-label is for assistive technologies and overrides buttonText for


### PR DESCRIPTION
## Description

This PR changes the `buttonText` prop type of the LanguageMenu component from string to ReactNode

## Motivation and Context

We got a request from a user that it would be nice to be able to have content in the button which allows displaying a different span based on CSS classes and media query

## Release notes

### LanguageMenu
- **Breaking change**: Change `buttonText` prop type from string to ReactNode
