### PR TITLE
[Fix] Alert icon color in default variant

### DIFF
--- a/src/core/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert.baseStyles.ts
@@ -82,7 +82,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       & .fi-alert_style-wrapper {
         & .fi-alert_icon--neutral {
           & .fi-icon-base-fill {
-            fill: ${theme.colors.accentSecondary};
+            fill: ${theme.colors.blackBase};
           }
         }
       }

--- a/src/core/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/__snapshots__/Alert.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-alert.fi-alert--neutral .fi-alert_style-wrapper .fi-alert_icon--neutral .fi-icon-base-fill {
-  fill: hsl(196,77%,44%);
+  fill: hsl(0,0%,13%);
 }
 
 .c1.fi-alert.fi-alert--error {


### PR DESCRIPTION
## Description
This PR changes the color of the default info variant of `Alert` component to match the designs. It is a supplement to previous PR #796

## Motivation and Context
It was an oversight in previous PR and needed to be fixed.

## How Has This Been Tested?
By checking locally in styleguidist.

## Release notes
None, covered in #796 
