### PR TITLE
[Fix] TimeInput width

### DIFF
--- a/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
+++ b/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
@@ -5,7 +5,7 @@ import { math } from 'polished';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')}
-  width: 290px;
+  max-width: 290px;
 
   & .fi-time-input_character-counter {
     ${font(theme)('bodyTextSmall')};

--- a/src/core/Form/TimeInput/__snapshots__/TimeInput.test.tsx.snap
+++ b/src/core/Form/TimeInput/__snapshots__/TimeInput.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`snapshots match error status with statustext 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  width: 290px;
+  max-width: 290px;
 }
 
 .c1 .fi-time-input_character-counter {
@@ -651,7 +651,7 @@ exports[`snapshots match hidden label 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  width: 290px;
+  max-width: 290px;
 }
 
 .c1 .fi-time-input_character-counter {
@@ -1116,7 +1116,7 @@ exports[`snapshots match hint text 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  width: 290px;
+  max-width: 290px;
 }
 
 .c1 .fi-time-input_character-counter {
@@ -1571,7 +1571,7 @@ exports[`snapshots match minimal implementation 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  width: 290px;
+  max-width: 290px;
 }
 
 .c1 .fi-time-input_character-counter {


### PR DESCRIPTION
## Description

This PR removes `width: 290px` from TimeInput styles and adds `max-width: 290px`

## Motivation and Context

It makes more sense not to have fixed width for TimeInput since it's usually laid out side by side with DateInput. Fixed widths cause problems when the screen gets narrower. With max-width, TimeInput can take less space but never more than 290 (so that e.g. hintText does not overflow unnecessarily)

## How Has This Been Tested?

Styleguidist & date + time pattern on the DS site

## Release notes

### TimeInput
- Change `width: 290px` to `max-width: 290px`
