### PR TITLE
[Feature] Add generics to Dropdown

### DIFF
--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode, ReactElement, forwardRef } from 'react';
+import React, { Component, ReactNode, ReactElement } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
@@ -46,13 +46,13 @@ export const dropdownClassNames = {
   fullWidth: `${baseClassName}--full-width`,
 };
 
-export interface DropdownProviderState {
+export interface DropdownProviderState<T extends string = string> {
   /** Callback for communicating DropdownItem click to parent  */
-  onItemClick: (itemValue: string) => void;
+  onItemClick: (itemValue: T) => void;
   /** Currently selected DropdownItem */
-  selectedDropdownValue: string | undefined | null;
+  selectedDropdownValue: T | undefined | null;
   /** Currently focused DropdownItem */
-  focusedItemValue: string | null | undefined;
+  focusedItemValue: T | null | undefined;
   /** ID of the Dropdown component.
    * Used in DropdownItem to create a derived ID for each item
    */
@@ -64,7 +64,7 @@ export interface DropdownProviderState {
    */
   onItemTabPress: () => void;
   /** Callback for communicating DropdownItem mouse over to parent  */
-  onItemMouseOver: (itemValue: string) => void;
+  onItemMouseOver: (itemValue: T) => void;
 }
 
 const defaultProviderValue: DropdownProviderState = {
@@ -80,8 +80,8 @@ const defaultProviderValue: DropdownProviderState = {
 const { Provider: DropdownProvider, Consumer: DropdownConsumer } =
   React.createContext(defaultProviderValue);
 
-interface DropdownState {
-  selectedValue: string | undefined | null;
+interface DropdownState<T> {
+  selectedValue: T | undefined | null;
   selectedValueNode: ReactNode | undefined | null;
   ariaExpanded: boolean;
   showPopover: boolean;
@@ -94,7 +94,7 @@ interface DropdownState {
   preventListScrolling: boolean;
 }
 
-export interface DropdownProps
+export interface DropdownProps<T extends string = string>
   extends StatusTextCommonProps,
     MarginProps,
     Omit<HtmlButtonProps, 'onChange'> {
@@ -106,9 +106,9 @@ export interface DropdownProps
   /** HTML name attribute. */
   name?: string;
   /** Sets a default, initially selected value for non controlled Dropdown */
-  defaultValue?: string;
+  defaultValue?: T;
   /** Controlled selected value, overrides `defaultValue` if provided. */
-  value?: string;
+  value?: T;
   /** Label for the Dropdown component. */
   labelText: ReactNode;
   /** Hint text to be shown below the label */
@@ -146,11 +146,12 @@ export interface DropdownProps
   /** Use `<DropdownItem>` components as children */
   children?:
     | Array<
-        ReactElement<DropdownItemProps> | Array<ReactElement<DropdownItemProps>>
+        | ReactElement<DropdownItemProps<T>>
+        | Array<ReactElement<DropdownItemProps<T>>>
       >
-    | ReactElement<DropdownItemProps>;
+    | ReactElement<DropdownItemProps<T>>;
   /** Callback that fires when the Dropdown value changes. */
-  onChange?(value: string): void;
+  onChange?(value: T): void;
   /** Callback that fires on blur */
   onBlur?: () => void;
   /** Tooltip component for the Dropdown's label */
@@ -166,8 +167,10 @@ export interface DropdownProps
   forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
 
-class BaseDropdown extends Component<DropdownProps> {
-  state: DropdownState = {
+class BaseDropdown<T extends string = string> extends Component<
+  DropdownProps<T>
+> {
+  state: DropdownState<T> = {
     selectedValue:
       'value' in this.props
         ? this.props.value
@@ -199,15 +202,15 @@ class BaseDropdown extends Component<DropdownProps> {
 
   componentIsMounted: boolean;
 
-  constructor(props: DropdownProps) {
+  constructor(props: DropdownProps<T>) {
     super(props);
     this.buttonRef = React.createRef();
     this.popoverRef = React.createRef();
   }
 
-  static getDerivedStateFromProps(
-    nextProps: DropdownProps,
-    prevState: DropdownState,
+  static getDerivedStateFromProps<U extends string>(
+    nextProps: DropdownProps<U>,
+    prevState: DropdownState<U>,
   ) {
     const { value } = nextProps;
     if ('value' in nextProps && value !== prevState.selectedValue) {
@@ -222,14 +225,14 @@ class BaseDropdown extends Component<DropdownProps> {
     return null;
   }
 
-  static getSelectedValueNode(
+  static getSelectedValueNode<U extends string>(
     selectedValue: string | undefined,
     children:
       | Array<
-          | ReactElement<DropdownItemProps>
-          | Array<ReactElement<DropdownItemProps>>
+          | ReactElement<DropdownItemProps<U>>
+          | Array<ReactElement<DropdownItemProps<U>>>
         >
-      | ReactElement<DropdownItemProps>
+      | ReactElement<DropdownItemProps<U>>
       | undefined,
   ): ReactNode | undefined {
     if (selectedValue === undefined || children === undefined) return undefined;
@@ -263,7 +266,7 @@ class BaseDropdown extends Component<DropdownProps> {
     );
   }
 
-  private handleItemSelection(itemValue: string) {
+  private handleItemSelection(itemValue: T) {
     if (!!this.props.onChange) {
       this.props.onChange(itemValue);
     }
@@ -288,8 +291,8 @@ class BaseDropdown extends Component<DropdownProps> {
   }
 
   private handleSpaceAndEnter = (
-    popoverItems: Array<ReactElement<DropdownItemProps>>,
-    getNextItem: () => ReactElement<DropdownItemProps>,
+    popoverItems: Array<ReactElement<DropdownItemProps<T>>>,
+    getNextItem: () => ReactElement<DropdownItemProps<T>>,
   ) => {
     const { focusedDescendantId, showPopover } = this.state;
     if (!showPopover) {
@@ -321,7 +324,8 @@ class BaseDropdown extends Component<DropdownProps> {
       ? [this.props.children]
       : undefined;
     if (!items) return;
-    const popoverItems: Array<ReactElement<DropdownItemProps>> = items.flat();
+    const popoverItems: Array<ReactElement<DropdownItemProps<T>>> =
+      items.flat();
     const index = !!focusedDescendantId
       ? popoverItems.findIndex(
           (item) => item?.props.value === focusedDescendantId,
@@ -625,7 +629,7 @@ class BaseDropdown extends Component<DropdownProps> {
             >
               <DropdownProvider
                 value={{
-                  onItemClick: (itemValue) =>
+                  onItemClick: (itemValue: T) =>
                     this.handleItemSelection(itemValue),
                   selectedDropdownValue: selectedValue,
                   id,
@@ -664,34 +668,43 @@ class BaseDropdown extends Component<DropdownProps> {
 }
 
 const StyledDropdown = styled(
-  ({ theme, ...passProps }: DropdownProps & SuomifiThemeProp) => (
-    <BaseDropdown {...passProps} />
-  ),
+  <T extends string = string>({
+    theme,
+    ...passProps
+  }: DropdownProps<T> & SuomifiThemeProp) => <BaseDropdown {...passProps} />,
 )`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const Dropdown = forwardRef(
-  (props: DropdownProps, ref: React.RefObject<HTMLButtonElement>) => {
-    const { id: propId, ...passProps } = props;
-    return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledDropdown
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
-            )}
-          </AutoId>
-        )}
-      </SuomifiThemeConsumer>
-    );
-  },
-);
+const DropdownInner = <T extends string = string>(
+  props: DropdownProps<T>,
+  ref: React.RefObject<HTMLButtonElement>,
+) => {
+  const { id: propId, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId id={propId}>
+          {(id) => (
+            <StyledDropdown
+              theme={suomifiTheme}
+              id={id}
+              forwardedRef={ref}
+              {...passProps}
+            />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
 
-Dropdown.displayName = 'Dropdown';
-export { Dropdown, DropdownProvider, DropdownConsumer };
+export const Dropdown = React.forwardRef(DropdownInner) as <
+  T extends string = string,
+>(
+  props: DropdownProps<T>,
+  ref: React.RefObject<HTMLButtonElement>,
+) => ReturnType<typeof DropdownInner>;
+
+DropdownInner.displayName = 'Dropdown';
+export { DropdownProvider, DropdownConsumer };

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -699,6 +699,7 @@ const DropdownInner = <T extends string = string>(
   );
 };
 
+// Not directly exporting the DropdownInner as styleguidist was not showing props then.
 export const Dropdown = React.forwardRef(DropdownInner) as <
   T extends string = string,
 >(

--- a/src/core/Dropdown/DropdownItem/DropdownItem.tsx
+++ b/src/core/Dropdown/DropdownItem/DropdownItem.tsx
@@ -12,9 +12,10 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { HtmlLi, HtmlLiProps } from '../../../reset';
 import { getOwnerDocument } from '../../../utils/common';
 
-export interface DropdownItemProps extends HtmlLiProps {
+export interface DropdownItemProps<T extends string = string>
+  extends HtmlLiProps {
   /** Item value */
-  value: string;
+  value: T;
   /** Item content */
   children: ReactNode;
   /** CSS class for custom styles */
@@ -25,8 +26,9 @@ export interface DropdownItemProps extends HtmlLiProps {
   disabled?: boolean;
 }
 
-interface BaseDropdownItemProps extends DropdownItemProps {
-  consumer: DropdownProviderState;
+interface BaseDropdownItemProps<T extends string = string>
+  extends DropdownItemProps<T> {
+  consumer: DropdownProviderState<T>;
 }
 
 const dropdownItemClassNames = {
@@ -37,7 +39,9 @@ const dropdownItemClassNames = {
   icon: `${dropdownClassNames.item}_icon`,
 };
 
-const BaseDropdownItem = (props: BaseDropdownItemProps & SuomifiThemeProp) => {
+const BaseDropdownItem = <T extends string>(
+  props: BaseDropdownItemProps<T> & SuomifiThemeProp,
+) => {
   const {
     children,
     className,
@@ -105,7 +109,9 @@ const StyledDropdownItem = styled(BaseDropdownItem)`
   ${({ theme }) => baseStyles(theme)}
 `;
 
-const DropdownItem = (props: DropdownItemProps) => (
+const DropdownItem = <T extends string = string>(
+  props: DropdownItemProps<T>,
+) => (
   <SuomifiThemeConsumer>
     {({ suomifiTheme }) => (
       <DropdownConsumer>


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Add generics to Dropdown (+ DropdownItem).
But it should not allow just any value, but value that extends String. 

This should be valid:
```tsx
type CountryKey = 'finland' | 'sweden' | 'norway' | 'denmark' | 'iceland';
```

This should not be valid (e.g number):
```tsx
type CountryKey =  1 | 2 | 3 | 4 | 5;
```

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Would ease the component usage as the given type safety.

## How Has This Been Tested?
Locally in the project and then in new next.js app started from scratch.

## Screenshots (if appropriate):

### With the changes
<img width="811" alt="SCR-20231116-imui" src="https://github.com/vrk-kpa/suomifi-ui-components/assets/53757053/a9e7d4a1-329a-45c3-9488-f95553f78123">

### Without the change (suomifi-ui-components: 12.0.2)
<img width="1126" alt="SCR-20231116-inwg" src="https://github.com/vrk-kpa/suomifi-ui-components/assets/53757053/edbb8ba5-25cb-4db9-b78f-5cfa90be610f">

To get rid of that error, we would need to cast it which is not nice:
```tsx
onChange={(newValue) => dropdownOnChange(newValue as CountryKey)}
```


## Example code

```tsx
import { Dropdown, DropdownItem } from 'suomifi-ui-components';

// ...

type CountryKey = 'finland' | 'sweden' | 'norway' | 'denmark' | 'iceland';

interface CountryItem {
  name: string;
  key: CountryKey;
};

const countries: CountryItem[] = [
  {
    name: 'Finland',
    key: 'finland'
  },
  {
    name: 'Sweden',
    key: 'sweden'
  },
  {
    name: 'Norway',
    key: 'norway'
  },
  {
    name: 'Denmark',
    key: 'denmark'
  },
  {
    name: 'Iceland',
    key: 'iceland'
  }
];

// ...

const [selectedCountry, setSelectedCountry] = React.useState<CountryKey>();

const dropdownOnChange = (newValue: CountryKey) => {
  setSelectedCountry(newValue);
};

// ...

<Dropdown
  labelText="Country"
  hintText="Select your current country of residence"
  visualPlaceholder="Choose country"
  value={selectedCountry}
  onChange={(newValue) => dropdownOnChange(newValue)}
>
  {countries.map((country) => (
    <DropdownItem key={country.key} value={country.key}
    >
      {country.name}
    </DropdownItem>
  ))}
</Dropdown>
```

## Links
Interesting article which I read before this>
https://gertrude.app/blog/generic-react-components-typescript


## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

- Add generic support for Dropdown (+DropdownItem)
