### PR TITLE
[Hotfix] LoadingSpinner ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "12.0.2",
+  "version": "12.0.3",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/core/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.tsx
@@ -65,6 +65,7 @@ class BaseLoadingSpinner extends Component<LoadingSpinnerProps> {
       textVisibility = 'visible',
       variant = 'normal',
       status = 'loading',
+      forwardedRef,
       ...passProps
     } = this.props;
 
@@ -79,6 +80,7 @@ class BaseLoadingSpinner extends Component<LoadingSpinnerProps> {
         })}
         as="section"
         id={id}
+        ref={forwardedRef}
         {...passProps}
       >
         {status === 'loading' && (


### PR DESCRIPTION
## Description

PR contains a hotfix to LoadingSpinner. Ref/forwardedRef was not correctly used inside the component and was not working at all. Similar thing was hotfixed to Alert & InlineAlert https://github.com/vrk-kpa/suomifi-ui-components/pull/790 previously

Also inreased version to 12.0.3 in anticipation of a hotfix release

## How Has This Been Tested?

Checking ref behavior in Styleguidist

## Release notes

### LoadingSpinner
- Fix ref/forwardedRef functionality
