### PR TITLE
[Fix] Button support for icon only implementation

### DIFF
--- a/src/core/ActionMenu/ActionMenu.baseStyles.tsx
+++ b/src/core/ActionMenu/ActionMenu.baseStyles.tsx
@@ -7,15 +7,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   & .fi-action-menu_button {
-    &--icon-only {
-      & .fi-button_icon--right {
-        & .fi-icon {
-          margin-left: 0; /* Fixes issue on Button margin when there is no text */
-        }
-      }
-
-      min-width: 40px;
-      padding: ${theme.spacing.xs};
-    }
+    min-width: 40px;
+    padding: ${theme.spacing.xs} 12px;
   }
 `;

--- a/src/core/ActionMenu/ActionMenu.test.tsx
+++ b/src/core/ActionMenu/ActionMenu.test.tsx
@@ -10,6 +10,7 @@ const actionMenuProps: ActionMenuProps = {
   name: 'am-test-name',
   className: 'am-test',
   id: 'test-id',
+  'aria-label': 'am-test',
 };
 
 const TestActionMenu = (props: ActionMenuProps) => (

--- a/src/core/ActionMenu/ActionMenu.tsx
+++ b/src/core/ActionMenu/ActionMenu.tsx
@@ -177,9 +177,7 @@ const BaseActionMenu = (props: ActionMenuProps) => {
         aria-haspopup="menu"
         forwardedRef={openButtonRef}
         fullWidth={fullWidth}
-        className={classnames(actionMenuClassNames.button, {
-          [actionMenuClassNames.iconOnly]: !buttonText || buttonText.length < 1,
-        })}
+        className={actionMenuClassNames.button}
         onClick={handleButtonClick}
         onKeyDown={handleKeyDown}
         onBlur={(event) => {

--- a/src/core/ActionMenu/ActionMenu.tsx
+++ b/src/core/ActionMenu/ActionMenu.tsx
@@ -40,50 +40,51 @@ export type MenuContent =
   | ReactElement<ActionMenuItemProps>
   | ReactElement<ActionMenuDividerProps>;
 
-export interface ActionMenuProps extends MarginProps, ButtonProps {
-  /** Text content for the menu button */
-  buttonText?: string;
-  /**
-   * `'default'` | `'inverted'` | `'secondary'` | `'secondaryLight'`| `'secondaryNoBorder'`
-   *
-   * Variant for the menu button:
-   * @default secondary
-   */
-  buttonVariant?: ButtonVariant;
-  /**
-   * Define a label if `buttonText` does not indicate the menu button purpose.
-   * In cases where the button has a visible label, make sure the visible text is included in the aria-label.
-   * Alternatively you can define `aria-labelledby` with a label element's id.
-   */
-  'aria-label'?: string;
-  /** Menu items. Use the `<ActionMenuItem>` or  `<ActionMenuDivider>` components as children */
-  children?: MenuContent;
-  /** CSS class for custom styles */
-  className?: string;
-  /** Menu container div CSS class for custom styles. Can be used to modify menu "popover" z-index. */
-  menuClassName?: string;
-  /** Disables the menu button */
-  disabled?: boolean;
-  /** Ref is forwarded to the underlying button element. Alternative for React `ref` attribute. */
-  forwardedRef?: React.RefObject<HTMLButtonElement>;
-  /** Sets component's width to 100% of its parent */
-  fullWidth?: boolean;
-  /**
-   * HTML id attribute.
-   * If no id is specified, one will be generated automatically
-   */
-  id?: string;
-  /** Name used for the menu button */
-  name?: string;
-  /** Callback fired on button onBlur
-   * @param {FocusEvent<HTMLButtonElement>} event FocusEvent
-   */
-  onBlur?: (event: FocusEvent<HTMLButtonElement>) => void;
-  /** Callback fired when menu opens */
-  onClose?: () => void;
-  /** Callback fired when menu closes */
-  onOpen?: () => void;
-}
+export type ActionMenuProps = MarginProps &
+  ButtonProps & {
+    /** Text content for the menu button */
+    buttonText?: string;
+    /**
+     * `'default'` | `'inverted'` | `'secondary'` | `'secondaryLight'`| `'secondaryNoBorder'`
+     *
+     * Variant for the menu button:
+     * @default secondary
+     */
+    buttonVariant?: ButtonVariant;
+    /**
+     * Define a label if `buttonText` does not indicate the menu button purpose.
+     * In cases where the button has a visible label, make sure the visible text is included in the aria-label.
+     * Alternatively you can define `aria-labelledby` with a label element's id.
+     */
+    'aria-label'?: string;
+    /** Menu items. Use the `<ActionMenuItem>` or  `<ActionMenuDivider>` components as children */
+    children?: MenuContent;
+    /** CSS class for custom styles */
+    className?: string;
+    /** Menu container div CSS class for custom styles. Can be used to modify menu "popover" z-index. */
+    menuClassName?: string;
+    /** Disables the menu button */
+    disabled?: boolean;
+    /** Ref is forwarded to the underlying button element. Alternative for React `ref` attribute. */
+    forwardedRef?: React.RefObject<HTMLButtonElement>;
+    /** Sets component's width to 100% of its parent */
+    fullWidth?: boolean;
+    /**
+     * HTML id attribute.
+     * If no id is specified, one will be generated automatically
+     */
+    id?: string;
+    /** Name used for the menu button */
+    name?: string;
+    /** Callback fired on button onBlur
+     * @param {FocusEvent<HTMLButtonElement>} event FocusEvent
+     */
+    onBlur?: (event: FocusEvent<HTMLButtonElement>) => void;
+    /** Callback fired when menu opens */
+    onClose?: () => void;
+    /** Callback fired when menu closes */
+    onOpen?: () => void;
+  };
 
 const BaseActionMenu = (props: ActionMenuProps) => {
   const {

--- a/src/core/ActionMenu/ActionMenu.tsx
+++ b/src/core/ActionMenu/ActionMenu.tsx
@@ -13,7 +13,12 @@ import {
   ActionMenuPopover,
   InitialActiveDescendant,
 } from './ActionMenuPopover';
-import { Button, ButtonProps, ButtonVariant } from '../Button/Button';
+import {
+  Button,
+  ButtonProps,
+  ButtonVariant,
+  ForcedAccessibleNameProps,
+} from '../Button/Button';
 import { HtmlDiv } from '../../reset';
 import {
   spacingStyles,
@@ -41,7 +46,7 @@ export type MenuContent =
   | ReactElement<ActionMenuDividerProps>;
 
 export type ActionMenuProps = MarginProps &
-  ButtonProps & {
+  Omit<ButtonProps, keyof ForcedAccessibleNameProps> & {
     /** Text content for the menu button */
     buttonText?: string;
     /**

--- a/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
@@ -462,6 +462,18 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c3.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c3.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -494,13 +506,9 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   width: 100%;
 }
 
-.c1 .fi-action-menu_button--icon-only {
+.c1 .fi-action-menu_button {
   min-width: 40px;
-  padding: 10px;
-}
-
-.c1 .fi-action-menu_button--icon-only .fi-button_icon--right .fi-icon {
-  margin-left: 0;
+  padding: 10px 12px;
 }
 
 .c8 {
@@ -671,15 +679,13 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
         aria-disabled="false"
         aria-expanded="false"
         aria-haspopup="menu"
+        aria-label="am-test"
         class="c2 fi-button c3 fi-action-menu_button fi-button--secondary"
         id="test-id"
         name="am-test-name"
         tabindex="0"
         type="button"
       >
-        <span
-          class="c4 fi-button_icon"
-        />
         Actions
         <span
           class="c4 fi-button_icon fi-button_icon--right"
@@ -1226,6 +1232,18 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c3.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c3.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -1258,13 +1276,9 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   width: 100%;
 }
 
-.c1 .fi-action-menu_button--icon-only {
+.c1 .fi-action-menu_button {
   min-width: 40px;
-  padding: 10px;
-}
-
-.c1 .fi-action-menu_button--icon-only .fi-button_icon--right .fi-icon {
-  margin-left: 0;
+  padding: 10px 12px;
 }
 
 .c8 {
@@ -1435,15 +1449,13 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
         aria-disabled="true"
         aria-expanded="false"
         aria-haspopup="menu"
+        aria-label="am-test"
         class="c2 fi-button c3 fi-action-menu_button fi-button--disabled fi-button--secondary"
         disabled=""
         id="test-id"
         name="am-test-name"
         type="button"
       >
-        <span
-          class="c4 fi-button_icon"
-        />
         Actions
         <span
           class="c4 fi-button_icon fi-button_icon--right"
@@ -1990,6 +2002,18 @@ exports[`No borders variant should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c3.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c3.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -2022,13 +2046,9 @@ exports[`No borders variant should match snapshot 1`] = `
   width: 100%;
 }
 
-.c1 .fi-action-menu_button--icon-only {
+.c1 .fi-action-menu_button {
   min-width: 40px;
-  padding: 10px;
-}
-
-.c1 .fi-action-menu_button--icon-only .fi-button_icon--right .fi-icon {
-  margin-left: 0;
+  padding: 10px 12px;
 }
 
 .c8 {
@@ -2206,9 +2226,6 @@ exports[`No borders variant should match snapshot 1`] = `
         tabindex="0"
         type="button"
       >
-        <span
-          class="c4 fi-button_icon"
-        />
         Actions
         <span
           class="c4 fi-button_icon fi-button_icon--right"
@@ -2755,6 +2772,18 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c3.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c3.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -2787,13 +2816,9 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   width: 100%;
 }
 
-.c1 .fi-action-menu_button--icon-only {
+.c1 .fi-action-menu_button {
   min-width: 40px;
-  padding: 10px;
-}
-
-.c1 .fi-action-menu_button--icon-only .fi-button_icon--right .fi-icon {
-  margin-left: 0;
+  padding: 10px 12px;
 }
 
 .c8 {
@@ -2964,15 +2989,13 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
         aria-disabled="false"
         aria-expanded="true"
         aria-haspopup="menu"
+        aria-label="am-test"
         class="c2 fi-button c3 fi-action-menu_button fi-button--secondary"
         id="test-id"
         name="am-test-name"
         tabindex="0"
         type="button"
       >
-        <span
-          class="c4 fi-button_icon"
-        />
         Actions
         <span
           class="c4 fi-button_icon fi-button_icon--right"
@@ -3520,6 +3543,18 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   margin-left: 8px;
 }
 
+.c3.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c3.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c3.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -3552,13 +3587,9 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   width: 100%;
 }
 
-.c1 .fi-action-menu_button--icon-only {
+.c1 .fi-action-menu_button {
   min-width: 40px;
-  padding: 10px;
-}
-
-.c1 .fi-action-menu_button--icon-only .fi-button_icon--right .fi-icon {
-  margin-left: 0;
+  padding: 10px 12px;
 }
 
 .c8 {
@@ -3729,15 +3760,13 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
         aria-disabled="false"
         aria-expanded="true"
         aria-haspopup="menu"
+        aria-label="am-test"
         class="c2 fi-button c3 fi-action-menu_button fi-button--secondary"
         id="test-id"
         name="am-test-name"
         tabindex="0"
         type="button"
       >
-        <span
-          class="c4 fi-button_icon"
-        />
         Actions
         <span
           class="c4 fi-button_icon fi-button_icon--right"

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -150,21 +150,24 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   ${secondaryLightStyles(theme)}
   
-  & > .fi-button_icon {
-    & > .fi-icon {
-      width: 16px;
-      height: 16px;
-      vertical-align: middle;
-      transform: translateY(-0.1em);
-    }
-    &.fi-button_icon--margin {
-      margin-right: ${theme.spacing.insetM};
-    }
+  & > .fi-button_icon > .fi-icon {
+    width: 16px;
+    height: 16px;
+    margin-right: ${theme.spacing.insetM};
+    vertical-align: middle;
+    transform: translateY(-0.1em);
   }
 
   & > .fi-button_icon--right > .fi-icon {
     margin-right: 0;
     margin-left: ${theme.spacing.insetM};
+  }
+
+  &.fi-button--icon-only {
+    padding: ${theme.spacing.insetS} 11px;
+    & > .fi-button_icon > .fi-icon {
+      margin-right: 0;
+    }
   }
 
   &.fi-button--disabled > .fi-button_icon {

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -164,9 +164,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   &.fi-button--icon-only {
-    padding: ${theme.spacing.insetS} 11px;
+    padding: ${theme.spacing.insetS} 12px;
     & > .fi-button_icon > .fi-icon {
       margin-right: 0;
+    }
+    & > .fi-button_icon--right > .fi-icon {
+      margin-left: 0;
     }
   }
 

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -150,13 +150,18 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   ${secondaryLightStyles(theme)}
   
-  & > .fi-button_icon > .fi-icon {
-    width: 16px;
-    height: 16px;
-    margin-right: ${theme.spacing.insetM};
-    vertical-align: middle;
-    transform: translateY(-0.1em);
+  & > .fi-button_icon {
+    & > .fi-icon {
+      width: 16px;
+      height: 16px;
+      vertical-align: middle;
+      transform: translateY(-0.1em);
+    }
+    &.fi-button_icon--margin {
+      margin-right: ${theme.spacing.insetM};
+    }
   }
+
   & > .fi-button_icon--right > .fi-icon {
     margin-right: 0;
     margin-left: ${theme.spacing.insetM};

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -83,14 +83,16 @@ describe('Button variant', () => {
 
   describe('Margin prop', () => {
     it('should have margin style from margin prop', () => {
-      const { container } = render(<Button margin="xs" />);
+      const { container } = render(<Button margin="xs">Test button</Button>);
       const button = container.querySelector('button');
       expect(button).toHaveAttribute('style', 'margin: 10px;');
     });
 
     it('should have margin prop style overwritten from style', () => {
       const { container } = render(
-        <Button margin="xs" style={{ margin: 2 }} />,
+        <Button margin="xs" style={{ margin: 2 }}>
+          Test button
+        </Button>,
       );
       const button = container.querySelector('button');
       expect(button).toHaveAttribute('style', 'margin: 2px;');

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -113,7 +113,7 @@ class BaseButton extends Component<ButtonProps> {
             variant === 'secondaryNoBorder',
           [`${baseClassName}--secondary-light`]: variant === 'secondaryLight',
           [fullWidthClassName]: fullWidth,
-          [iconStandaloneClassName]: !!icon && !children,
+          [iconStandaloneClassName]: (!!icon || !!iconRight) && !children,
         })}
         style={{ ...marginStyle, ...style }}
       >

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -19,6 +19,10 @@ export type ButtonVariant =
 
 type ForcedAccessibleNameProps =
   | {
+      children: ReactNode;
+      'aria-label'?: string;
+    }
+  | {
       /**
        * Button element content
        */
@@ -29,10 +33,6 @@ type ForcedAccessibleNameProps =
        * Alternatively you can define an `aria-labelledby`.
        */
       'aria-label': string;
-    }
-  | {
-      children: ReactNode;
-      'aria-label'?: string;
     };
 
 interface InternalButtonProps

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -17,7 +17,7 @@ export type ButtonVariant =
   | 'secondaryNoBorder'
   | 'secondaryLight';
 
-type ForcedAccessibleNameProps =
+export type ForcedAccessibleNameProps =
   | {
       children: ReactNode;
       'aria-label'?: string;

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -63,6 +63,7 @@ export interface ButtonProps
 const baseClassName = 'fi-button';
 const disabledClassName = `${baseClassName}--disabled`;
 const iconClassName = `${baseClassName}_icon`;
+const iconMarginClassName = `${baseClassName}_icon--margin`;
 const iconRightClassName = `${baseClassName}_icon--right`;
 const fullWidthClassName = `${baseClassName}--fullwidth`;
 
@@ -105,11 +106,21 @@ class BaseButton extends Component<ButtonProps> {
         })}
         style={{ ...marginStyle, ...style }}
       >
-        <HtmlSpan className={iconClassName}>{!!icon && icon}</HtmlSpan>
+        {!!icon && (
+          <HtmlSpan
+            className={classnames(iconClassName, {
+              [iconMarginClassName]: !!children,
+            })}
+          >
+            {icon}
+          </HtmlSpan>
+        )}
         {children}
-        <HtmlSpan className={classnames(iconClassName, iconRightClassName)}>
-          {!!iconRight && iconRight}
-        </HtmlSpan>
+        {!!iconRight && (
+          <HtmlSpan className={classnames(iconClassName, iconRightClassName)}>
+            {iconRight}
+          </HtmlSpan>
+        )}
       </HtmlButton>
     );
   }

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { Component, forwardRef, ReactNode } from 'react';
+import React, { Component, forwardRef, ReactElement, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { baseStyles } from './Button.baseStyles';
@@ -57,11 +57,11 @@ interface InternalButtonProps
   /**
    * Icon from suomifi-icons
    */
-  icon?: ReactNode;
+  icon?: ReactElement;
   /**
    * Icon from suomifi-icons to be placed on the right side
    */
-  iconRight?: ReactNode;
+  iconRight?: ReactElement;
   /** Callback fired on button click */
   onClick?: (event: React.MouseEvent) => void;
   /** Ref object is passed to the button element. Alternative to React `ref` attribute. */

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -63,7 +63,7 @@ export interface ButtonProps
 const baseClassName = 'fi-button';
 const disabledClassName = `${baseClassName}--disabled`;
 const iconClassName = `${baseClassName}_icon`;
-const iconMarginClassName = `${baseClassName}_icon--margin`;
+const iconStandaloneClassName = `${baseClassName}--icon-only`;
 const iconRightClassName = `${baseClassName}_icon--right`;
 const fullWidthClassName = `${baseClassName}--fullwidth`;
 
@@ -103,18 +103,11 @@ class BaseButton extends Component<ButtonProps> {
             variant === 'secondaryNoBorder',
           [`${baseClassName}--secondary-light`]: variant === 'secondaryLight',
           [fullWidthClassName]: fullWidth,
+          [iconStandaloneClassName]: !!icon && !children,
         })}
         style={{ ...marginStyle, ...style }}
       >
-        {!!icon && (
-          <HtmlSpan
-            className={classnames(iconClassName, {
-              [iconMarginClassName]: !!children,
-            })}
-          >
-            {icon}
-          </HtmlSpan>
-        )}
+        {!!icon && <HtmlSpan className={iconClassName}>{icon}</HtmlSpan>}
         {children}
         {!!iconRight && (
           <HtmlSpan className={classnames(iconClassName, iconRightClassName)}>

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -17,7 +17,25 @@ export type ButtonVariant =
   | 'secondaryNoBorder'
   | 'secondaryLight';
 
-export interface ButtonProps
+type ForcedAccessibleNameProps =
+  | {
+      /**
+       * Button element content
+       */
+      children?: never;
+      /**
+       * Define a label if button's text content does not indicate the button's purpose (for example, button with only an icon).
+       * If the button has a visible label, make sure the aria-label includes the visible text.
+       * Alternatively you can define an `aria-labelledby`.
+       */
+      'aria-label': string;
+    }
+  | {
+      children: ReactNode;
+      'aria-label'?: string;
+    };
+
+interface InternalButtonProps
   extends Omit<HtmlButtonProps, 'aria-disabled' | 'onClick'>,
     MarginProps {
   /**
@@ -26,16 +44,6 @@ export interface ButtonProps
    * @default default
    */
   variant?: ButtonVariant;
-  /**
-   * Button element content
-   */
-  children?: ReactNode;
-  /**
-   * Define a label if button's text content does not indicate the button's purpose (for example, button with only an icon).
-   * If the button has a visible label, make sure the aria-label includes the visible text.
-   * Alternatively you can define an `aria-labelledby`.
-   */
-  'aria-label'?: string;
   /** Disables the button */
   disabled?: boolean;
   /** Soft disables the button to allow tab-focus. Disables onClick() functionality */
@@ -59,6 +67,8 @@ export interface ButtonProps
   /** Ref object is passed to the button element. Alternative to React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLButtonElement>;
 }
+
+export type ButtonProps = InternalButtonProps & ForcedAccessibleNameProps;
 
 const baseClassName = 'fi-button';
 const disabledClassName = `${baseClassName}--disabled`;

--- a/src/core/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/core/Button/__snapshots__/Button.test.tsx.snap
@@ -54,35 +54,6 @@ exports[`Button variant default should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
 .c1 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -304,6 +275,18 @@ exports[`Button variant default should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c1.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c1.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -314,13 +297,7 @@ exports[`Button variant default should match snapshot 1`] = `
   tabindex="0"
   type="button"
 >
-  <span
-    class="c2 fi-button_icon"
-  />
   Button
-  <span
-    class="c2 fi-button_icon fi-button_icon--right"
-  />
 </button>
 `;
 
@@ -378,35 +355,6 @@ exports[`Button variant inverted should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
 .c1 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -628,6 +576,18 @@ exports[`Button variant inverted should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c1.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c1.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -638,13 +598,7 @@ exports[`Button variant inverted should match snapshot 1`] = `
   tabindex="0"
   type="button"
 >
-  <span
-    class="c2 fi-button_icon"
-  />
   Inverted button
-  <span
-    class="c2 fi-button_icon fi-button_icon--right"
-  />
 </button>
 `;
 
@@ -702,35 +656,6 @@ exports[`Button variant link match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
 .c1 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -952,6 +877,18 @@ exports[`Button variant link match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c1.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c1.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -962,13 +899,7 @@ exports[`Button variant link match snapshot 1`] = `
   tabindex="0"
   type="button"
 >
-  <span
-    class="c2 fi-button_icon"
-  />
   Secondary light button
-  <span
-    class="c2 fi-button_icon fi-button_icon--right"
-  />
 </button>
 `;
 
@@ -1026,35 +957,6 @@ exports[`Button variant secondary should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
 .c1 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -1276,6 +1178,18 @@ exports[`Button variant secondary should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c1.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c1.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -1286,13 +1200,7 @@ exports[`Button variant secondary should match snapshot 1`] = `
   tabindex="0"
   type="button"
 >
-  <span
-    class="c2 fi-button_icon"
-  />
   Secondary button
-  <span
-    class="c2 fi-button_icon fi-button_icon--right"
-  />
 </button>
 `;
 
@@ -1350,35 +1258,6 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c2::before,
-.c2::after {
-  box-sizing: border-box;
-}
-
 .c1 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -1600,6 +1479,18 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c1.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c1.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c1.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -1610,12 +1501,6 @@ exports[`Button variant secondaryNoBorder should match snapshot 1`] = `
   tabindex="0"
   type="button"
 >
-  <span
-    class="c2 fi-button_icon"
-  />
   secondaryNoBorder button
-  <span
-    class="c2 fi-button_icon fi-button_icon--right"
-  />
 </button>
 `;

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3292,6 +3292,18 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin-left: 8px;
 }
 
+.c13.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c13.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c13.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c13.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -4323,9 +4335,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
             tabindex="0"
             type="button"
           >
-            <span
-              class="c4 fi-button_icon"
-            />
             <svg
               aria-hidden="true"
               class="fi-icon c14 fi-date-selectors_month-button_icon"
@@ -4342,9 +4351,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 fill-rule="evenodd"
               />
             </svg>
-            <span
-              class="c4 fi-button_icon fi-button_icon--right"
-            />
           </button>
           <button
             aria-disabled="false"
@@ -4353,9 +4359,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
             tabindex="0"
             type="button"
           >
-            <span
-              class="c4 fi-button_icon"
-            />
             <svg
               aria-hidden="true"
               class="fi-icon c15 fi-date-selectors_month-button_icon"
@@ -4372,9 +4375,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
                 fill-rule="evenodd"
               />
             </svg>
-            <span
-              class="c4 fi-button_icon fi-button_icon--right"
-            />
           </button>
         </div>
       </div>
@@ -4994,13 +4994,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
           tabindex="0"
           type="button"
         >
-          <span
-            class="c4 fi-button_icon"
-          />
           Sulje
-          <span
-            class="c4 fi-button_icon fi-button_icon--right"
-          />
         </button>
       </div>
     </div>
@@ -5478,6 +5472,18 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 .c13 > .fi-button_icon--right > .fi-icon {
   margin-right: 0;
   margin-left: 8px;
+}
+
+.c13.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c13.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c13.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
 }
 
 .c13.fi-button--disabled > .fi-button_icon {
@@ -6520,9 +6526,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               tabindex="0"
               type="button"
             >
-              <span
-                class="c4 fi-button_icon"
-              />
               <svg
                 aria-hidden="true"
                 class="fi-icon c14 fi-date-selectors_month-button_icon"
@@ -6539,9 +6542,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-              <span
-                class="c4 fi-button_icon fi-button_icon--right"
-              />
             </button>
             <button
               aria-disabled="false"
@@ -6550,9 +6550,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               tabindex="0"
               type="button"
             >
-              <span
-                class="c4 fi-button_icon"
-              />
               <svg
                 aria-hidden="true"
                 class="fi-icon c15 fi-date-selectors_month-button_icon"
@@ -6569,9 +6566,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-              <span
-                class="c4 fi-button_icon fi-button_icon--right"
-              />
             </button>
           </div>
         </div>
@@ -7191,13 +7185,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
             tabindex="0"
             type="button"
           >
-            <span
-              class="c4 fi-button_icon"
-            />
             Sulje
-            <span
-              class="c4 fi-button_icon fi-button_icon--right"
-            />
           </button>
         </div>
       </div>

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1079,6 +1079,18 @@ exports[`has matching snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c15.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c15.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c15.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c15.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -1424,9 +1436,6 @@ exports[`has matching snapshot 1`] = `
             </svg>
           </span>
           Remove all selections
-          <span
-            class="c5 fi-button_icon fi-button_icon--right"
-          />
         </button>
       </div>
     </div>

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -838,6 +838,18 @@ exports[`Basic modal should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c9.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c9.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c9.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c9.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -901,13 +913,7 @@ exports[`Basic modal should match snapshot 1`] = `
               tabindex="0"
               type="button"
             >
-              <span
-                class="c3 fi-button_icon"
-              />
               OK
-              <span
-                class="c3 fi-button_icon fi-button_icon--right"
-              />
             </button>
           </div>
           <div

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -171,35 +171,6 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
-  line-height: 1.15;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  box-sizing: border-box;
-  font: 100% inherit;
-  line-height: 1;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  vertical-align: baseline;
-  color: inherit;
-  background: none;
-  cursor: inherit;
-  display: inline;
-  max-width: 100%;
-  word-wrap: normal;
-  word-break: normal;
-  white-space: normal;
-}
-
-.c5::before,
-.c5::after {
-  box-sizing: border-box;
-}
-
 .c2.fi-modal_footer {
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
@@ -466,6 +437,18 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c4.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c4.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c4.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c4.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -513,13 +496,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
               tabindex="0"
               type="button"
             >
-              <span
-                class="c5 fi-button_icon"
-              />
               OK
-              <span
-                class="c5 fi-button_icon fi-button_icon--right"
-              />
             </button>
             <button
               aria-disabled="false"
@@ -527,13 +504,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
               tabindex="0"
               type="button"
             >
-              <span
-                class="c5 fi-button_icon"
-              />
               Cancel
-              <span
-                class="c5 fi-button_icon fi-button_icon--right"
-              />
             </button>
           </div>
           <div

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -697,6 +697,18 @@ exports[`props children should match snapshot 1`] = `
   margin-left: 8px;
 }
 
+.c7.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c7.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c7.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c7.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -976,9 +988,6 @@ exports[`props children should match snapshot 1`] = `
         tabindex="0"
         type="button"
       >
-        <span
-          class="c8 fi-button_icon"
-        />
         Close
         <span
           class="c8 fi-button_icon fi-button_icon--right"

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -792,6 +792,18 @@ exports[`snapshot should have matching default structure 1`] = `
   margin-left: 8px;
 }
 
+.c6.fi-button--icon-only {
+  padding: 6px 12px;
+}
+
+.c6.fi-button--icon-only > .fi-button_icon > .fi-icon {
+  margin-right: 0;
+}
+
+.c6.fi-button--icon-only > .fi-button_icon--right > .fi-icon {
+  margin-left: 0;
+}
+
 .c6.fi-button--disabled > .fi-button_icon {
   cursor: not-allowed;
 }
@@ -934,7 +946,7 @@ exports[`snapshot should have matching default structure 1`] = `
       <button
         aria-disabled="true"
         aria-label="Previous page"
-        class="c5 fi-button c6 fi-pagination_arrow-button fi-button--disabled fi-button--secondary"
+        class="c5 fi-button c6 fi-pagination_arrow-button fi-button--disabled fi-button--secondary fi-button--icon-only"
         disabled=""
         id="1-previous-button"
         type="button"
@@ -959,9 +971,6 @@ exports[`snapshot should have matching default structure 1`] = `
             />
           </svg>
         </span>
-        <span
-          class="c3 fi-button_icon fi-button_icon--right"
-        />
       </button>
       <span
         class="c3 fi-pagination_page-numbers"
@@ -971,7 +980,7 @@ exports[`snapshot should have matching default structure 1`] = `
       <button
         aria-disabled="false"
         aria-label="Next page"
-        class="c5 fi-button c6 fi-pagination_arrow-button fi-button--secondary"
+        class="c5 fi-button c6 fi-pagination_arrow-button fi-button--secondary fi-button--icon-only"
         id="1-next-button"
         tabindex="0"
         type="button"
@@ -996,9 +1005,6 @@ exports[`snapshot should have matching default structure 1`] = `
             />
           </svg>
         </span>
-        <span
-          class="c3 fi-button_icon fi-button_icon--right"
-        />
       </button>
     </div>
     <div

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,11 @@ export {
 } from './core/Notification/Notification';
 export { Toast, ToastProps } from './core/Toast/Toast';
 export { Block, BlockProps } from './core/Block/Block';
-export { Button, ButtonProps } from './core/Button/Button';
+export {
+  Button,
+  ButtonProps,
+  ForcedAccessibleNameProps,
+} from './core/Button/Button';
 export { Dropdown, DropdownProps } from './core/Dropdown/';
 export { DropdownItem, DropdownItemProps } from './core/Dropdown/';
 export { Chip, ChipProps } from './core/Chip/';


### PR DESCRIPTION
## Description
This PR improves support for Buttons with only an icon and no text content out of the box. Some changes:
- Icon wrapper elements are no longer rendered if corresponding icon is not specified
- Buttons are square with equal proportions when no text content is given
- Buttons require either children or an `aria-label` attribute
- Button component's `icon` and `iconRight` prop types changed from `ReactNode` to `ReactElement`
- `ActionMenuProps` changed from an interface to a type to accommodate changes

## Motivation and Context
This was requested by users and the redundant wrappers were noticed by the team.

## How Has This Been Tested?
Tested by running locally on styleguidist and by trying out the new typing inside the project. Needs to be tested in another project to check the typing just in case.

## Release notes
### Button
**Breaking change:** Adjusted paddings to accommodate use with only icon and no content.
**Breaking change:** ButtonProps now require either `children` or `aria-label`
### ActionMenu
**Breaking change:** Remove redundant custom styling via "icon only" class.
