### PR TITLE
[Feature] Checkbox and RadioButton visual updates

### DIFF
--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -106,9 +106,7 @@ const largeVariantStyles = (theme: SuomifiTheme) => css`
 
     &:focus-within {
       & .fi-checkbox_label {
-        /* Modified version of theme.focuses.absoluteFocus */
         &::after {
-          ${theme.focuses.absoluteFocus};
           width: 32px;
           height: 32px;
           top: -1px;

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -14,6 +14,29 @@ const checkedStyles = (theme: SuomifiTheme) => css`
         fill: ${theme.colors.whiteBase};
       }
     }
+    &.fi-checkbox--disabled {
+      & .fi-checkbox_label {
+        &::before {
+          border-color: ${theme.colors.depthLight1};
+          background-color: ${theme.colors.depthLight1};
+        }
+        & > .fi-checkbox_icon .fi-icon-base-fill {
+          fill: ${theme.colors.depthLight3};
+        }
+      }
+    }
+    &.fi-checkbox--error {
+      & .fi-checkbox_label {
+        &::before {
+          border-color: ${theme.colors.alertBase};
+          background-color: ${theme.colors.alertBase};
+          border-width: 2px;
+        }
+        & > .fi-checkbox_icon .fi-icon-base-fill {
+          fill: ${theme.colors.whiteBase};
+        }
+      }
+    }
   }
 `;
 
@@ -28,7 +51,7 @@ const disabledStyles = (theme: SuomifiTheme) => css`
         border-width: 1px;
       }
       & > .fi-checkbox_icon .fi-icon-base-fill {
-        fill: ${theme.colors.depthLight1};
+        fill: ${theme.colors.depthLight3};
       }
     }
     &.fi-checkbox--large {
@@ -79,6 +102,19 @@ const largeVariantStyles = (theme: SuomifiTheme) => css`
     }
     & .fi-hint-text {
       padding-left: ${theme.spacing.xxl};
+    }
+
+    &:focus-within {
+      & .fi-checkbox_label {
+        /* Modified version of theme.focuses.absoluteFocus */
+        &::after {
+          ${theme.focuses.absoluteFocus};
+          width: 32px;
+          height: 32px;
+          top: -1px;
+          left: -1px;
+        }
+      }
     }
   }
 `;

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -8,9 +8,10 @@ const checkedStyles = (theme: SuomifiTheme) => css`
     & .fi-checkbox_label {
       &::before {
         border-color: ${theme.colors.highlightBase};
+        background-color: ${theme.colors.highlightBase};
       }
       & > .fi-checkbox_icon .fi-icon-base-fill {
-        fill: ${theme.colors.highlightBase};
+        fill: ${theme.colors.whiteBase};
       }
     }
   }
@@ -117,8 +118,21 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   &:focus-within {
     & .fi-checkbox_label {
-      &::before {
-        ${theme.focuses.boxShadowFocus}
+      /* Modified version of theme.focuses.absoluteFocus */
+      &::after {
+        content: '';
+        position: absolute;
+        pointer-events: none;
+        top: 4px;
+        left: -1px;
+        border-radius: 2px;
+        background-color: transparent;
+        border: 0px solid ${theme.colors.whiteBase};
+        box-sizing: border-box;
+        box-shadow: 0 0 0 2px ${theme.colors.accentSecondary};
+        z-index: 9999;
+        width: 20px;
+        height: 20px;
         outline: 2px solid transparent; /* For high contrast mode */
       }
     }

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -190,10 +190,20 @@ exports[`props children has matching snapshot 1`] = `
   top: 9px;
 }
 
-.c1:focus-within .fi-checkbox_label::before {
+.c1:focus-within .fi-checkbox_label::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: 4px;
+  left: -1px;
   border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   outline: 2px solid transparent;
 }
 
@@ -246,10 +256,11 @@ exports[`props children has matching snapshot 1`] = `
 
 .c1.fi-checkbox--checked .fi-checkbox_label::before {
   border-color: hsl(212,63%,45%);
+  background-color: hsl(212,63%,45%);
 }
 
 .c1.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(212,63%,45%);
+  fill: hsl(0,0%,100%);
 }
 
 .c1.fi-checkbox--error .fi-checkbox_label::before {

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -254,12 +254,38 @@ exports[`props children has matching snapshot 1`] = `
   padding-left: 40px;
 }
 
+.c1.fi-checkbox--large:focus-within .fi-checkbox_label::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c1.fi-checkbox--checked .fi-checkbox_label::before {
   border-color: hsl(212,63%,45%);
   background-color: hsl(212,63%,45%);
 }
 
 .c1.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(0,0%,100%);
+}
+
+.c1.fi-checkbox--checked.fi-checkbox--disabled .fi-checkbox_label::before {
+  border-color: hsl(202,7%,80%);
+  background-color: hsl(202,7%,80%);
+}
+
+.c1.fi-checkbox--checked.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,97%);
+}
+
+.c1.fi-checkbox--checked.fi-checkbox--error .fi-checkbox_label::before {
+  border-color: hsl(3,59%,43%);
+  background-color: hsl(3,59%,43%);
+  border-width: 2px;
+}
+
+.c1.fi-checkbox--checked.fi-checkbox--error .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
   fill: hsl(0,0%,100%);
 }
 
@@ -284,7 +310,7 @@ exports[`props children has matching snapshot 1`] = `
 }
 
 .c1.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(202,7%,80%);
+  fill: hsl(202,7%,97%);
 }
 
 .c1.fi-checkbox--disabled.fi-checkbox--large .fi-checkbox_label::before {

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -392,12 +392,38 @@ exports[`default, with only required props should match snapshot 1`] = `
   padding-left: 40px;
 }
 
+.c7.fi-checkbox--large:focus-within .fi-checkbox_label::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c7.fi-checkbox--checked .fi-checkbox_label::before {
   border-color: hsl(212,63%,45%);
   background-color: hsl(212,63%,45%);
 }
 
 .c7.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(0,0%,100%);
+}
+
+.c7.fi-checkbox--checked.fi-checkbox--disabled .fi-checkbox_label::before {
+  border-color: hsl(202,7%,80%);
+  background-color: hsl(202,7%,80%);
+}
+
+.c7.fi-checkbox--checked.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
+  fill: hsl(202,7%,97%);
+}
+
+.c7.fi-checkbox--checked.fi-checkbox--error .fi-checkbox_label::before {
+  border-color: hsl(3,59%,43%);
+  background-color: hsl(3,59%,43%);
+  border-width: 2px;
+}
+
+.c7.fi-checkbox--checked.fi-checkbox--error .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
   fill: hsl(0,0%,100%);
 }
 
@@ -422,7 +448,7 @@ exports[`default, with only required props should match snapshot 1`] = `
 }
 
 .c7.fi-checkbox--disabled .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(202,7%,80%);
+  fill: hsl(202,7%,97%);
 }
 
 .c7.fi-checkbox--disabled.fi-checkbox--large .fi-checkbox_label::before {

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -328,10 +328,20 @@ exports[`default, with only required props should match snapshot 1`] = `
   top: 9px;
 }
 
-.c7:focus-within .fi-checkbox_label::before {
+.c7:focus-within .fi-checkbox_label::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: 4px;
+  left: -1px;
   border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   outline: 2px solid transparent;
 }
 
@@ -384,10 +394,11 @@ exports[`default, with only required props should match snapshot 1`] = `
 
 .c7.fi-checkbox--checked .fi-checkbox_label::before {
   border-color: hsl(212,63%,45%);
+  background-color: hsl(212,63%,45%);
 }
 
 .c7.fi-checkbox--checked .fi-checkbox_label > .fi-checkbox_icon .fi-icon-base-fill {
-  fill: hsl(212,63%,45%);
+  fill: hsl(0,0%,100%);
 }
 
 .c7.fi-checkbox--error .fi-checkbox_label::before {

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -140,7 +140,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
       &:focus:not(:focus-visible) {
         + .fi-radio-button_icon_wrapper {
-          box-shadow: none;
+          &::after {
+            box-shadow: none;
+          }
         }
       }
     }

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -108,9 +108,22 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
       &:focus {
         + .fi-radio-button_icon_wrapper {
-          ${theme.focuses.boxShadowFocus}
-          border-radius: 50%;
-          ${theme.focuses.highContrastFocus}
+          &::after {
+            content: '';
+            position: absolute;
+            pointer-events: none;
+            top: -1px;
+            left: -1px;
+            background-color: transparent;
+            border: 0px solid ${theme.colors.whiteBase};
+            box-sizing: border-box;
+            box-shadow: 0 0 0 2px ${theme.colors.accentSecondary};
+            z-index: 9999;
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            outline: 2px solid transparent; /* For high contrast mode */
+          }
         }
       }
       &:focus:not(:focus-visible) {

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -34,6 +34,7 @@ const largeStyles = () => css`
     & .fi-radio-button_hintText {
       padding-left: 40px;
     }
+
     & .fi-radio-button_input {
       top: 2px;
       left: 2px;
@@ -49,7 +50,18 @@ const largeStyles = () => css`
           width: 30px;
         }
       }
+      &:focus {
+        + .fi-radio-button_icon_wrapper {
+          &::after {
+            width: 32px;
+            height: 32px;
+            top: -1px;
+            left: -1px;
+          }
+        }
+      }
     }
+
     & .fi-radio-button_label {
       padding-left: 40px;
       line-height: 34px;

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`children should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -545,7 +545,7 @@ exports[`className should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -872,7 +872,7 @@ exports[`disabled should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -1221,7 +1221,7 @@ exports[`hintText should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -1555,7 +1555,7 @@ exports[`id should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -1882,7 +1882,7 @@ exports[`name should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -2210,7 +2210,7 @@ exports[`value should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -2537,7 +2537,7 @@ exports[`variant should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -264,6 +264,13 @@ exports[`children should match snapshot 1`] = `
   width: 30px;
 }
 
+.c1.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c1.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -584,6 +591,13 @@ exports[`className should match snapshot 1`] = `
   width: 30px;
 }
 
+.c1.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c1.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -902,6 +916,13 @@ exports[`disabled should match snapshot 1`] = `
 .c1.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
+}
+
+.c1.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
 }
 
 .c1.fi-radio-button--large .fi-radio-button_label {
@@ -1246,6 +1267,13 @@ exports[`hintText should match snapshot 1`] = `
   width: 30px;
 }
 
+.c1.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c1.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -1573,6 +1601,13 @@ exports[`id should match snapshot 1`] = `
   width: 30px;
 }
 
+.c1.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c1.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -1891,6 +1926,13 @@ exports[`name should match snapshot 1`] = `
 .c1.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
+}
+
+.c1.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
 }
 
 .c1.fi-radio-button--large .fi-radio-button_label {
@@ -2214,6 +2256,13 @@ exports[`value should match snapshot 1`] = `
   width: 30px;
 }
 
+.c1.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c1.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -2532,6 +2581,13 @@ exports[`variant should match snapshot 1`] = `
 .c1.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
+}
+
+.c1.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
 }
 
 .c1.fi-radio-button--large .fi-radio-button_label {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -201,12 +201,21 @@ exports[`children should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -512,12 +521,21 @@ exports[`className should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -823,12 +841,21 @@ exports[`disabled should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -1156,12 +1183,21 @@ exports[`hintText should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -1474,12 +1510,21 @@ exports[`id should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -1785,12 +1830,21 @@ exports[`name should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -2097,12 +2151,21 @@ exports[`value should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -2408,12 +2471,21 @@ exports[`variant should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c1.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c1.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -434,6 +434,13 @@ exports[`default, with only required props should match snapshot 1`] = `
   width: 30px;
 }
 
+.c7.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -1048,6 +1055,13 @@ exports[`props className should match snapshot 1`] = `
   width: 30px;
 }
 
+.c7.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -1660,6 +1674,13 @@ exports[`props defaultValue should match snapshot 1`] = `
 .c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
+}
+
+.c7.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
 }
 
 .c7.fi-radio-button--large .fi-radio-button_label {
@@ -2298,6 +2319,13 @@ exports[`props hintText should match snapshot 1`] = `
   width: 30px;
 }
 
+.c8.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c8.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -2917,6 +2945,13 @@ exports[`props id should match snapshot 1`] = `
   width: 30px;
 }
 
+.c7.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -3529,6 +3564,13 @@ exports[`props label should match snapshot 1`] = `
 .c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
+}
+
+.c7.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
 }
 
 .c7.fi-radio-button--large .fi-radio-button_label {
@@ -4157,6 +4199,13 @@ exports[`props labelMode should match snapshot 1`] = `
   width: 30px;
 }
 
+.c7.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -4771,6 +4820,13 @@ exports[`props name should match snapshot 1`] = `
   width: 30px;
 }
 
+.c7.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
+}
+
 .c7.fi-radio-button--large .fi-radio-button_label {
   padding-left: 40px;
   line-height: 34px;
@@ -5383,6 +5439,13 @@ exports[`props value should match snapshot 1`] = `
 .c7.fi-radio-button--large .fi-radio-button_input + .fi-radio-button_icon_wrapper .fi-radio-button_icon {
   height: 30px;
   width: 30px;
+}
+
+.c7.fi-radio-button--large .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  width: 32px;
+  height: 32px;
+  top: -1px;
+  left: -1px;
 }
 
 .c7.fi-radio-button--large .fi-radio-button_label {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -371,12 +371,21 @@ exports[`default, with only required props should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -976,12 +985,21 @@ exports[`props className should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -1581,12 +1599,21 @@ exports[`props defaultValue should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -2208,12 +2235,21 @@ exports[`props hintText should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c8.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c8.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -2818,12 +2854,21 @@ exports[`props id should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -3423,12 +3468,21 @@ exports[`props label should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -4040,12 +4094,21 @@ exports[`props labelMode should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -4645,12 +4708,21 @@ exports[`props name should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
@@ -5250,12 +5322,21 @@ exports[`props value should match snapshot 1`] = `
   stroke: hsl(212,63%,45%);
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper {
-  border-radius: 2px;
+.c7.fi-radio-button .fi-radio-button_input:focus + .fi-radio-button_icon_wrapper::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -1px;
+  left: -1px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  outline: 0;
+  z-index: 9999;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  outline: 3px solid transparent;
+  outline: 2px solid transparent;
 }
 
 .c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -388,7 +388,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -1009,7 +1009,7 @@ exports[`props className should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -1630,7 +1630,7 @@ exports[`props defaultValue should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -2273,7 +2273,7 @@ exports[`props hintText should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c8.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c8.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -2899,7 +2899,7 @@ exports[`props id should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -3520,7 +3520,7 @@ exports[`props label should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -4153,7 +4153,7 @@ exports[`props labelMode should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -4774,7 +4774,7 @@ exports[`props name should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 
@@ -5395,7 +5395,7 @@ exports[`props value should match snapshot 1`] = `
   outline: 2px solid transparent;
 }
 
-.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper {
+.c7.fi-radio-button .fi-radio-button_input:focus:not(:focus-visible) + .fi-radio-button_icon_wrapper::after {
   box-shadow: none;
 }
 


### PR DESCRIPTION
## Description
This PR updates the styling of the `Checkbox` component checked state as well as the focus indicator of both `Checkbox` and `RadioButton`. The checked state style also affects the error variant.

## Motivation and Context
This visual change improves accessibility and overall readability of the different Checkbox states, as well as makes the focus indicator clearer matching the style of most other components.

## How Has This Been Tested?
By running locally on styleguidist on Chrome and Firefox.

## Release notes
### Checkbox
**Breaking change:** Change styling of the checked state and focus indicator
### RadioButton
**Breaking change:** Change focus indicator styling
