### PR TITLE
[Feature] Notification close button to optional

### DIFF
--- a/src/core/Notification/Notification.md
+++ b/src/core/Notification/Notification.md
@@ -8,6 +8,7 @@ Examples:
 - [Heading levels](./#/Components/Notification?id=heading-levels)
 - [Action elements](./#/Components/Notification?id=action-elements)
 - [Error status](./#/Components/Notification?id=error-status)
+- [Without close button](./#/Components/Notification?id=without-close-button)
 - [Small screen](./#/Components/Notification?id=small-screen)
 
 <div style="margin-bottom: 40px">
@@ -101,6 +102,22 @@ showNotification && (
     document
   </Notification>
 );
+```
+
+### Without close button
+
+In some cases, like when the notification is the sole content on the page, the notification may be rendered as a non-interactive version by disabling the close button. This can be done via the `showCloseButton` prop.
+
+```js
+import { Notification } from 'suomifi-ui-components';
+
+<Notification
+  showCloseButton={false}
+  headingText="Content not found"
+  status="error"
+>
+  The resource you were looking for could not be found.
+</Notification>;
 ```
 
 ### Small screen

--- a/src/core/Notification/Notification.test.tsx
+++ b/src/core/Notification/Notification.test.tsx
@@ -100,6 +100,15 @@ describe('props', () => {
     });
   });
 
+  describe('showCloseButton', () => {
+    it('should hide the close button when applied', () => {
+      const { queryByRole } = render(
+        <Notification showCloseButton={false}>Test</Notification>,
+      );
+      expect(queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
   describe('closeButtonProps', () => {
     const NotificationWithButtonProps = (
       <Notification

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -32,6 +32,12 @@ export const notificationClassNames = {
 
 export type CloseButtonProps =
   | {
+      closeButton: false;
+      closeText?: string;
+      onCloseButtonClick?: () => void;
+      closeButtonProps?: Omit<ButtonProps, 'onClick'>;
+    }
+  | {
       /** Show or hide close button
        * @default true
        */
@@ -45,12 +51,6 @@ export type CloseButtonProps =
       /** Callback fired on close button click */
       onCloseButtonClick?: () => void;
       /** Custom props passed to the close button */
-      closeButtonProps?: Omit<ButtonProps, 'onClick'>;
-    }
-  | {
-      closeButton: false;
-      closeText?: string;
-      onCloseButtonClick?: () => void;
       closeButtonProps?: Omit<ButtonProps, 'onClick'>;
     };
 

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -32,7 +32,7 @@ export const notificationClassNames = {
 
 export type CloseButtonProps =
   | {
-      closeButton: false;
+      showCloseButton: false;
       closeText?: string;
       onCloseButtonClick?: () => void;
       closeButtonProps?: Omit<ButtonProps, 'onClick'>;
@@ -41,7 +41,7 @@ export type CloseButtonProps =
       /** Show or hide close button
        * @default true
        */
-      closeButton?: true;
+      showCloseButton?: true;
       /**
        * Text to label the close button.
        * Is visible and as `aria-label` in regular size and only used as `aria-label` in small screen variant.
@@ -99,7 +99,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
       headingVariant = 'h2',
       style,
       regionAriaLabel,
-      closeButton = true,
+      showCloseButton = true,
       ...rest
     } = this.props;
     const [marginProps, passProps] = separateMarginProps(rest);
@@ -165,7 +165,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
               </HtmlDiv>
             </HtmlDiv>
           </HtmlDiv>
-          {closeButton && (
+          {showCloseButton && (
             <Button
               variant="secondaryNoBorder"
               className={classnames(

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -30,37 +30,54 @@ export const notificationClassNames = {
   actionElementWrapper: `${baseClassName}_action-element-wrapper`,
 };
 
-export interface NotificationProps extends HtmlDivWithRefProps, MarginProps {
-  /** Style variant. Affects color and icon used.
-   * @default 'neutral'
-   */
-  status?: 'neutral' | 'error';
-  /** Heading for the Notification */
-  headingText?: string;
-  /** Main content of the Notification */
-  children?: ReactNode;
-  /** Elements to be rendered under the notification text. Can be e.g. buttons, links etc. */
-  actionElements?: ReactNode;
-  /** Heading variant for Notification.
-   * @default 'h2'
-   */
-  headingVariant?: Exclude<hLevels, 'h1'>;
-  /**
-   * Text to label the close button.
-   * Is visible and as `aria-label` in regular size and only used as `aria-label` in small screen variant
-   */
-  closeText: string;
-  /** Callback fired on close button click */
-  onCloseButtonClick?: () => void;
-  /** Custom props passed to the close button */
-  closeButtonProps?: Omit<ButtonProps, 'onClick'>;
-  /** Toggles small screen styling */
-  smallScreen?: boolean;
-  /** Label for the notification region for screen reader users.
-   * If one is not provided, `headingText` or finally notification content will be used as the label.
-   */
-  regionAriaLabel?: string;
-}
+export type CloseButtonProps =
+  | {
+      /** Show or hide close button
+       * @default true
+       */
+      closeButton?: true;
+      /**
+       * Text to label the close button.
+       * Is visible and as `aria-label` in regular size and only used as `aria-label` in small screen variant.
+       * Required when clear button is shown.
+       */
+      closeText: string;
+      /** Callback fired on close button click */
+      onCloseButtonClick?: () => void;
+      /** Custom props passed to the close button */
+      closeButtonProps?: Omit<ButtonProps, 'onClick'>;
+    }
+  | {
+      closeButton: false;
+      closeText?: string;
+      onCloseButtonClick?: () => void;
+      closeButtonProps?: Omit<ButtonProps, 'onClick'>;
+    };
+
+export type NotificationProps = HtmlDivWithRefProps &
+  MarginProps &
+  CloseButtonProps & {
+    /** Style variant. Affects color and icon used.
+     * @default 'neutral'
+     */
+    status?: 'neutral' | 'error';
+    /** Heading for the Notification */
+    headingText?: string;
+    /** Main content of the Notification */
+    children?: ReactNode;
+    /** Elements to be rendered under the notification text. Can be e.g. buttons, links etc. */
+    actionElements?: ReactNode;
+    /** Heading variant for Notification.
+     * @default 'h2'
+     */
+    headingVariant?: Exclude<hLevels, 'h1'>;
+    /** Toggles small screen styling */
+    smallScreen?: boolean;
+    /** Label for the notification region for screen reader users.
+     * If one is not provided, `headingText` or finally notification content will be used as the label.
+     */
+    regionAriaLabel?: string;
+  };
 
 interface InnerRef {
   forwardedRef: React.RefObject<HTMLDivElement>;
@@ -82,6 +99,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
       headingVariant = 'h2',
       style,
       regionAriaLabel,
+      closeButton = true,
       ...rest
     } = this.props;
     const [marginProps, passProps] = separateMarginProps(rest);
@@ -147,25 +165,27 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
               </HtmlDiv>
             </HtmlDiv>
           </HtmlDiv>
-          <Button
-            variant="secondaryNoBorder"
-            className={classnames(
-              notificationClassNames.closeButton,
-              customCloseButtonClassName,
-            )}
-            {...getConditionalAriaProp('aria-label', [
-              closeButtonPropsAriaLabel ||
-                (smallScreen ? closeText : undefined),
-            ])}
-            {...getConditionalAriaProp('aria-describedby', [
-              closeButtonPropsAriaDescribedBy,
-            ])}
-            onClick={onCloseButtonClick}
-            {...closeButtonPassProps}
-            iconRight={<IconClose />}
-          >
-            {!smallScreen ? closeText : ''}
-          </Button>
+          {closeButton && (
+            <Button
+              variant="secondaryNoBorder"
+              className={classnames(
+                notificationClassNames.closeButton,
+                customCloseButtonClassName,
+              )}
+              {...getConditionalAriaProp('aria-label', [
+                closeButtonPropsAriaLabel ||
+                  (smallScreen ? closeText : undefined),
+              ])}
+              {...getConditionalAriaProp('aria-describedby', [
+                closeButtonPropsAriaDescribedBy,
+              ])}
+              onClick={onCloseButtonClick}
+              {...closeButtonPassProps}
+              iconRight={<IconClose />}
+            >
+              {!smallScreen ? closeText : ''}
+            </Button>
+          )}
         </HtmlDiv>
         {actionElements && (
           <HtmlDiv className={notificationClassNames.actionElementWrapper}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ export { InlineAlert, InlineAlertProps } from './core/InlineAlert/InlineAlert';
 export {
   Notification,
   NotificationProps,
+  CloseButtonProps,
 } from './core/Notification/Notification';
 export { Toast, ToastProps } from './core/Toast/Toast';
 export { Block, BlockProps } from './core/Block/Block';


### PR DESCRIPTION
## Description
This PR makes the presence of the close button in Notification optional. This is controlled via the `showCloseButton` prop. the `closeText` prop is now required depending on the value of the `showCloseButton` prop. The new union type is also exported to help mitigate any issues that may rise due to the typing.

## Motivation and Context
This feature was requested by a service, discussed among the DS team and deemed worth implementing.

## How Has This Been Tested?
By testing the typing inside the project and checking that the outcome is desired in styleguidist on Chrome.

## Release notes
### Notification
- Make close button optional via `showCloseButton` prop.
