### PR TITLE
[Feature] SideNav & ServiceNav: Remove forced uppercases

### DIFF
--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -338,7 +338,6 @@ exports[`should match snapshot 1`] = `
   display: -ms-flexbox;
   display: flex;
   padding: 10px 20px;
-  text-transform: uppercase;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -427,7 +426,6 @@ exports[`should match snapshot 1`] = `
   display: flex;
   padding: 10px 25px;
   padding-left: calc(20px - 4px);
-  text-transform: uppercase;
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigationItem/ServiceNavigationItem.baseStyles.tsx
@@ -32,7 +32,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       color: ${theme.colors.blackBase};
       display: flex;
       padding: ${theme.spacing.xs} ${theme.spacing.m};
-      text-transform: uppercase;
       flex: 1;
       cursor: pointer;
       background: inherit;
@@ -94,7 +93,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         display: flex;
         padding: ${theme.spacing.xs} ${theme.spacing.l};
         padding-left: calc(${theme.spacing.m} - 4px);
-        text-transform: uppercase;
         flex: 1;
 
         &:hover,

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -476,15 +476,10 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c7.fi-side-navigation-item--level-1.fi-side-navigation-item--selected > span > .fi-link--router {
-  text-transform: uppercase;
   color: hsl(0,0%,100%);
   font-weight: 600;
   background: hsl(212,63%,45%);
   border-radius: 4px;
-}
-
-.c7.fi-side-navigation-item--level-1 > span > .fi-link--router {
-  text-transform: uppercase;
 }
 
 .c7.fi-side-navigation-item--level-2.fi-side-navigation-item--selected > span > .fi-link--router {

--- a/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigationItem/SideNavigationItem.baseStyles.tsx
@@ -84,16 +84,11 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &--level-1 {
       &.fi-side-navigation-item--selected {
         > span > .fi-link--router {
-          text-transform: uppercase;
           color: ${theme.colors.whiteBase};
           font-weight: 600;
           background: ${theme.colors.highlightBase};
           border-radius: ${theme.radiuses.modal};
         }
-      }
-
-      > span > .fi-link--router {
-        text-transform: uppercase;
       }
     }
 


### PR DESCRIPTION
## Description

PR removes forced uppercase text from `<ServiceNavigation>` and `<SideNavigation>` components. This corresponds with the latest design changes. 

## Motivation and Context

Uppercase letters were thought difficult to read and depicted as "screaming"

## Screenshots:

SideNavigation before:
![image](https://github.com/vrk-kpa/suomifi-ui-components/assets/17459942/4822c4eb-51e2-438d-94b1-0304a9dccead)

SideNavigation after:
![image](https://github.com/vrk-kpa/suomifi-ui-components/assets/17459942/512a23a7-791f-403c-a677-4c45d8d4e491)

----

ServiceNavigation before:
![image](https://github.com/vrk-kpa/suomifi-ui-components/assets/17459942/eca183ef-d0c9-4faa-ba8d-c740f5dea407)

ServiceNavigation after:
![image](https://github.com/vrk-kpa/suomifi-ui-components/assets/17459942/8f47f27a-976c-4d09-be4b-00b9bc9765aa)



## Release notes

### SideNavigation
- **Breaking change**: Remove forced uppercase text from level 1 `<SideNavigationItem>`

### ServiceNavigation
- **Breaking change**: Remove forced uppercase text from `<ServiceNavigationItem>`
