### PR TITLE
[Fix] LinkList aria label

### DIFF
--- a/src/core/Link/LinkList/LinkList.md
+++ b/src/core/Link/LinkList/LinkList.md
@@ -14,7 +14,7 @@ Examples:
 ### Basic use
 
 - Use a descriptive heading or a label with the list.
-- Link the heading/label to the list via the `ariaDescribedBy` prop.
+- Link the heading/label to the list via the `ariaLabelledBy` prop.
 - Use the right heading level semantically and use the `<Heading>` component's `as` prop for changing the styling if needed.
 - Wrap each child in `LinkListItem` component to get the correct styling.
 - `<LinkListItem>` supports `<Link>`, `<ExternalLink>` and `<RouterLink>` as its children.
@@ -33,7 +33,7 @@ import {
   <Heading variant="h4" as="h3" id="heading">
     More on the topic
   </Heading>
-  <LinkList ariaDescribedBy="heading">
+  <LinkList ariaLabelledBy="heading">
     <LinkListItem>
       <Link href="#">Granting mandates as a person</Link>
     </LinkListItem>

--- a/src/core/Link/LinkList/LinkList.test.tsx
+++ b/src/core/Link/LinkList/LinkList.test.tsx
@@ -9,7 +9,7 @@ import { Link } from '../Link/Link';
 const TestLinkList = (
   <>
     <h1 id="a">Heading</h1>
-    <LinkList ariaDescribedBy="a">
+    <LinkList ariaLabelledBy="a">
       <LinkListItem data-testid="test-link">
         <Link href="/">Link</Link>
       </LinkListItem>
@@ -37,13 +37,13 @@ describe('Simple link list with one item', () => {
 
 describe('Margin prop', () => {
   it('should have margin style from margin prop', () => {
-    const { container } = render(<LinkList ariaDescribedBy="" margin="xs" />);
+    const { container } = render(<LinkList ariaLabelledBy="" margin="xs" />);
     expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
   });
 
   it('should have margin prop overwritten from style prop', () => {
     const { container } = render(
-      <LinkList ariaDescribedBy="" margin="xs" style={{ margin: 2 }} />,
+      <LinkList ariaLabelledBy="" margin="xs" style={{ margin: 2 }} />,
     );
     expect(container.firstChild).toHaveAttribute('style', 'margin: 2px;');
   });

--- a/src/core/Link/LinkList/LinkList.tsx
+++ b/src/core/Link/LinkList/LinkList.tsx
@@ -18,7 +18,7 @@ export interface LinkListProps extends HtmlUlProps, MarginProps {
   /** Ref is forwarded to the list element. Alternative to React `ref` attribute. */
   forwardedRef?: React.Ref<HTMLUListElement>;
   /** Id of the heading or label of the list */
-  ariaDescribedBy: string;
+  ariaLabelledBy: string;
   /** Sets smaller font size for the list elements */
   smallScreen?: boolean;
 }
@@ -29,7 +29,7 @@ const StyledLinkList = styled(
     theme,
     children,
     smallScreen,
-    ariaDescribedBy,
+    ariaLabelledBy,
     forwardedRef,
     ...rest
   }: LinkListProps & SuomifiThemeProp) => {
@@ -42,7 +42,7 @@ const StyledLinkList = styled(
         className={classnames(className, LinkListClassName, {
           [SmallScreenClassName]: smallScreen,
         })}
-        {...getConditionalAriaProp('aria-describedby', [ariaDescribedBy])}
+        {...getConditionalAriaProp('aria-labelledby', [ariaLabelledBy])}
         style={{ ...marginStyle, ...passProps?.style }}
       >
         {children}

--- a/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
+++ b/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
@@ -302,7 +302,7 @@ exports[`Simple link list with one item should match snapshot 1`] = `
       Heading
     </h1>
     <ul
-      aria-describedby="a"
+      aria-labelledby="a"
       class="c0 c1 fi-link-list"
     >
       <li


### PR DESCRIPTION
## Description
This PR changes the `LinkList` component to use `aria-labelledby` instead of `aria-describedby` to connect the list heading to the list itself.

## Motivation and Context
This is the correct aria prop to use in this case and may improve the behavior on some devices and screen readers.

## How Has This Been Tested?
Tested on NVDA on Chrome and TalkBack on Android.

## Release notes
### LinkList
- **Breaking change:** Change `ariaDescribedBy` prop to `ariaLabelledBy`.
