### PR TITLE
[Feature] Add status icons to StatusText

### DIFF
--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -326,6 +326,14 @@ exports[`Basic dropdown should match snapshot 1`] = `
   color: hsl(3,59%,43%);
 }
 
+.c7.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
 .c1 {
   width: 290px;
 }
@@ -969,6 +977,30 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   overflow-x: hidden;
 }
 
+.c12 {
+  vertical-align: baseline;
+}
+
+.c12.fi-icon {
+  display: inline-block;
+}
+
+.c12 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c12 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c12.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c12.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
 .c7 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -994,6 +1026,14 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 
 .c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c7.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {
@@ -1175,30 +1215,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
-}
-
-.c12 {
-  vertical-align: baseline;
-}
-
-.c12.fi-icon {
-  display: inline-block;
-}
-
-.c12 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c12 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c12.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c12.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c11.fi-dropdown_item {
@@ -1705,6 +1721,14 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 
 .c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c7.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {
@@ -2292,6 +2316,14 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 
 .c8.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c8.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -144,6 +144,14 @@ exports[`props children has matching snapshot 1`] = `
   color: hsl(3,59%,43%);
 }
 
+.c5.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
 .c1 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -223,6 +223,14 @@ exports[`default, with only required props should match snapshot 1`] = `
   color: hsl(3,59%,43%);
 }
 
+.c10.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
 .c4.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -1,6 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snapshots match date input error status with statustext 1`] = `
+.c7 {
+  vertical-align: baseline;
+}
+
+.c7.fi-icon {
+  display: inline-block;
+}
+
+.c7 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c7 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c7.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c7.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -176,6 +200,14 @@ exports[`snapshots match date input error status with statustext 1`] = `
 
 .c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {
@@ -458,6 +490,22 @@ exports[`snapshots match date input error status with statustext 1`] = `
           class="c4 c6 fi-date-input_statusText--has-content fi-status-text fi-status-text--error"
           id="7-statusText"
         >
+          <svg
+            aria-hidden="true"
+            class="fi-icon c7"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              class="fi-icon-base-fill"
+              d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0Zm.71 17.29c-.38-.37-1.05-.37-1.42 0-.181.19-.29.44-.29.71 0 .26.109.52.29.71.189.18.45.29.71.29.26 0 .52-.11.71-.29.18-.19.29-.45.29-.71 0-.27-.11-.52-.29-.71ZM12 5a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V6a1 1 0 0 0-1-1Z"
+              fill="#222"
+              fill-rule="evenodd"
+            />
+          </svg>
           Error
         </span>
       </div>
@@ -654,6 +702,14 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
 
 .c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c7.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {
@@ -1140,6 +1196,14 @@ exports[`snapshots match date input hint text 1`] = `
   color: hsl(3,59%,43%);
 }
 
+.c7.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
 .c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1609,6 +1673,14 @@ exports[`snapshots match date input minimal implementation 1`] = `
   color: hsl(3,59%,43%);
 }
 
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
 .c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -2071,6 +2143,14 @@ exports[`snapshots match date input optional text 1`] = `
   color: hsl(3,59%,43%);
 }
 
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
 .c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -2361,6 +2441,30 @@ exports[`snapshots match date input optional text 1`] = `
 `;
 
 exports[`snapshots match date input success status with statustext 1`] = `
+.c7 {
+  vertical-align: baseline;
+}
+
+.c7.fi-icon {
+  display: inline-block;
+}
+
+.c7 .fi-icon-base-fill {
+  fill: hsl(166,90%,34%);
+}
+
+.c7 .fi-icon-base-stroke {
+  stroke: hsl(166,90%,34%);
+}
+
+.c7.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c7.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
 .c0 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -2536,6 +2640,14 @@ exports[`snapshots match date input success status with statustext 1`] = `
 
 .c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {
@@ -2817,6 +2929,22 @@ exports[`snapshots match date input success status with statustext 1`] = `
           class="c4 c6 fi-date-input_statusText--has-content fi-status-text"
           id="6-statusText"
         >
+          <svg
+            aria-hidden="true"
+            class="fi-icon c7"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              class="fi-icon-base-fill"
+              d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0Zm5.65 8.24a1 1 0 0 0-1.41.11l-5.296 6.18-2.237-2.237a1 1 0 1 0-1.414 1.414l3 3a1 1 0 0 0 1.466-.056l6-7a1 1 0 0 0-.108-1.41Z"
+              fill="#222"
+              fill-rule="evenodd"
+            />
+          </svg>
           Success
         </span>
       </div>
@@ -3528,6 +3656,14 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c9.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c9.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c12 {
@@ -5720,6 +5856,14 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 
 .c9.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c9.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c12 {

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -178,6 +178,14 @@ exports[`snapshot matches 1`] = `
   color: hsl(3,59%,43%);
 }
 
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
 .c1 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -186,63 +186,6 @@ exports[`snapshot should have matching default structure 1`] = `
   overflow: hidden;
 }
 
-.c11 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(0,0%,13%);
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.c11.fi-status-text {
-  display: block;
-}
-
-.c11.fi-status-text.fi-status-text--error {
-  color: hsl(3,59%,43%);
-}
-
-.c4.fi-label .fi-label_label-span {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-  display: inline-block;
-  vertical-align: middle;
-  color: hsl(0,0%,13%);
-}
-
-.c4.fi-label .fi-label_label-span .fi-label_optional-text {
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 400;
-}
-
-.c4.fi-label .fi-label_label-span .fi-tooltip {
-  margin-left: 6px;
-}
-
 .c9 {
   vertical-align: baseline;
 }
@@ -289,6 +232,71 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c10.fi-icon--cursor-pointer * {
   cursor: inherit;
+}
+
+.c11 {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(0,0%,13%);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c11.fi-status-text {
+  display: block;
+}
+
+.c11.fi-status-text.fi-status-text--error {
+  color: hsl(3,59%,43%);
+}
+
+.c11.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
+.c4.fi-label .fi-label_label-span {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+  display: inline-block;
+  vertical-align: middle;
+  color: hsl(0,0%,13%);
+}
+
+.c4.fi-label .fi-label_label-span .fi-label_optional-text {
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.c4.fi-label .fi-label_label-span .fi-tooltip {
+  margin-left: 6px;
 }
 
 .c7 {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -272,6 +272,102 @@ exports[`has matching snapshot 1`] = `
   margin-left: 6px;
 }
 
+.c10 {
+  vertical-align: baseline;
+}
+
+.c10.fi-icon {
+  display: inline-block;
+}
+
+.c10 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c10 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c10.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c10.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c21 {
+  vertical-align: baseline;
+}
+
+.c21.fi-icon {
+  display: inline-block;
+}
+
+.c21 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c21 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c21.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c21.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c14 {
+  vertical-align: baseline;
+}
+
+.c14.fi-icon {
+  display: inline-block;
+}
+
+.c14 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c14 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c14.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c14.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c16 {
+  vertical-align: baseline;
+}
+
+.c16.fi-icon {
+  display: inline-block;
+}
+
+.c16 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c16 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c16.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c16.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
 .c11 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -297,6 +393,14 @@ exports[`has matching snapshot 1`] = `
 
 .c11.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c11.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c2 {
@@ -532,102 +636,6 @@ exports[`has matching snapshot 1`] = `
   max-height: inherit;
   overflow-y: auto;
   overflow-x: hidden;
-}
-
-.c10 {
-  vertical-align: baseline;
-}
-
-.c10.fi-icon {
-  display: inline-block;
-}
-
-.c10 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c10 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c10.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c10.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c21 {
-  vertical-align: baseline;
-}
-
-.c21.fi-icon {
-  display: inline-block;
-}
-
-.c21 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c21 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c21.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c21.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c14 {
-  vertical-align: baseline;
-}
-
-.c14.fi-icon {
-  display: inline-block;
-}
-
-.c14 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c14 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c14.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c14.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c16 {
-  vertical-align: baseline;
-}
-
-.c16.fi-icon {
-  display: inline-block;
-}
-
-.c16 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c16 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c16.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c16.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c20 {

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -293,6 +293,78 @@ exports[`has matching snapshot 1`] = `
   display: block;
 }
 
+.c13 {
+  vertical-align: baseline;
+}
+
+.c13.fi-icon {
+  display: inline-block;
+}
+
+.c13 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c13 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c13.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c13.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c19 {
+  vertical-align: baseline;
+}
+
+.c19.fi-icon {
+  display: inline-block;
+}
+
+.c19 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c19 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c19.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c19.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c11 {
+  vertical-align: baseline;
+}
+
+.c11.fi-icon {
+  display: inline-block;
+}
+
+.c11 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c11 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c11.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c11.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
 .c14 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -318,6 +390,14 @@ exports[`has matching snapshot 1`] = `
 
 .c14.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c14.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c2 {
@@ -514,78 +594,6 @@ exports[`has matching snapshot 1`] = `
 
 .c2.fi-filter-input--label-align-left .fi-filter-input_wrapper .fi-label .fi-label_label-span {
   margin-bottom: 0;
-}
-
-.c13 {
-  vertical-align: baseline;
-}
-
-.c13.fi-icon {
-  display: inline-block;
-}
-
-.c13 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c13 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c13.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c13.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c19 {
-  vertical-align: baseline;
-}
-
-.c19.fi-icon {
-  display: inline-block;
-}
-
-.c19 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c19 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c19.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c19.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c11 {
-  vertical-align: baseline;
-}
-
-.c11.fi-icon {
-  display: inline-block;
-}
-
-.c11 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c11 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c11.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c11.fi-icon--cursor-pointer * {
-  cursor: inherit;
 }
 
 .c9 {

--- a/src/core/Form/StatusText/StatusText.baseStyles.tsx
+++ b/src/core/Form/StatusText/StatusText.baseStyles.tsx
@@ -13,5 +13,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     &.fi-status-text--error {
       color: ${theme.colors.alertBase};
     }
+    & .fi-icon {
+      vertical-align: middle;
+      transform: translateY(-0.1em);
+      margin-right: ${theme.spacing.xxs};
+    }
   }
 `;

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -1,7 +1,11 @@
 import React, { forwardRef, ReactNode } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SuomifiTheme,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
@@ -10,6 +14,7 @@ import {
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
 import { InputStatus, AriaLiveMode } from '../types';
 import { baseStyles } from './StatusText.baseStyles';
+import { IconErrorFilled, IconCheckCircleFilled } from 'suomifi-icons';
 
 const baseClassName = 'fi-status-text';
 const statusTextClassNames = {
@@ -42,6 +47,19 @@ export interface StatusTextProps extends HtmlSpanProps, MarginProps {
   forwardedRef?: React.Ref<HTMLSpanElement>;
 }
 
+const getIcon = (status: InputStatus | undefined, theme: SuomifiTheme) => {
+  if (status === undefined || status === 'default') return null;
+  if (status === 'error') return <IconErrorFilled aria-hidden="true" />;
+  if (status === 'success') {
+    return (
+      <IconCheckCircleFilled
+        aria-hidden="true"
+        color={theme.colors.successBase}
+      />
+    );
+  }
+};
+
 const StyledStatusText = styled(
   ({
     className,
@@ -68,6 +86,7 @@ const StyledStatusText = styled(
         aria-atomic="true"
         style={{ ...marginStyle, ...passProps?.style }}
       >
+        {getIcon(status, theme)}
         {children}
       </HtmlSpan>
     );

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -151,6 +151,30 @@ exports[`snapshots match error status with statustext 1`] = `
   margin-left: 6px;
 }
 
+.c7 {
+  vertical-align: baseline;
+}
+
+.c7.fi-icon {
+  display: inline-block;
+}
+
+.c7 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c7 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c7.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c7.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
 .c6 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -176,6 +200,14 @@ exports[`snapshots match error status with statustext 1`] = `
 
 .c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {
@@ -443,6 +475,22 @@ exports[`snapshots match error status with statustext 1`] = `
         class="c2 c6 fi-text-input_statusText--has-content fi-status-text fi-status-text--error"
         id="test-id2-statusText"
       >
+        <svg
+          aria-hidden="true"
+          class="fi-icon c7"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            class="fi-icon-base-fill"
+            d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0Zm.71 17.29c-.38-.37-1.05-.37-1.42 0-.181.19-.29.44-.29.71 0 .26.109.52.29.71.189.18.45.29.71.29.26 0 .52-.11.71-.29.18-.19.29-.45.29-.71 0-.27-.11-.52-.29-.71ZM12 5a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V6a1 1 0 0 0-1-1Z"
+            fill="#222"
+            fill-rule="evenodd"
+          />
+        </svg>
         This is a status text
       </span>
     </div>
@@ -638,6 +686,14 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 
 .c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c7.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {
@@ -1085,6 +1141,14 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -178,6 +178,14 @@ exports[`snapshot default structure should match snapshot 1`] = `
   color: hsl(3,59%,43%);
 }
 
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
 .c1 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;

--- a/src/core/Form/TimeInput/__snapshots__/TimeInput.test.tsx.snap
+++ b/src/core/Form/TimeInput/__snapshots__/TimeInput.test.tsx.snap
@@ -151,6 +151,30 @@ exports[`snapshots match error status with statustext 1`] = `
   margin-left: 6px;
 }
 
+.c7 {
+  vertical-align: baseline;
+}
+
+.c7.fi-icon {
+  display: inline-block;
+}
+
+.c7 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c7 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c7.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c7.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
 .c6 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -176,6 +200,14 @@ exports[`snapshots match error status with statustext 1`] = `
 
 .c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {
@@ -441,6 +473,22 @@ exports[`snapshots match error status with statustext 1`] = `
       class="c2 c6 fi-time-input_statusText--has-content fi-status-text fi-status-text--error"
       id="test-id4-statusText"
     >
+      <svg
+        aria-hidden="true"
+        class="fi-icon c7"
+        focusable="false"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          class="fi-icon-base-fill"
+          d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0Zm.71 17.29c-.38-.37-1.05-.37-1.42 0-.181.19-.29.44-.29.71 0 .26.109.52.29.71.189.18.45.29.71.29.26 0 .52-.11.71-.29.18-.19.29-.45.29-.71 0-.27-.11-.52-.29-.71ZM12 5a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V6a1 1 0 0 0-1-1Z"
+          fill="#222"
+          fill-rule="evenodd"
+        />
+      </svg>
       This is a status text
     </span>
   </span>
@@ -635,6 +683,14 @@ exports[`snapshots match hidden label 1`] = `
 
 .c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c7.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {
@@ -1079,6 +1135,14 @@ exports[`snapshots match hint text 1`] = `
 
 .c7.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c7.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c5 {
@@ -1555,6 +1619,14 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c6.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
+}
+
+.c6.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
 }
 
 .c1 {

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -311,6 +311,14 @@ exports[`snapshot should have matching default structure 1`] = `
   color: hsl(3,59%,43%);
 }
 
+.c14.fi-status-text .fi-icon {
+  vertical-align: middle;
+  -webkit-transform: translateY(-0.1em);
+  -ms-transform: translateY(-0.1em);
+  transform: translateY(-0.1em);
+  margin-right: 5px;
+}
+
 .c11.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1088,7 +1096,9 @@ exports[`snapshot should have matching default structure 1`] = `
             aria-live="assertive"
             class="c3 c14 fi-page-input_statusText--has-content fi-status-text"
             id="1-pageInput-statusText"
-          />
+          >
+            
+          </span>
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Description
This PR adds icons to StatusText component so that conveying the status does not solely depend on the color.

## Motivation and Context
This was an accessibility issue needing a fix.

## How Has This Been Tested?
Tested by running locally in styleguidist on Chrome and Firefox
## Screenshots (if appropriate):
![image](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/914675be-c79c-45d6-ae20-0c1d61ffa697)


## Release notes
### StatusText, Dropdown, Checkbox, DateInput, MultiSelect, SingleSelect, SearchInput, TextInput, TimeInput, Textarea, Pagination
- **Breaking change:** Add icons to status text to signify error or success status
