### PR TITLE
[Feature] SingleSelect & MultiSelect: Add onChangeWithoutDebounce()

### DIFF
--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -609,7 +609,9 @@ const countries = [
 
 The example below simulates a data fetch operation from a backend.
 
-Use the `loading` and `loadingText` props to enable a loading spinner. This can be done in the `onChange()` function, which runs when the user types into the filter text input.
+Use the `loading` and `loadingText` props to enable a loading spinner for MultiSelect. This can be done in the `onChangeWithoutDebounce()` function, which runs immediately when the user types into the filter text input.
+
+The backend data fetch operation can be performed in the `onChange()` function, which uses a `debounce` time so that the request is made only after the user has stopped typing for a set amount of time.
 
 ```js
 import { useState } from 'react';
@@ -617,7 +619,7 @@ import { MultiSelect } from 'suomifi-ui-components';
 
 const [loading, setLoading] = useState(false);
 const [countries, setCountries] = useState([]);
-const countriesFromBackend = [
+const allCountries = [
   {
     labelText: 'Switzerland',
     uniqueItemId: 'sw2435626'
@@ -656,27 +658,15 @@ const countriesFromBackend = [
   }
 ];
 
-const runLoader = () => {
-  let progress = 0;
-  setLoading(true);
+const simulateBackendCall = (searchStr) => {
   setCountries([]);
-  const id = setInterval(frame, 100);
-  function frame() {
-    if (progress >= 10) {
-      clearInterval(id);
-      setCountries(countriesFromBackend);
-      setLoading(false);
-      progress = 0;
-    } else {
-      progress = progress + 1;
-    }
-  }
-};
-
-const startup = (event) => {
-  if (!loading) {
-    runLoader();
-  }
+  setTimeout(() => {
+    const matchingCountries = allCountries.filter((c) =>
+      c.labelText.toLowerCase().includes(searchStr.toLowerCase())
+    );
+    setCountries(matchingCountries);
+    setLoading(false);
+  }, 1000);
 };
 
 <MultiSelect
@@ -693,7 +683,13 @@ const startup = (event) => {
   ariaOptionChipRemovedText="removed"
   loading={loading}
   loadingText="Loading data"
-  onChange={startup}
+  debounce={1000}
+  onChange={simulateBackendCall}
+  onChangeWithoutDebounce={() => {
+    if (!loading) {
+      setLoading(true);
+    }
+  }}
 />;
 ```
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -619,6 +619,9 @@ import { MultiSelect } from 'suomifi-ui-components';
 
 const [loading, setLoading] = useState(false);
 const [countries, setCountries] = useState([]);
+const [backendSimulationTimeout, setBackendSimulationTimeout] =
+  useState(null);
+
 const allCountries = [
   {
     labelText: 'Switzerland',
@@ -660,13 +663,18 @@ const allCountries = [
 
 const simulateBackendCall = (searchStr) => {
   setCountries([]);
-  setTimeout(() => {
+  if (backendSimulationTimeout) {
+    clearTimeout(backendSimulationTimeout);
+  }
+  const backendSimulationTimeoutScoped = setTimeout(() => {
     const matchingCountries = allCountries.filter((c) =>
       c.labelText.toLowerCase().includes(searchStr.toLowerCase())
     );
     setCountries(matchingCountries);
     setLoading(false);
+    setBackendSimulationTimeout(null);
   }, 1000);
+  setBackendSimulationTimeout(backendSimulationTimeoutScoped);
 };
 
 <MultiSelect

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -158,6 +158,11 @@ interface InternalMultiSelectProps<T extends MultiSelectData> {
   defaultSelectedItems?: Array<T & MultiSelectData>;
   /** Callback fired when filter changes */
   onChange?: (value: string) => void;
+  /**
+   * Callback fired when filter changes. This function does not use debounce.
+   * Intended use cases are, for example, to set the `loading` prop
+   */
+  onChangeWithoutDebounce?: (value: string) => void;
   /** Callback fired on input blur */
   onBlur?: () => void;
   /** Debounce time in milliseconds for `onChange()` function. No debounce is applied if no value is given. */
@@ -628,6 +633,7 @@ class BaseMultiSelect<T> extends Component<
       noItemsText,
       defaultSelectedItems,
       onChange: propOnChange,
+      onChangeWithoutDebounce,
       debounce,
       status,
       statusText,
@@ -728,6 +734,9 @@ class BaseMultiSelect<T> extends Component<
                   onChange={(value: string) => {
                     if (propOnChange) {
                       debouncer(propOnChange, value);
+                    }
+                    if (onChangeWithoutDebounce) {
+                      onChangeWithoutDebounce(value);
                     }
                     this.setState({
                       filterInputValue: value,

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -517,6 +517,9 @@ import { SingleSelect } from 'suomifi-ui-components';
 
 const [loading, setLoading] = useState(false);
 const [countries, setCountries] = useState([]);
+const [backendSimulationTimeout, setBackendSimulationTimeout] =
+  useState(null);
+
 const allCountries = [
   {
     labelText: 'Switzerland',
@@ -558,13 +561,18 @@ const allCountries = [
 
 const simulateBackendCall = (searchStr) => {
   setCountries([]);
-  setTimeout(() => {
+  if (backendSimulationTimeout) {
+    clearTimeout(backendSimulationTimeout);
+  }
+  const backendSimulationTimeoutScoped = setTimeout(() => {
     const matchingCountries = allCountries.filter((c) =>
       c.labelText.toLowerCase().includes(searchStr.toLowerCase())
     );
     setCountries(matchingCountries);
     setLoading(false);
+    setBackendSimulationTimeout(null);
   }, 1000);
+  setBackendSimulationTimeout(backendSimulationTimeoutScoped);
 };
 
 <SingleSelect

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -507,7 +507,9 @@ const countries = [
 
 The example below simulates a data fetch operation from a backend.
 
-Use the `loading` and `loadingText` props to enable a loading spinner. This can be done in the `onChange()` function, which runs when the user types into the filter text input.
+Use the `loading` and `loadingText` props to enable a loading spinner for SingleSelect. This can be done in the `onChangeWithoutDebounce()` function, which runs immediately when the user types into the filter text input.
+
+The backend data fetch operation can be performed in the `onChange()` function, which uses a `debounce` time so that the request is made only after the user has stopped typing for a set amount of time.
 
 ```js
 import { useState } from 'react';
@@ -515,7 +517,7 @@ import { SingleSelect } from 'suomifi-ui-components';
 
 const [loading, setLoading] = useState(false);
 const [countries, setCountries] = useState([]);
-const countriesFromBackend = [
+const allCountries = [
   {
     labelText: 'Switzerland',
     uniqueItemId: 'sw2435626'
@@ -554,27 +556,15 @@ const countriesFromBackend = [
   }
 ];
 
-const runLoader = () => {
-  let progress = 0;
-  setLoading(true);
+const simulateBackendCall = (searchStr) => {
   setCountries([]);
-  const id = setInterval(frame, 100);
-  function frame() {
-    if (progress >= 10) {
-      clearInterval(id);
-      setCountries(countriesFromBackend);
-      setLoading(false);
-      progress = 0;
-    } else {
-      progress = progress + 1;
-    }
-  }
-};
-
-const startup = (event) => {
-  if (!loading) {
-    runLoader();
-  }
+  setTimeout(() => {
+    const matchingCountries = allCountries.filter((c) =>
+      c.labelText.toLowerCase().includes(searchStr.toLowerCase())
+    );
+    setCountries(matchingCountries);
+    setLoading(false);
+  }, 1000);
 };
 
 <SingleSelect
@@ -587,9 +577,15 @@ const startup = (event) => {
   ariaOptionsAvailableTextFunction={(amount) =>
     amount === 1 ? 'option available' : 'options available'
   }
+  debounce={1000}
   loading={loading}
   loadingText="Loading data"
-  onChange={startup}
+  onChange={simulateBackendCall}
+  onChangeWithoutDebounce={() => {
+    if (!loading) {
+      setLoading(true);
+    }
+  }}
 />;
 ```
 

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -243,14 +243,20 @@ class BaseSingleSelect<T> extends Component<
               (item) =>
                 item.uniqueItemId === prevState.selectedItem?.uniqueItemId,
             );
-      const resolvedInputValue = selectedItemChanged
-        ? selectedItem !== null
-          ? selectedItem?.labelText || prevState.filterInputValue
-          : ''
-        : propItems.find(
-            (item) =>
-              item.uniqueItemId === prevState.selectedItem?.uniqueItemId,
-          )?.labelText || prevState.filterInputValue;
+      let resolvedInputValue = prevState.filterInputValue;
+      if (selectedItemChanged) {
+        resolvedInputValue = selectedItem
+          ? selectedItem.labelText || prevState.filterInputValue
+          : '';
+      } else {
+        const matchingItem = propItems.find(
+          (item) => item.uniqueItemId === prevState.selectedItem?.uniqueItemId,
+        );
+        if (matchingItem) {
+          resolvedInputValue =
+            matchingItem.labelText || prevState.filterInputValue;
+        }
+      }
 
       return {
         selectedItem: resolvedSelectedItem,

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -98,6 +98,11 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
   defaultSelectedItem?: T & SingleSelectData;
   /** Callback fired when filter changes */
   onChange?: (value: string) => void;
+  /**
+   * Callback fired when filter changes. This function does not use debounce.
+   * Intended use cases are, for example, to set the `loading` prop
+   */
+  onChangeWithoutDebounce?: (value: string) => void;
   /** Callback fired on inpur blur */
   onBlur?: () => void;
   /** Debounce time in milliseconds for onChange function. No debounce is applied if no value is given. */
@@ -239,11 +244,13 @@ class BaseSingleSelect<T> extends Component<
                 item.uniqueItemId === prevState.selectedItem?.uniqueItemId,
             );
       const resolvedInputValue = selectedItemChanged
-        ? selectedItem?.labelText || ''
+        ? selectedItem !== null
+          ? selectedItem?.labelText || prevState.filterInputValue
+          : ''
         : propItems.find(
             (item) =>
               item.uniqueItemId === prevState.selectedItem?.uniqueItemId,
-          )?.labelText || '';
+          )?.labelText || prevState.filterInputValue;
 
       return {
         selectedItem: resolvedSelectedItem,
@@ -515,6 +522,7 @@ class BaseSingleSelect<T> extends Component<
       noItemsText,
       defaultSelectedItem,
       onChange: propOnChange,
+      onChangeWithoutDebounce,
       onBlur,
       debounce,
       loading,
@@ -612,6 +620,9 @@ class BaseSingleSelect<T> extends Component<
               onChange={(value: string) => {
                 if (propOnChange) {
                   debouncer(propOnChange, value);
+                }
+                if (onChangeWithoutDebounce) {
+                  onChangeWithoutDebounce(value);
                 }
                 this.handleOnChange(value);
               }}


### PR DESCRIPTION
## Description

This PR adds a new prop called `onChangeWithoutDebounce()` to `<SingleSelect>` & `<MultiSelect>`. The prop is basically the same as `onChange()` but does not use the debounce time even if it is specified. 

Its inteded use case is mainly enabling the `loading` state of the component. It makes sense to show the loading spinner immediately when the user starts filtering and only make a backend call after a certain debounce time. 

In addition, this PR also fixes an oversight in the SingleSelect component `getDerivedStateFromProps()` logic. Previously, when the value of the `items` prop or the `selectedItem` prop changed, the filter input's value was always set to an empty string `''`. Now it only does that if `selectedItem` is set to null. 

## Motivation and Context

It was reported by users that having the `loading` state of the component only be applied after the debounce time is not ideal. It causes the existing items to be filtered briefly by the new input before the loading process begins. 

## How Has This Been Tested?

Styleguidist on Chrome & library's programmatic tests

## Release notes

### SingleSelect
- Fix filter input value parsing when `items` or `selectedItem` prop changes
- Add `onChangeWithoutDebounce()` prop. Inteded to be used to set the `loading`prop

### MultiSelect
- Add `onChangeWithoutDebounce()` prop. Inteded to be used to set the `loading`prop


