### PR TITLE
[Fix] Unintended typing change in callback function props

### DIFF
--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -158,7 +158,7 @@ export interface DateInputProps
   extends DatePickerProps,
     MarginProps,
     StatusTextCommonProps,
-    Omit<HtmlInputProps, 'type' | 'onChange'> {
+    Omit<HtmlInputProps, 'type' | 'onChange' | 'onClick' | 'onBlur'> {
   /** DateInput container div class name for custom styling. */
   className?: string;
   /** Disable input usage */

--- a/src/core/Form/RadioButton/RadioButton.tsx
+++ b/src/core/Form/RadioButton/RadioButton.tsx
@@ -35,7 +35,9 @@ const radioButtonClassNames = {
   checked: `${baseClassName}--checked`,
 };
 
-export interface RadioButtonProps extends MarginProps, HtmlInputProps {
+export interface RadioButtonProps
+  extends MarginProps,
+    Omit<HtmlInputProps, 'onChange'> {
   /** CSS class for custom styles */
   className?: string;
   /** RadioButton text content (label) */

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -45,6 +45,8 @@ export interface SearchInputProps
       | 'type'
       | 'disabled'
       | 'onChange'
+      | 'onBlur'
+      | 'onSearch'
       | 'children'
       | 'onClick'
       | 'value'

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -223,7 +223,7 @@ export type MultiSelectProps<T> = InternalMultiSelectProps<
   AriaOptionChipRemovedProps &
   AriaSelectedAmountProps &
   MarginProps &
-  HtmlDivProps &
+  Omit<HtmlDivProps, 'onChange' | 'onBlur'> &
   LoadingProps;
 
 interface MultiSelectState<T extends MultiSelectData> {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -166,7 +166,7 @@ type AllowItemAdditionProps =
 export type SingleSelectProps<T> = InternalSingleSelectProps<
   T & SingleSelectData
 > &
-  HtmlDivProps &
+  Omit<HtmlDivProps, 'onChange' | 'onBlur'> &
   AllowItemAdditionProps &
   AriaOptionsAvailableProps &
   MarginProps &

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -55,7 +55,7 @@ type TextInputValue = string | number | undefined;
 interface BaseTextInputProps
   extends StatusTextCommonProps,
     MarginProps,
-    Omit<HtmlInputProps, 'type' | 'onChange'> {
+    Omit<HtmlInputProps, 'type' | 'onChange' | 'onClick' | 'onBlur'> {
   /** CSS class for custom styles */
   className?: string;
   /** Disables the input */

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -52,7 +52,10 @@ type TextareaStatus = Exclude<InputStatus, 'success'>;
 interface BaseTextareaProps
   extends StatusTextCommonProps,
     MarginProps,
-    Omit<HtmlTextareaProps, 'placeholder' | 'forwardedRef'> {
+    Omit<
+      HtmlTextareaProps,
+      'placeholder' | 'forwardedRef' | 'onChange' | 'onBlur'
+    > {
   /** CSS class for custom styles */
   className?: string;
   /** Disables the input */

--- a/src/core/Form/TimeInput/TimeInput.tsx
+++ b/src/core/Form/TimeInput/TimeInput.tsx
@@ -41,7 +41,10 @@ export const timeInputClassNames = {
 export interface TimeInputProps
   extends StatusTextCommonProps,
     MarginProps,
-    Omit<HtmlInputProps, 'type' | 'onChange' | 'onBlur' | 'defaultValue'> {
+    Omit<
+      HtmlInputProps,
+      'type' | 'onChange' | 'onBlur' | 'defaultValue' | 'onClick'
+    > {
   /** CSS class for custom styles */
   className?: string;
   /** Disables the input */

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -41,7 +41,9 @@ export type MenuContent =
   | Array<ReactElement<LanguageMenuItemProps>>
   | ReactElement<LanguageMenuItemProps>;
 
-export interface LanguageMenuProps extends MarginProps, HtmlButtonProps {
+export interface LanguageMenuProps
+  extends MarginProps,
+    Omit<HtmlButtonProps, 'onBlur'> {
   /** Content for the menu button. Should indicate the currently selected language */
   buttonText: ReactNode;
   /**

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -87,7 +87,7 @@ interface InternalPaginationProps {
 
 export type PaginationProps = ShowInputProps &
   InternalPaginationProps &
-  HtmlNavProps &
+  Omit<HtmlNavProps, 'onChange'> &
   MarginProps;
 
 const baseClassName = 'fi-pagination';


### PR DESCRIPTION
## Description
This PR fixes some overlap in typing related to callbacks such as `onChange`, `onClick` and `onBlur`. After the recent change of extending component props with relevant HTML props, the typings were accidentally changed in components where there were differing typings for the callbacks in the component APIs and the HTML props they extended.

The issue was fixed by omitting the overlapping props from the extended HTML props.

## Motivation and Context
There was an unintended change in typings which caused issues for developers.

## How Has This Been Tested?
Tested in a React+Vite test project with latest Typescript to see if the issues were indeed fixed.

## Release notes
- Fix unintentionally changed typings in `onChange`, `onClick` and `onBlur` props in several components
