### PR TITLE
[Bugfix] Block spacing props to CSS

### DIFF
--- a/src/core/Block/Block.baseStyles.ts
+++ b/src/core/Block/Block.baseStyles.ts
@@ -2,9 +2,15 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
 import { BlockVariant } from './Block';
+import { SpacingProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, variant?: BlockVariant) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  variant?: BlockVariant,
+  spacingProps?: SpacingProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   ${!!variant && variant === 'span' ? 'display: inline-block' : ''}
+  ${buildSpacingCSS(spacingProps)}
 `;

--- a/src/core/Block/Block.test.tsx
+++ b/src/core/Block/Block.test.tsx
@@ -15,28 +15,26 @@ const TestBlock = (
 describe('margin', () => {
   it('should have margin style from margin prop', () => {
     const { container } = render(<Block margin="xs">Test</Block>);
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin right and margin left from mx prop', () => {
     const { container } = render(<Block mx="xs">Test</Block>);
-    expect(container.firstChild).toHaveAttribute(
-      'style',
+    expect(container.firstChild).toHaveStyle(
       'margin-right: 10px; margin-left: 10px;',
     );
   });
 });
 
 describe('padding', () => {
-  it('should have padding style from margin prop', () => {
+  it('should have padding style from padding prop', () => {
     const { container } = render(<Block padding="xs">Test</Block>);
-    expect(container.firstChild).toHaveAttribute('style', 'padding: 10px;');
+    expect(container.firstChild).toHaveStyle('padding: 10px');
   });
 
   it('should have padding top and padding bottom from py prop', () => {
     const { container } = render(<Block py="xs">Test</Block>);
-    expect(container.firstChild).toHaveAttribute(
-      'style',
+    expect(container.firstChild).toHaveStyle(
       'padding-top: 10px; padding-bottom: 10px;',
     );
   });

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -4,7 +4,6 @@ import classnames from 'classnames';
 import {
   SpacingProps,
   separateMarginAndPaddingProps,
-  spacingStyles,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Block.baseStyles';
 import { HtmlDivWithNativeRef, HtmlDivProps } from '../../reset';
@@ -37,9 +36,9 @@ export interface BlockProps extends HtmlDivProps, SpacingProps {
 
 class SemanticBlock extends Component<BlockProps> {
   render() {
-    const { className, variant, style, forwardedRef, ...rest } = this.props;
-    const [spacingProps, passProps] = separateMarginAndPaddingProps(rest);
-    const spacingStyle = spacingStyles(spacingProps);
+    const { className, variant, forwardedRef, ...rest } = this.props;
+
+    const [_, passProps] = separateMarginAndPaddingProps(rest);
 
     const ComponentVariant =
       !variant || variant === 'default' ? HtmlDivWithNativeRef : variant;
@@ -51,17 +50,21 @@ class SemanticBlock extends Component<BlockProps> {
         className={classnames(baseClassName, className, {
           [`${baseClassName}--${variant}`]: !!variant,
         })}
-        style={{ ...spacingStyle, ...style }}
       />
     );
   }
 }
 
-const StyledBlock = styled((props: BlockProps & SuomifiThemeProp) => {
-  const { theme, variant, ...passProps } = props;
-  return <SemanticBlock variant={variant} {...passProps} />;
-})`
-  ${({ theme, variant }) => baseStyles(theme, variant)}
+const StyledBlock = styled(
+  ({ theme, variant, ...passProps }: BlockProps & SuomifiThemeProp) => (
+    <SemanticBlock variant={variant} {...passProps} />
+  ),
+)`
+  ${(props) => {
+    const { theme, variant, ...rest } = props;
+    const [spacingProps] = separateMarginAndPaddingProps(rest);
+    return baseStyles(theme, variant, spacingProps);
+  }}
 `;
 
 const Block = forwardRef((props: BlockProps, ref: React.Ref<any>) => (

--- a/src/core/Block/__snapshots__/Block.test.tsx.snap
+++ b/src/core/Block/__snapshots__/Block.test.tsx.snap
@@ -47,6 +47,24 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
+.c2 {
+  color: hsl(0,0%,13%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  padding: 60px;
+}
+
 <div
   data-testid="test-block"
 >
@@ -56,8 +74,7 @@ exports[`calling render with the same component on the same container does not r
     Hey this is test
   </div>
   <div
-    class="c0 fi-block c1"
-    style="padding: 60px;"
+    class="c0 fi-block c2"
   >
     Hey this is test lead
   </div>

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -56,11 +56,24 @@ export interface MarginProps {
 
 export interface SpacingProps extends PaddingProps, MarginProps {}
 
-export const spacingStyles = (props: SpacingProps) => {
+export const spacingStyles = (props: SpacingProps | undefined) => {
+  if (!props) return;
   const array = Object.entries(props).map(([key, value]) =>
     getSpacingStyle(defaultSuomifiTheme, key as keyof SpacingProps, value),
   );
   return Object.assign({}, ...array);
+};
+
+export const buildSpacingCSS = (props: SpacingProps | undefined): string => {
+  if (!props) return '';
+
+  const cssStyles = Object.entries(props)
+    .map(([key, value]) =>
+      getCSSSpacing(defaultSuomifiTheme, key as keyof SpacingProps, value),
+    )
+    .join('');
+
+  return cssStyles;
 };
 
 const inlineStyle = {
@@ -74,6 +87,19 @@ const inlineStyle = {
   pr: 'paddingRight',
   pb: 'paddingBottom',
   pl: 'paddingLeft',
+};
+
+const cssSelector = {
+  margin: 'margin',
+  mt: 'margin-top',
+  mr: 'margin-right',
+  mb: 'margin-bottom',
+  ml: 'margin-left',
+  padding: 'padding',
+  pt: 'padding-top',
+  pr: 'padding-right',
+  pb: 'padding-bottom',
+  pl: 'padding-left',
 };
 
 const getSpacingStyle = (
@@ -104,6 +130,26 @@ const getSpacingStyle = (
       return { [inlineStyle[key]]: `${amount}` };
     default:
       return '';
+  }
+};
+
+const getCSSSpacing = (
+  theme: SuomifiTheme,
+  key: keyof SpacingProps,
+  value: SpacingProp,
+) => {
+  const amount = spaceVal(theme)(value);
+  switch (key) {
+    case 'mx':
+      return `margin-right: ${amount}; margin-left: ${amount};`;
+    case 'my':
+      return `margin-top: ${amount}; margin-bottom: ${amount};`;
+    case 'px':
+      return `padding-right: ${amount}; padding-left: ${amount};`;
+    case 'py':
+      return `padding-top: ${amount}; padding-bottom: ${amount};`;
+    default:
+      return `${[cssSelector[key]]}: ${amount};`;
   }
 };
 


### PR DESCRIPTION
## Description
This PR changes the spacing prop implementation of block back to a CSS-based solution from the style prop based one introduced last fall. The previous change caused issues with strict content security policies which disallow inline styles.

## Motivation and Context
The issue was reported by services using the library and upon discussion it seemed like multiple projects were affected

## How Has This Been Tested?
Tested by running styleguidist locally on chrome and checking that the props work

## Release notes
### Block
- **Breaking change:** Change spacing props to use CSS spaced implementation instead of style prop
