### PR TITLE
[Bugfix] LinkListItem icon redundant color prop

### DIFF
--- a/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
+++ b/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
@@ -10,11 +10,11 @@ exports[`Simple link list with one item should match snapshot 1`] = `
 }
 
 .c5 .fi-icon-base-fill {
-  fill: hsl(212,63%,45%);
+  fill: currentColor;
 }
 
 .c5 .fi-icon-base-stroke {
-  stroke: hsl(212,63%,45%);
+  stroke: currentColor;
 }
 
 .c5.fi-icon--cursor-pointer {

--- a/src/core/Link/LinkListItem/LinkListItem.tsx
+++ b/src/core/Link/LinkListItem/LinkListItem.tsx
@@ -38,11 +38,7 @@ const StyledLinkListItem = styled(
   }: LinkListItemProps & SuomifiThemeProp) => (
     <HtmlLi {...passProps} className={classnames(baseClassName, className)}>
       <HtmlSpan className={listLinkClassNames.icon}>
-        {!!icon ? (
-          icon
-        ) : (
-          <IconChevronRight color={theme.colors.highlightBase} />
-        )}
+        {!!icon ? icon : <IconChevronRight />}
       </HtmlSpan>
       {children}
     </HtmlLi>


### PR DESCRIPTION
## Description
There was a redundant color prop in LinkListItem's default icon, which caused some weird issues in some cases. The quickest fix was to remove the prop, since the color was specified in the styles already.

## Motivation and Context
This was reported by a developer and was clearly redundant code

## How Has This Been Tested?
Tested in React + Vite test project on Chrome

## Release notes
### LinkListItem
- Remove redundant color prop from default icon
