### PR TITLE
[Bugfix] Remove Tooltip anchorElement prop from DOM

### DIFF
--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -152,6 +152,7 @@ class BaseTooltip extends Component<TooltipProps & { className?: string }> {
       toggleButtonClassName,
       contentClassName,
       forwardedRef,
+      anchorElement,
       className,
       ...passProps
     } = this.props;


### PR DESCRIPTION
## Description
This PR prevents an unwanted Tooltip prop from ending up in DOM. The `anchorElement` props is used in some hooks, but it was not destructured away upon rendering the component, causing it to end up in DOM.

## Motivation and Context
This was noticed when making other changes and was clearly a minor bug with an easy fix.

## How Has This Been Tested?
Tested in styleguidist on chrome by checking that the prop no longer appears in DOM

## Release notes
### Tooltip
- Prevent an unwanted prop from showing up in DOM
