### PR TITLE
[Bugfix] Remove aria-expanded from ExpanderGroup open/close all button

### DIFF
--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -188,7 +188,6 @@ class BaseExpanderGroup extends Component<
               toggleAllButtonProps?.className,
               openAllButtonClassName,
             )}
-            aria-expanded={allOpen}
             forwardedRef={forwardedRef}
           >
             <HtmlSpan aria-hidden={true}>

--- a/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
+++ b/src/core/Expander/ExpanderGroup/__snapshots__/ExpanderGroup.test.tsx.snap
@@ -515,7 +515,6 @@ exports[`Basic expander group should match snapshot 1`] = `
   class="c0 c1 fi-expander-group"
 >
   <button
-    aria-expanded="false"
     class="c2 fi-expander-group_all-button"
     type="button"
   >


### PR DESCRIPTION
## Description
This PR removes the `aria-expanded` property from the ExpanderGroup open/close all button.

## Motivation and Context
It was deemed unnecessary an somewhat of an anti-pattern by multiple accessibility specialists and thus needed to be removed.

## How Has This Been Tested?
Tested by running locally on styleguidist on chrome, checking the DOM and testing with NVDA to see that the `aria-expanded` prop was gone.

## Release notes
### ExpanderGroup
-Remove `aria-expanded` from open/close all button
