### PR TITLE
[Bugfix] TextInput and Textarea spacings

### DIFF
--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -4,8 +4,8 @@ import { input, containerIEFocus, font } from '../../theme/reset';
 import { math } from 'polished';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  ${font(theme)('bodyText')}
   width: 290px;
+  line-height: 0;
 
   & .fi-text-input_character-counter {
     ${font(theme)('bodyTextSmall')};
@@ -13,7 +13,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     font-size: 14px;
     line-height: 20px;
     flex: none;
-    margin-top: 4px;
+    margin-top: ${theme.spacing.xxs};
 
     &.fi-text-input_character-counter--error {
       color: ${theme.colors.alertBase};

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -211,20 +211,8 @@ exports[`snapshots match error status with statustext 1`] = `
 }
 
 .c1 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
   width: 290px;
+  line-height: 0;
 }
 
 .c1 .fi-text-input_character-counter {
@@ -247,7 +235,7 @@ exports[`snapshots match error status with statustext 1`] = `
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  margin-top: 4px;
+  margin-top: 5px;
 }
 
 .c1 .fi-text-input_character-counter.fi-text-input_character-counter--error {
@@ -697,20 +685,8 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 }
 
 .c1 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
   width: 290px;
+  line-height: 0;
 }
 
 .c1 .fi-text-input_character-counter {
@@ -733,7 +709,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  margin-top: 4px;
+  margin-top: 5px;
 }
 
 .c1 .fi-text-input_character-counter.fi-text-input_character-counter--error {
@@ -1152,20 +1128,8 @@ exports[`snapshots match minimal implementation 1`] = `
 }
 
 .c1 {
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
   width: 290px;
+  line-height: 0;
 }
 
 .c1 .fi-text-input_character-counter {
@@ -1188,7 +1152,7 @@ exports[`snapshots match minimal implementation 1`] = `
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  margin-top: 4px;
+  margin-top: 5px;
 }
 
 .c1 .fi-text-input_character-counter.fi-text-input_character-counter--error {

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -23,7 +23,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       font-size: 14px;
       line-height: 20px;
       flex: none;
-      margin-top: 4px;
+      margin-top: ${theme.spacing.xxs};
 
       &.fi-textarea_character-counter--error {
         color: ${theme.colors.alertBase};
@@ -47,6 +47,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
           ${theme.focuses.absoluteFocus}
         }
       }
+    }
+
+    & .fi-label {
+      margin-bottom: ${theme.spacing.xs};
     }
 
     & .fi-textarea_textarea {

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -38,7 +38,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     & .fi-textarea_textarea-element-container {
-      margin-top: ${theme.spacing.insetL};
       &:focus-within {
         ${theme.focuses.highContrastFocus} /* For high contrast mode */
         position: relative;
@@ -50,6 +49,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     & .fi-label {
+      margin-bottom: ${theme.spacing.xs};
+    }
+
+    & .fi-hint-text {
       margin-bottom: ${theme.spacing.xs};
     }
 

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -272,10 +272,6 @@ exports[`snapshot default structure should match snapshot 1`] = `
   margin-top: 5px;
 }
 
-.c1.fi-textarea .fi-textarea_textarea-element-container {
-  margin-top: 10px;
-}
-
 .c1.fi-textarea .fi-textarea_textarea-element-container:focus-within {
   outline: 3px solid transparent;
   position: relative;
@@ -298,6 +294,10 @@ exports[`snapshot default structure should match snapshot 1`] = `
 }
 
 .c1.fi-textarea .fi-label {
+  margin-bottom: 10px;
+}
+
+.c1.fi-textarea .fi-hint-text {
   margin-bottom: 10px;
 }
 

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -246,7 +246,7 @@ exports[`snapshot default structure should match snapshot 1`] = `
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  margin-top: 4px;
+  margin-top: 5px;
 }
 
 .c1.fi-textarea .fi-textarea_character-counter.fi-textarea_character-counter--error {
@@ -295,6 +295,10 @@ exports[`snapshot default structure should match snapshot 1`] = `
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
+}
+
+.c1.fi-textarea .fi-label {
+  margin-bottom: 10px;
 }
 
 .c1.fi-textarea .fi-textarea_textarea {


### PR DESCRIPTION
## Description
There were a few issues with the spacings of TextInput and Textarea, which this PR fixes:
- TextInput had an implicit line-height set at the top level, which caused the component to take up unnecessary extra space
- There was a 1px difference between status text and character counter top margins
- Textarea label was lacking the correct bottom margin

## Motivation and Context
The line height issue was reported by a developer, and the other issues were noticed during the fixing and testing of that change.

## How Has This Been Tested?
Tested by running locally on styleguidist on chrome and inspecting the rendered styles and visual representations.

## Release notes
### TextInput
- **Breaking change:** Remove redundant root level font styles and set line-height to 0 on top level.
- **Breaking change:** Increase character counter top margin by 1px
### Textarea
- **Breaking change:** Set the correct bottom margin for the label
- **Breaking change:** Increase character counter top margin by 1px