### PR TITLE
[Feature] Add type exports

### DIFF
--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -50,7 +50,7 @@ export const textInputClassNames = {
   characterCounterError: `${baseClassName}_character-counter--error`,
 };
 
-type TextInputValue = string | number | undefined;
+export type TextInputValue = string | number | undefined;
 
 interface BaseTextInputProps
   extends StatusTextCommonProps,

--- a/src/core/Form/index.ts
+++ b/src/core/Form/index.ts
@@ -4,7 +4,11 @@ export {
   ToggleButton,
   ToggleButtonProps,
 } from './Toggle';
-export { TextInput, TextInputProps } from './TextInput/TextInput';
+export {
+  TextInput,
+  TextInputProps,
+  TextInputValue,
+} from './TextInput/TextInput';
 export { TimeInput, TimeInputProps } from './TimeInput/TimeInput';
 export { SearchInput, SearchInputProps } from './SearchInput/SearchInput';
 export { Checkbox, CheckboxProps } from './Checkbox/Checkbox';

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -18,3 +18,9 @@ export {
   SpacingProp,
   GradientProp,
 } from './SuomifiTheme/SuomifiTheme';
+export {
+  MarginProps,
+  PaddingProps,
+  SpacingProps,
+  SpacingWithoutInsetProp,
+} from './utils/spacing';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,7 @@ export {
   CheckboxGroupProps,
   TextInput,
   TextInputProps,
+  TextInputValue,
   TimeInput,
   TimeInputProps,
   ToggleInput,
@@ -163,6 +164,10 @@ export {
   ColorProp,
   TypographyProp,
   SpacingProp,
+  MarginProps,
+  PaddingProps,
+  SpacingProps,
+  SpacingWithoutInsetProp,
 } from './core/theme';
 export { getLogger, setLogger, Logger } from './utils/log/logger';
 export { autocompleteTimeString } from './utils/common';


### PR DESCRIPTION
## Description
This PR adds exports to some types requested by the developers, namely:
- `TextInputValue` from TextInput
- `PaddingProps`, `MarginProps`, `SpacingProps` and `SpacingWithoutInsetProp`

## Motivation and Context
These types were requested by developers.

## How Has This Been Tested?
Tested by using the library in a React + Vite project and using the types both correctly and incorrectly in a component.

## Release notes
### General
- Add exports for several types:
  - `TextInputValue` from TextInput
  - `PaddingProps`, `MarginProps`, `SpacingProps` and `SpacingWithoutInsetProp`
