### PR TITLE
[Bugfix] Disabled checkbox icon visibility

### DIFF
--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -194,7 +194,7 @@ class BaseCheckbox extends Component<CheckboxProps> {
           baseClassName,
           {
             [checkboxClassNames.error]: status === 'error' && !disabled,
-            [checkboxClassNames.checked]: checkedState && !disabled,
+            [checkboxClassNames.checked]: checkedState,
             [checkboxClassNames.large]: variant === 'large',
             [checkboxClassNames.disabled]: !!disabled,
           },
@@ -225,7 +225,7 @@ class BaseCheckbox extends Component<CheckboxProps> {
           {!!checkedState && (
             <IconCheck
               className={classnames(iconBaseClassName, {
-                [iconClassnames.checked]: checkedState && !disabled,
+                [iconClassnames.checked]: checkedState,
                 [iconClassnames.error]: status === 'error' && !disabled,
                 [iconClassnames.disabled]: !!disabled,
               })}

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -30,14 +30,7 @@ const checkboxClassNames = {
   error: `${baseClassName}--error`,
   checked: `${baseClassName}--checked`,
   large: `${baseClassName}--large`,
-};
-
-const iconBaseClassName = 'fi-checkbox_icon';
-
-const iconClassnames = {
-  disabled: `${iconBaseClassName}--disabled`,
-  checked: `${iconBaseClassName}--checked`,
-  error: `${iconBaseClassName}--error`,
+  icon: `${baseClassName}_icon`,
 };
 
 type CheckboxStatus = Exclude<InputStatus, 'success'>;
@@ -222,15 +215,7 @@ class BaseCheckbox extends Component<CheckboxProps> {
           {...passProps}
         />
         <HtmlLabel htmlFor={id} className={checkboxClassNames.label}>
-          {!!checkedState && (
-            <IconCheck
-              className={classnames(iconBaseClassName, {
-                [iconClassnames.checked]: checkedState,
-                [iconClassnames.error]: status === 'error' && !disabled,
-                [iconClassnames.disabled]: !!disabled,
-              })}
-            />
-          )}
+          {!!checkedState && <IconCheck className={checkboxClassNames.icon} />}
           {children}
         </HtmlLabel>
         <HintText id={hintTextId}>{hintText}</HintText>


### PR DESCRIPTION
## Description
This PR fixes an issue where the checkbox check mark color was not visible in disabled state.

## Motivation and Context
This is a bug that was reported by a developer.

## How Has This Been Tested?
Tested by running locally on styleguidist and checking the rendered styles as well as the visual result.

## Release notes
### Checkbox
- Fixed an issue where checkmark was not visible in disabled state
