### PR TITLE
[Bugfix] Empty StatusText icon render

### DIFF
--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -86,7 +86,7 @@ const StyledStatusText = styled(
         aria-atomic="true"
         style={{ ...marginStyle, ...passProps?.style }}
       >
-        {getIcon(status, theme)}
+        {!!children && getIcon(status, theme)}
         {children}
       </HtmlSpan>
     );


### PR DESCRIPTION
## Description
This PR sets the StatusText to only render the icon corresponding the status when the component has content. This is to avoid showing orphaned icons when the StatusText is present without content.

## Motivation and Context
This was a clear but that was noticed while making other changes.

## How Has This Been Tested?
Tested in styleguidist locally on Chrome

## Release notes
### StatusText
- Set icon to render only when component has children
