### PR TITLE
[Fix] Dropdown selected value when children change (case language change)

### DIFF
--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -213,11 +213,32 @@ class BaseDropdown<T extends string = string> extends Component<
     prevState: DropdownState<U>,
   ) {
     const { value } = nextProps;
-    if ('value' in nextProps && value !== prevState.selectedValue) {
+    if (
+      // Handle selected value parsing with controlled state and changed value
+      'value' in nextProps &&
+      value !== prevState.selectedValue
+    ) {
       return {
         selectedValue: value,
         selectedValueNode: BaseDropdown.getSelectedValueNode(
           value,
+          nextProps.children,
+        ),
+      };
+    }
+    // Case language change. Make sure selectedValueNode gets updated with new text from children
+    if (
+      prevState.selectedValue &&
+      nextProps.children &&
+      BaseDropdown.valueExistsInChildren(
+        prevState.selectedValue,
+        nextProps.children,
+      )
+    ) {
+      return {
+        selectedValue: prevState.selectedValue,
+        selectedValueNode: BaseDropdown.getSelectedValueNode(
+          prevState.selectedValue,
           nextProps.children,
         ),
       };
@@ -249,6 +270,22 @@ class BaseDropdown<T extends string = string> extends Component<
     } else {
       return children.props.children;
     }
+  }
+
+  static valueExistsInChildren<U extends string>(
+    value: string,
+    children:
+      | Array<
+          | ReactElement<DropdownItemProps<U>>
+          | Array<ReactElement<DropdownItemProps<U>>>
+        >
+      | ReactElement<DropdownItemProps<U>>,
+  ) {
+    if (Array.isArray(children)) {
+      const flatChildren = children.flat();
+      return flatChildren.some((child) => child.props.value === value);
+    }
+    return children.props.value === value;
   }
 
   componentDidMount(): void {


### PR DESCRIPTION
## Description

PR fixes an issue with `<Dropdown>` where its apparent selected value did not get updated when children change. 

Case: Switching application's language. The selected DropdownItem's `value` remains the same, but its displayed value changes. We need to handle this case and force the recalculation of `selectedValueNode` in the Dropdown's state. 

## How Has This Been Tested?

Styleguidist on Chrome

## Release notes

### Dropdown
- Fix an issue where visible selected value did not get updated when changing application language (DropdownItem visible text changes but value remains the same) 
