### PR TITLE
[Fix] Remove unwanted props from DOM + remove redundant never types from some conditional props

### DIFF
--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -39,7 +39,7 @@ export type ForcedAccessibleNameProps =
 
 export type LoadingProps =
   | {
-      loading?: false | never;
+      loading?: false;
       ariaLoadingText?: never;
     }
   | {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -198,7 +198,7 @@ interface InternalMultiSelectProps<T extends MultiSelectData> {
 
 type AllowItemAdditionProps =
   | {
-      allowItemAddition?: false | never;
+      allowItemAddition?: false;
       itemAdditionHelpText?: never;
       noItemsText: string;
     }

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -106,7 +106,7 @@ type AriaSelectedAmountProps =
 
 type LoadingProps =
   | {
-      loading?: false | never;
+      loading?: false;
       loadingText?: string;
     }
   | {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -132,7 +132,7 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
 
 type LoadingProps =
   | {
-      loading?: false | never;
+      loading?: false;
       loadingText?: string;
     }
   | {
@@ -146,7 +146,7 @@ type LoadingProps =
 
 type AllowItemAdditionProps =
   | {
-      allowItemAddition?: false | never;
+      allowItemAddition?: false;
       itemAdditionHelpText?: never;
       noItemsText: string;
     }

--- a/src/core/Tooltip/Tooltip.tsx
+++ b/src/core/Tooltip/Tooltip.tsx
@@ -154,6 +154,8 @@ class BaseTooltip extends Component<TooltipProps & { className?: string }> {
       forwardedRef,
       anchorElement,
       className,
+      onToggleButtonClick,
+      onCloseButtonClick,
       ...passProps
     } = this.props;
     const open = 'open' in this.props ? propsOpen : this.state.open;

--- a/src/core/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/core/VisuallyHidden/VisuallyHidden.tsx
@@ -12,9 +12,10 @@ export interface VisuallyHiddenProps extends HtmlSpanProps {
 
 const baseClassName = 'fi-visually-hidden';
 
-const StyledVisuallyHidden = styled((props: VisuallyHiddenProps) => (
-  <HtmlSpan {...props} />
-))`
+const StyledVisuallyHidden = styled((props: VisuallyHiddenProps) => {
+  const { forwardedRef, ...passProps } = props;
+  return <HtmlSpan forwardedRef={forwardedRef} {...passProps} />;
+})`
   position: absolute;
   clip: rect(0 0 0 0);
   height: 1px;


### PR DESCRIPTION
## Description

PR removes unwanted props from leaking to DOM in the `<Tooltip>` and `<VisuallyHidden>` components. 

Also remove redundant `never` typings from a few conditional prop types in `<Button>`, `<MultiSelect>` and `<SingleSelect>`

## Motivation and Context

These were reported as bugs by a user

## How Has This Been Tested?

Styleguidist + CRA project + Typescript tests in this repo

## Release notes

### Tooltip
- Prevent `onToggleButtonClick` and `onCloseButtonClick` props from leaking to DOM

### VisuallyHidden
- Fix `forwardedRef` behavior

### Button
- Remove redundant `never` typing from `LoadingProps`

### SingleSelect
- Remove redundant `never` typing from `LoadingProps`
- Remove redundant `never` typing from `AllowItemAdditionProps`

### MultiSelect
- Remove redundant `never` typing from `LoadingProps`
- Remove redundant `never` typing from `AllowItemAdditionProps`
