### PR TITLE
[Feature] datePickerProps

### DIFF
--- a/src/core/Form/DateInput/DateInput.test.tsx
+++ b/src/core/Form/DateInput/DateInput.test.tsx
@@ -258,521 +258,24 @@ describe('props', () => {
     });
   });
 
-  describe('maxDate', () => {
-    beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
-    });
-
-    afterAll(() => {
-      jest.useRealTimers();
-    });
-
-    it('has next date as table cell (instead of button)', () => {
-      const { getByRole, getByText } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          maxDate={new Date(2020, 0, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dateCell = getByText('16');
-      expect(dateCell.tagName).toBe('TD');
-    });
-
-    it('has next years removed from dropdown', () => {
-      const { baseElement, getByRole } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          maxDate={new Date(2020, 0, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dropdown = baseElement.querySelector(
-        '.fi-date-selectors_year-select',
-      );
-      const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
-      if (dropdownButton) {
-        fireEvent.click(dropdownButton);
-        const lis = dropdown?.querySelectorAll('li');
-        expect(lis?.length).toBe(11);
-        expect(lis?.[10]).toHaveTextContent('2020');
-      }
-    });
-
-    it('has next months removed from dropdown', () => {
-      const { baseElement, getByRole } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          maxDate={new Date(2020, 0, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dropdown = baseElement.querySelector(
-        '.fi-date-selectors_month-select',
-      );
-      const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
-      if (dropdownButton) {
-        fireEvent.click(dropdownButton);
-        const lis = dropdown?.querySelectorAll('li');
-        expect(lis?.[0]).toHaveTextContent('Tammikuu');
-        expect(lis?.length).toBe(1);
-      }
-    });
-
-    it('has next month button disabled', () => {
-      const { baseElement, getByRole } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          maxDate={new Date(2020, 0, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const button = baseElement.querySelectorAll(
-        '.fi-date-selectors_month-button',
-      )[1];
-      expect(button).toBeDisabled();
-    });
-  });
-
-  describe('minDate', () => {
-    beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
-    });
-
-    afterAll(() => {
-      jest.useRealTimers();
-    });
-
-    it('has previous date as table cell (instead of button)', () => {
-      const { getByRole, getByText } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          minDate={new Date(2020, 6, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dateCell = getByText('14');
-      expect(dateCell.tagName).toBe('TD');
-    });
-
-    it('has previous years removed from dropdown', () => {
-      const { baseElement, getByRole } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          minDate={new Date(2020, 6, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dropdown = baseElement.querySelector(
-        '.fi-date-selectors_year-select',
-      );
-      const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
-      if (dropdownButton) {
-        fireEvent.click(dropdownButton);
-        const lis = dropdown?.querySelectorAll('li');
-        expect(lis?.[0]).toHaveTextContent('2020');
-        expect(lis?.length).toBe(11);
-      }
-    });
-
-    it('has previous months removed from dropdown', () => {
-      const { baseElement, getByRole } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          minDate={new Date(2020, 6, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dropdown = baseElement.querySelector(
-        '.fi-date-selectors_month-select',
-      );
-      const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
-      if (dropdownButton) {
-        fireEvent.click(dropdownButton);
-        const lis = dropdown?.querySelectorAll('li');
-        expect(lis?.[0]).toHaveTextContent('Heinäkuu');
-        expect(lis?.length).toBe(6);
-      }
-    });
-
-    it('has previous month button disabled', () => {
-      const { baseElement, getByRole } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          minDate={new Date(2020, 6, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const button = baseElement.querySelectorAll(
-        '.fi-date-selectors_month-button',
-      )[0];
-      expect(button).toBeDisabled();
-    });
-  });
-
-  describe('initialDate', () => {
-    beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
-    });
-
-    afterAll(() => {
-      jest.useRealTimers();
-    });
-
-    it('has correct date', () => {
-      const { getByRole, getByText } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          initialDate={new Date(2015, 5, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dateButton = getByText('15').closest('button');
-      expect(dateButton).toHaveAttribute(
-        'aria-label',
-        '15 maanantai Kesäkuu 2015',
-      );
-    });
-
-    it('has focus', () => {
-      const { getByRole, getByText } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          initialDate={new Date(2015, 5, 15)}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dateButton = getByText('15').closest('button');
-      expect(dateButton).toHaveFocus();
-    });
-  });
-
-  describe('dateAdapter', () => {
-    const dateAdapter = {
-      format: (date: Date) =>
-        `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
-      parse: (value: string) => {
-        const values = value.split('-');
-        return new Date(
-          Number(values[0]),
-          Number(values[1]) - 1,
-          Number(values[2]),
-        );
-      },
-    };
-
-    beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
-    });
-
-    afterAll(() => {
-      jest.useRealTimers();
-    });
-
-    it('parses date from input field', () => {
-      const { baseElement, getByRole } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          dateAdapter={dateAdapter}
-        />,
-      );
-      fireEvent.change(getByRole('textbox'), {
-        target: { value: '2020-8-15' },
-      });
-      fireEvent.click(getByRole('button'));
-      const dateButton = baseElement.querySelector(
-        '.fi-month-day_button--selected',
-      );
-      expect(dateButton).toHaveAttribute(
-        'aria-label',
-        '15 lauantai Elokuu 2020',
-      );
-    });
-
-    it('formats selected date to input field', () => {
-      const { getByRole, getByText } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          dateAdapter={dateAdapter}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dateButton = getByText('16').closest('button') as HTMLButtonElement;
-      fireEvent.click(dateButton);
-      expect(getByRole('textbox')).toHaveValue('2020-1-16');
-    });
-  });
-
-  describe('datePickerEnabled', () => {
-    it('has no datePicker wrapper div when false', () => {
-      const { baseElement } = render(<DateInput labelText="Date" />);
-      const div = baseElement.querySelector(
-        '.fi-date-input_picker-element-container',
-      );
-      expect(div).toBeNull();
-    });
-
-    it('has datePicker wrapper div when true', () => {
+  describe('datePickerProps', () => {
+    it('has user given className', () => {
       const { baseElement } = render(
-        <DateInput labelText="Date" datePickerEnabled />,
-      );
-      const div = baseElement.querySelector(
-        '.fi-date-input_picker-element-container',
-      );
-      expect(div).not.toBeNull();
-    });
-  });
-
-  describe('language', () => {
-    it('has Finnish language option', () => {
-      const { getByRole } = render(
-        <DateInput labelText="Date" datePickerEnabled language="fi" />,
-      );
-      expect(getByRole('button')).toHaveTextContent('Valitse päivämäärä');
-    });
-
-    it('has English language option', () => {
-      const { getByRole } = render(
-        <DateInput labelText="Date" datePickerEnabled language="en" />,
-      );
-      expect(getByRole('button')).toHaveTextContent('Choose date');
-    });
-
-    it('has Swedish language option', () => {
-      const { getByRole } = render(
-        <DateInput labelText="Date" datePickerEnabled language="sv" />,
-      );
-      expect(getByRole('button')).toHaveTextContent('Välj datum');
-    });
-  });
-
-  describe('datePickerTexts', () => {
-    beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
-    });
-
-    afterAll(() => {
-      jest.useRealTimers();
-    });
-
-    it('overwrites text in open button', () => {
-      const { getByRole } = render(
         <DateInput
           labelText="Date"
           datePickerEnabled
-          datePickerTexts={{ openButtonLabel: 'Avaa kalenteri ' }}
+          datePickerProps={{
+            className: 'custom-datePicker-class',
+            'aria-disabled': true,
+          }}
         />,
       );
-      expect(getByRole('button')).toHaveTextContent('Avaa kalenteri');
+      const datePicker = baseElement.querySelector('.fi-date-picker');
+      expect(datePicker).toHaveClass('custom-datePicker-class');
+      expect(datePicker).toHaveAttribute('aria-disabled');
     });
 
-    it('overwrites texts in previous month button', () => {
-      const { baseElement, getByRole } = render(
-        <DateInput
-          labelText="Date"
-          datePickerEnabled
-          datePickerTexts={{ prevMonthButtonLabel: 'vorheriger Monat' }}
-        />,
-      );
-      fireEvent.click(getByRole('button'));
-      const button = baseElement.querySelectorAll(
-        '.fi-date-selectors_month-button',
-      )[0];
-      expect(button).toHaveAttribute('aria-label', 'vorheriger Monat Joulukuu');
-    });
-  });
-
-  describe('debounce', () => {
-    it('delays the running of onChange by the given time', () => {
-      jest.useFakeTimers();
-      const mockOnChange = jest.fn();
-      const { getByRole } = render(
-        <DateInput labelText="Date" debounce={1000} onChange={mockOnChange} />,
-      );
-      fireEvent.change(getByRole('textbox'), { target: { value: '1.1.' } });
-      fireEvent.change(getByRole('textbox'), { target: { value: '1.1.2022' } });
-      expect(getByRole('textbox')).toHaveValue('1.1.2022');
-      expect(mockOnChange).not.toBeCalled();
-      jest.advanceTimersByTime(1000);
-      expect(mockOnChange).toBeCalledTimes(1);
-    });
-    it('resolves right away when no debounce is given', () => {
-      const mockOnChange = jest.fn();
-      const { getByRole } = render(
-        <DateInput labelText="Date" onChange={mockOnChange} />,
-      );
-      fireEvent.change(getByRole('textbox'), { target: { value: '1.1.' } });
-      fireEvent.change(getByRole('textbox'), { target: { value: '1.1.2022' } });
-      expect(mockOnChange).toBeCalledTimes(2);
-    });
-  });
-
-  describe('disabled', () => {
-    it('has input field disabled', () => {
-      const { getByRole } = render(<DateInput labelText="Date" disabled />);
-      expect(getByRole('textbox')).toHaveAttribute('disabled');
-    });
-
-    it('has date picker button disabled', () => {
-      const { getByRole } = render(
-        <DateInput labelText="Date" datePickerEnabled disabled />,
-      );
-      expect(getByRole('button')).toHaveAttribute('disabled');
-    });
-  });
-
-  describe('statusText', () => {
-    it('has status text defined by prop', () => {
-      const { getByText } = render(
-        <DateInput labelText="Date" statusText="Test status" />,
-      );
-      expect(getByText('Test status')).toBeDefined();
-    });
-  });
-
-  describe('statusTextAriaLiveMode', () => {
-    it('has assertive aria-live by default', () => {
-      const { getByText } = render(
-        <DateInput labelText="Date" statusText="Test status" />,
-      );
-      expect(getByText('Test status')).toHaveAttribute(
-        'aria-live',
-        'assertive',
-      );
-    });
-    it('has aria-live defined by prop', () => {
-      const { getByText } = render(
-        <DateInput
-          labelText="Date"
-          statusText="Test status"
-          statusTextAriaLiveMode="off"
-        />,
-      );
-      expect(getByText('Test status')).toHaveAttribute('aria-live', 'off');
-    });
-  });
-
-  describe('smallScreen', () => {
-    beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(new Date('2020-01-15'));
-    });
-
-    afterAll(() => {
-      jest.useRealTimers();
-    });
-
-    describe('not enabled', () => {
-      it('has position fixed', () => {
-        const { baseElement } = render(
-          <DateInput labelText="Date" datePickerEnabled />,
-        );
-        const dialog = baseElement.querySelector('[role="dialog"]');
-        expect(dialog).toHaveClass('fi-date-picker');
-        expect(dialog).toHaveStyle('position: fixed');
-      });
-    });
-
-    describe('enabled', () => {
-      it('does not have position fixed', () => {
-        const { baseElement } = render(
-          <DateInput labelText="Date" smallScreen datePickerEnabled />,
-        );
-        const dialog = baseElement.querySelector('.fi-date-picker');
-        expect(dialog).toHaveClass('fi-date-picker--small-screen');
-        expect(dialog).not.toHaveAttribute('style');
-      });
-
-      it('has current date focused in smallScreen variant', () => {
-        const { getByRole, getByText } = render(
-          <DateInput labelText="Date" smallScreen datePickerEnabled />,
-        );
-        fireEvent.click(getByRole('button'));
-        const dateButton = getByText('15').closest(
-          'button',
-        ) as HTMLButtonElement;
-        expect(dateButton).toHaveAttribute(
-          'aria-label',
-          '15 keskiviikko Tammikuu 2020',
-        );
-        expect(dateButton).toHaveFocus();
-      });
-    });
-  });
-
-  describe('value', () => {
-    beforeAll(() => {
-      jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
-    });
-
-    afterAll(() => {
-      jest.useRealTimers();
-    });
-
-    it('has user given value in input', () => {
-      const { getByRole } = render(
-        <DateInput labelText="Date" value="1.5.2020" />,
-      );
-      expect(getByRole('textbox')).toHaveValue('1.5.2020');
-    });
-
-    it('has user given value selected in calendar', () => {
-      const { getByRole, baseElement } = render(
-        <DateInput labelText="Date" datePickerEnabled value="1.5.2020" />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dateButton = baseElement.querySelector(
-        '.fi-month-day_button--selected',
-      );
-      expect(dateButton).toHaveAttribute(
-        'aria-label',
-        '1 perjantai Toukokuu 2020',
-      );
-    });
-
-    it('has user given value focused in calendar', () => {
-      const { getByRole, baseElement } = render(
-        <DateInput labelText="Date" datePickerEnabled value="1.5.2020" />,
-      );
-      fireEvent.click(getByRole('button'));
-      const dateButton = baseElement.querySelector(
-        '.fi-month-day_button--selected',
-      );
-      expect(dateButton).toHaveAttribute(
-        'aria-label',
-        '1 perjantai Toukokuu 2020',
-      );
-      expect(dateButton).toHaveFocus();
-    });
-  });
-
-  describe('visualPlaceholder', () => {
-    it('does not have placeholder by default', () => {
-      const { getByRole } = render(<DateInput labelText="Date" />);
-      expect(getByRole('textbox')).not.toHaveAttribute('placeholder');
-    });
-
-    it('has given text', () => {
-      const { getByRole } = render(
-        <DateInput labelText="Date" visualPlaceholder="1.1.2022" />,
-      );
-      expect(getByRole('textbox')).toHaveAttribute('placeholder', '1.1.2022');
-    });
-  });
-
-  describe('passProps', () => {
-    describe('defaultValue', () => {
+    describe('maxDate', () => {
       beforeAll(() => {
         jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
       });
@@ -781,20 +284,482 @@ describe('props', () => {
         jest.useRealTimers();
       });
 
-      it('has user given defaultValue in input', () => {
+      it('has next date as table cell (instead of button)', () => {
+        const { getByRole, getByText } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            maxDate={new Date(2020, 0, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const dateCell = getByText('16');
+        expect(dateCell.tagName).toBe('TD');
+      });
+
+      it('has next years removed from dropdown', () => {
+        const { baseElement, getByRole } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            maxDate={new Date(2020, 0, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const dropdown = baseElement.querySelector(
+          '.fi-date-selectors_year-select',
+        );
+        const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
+        if (dropdownButton) {
+          fireEvent.click(dropdownButton);
+          const lis = dropdown?.querySelectorAll('li');
+          expect(lis?.length).toBe(11);
+          expect(lis?.[10]).toHaveTextContent('2020');
+        }
+      });
+
+      it('has next months removed from dropdown', () => {
+        const { baseElement, getByRole } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            maxDate={new Date(2020, 0, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const dropdown = baseElement.querySelector(
+          '.fi-date-selectors_month-select',
+        );
+        const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
+        if (dropdownButton) {
+          fireEvent.click(dropdownButton);
+          const lis = dropdown?.querySelectorAll('li');
+          expect(lis?.[0]).toHaveTextContent('Tammikuu');
+          expect(lis?.length).toBe(1);
+        }
+      });
+
+      it('has next month button disabled', () => {
+        const { baseElement, getByRole } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            maxDate={new Date(2020, 0, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const button = baseElement.querySelectorAll(
+          '.fi-date-selectors_month-button',
+        )[1];
+        expect(button).toBeDisabled();
+      });
+    });
+
+    describe('minDate', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+      });
+
+      afterAll(() => {
+        jest.useRealTimers();
+      });
+
+      it('has previous date as table cell (instead of button)', () => {
+        const { getByRole, getByText } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            minDate={new Date(2020, 6, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const dateCell = getByText('14');
+        expect(dateCell.tagName).toBe('TD');
+      });
+
+      it('has previous years removed from dropdown', () => {
+        const { baseElement, getByRole } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            minDate={new Date(2020, 6, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const dropdown = baseElement.querySelector(
+          '.fi-date-selectors_year-select',
+        );
+        const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
+        if (dropdownButton) {
+          fireEvent.click(dropdownButton);
+          const lis = dropdown?.querySelectorAll('li');
+          expect(lis?.[0]).toHaveTextContent('2020');
+          expect(lis?.length).toBe(11);
+        }
+      });
+
+      it('has previous months removed from dropdown', () => {
+        const { baseElement, getByRole } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            minDate={new Date(2020, 6, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const dropdown = baseElement.querySelector(
+          '.fi-date-selectors_month-select',
+        );
+        const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
+        if (dropdownButton) {
+          fireEvent.click(dropdownButton);
+          const lis = dropdown?.querySelectorAll('li');
+          expect(lis?.[0]).toHaveTextContent('Heinäkuu');
+          expect(lis?.length).toBe(6);
+        }
+      });
+
+      it('has previous month button disabled', () => {
+        const { baseElement, getByRole } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            minDate={new Date(2020, 6, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const button = baseElement.querySelectorAll(
+          '.fi-date-selectors_month-button',
+        )[0];
+        expect(button).toBeDisabled();
+      });
+    });
+
+    describe('initialDate', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+      });
+
+      afterAll(() => {
+        jest.useRealTimers();
+      });
+
+      it('has correct date', () => {
+        const { getByRole, getByText } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            initialDate={new Date(2015, 5, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const dateButton = getByText('15').closest('button');
+        expect(dateButton).toHaveAttribute(
+          'aria-label',
+          '15 maanantai Kesäkuu 2015',
+        );
+      });
+
+      it('has focus', () => {
+        const { getByRole, getByText } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            initialDate={new Date(2015, 5, 15)}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const dateButton = getByText('15').closest('button');
+        expect(dateButton).toHaveFocus();
+      });
+    });
+
+    describe('dateAdapter', () => {
+      const dateAdapter = {
+        format: (date: Date) =>
+          `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
+        parse: (value: string) => {
+          const values = value.split('-');
+          return new Date(
+            Number(values[0]),
+            Number(values[1]) - 1,
+            Number(values[2]),
+          );
+        },
+      };
+
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+      });
+
+      afterAll(() => {
+        jest.useRealTimers();
+      });
+
+      it('parses date from input field', () => {
+        const { baseElement, getByRole } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            dateAdapter={dateAdapter}
+          />,
+        );
+        fireEvent.change(getByRole('textbox'), {
+          target: { value: '2020-8-15' },
+        });
+        fireEvent.click(getByRole('button'));
+        const dateButton = baseElement.querySelector(
+          '.fi-month-day_button--selected',
+        );
+        expect(dateButton).toHaveAttribute(
+          'aria-label',
+          '15 lauantai Elokuu 2020',
+        );
+      });
+
+      it('formats selected date to input field', () => {
+        const { getByRole, getByText } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            dateAdapter={dateAdapter}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const dateButton = getByText('16').closest(
+          'button',
+        ) as HTMLButtonElement;
+        fireEvent.click(dateButton);
+        expect(getByRole('textbox')).toHaveValue('2020-1-16');
+      });
+    });
+
+    describe('datePickerEnabled', () => {
+      it('has no datePicker wrapper div when false', () => {
+        const { baseElement } = render(<DateInput labelText="Date" />);
+        const div = baseElement.querySelector(
+          '.fi-date-input_picker-element-container',
+        );
+        expect(div).toBeNull();
+      });
+
+      it('has datePicker wrapper div when true', () => {
+        const { baseElement } = render(
+          <DateInput labelText="Date" datePickerEnabled />,
+        );
+        const div = baseElement.querySelector(
+          '.fi-date-input_picker-element-container',
+        );
+        expect(div).not.toBeNull();
+      });
+    });
+
+    describe('language', () => {
+      it('has Finnish language option', () => {
         const { getByRole } = render(
-          <DateInput labelText="Date" defaultValue="31.1.2020" />,
+          <DateInput labelText="Date" datePickerEnabled language="fi" />,
         );
-        expect(getByRole('textbox')).toHaveValue('31.1.2020');
+        expect(getByRole('button')).toHaveTextContent('Valitse päivämäärä');
       });
 
-      it('has user given defaultValue selected in calendar', () => {
-        const { getByRole, baseElement } = render(
+      it('has English language option', () => {
+        const { getByRole } = render(
+          <DateInput labelText="Date" datePickerEnabled language="en" />,
+        );
+        expect(getByRole('button')).toHaveTextContent('Choose date');
+      });
+
+      it('has Swedish language option', () => {
+        const { getByRole } = render(
+          <DateInput labelText="Date" datePickerEnabled language="sv" />,
+        );
+        expect(getByRole('button')).toHaveTextContent('Välj datum');
+      });
+    });
+
+    describe('datePickerTexts', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+      });
+
+      afterAll(() => {
+        jest.useRealTimers();
+      });
+
+      it('overwrites text in open button', () => {
+        const { getByRole } = render(
           <DateInput
             labelText="Date"
             datePickerEnabled
-            defaultValue="31.1.2020"
+            datePickerTexts={{ openButtonLabel: 'Avaa kalenteri ' }}
           />,
+        );
+        expect(getByRole('button')).toHaveTextContent('Avaa kalenteri');
+      });
+
+      it('overwrites texts in previous month button', () => {
+        const { baseElement, getByRole } = render(
+          <DateInput
+            labelText="Date"
+            datePickerEnabled
+            datePickerTexts={{ prevMonthButtonLabel: 'vorheriger Monat' }}
+          />,
+        );
+        fireEvent.click(getByRole('button'));
+        const button = baseElement.querySelectorAll(
+          '.fi-date-selectors_month-button',
+        )[0];
+        expect(button).toHaveAttribute(
+          'aria-label',
+          'vorheriger Monat Joulukuu',
+        );
+      });
+    });
+
+    describe('debounce', () => {
+      it('delays the running of onChange by the given time', () => {
+        jest.useFakeTimers();
+        const mockOnChange = jest.fn();
+        const { getByRole } = render(
+          <DateInput
+            labelText="Date"
+            debounce={1000}
+            onChange={mockOnChange}
+          />,
+        );
+        fireEvent.change(getByRole('textbox'), { target: { value: '1.1.' } });
+        fireEvent.change(getByRole('textbox'), {
+          target: { value: '1.1.2022' },
+        });
+        expect(getByRole('textbox')).toHaveValue('1.1.2022');
+        expect(mockOnChange).not.toBeCalled();
+        jest.advanceTimersByTime(1000);
+        expect(mockOnChange).toBeCalledTimes(1);
+      });
+      it('resolves right away when no debounce is given', () => {
+        const mockOnChange = jest.fn();
+        const { getByRole } = render(
+          <DateInput labelText="Date" onChange={mockOnChange} />,
+        );
+        fireEvent.change(getByRole('textbox'), { target: { value: '1.1.' } });
+        fireEvent.change(getByRole('textbox'), {
+          target: { value: '1.1.2022' },
+        });
+        expect(mockOnChange).toBeCalledTimes(2);
+      });
+    });
+
+    describe('disabled', () => {
+      it('has input field disabled', () => {
+        const { getByRole } = render(<DateInput labelText="Date" disabled />);
+        expect(getByRole('textbox')).toHaveAttribute('disabled');
+      });
+
+      it('has date picker button disabled', () => {
+        const { getByRole } = render(
+          <DateInput labelText="Date" datePickerEnabled disabled />,
+        );
+        expect(getByRole('button')).toHaveAttribute('disabled');
+      });
+    });
+
+    describe('statusText', () => {
+      it('has status text defined by prop', () => {
+        const { getByText } = render(
+          <DateInput labelText="Date" statusText="Test status" />,
+        );
+        expect(getByText('Test status')).toBeDefined();
+      });
+    });
+
+    describe('statusTextAriaLiveMode', () => {
+      it('has assertive aria-live by default', () => {
+        const { getByText } = render(
+          <DateInput labelText="Date" statusText="Test status" />,
+        );
+        expect(getByText('Test status')).toHaveAttribute(
+          'aria-live',
+          'assertive',
+        );
+      });
+      it('has aria-live defined by prop', () => {
+        const { getByText } = render(
+          <DateInput
+            labelText="Date"
+            statusText="Test status"
+            statusTextAriaLiveMode="off"
+          />,
+        );
+        expect(getByText('Test status')).toHaveAttribute('aria-live', 'off');
+      });
+    });
+
+    describe('smallScreen', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2020-01-15'));
+      });
+
+      afterAll(() => {
+        jest.useRealTimers();
+      });
+
+      describe('not enabled', () => {
+        it('has position fixed', () => {
+          const { baseElement } = render(
+            <DateInput labelText="Date" datePickerEnabled />,
+          );
+          const dialog = baseElement.querySelector('[role="dialog"]');
+          expect(dialog).toHaveClass('fi-date-picker');
+          expect(dialog).toHaveStyle('position: fixed');
+        });
+      });
+
+      describe('enabled', () => {
+        it('does not have position fixed', () => {
+          const { baseElement } = render(
+            <DateInput labelText="Date" smallScreen datePickerEnabled />,
+          );
+          const dialog = baseElement.querySelector('.fi-date-picker');
+          expect(dialog).toHaveClass('fi-date-picker--small-screen');
+          expect(dialog).not.toHaveAttribute('style');
+        });
+
+        it('has current date focused in smallScreen variant', () => {
+          const { getByRole, getByText } = render(
+            <DateInput labelText="Date" smallScreen datePickerEnabled />,
+          );
+          fireEvent.click(getByRole('button'));
+          const dateButton = getByText('15').closest(
+            'button',
+          ) as HTMLButtonElement;
+          expect(dateButton).toHaveAttribute(
+            'aria-label',
+            '15 keskiviikko Tammikuu 2020',
+          );
+          expect(dateButton).toHaveFocus();
+        });
+      });
+    });
+
+    describe('value', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+      });
+
+      afterAll(() => {
+        jest.useRealTimers();
+      });
+
+      it('has user given value in input', () => {
+        const { getByRole } = render(
+          <DateInput labelText="Date" value="1.5.2020" />,
+        );
+        expect(getByRole('textbox')).toHaveValue('1.5.2020');
+      });
+
+      it('has user given value selected in calendar', () => {
+        const { getByRole, baseElement } = render(
+          <DateInput labelText="Date" datePickerEnabled value="1.5.2020" />,
         );
         fireEvent.click(getByRole('button'));
         const dateButton = baseElement.querySelector(
@@ -802,17 +767,13 @@ describe('props', () => {
         );
         expect(dateButton).toHaveAttribute(
           'aria-label',
-          '31 perjantai Tammikuu 2020',
+          '1 perjantai Toukokuu 2020',
         );
       });
 
-      it('has user given defaultValue focused in calendar', () => {
+      it('has user given value focused in calendar', () => {
         const { getByRole, baseElement } = render(
-          <DateInput
-            labelText="Date"
-            datePickerEnabled
-            defaultValue="31.1.2020"
-          />,
+          <DateInput labelText="Date" datePickerEnabled value="1.5.2020" />,
         );
         fireEvent.click(getByRole('button'));
         const dateButton = baseElement.querySelector(
@@ -820,40 +781,110 @@ describe('props', () => {
         );
         expect(dateButton).toHaveAttribute(
           'aria-label',
-          '31 perjantai Tammikuu 2020',
+          '1 perjantai Toukokuu 2020',
         );
         expect(dateButton).toHaveFocus();
       });
     });
 
-    describe('aria-describedby', () => {
-      it('has user given aria-describedby on input', () => {
+    describe('visualPlaceholder', () => {
+      it('does not have placeholder by default', () => {
+        const { getByRole } = render(<DateInput labelText="Date" />);
+        expect(getByRole('textbox')).not.toHaveAttribute('placeholder');
+      });
+
+      it('has given text', () => {
         const { getByRole } = render(
-          <DateInput labelText="Date" aria-describedby="something" />,
+          <DateInput labelText="Date" visualPlaceholder="1.1.2022" />,
         );
-        expect(getByRole('textbox')).toHaveAttribute(
-          'aria-describedby',
-          'something',
-        );
+        expect(getByRole('textbox')).toHaveAttribute('placeholder', '1.1.2022');
       });
     });
-  });
 
-  describe('margin', () => {
-    it('has margin style from margin prop', () => {
-      const { baseElement } = render(
-        <DateInput labelText="Date" margin="xs" />,
-      );
-      const div = baseElement.querySelector('.fi-date-input');
-      expect(div).toHaveAttribute('style', 'margin: 10px;');
+    describe('passProps', () => {
+      describe('defaultValue', () => {
+        beforeAll(() => {
+          jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
+        });
+
+        afterAll(() => {
+          jest.useRealTimers();
+        });
+
+        it('has user given defaultValue in input', () => {
+          const { getByRole } = render(
+            <DateInput labelText="Date" defaultValue="31.1.2020" />,
+          );
+          expect(getByRole('textbox')).toHaveValue('31.1.2020');
+        });
+
+        it('has user given defaultValue selected in calendar', () => {
+          const { getByRole, baseElement } = render(
+            <DateInput
+              labelText="Date"
+              datePickerEnabled
+              defaultValue="31.1.2020"
+            />,
+          );
+          fireEvent.click(getByRole('button'));
+          const dateButton = baseElement.querySelector(
+            '.fi-month-day_button--selected',
+          );
+          expect(dateButton).toHaveAttribute(
+            'aria-label',
+            '31 perjantai Tammikuu 2020',
+          );
+        });
+
+        it('has user given defaultValue focused in calendar', () => {
+          const { getByRole, baseElement } = render(
+            <DateInput
+              labelText="Date"
+              datePickerEnabled
+              defaultValue="31.1.2020"
+            />,
+          );
+          fireEvent.click(getByRole('button'));
+          const dateButton = baseElement.querySelector(
+            '.fi-month-day_button--selected',
+          );
+          expect(dateButton).toHaveAttribute(
+            'aria-label',
+            '31 perjantai Tammikuu 2020',
+          );
+          expect(dateButton).toHaveFocus();
+        });
+      });
+
+      describe('aria-describedby', () => {
+        it('has user given aria-describedby on input', () => {
+          const { getByRole } = render(
+            <DateInput labelText="Date" aria-describedby="something" />,
+          );
+          expect(getByRole('textbox')).toHaveAttribute(
+            'aria-describedby',
+            'something',
+          );
+        });
+      });
     });
 
-    it('has margin style overwritten by style prop', () => {
-      const { baseElement } = render(
-        <DateInput style={{ margin: 2 }} labelText="Date" margin="xs" />,
-      );
-      const div = baseElement.querySelector('.fi-date-input');
-      expect(div).toHaveAttribute('style', 'margin: 2px;');
+    describe('margin', () => {
+      it('has margin style from margin prop', () => {
+        const { baseElement } = render(
+          <DateInput labelText="Date" margin="xs" />,
+        );
+        const div = baseElement.querySelector('.fi-date-input');
+        expect(div).toHaveAttribute('style', 'margin: 10px;');
+      });
+
+      it('has margin style overwritten by style prop', () => {
+        const { baseElement } = render(
+          <DateInput style={{ margin: 2 }} labelText="Date" margin="xs" />,
+        );
+        const div = baseElement.querySelector('.fi-date-input');
+        expect(div).toHaveAttribute('style', 'margin: 2px;');
+      });
     });
   });
 });

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -74,6 +74,10 @@ export interface DatePickerProps {
    */
   datePickerEnabled?: boolean;
   /**
+   * A custom class for styling the date picker
+   */
+  datePickerClassName?: string;
+  /**
    * Enables small screen version of calendar
    * @default false
    */
@@ -223,6 +227,7 @@ const BaseDateInput = (props: DateInputProps) => {
     defaultValue,
     value,
     datePickerEnabled = false,
+    datePickerClassName,
     smallScreen = false,
     datePickerTexts = undefined,
     language = defaultLanguage,
@@ -435,6 +440,7 @@ const BaseDateInput = (props: DateInputProps) => {
                 minDate={minDate}
                 maxDate={maxDate}
                 smallScreen={smallScreen}
+                datePickerClassName={datePickerClassName}
               />
             </HtmlDiv>
           )}

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -16,14 +16,11 @@ import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
-import { forkRefs } from '../../../utils/common/common';
 import {
-  HtmlInputProps,
-  HtmlDiv,
-  HtmlInput,
-  HtmlButton,
-  HtmlDivProps,
-} from '../../../reset';
+  HTMLAttributesIncludingDataAttributes,
+  forkRefs,
+} from '../../../utils/common/common';
+import { HtmlInputProps, HtmlDiv, HtmlInput, HtmlButton } from '../../../reset';
 import { DatePicker } from './DatePicker/DatePicker';
 import { Label, LabelMode } from '../Label/Label';
 import { StatusText } from '../StatusText/StatusText';
@@ -83,7 +80,7 @@ export interface DatePickerProps {
    * A custom class for styling the date picker
    */
   datePickerProps?: Omit<
-    HtmlDivProps,
+    HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
     'onChange' | 'style' | 'aria-hidden' | 'ref'
   >;
   /**

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -17,7 +17,13 @@ import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
 import { forkRefs } from '../../../utils/common/common';
-import { HtmlInputProps, HtmlDiv, HtmlInput, HtmlButton } from '../../../reset';
+import {
+  HtmlInputProps,
+  HtmlDiv,
+  HtmlInput,
+  HtmlButton,
+  HtmlDivProps,
+} from '../../../reset';
 import { DatePicker } from './DatePicker/DatePicker';
 import { Label, LabelMode } from '../Label/Label';
 import { StatusText } from '../StatusText/StatusText';
@@ -76,7 +82,10 @@ export interface DatePickerProps {
   /**
    * A custom class for styling the date picker
    */
-  datePickerClassName?: string;
+  datePickerProps?: Omit<
+    HtmlDivProps,
+    'onChange' | 'style' | 'aria-hidden' | 'ref'
+  >;
   /**
    * Enables small screen version of calendar
    * @default false
@@ -227,7 +236,7 @@ const BaseDateInput = (props: DateInputProps) => {
     defaultValue,
     value,
     datePickerEnabled = false,
-    datePickerClassName,
+    datePickerProps: customDatePickerProps,
     smallScreen = false,
     datePickerTexts = undefined,
     language = defaultLanguage,
@@ -440,7 +449,7 @@ const BaseDateInput = (props: DateInputProps) => {
                 minDate={minDate}
                 maxDate={maxDate}
                 smallScreen={smallScreen}
-                datePickerClassName={datePickerClassName}
+                userProps={customDatePickerProps}
               />
             </HtmlDiv>
           )}

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -5,7 +5,7 @@ import { usePopper } from 'react-popper';
 import classnames from 'classnames';
 import { useEnhancedEffect } from '../../../../utils/common';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../theme';
-import { HtmlDiv, HtmlDivWithRef } from '../../../../reset';
+import { HtmlDiv, HtmlDivProps, HtmlDivWithRef } from '../../../../reset';
 import { DatePickerProps } from '../DateInput';
 import { InternalDatePickerTextProps } from '../datePickerTexts';
 import { baseStyles } from './DatePicker.baseStyles';
@@ -60,6 +60,8 @@ export interface InternalDatePickerProps
   minDate: Date;
   /** Maximum date user can select from date picker. */
   maxDate: Date;
+  /** Custom props given to the datepicker component */
+  userProps?: Omit<HtmlDivProps, 'onChange' | 'style' | 'aria-hidden' | 'ref'>;
 }
 
 export const BaseDatePicker = (props: InternalDatePickerProps) => {
@@ -76,7 +78,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
     minDate,
     maxDate,
     smallScreen,
-    datePickerClassName: customClassName,
+    userProps = {},
   } = props;
 
   const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
@@ -464,6 +466,8 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
     </HtmlDiv>
   );
 
+  const { className: customClassName, ...passProps } = userProps;
+
   const dialogClasses = [
     className,
     baseClassName,
@@ -480,6 +484,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
       className={classnames(...dialogClasses)}
       style={styles.popper}
       forwardedRef={setDialogElement}
+      {...passProps}
     >
       {application}
       <div
@@ -512,6 +517,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
         onPointerLeave={handlePointerUp}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
+        {...passProps}
       >
         <HtmlDivWithRef
           className={datePickerClassNames.slideIndicatorWrapper}

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -5,7 +5,7 @@ import { usePopper } from 'react-popper';
 import classnames from 'classnames';
 import { useEnhancedEffect } from '../../../../utils/common';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../theme';
-import { HtmlDiv, HtmlDivProps, HtmlDivWithRef } from '../../../../reset';
+import { HtmlDiv, HtmlDivWithRef } from '../../../../reset';
 import { DatePickerProps } from '../DateInput';
 import { InternalDatePickerTextProps } from '../datePickerTexts';
 import { baseStyles } from './DatePicker.baseStyles';
@@ -23,6 +23,7 @@ import {
   moveMonths,
 } from '../dateUtils';
 import { getLogger } from '../../../../utils/log';
+import { HTMLAttributesIncludingDataAttributes } from 'utils/common/common';
 
 const baseClassName = 'fi-date-picker';
 
@@ -61,7 +62,10 @@ export interface InternalDatePickerProps
   /** Maximum date user can select from date picker. */
   maxDate: Date;
   /** Custom props given to the datepicker component */
-  userProps?: Omit<HtmlDivProps, 'onChange' | 'style' | 'aria-hidden' | 'ref'>;
+  userProps?: Omit<
+    HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
+    'onChange' | 'style' | 'aria-hidden' | 'ref'
+  >;
 }
 
 export const BaseDatePicker = (props: InternalDatePickerProps) => {

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -76,6 +76,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
     minDate,
     maxDate,
     smallScreen,
+    datePickerClassName: customClassName,
   } = props;
 
   const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
@@ -466,6 +467,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   const dialogClasses = [
     className,
     baseClassName,
+    customClassName,
     {
       [datePickerClassNames.hidden]: !isOpen,
     },


### PR DESCRIPTION
## Description
This PR adds the possibility to add a collection of props in DateInput props that get passed to the datepicker element. This allows, for exampke, giving the picker a custom className and targeting the picker in certain situation where it wouldn't otherwise be possible due to the use of portal in the implementation.

## Motivation and Context
This was reported by a developer and the solution should make it easier for them to use the component in certain situations, like inside modals.

## How Has This Been Tested?
Tested in a Vite + React project with Suomi.fi modal and some modified styles. Also tested in a CRA project

## Release notes
### DateInput
- Add `datePickerProps` prop
