### PR TITLE
[Fix] Disabled checkbox hint text color

### DIFF
--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -54,6 +54,9 @@ const disabledStyles = (theme: SuomifiTheme) => css`
         fill: ${theme.colors.depthLight3};
       }
     }
+    & .fi-hint-text {
+      color: ${theme.colors.depthBase};
+    }
     &.fi-checkbox--large {
       & .fi-checkbox_label::before {
         border-width: 2px;

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -321,6 +321,10 @@ exports[`props children has matching snapshot 1`] = `
   fill: hsl(202,7%,97%);
 }
 
+.c1.fi-checkbox--disabled .fi-hint-text {
+  color: hsl(202,7%,67%);
+}
+
 .c1.fi-checkbox--disabled.fi-checkbox--large .fi-checkbox_label::before {
   border-width: 2px;
 }

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -459,6 +459,10 @@ exports[`default, with only required props should match snapshot 1`] = `
   fill: hsl(202,7%,97%);
 }
 
+.c7.fi-checkbox--disabled .fi-hint-text {
+  color: hsl(202,7%,67%);
+}
+
 .c7.fi-checkbox--disabled.fi-checkbox--large .fi-checkbox_label::before {
   border-width: 2px;
 }


### PR DESCRIPTION
## Description
This PR changes the Checkbox hint text color to match the designs.

## Motivation and Context
This was a minor visual bug and needed to be fixed.

## How Has This Been Tested?
Tested by checking the corrected visual outcome in styleguidist.

## Release notes
### Checkbox
- **Breaking change:** change disabled variant hint text color to match the label color 
