### PR TITLE
[Feature] Margin provider and CSS-based margin props

### DIFF
--- a/.styleguidist/spacingprops.md
+++ b/.styleguidist/spacingprops.md
@@ -12,9 +12,9 @@ import { Button } from 'suomifi-ui-components';
 </div>;
 ```
 
-### Overriding with style attribute
+### Margin props and style attributes
 
-Margin properties add inline styling to the rendered HTML. If the component interface also accepts a style attribute, it takes precedence over margin property.
+Margin properties add CSS styling marked `!important` so it acts as an override all other styles, including HTML style attributes.
 
 ```jsx
 import { Button } from 'suomifi-ui-components';

--- a/.styleguidist/spacingprovider.md
+++ b/.styleguidist/spacingprovider.md
@@ -63,7 +63,7 @@ const StyledButton = styled(Button)`
     }}
   >
     <Button>Button with global margins</Button>
-    <SpacingProvider margins={{ button: {} }}>
+    <SpacingProvider margins={{ button: { margin: 0 } }}>
       <Button>Margins overridden with nested provider</Button>
     </SpacingProvider>
     <Button>Button with global margins</Button>
@@ -99,12 +99,8 @@ import {
 >
   <SpacingProvider
     margins={{
-      all: { margin: 'xl' },
-      button: { mb: 'xs' }
-      // textInput: { mb: 'm' },
-      // textarea: { mb: 'm' },
-      // heading: { my: 'm' },
-      // paragraph: { mb: 'm' }
+      all: { mb: 'xs' },
+      button: { mb: 'xxs' }
     }}
   >
     <Heading variant="h2">Feedback</Heading>

--- a/.styleguidist/spacingprovider.md
+++ b/.styleguidist/spacingprovider.md
@@ -1,104 +1,125 @@
-Spacing provider is a wrapper component that allows giving its children margin rules to follow.
+Spacing provider is a wrapper component that allows giving its children margin rules to follow. You can specify the rules per component, and all components of the given type will follow the margin rules.
+
+The margin values can be given using the desired spacing token.
+
+### Basic example
 
 ```js
 import {
-  ActionMenu,
-  Alert,
-  ActionMenuItem,
   SpacingProvider,
+  TextInput,
+  Button
+} from 'suomifi-ui-components';
+
+<SpacingProvider
+  margins={{
+    textInput: { margin: 's' },
+    button: { mb: 'm', ml: 's' }
+  }}
+>
+  <div style={{ border: '1px dotted blue' }}>
+    <TextInput labelText="First name" />
+    <TextInput labelText="Last name" />
+    <Button>Submit</Button>
+  </div>
+</SpacingProvider>;
+```
+
+### Overriding global margins
+
+The global margins given via the provider are set as low specificity css styles, and can thus be easily overridden where needed. Override can be made using one of these options:
+
+- CSS styles using class selectors
+- Styled-component with margin specified
+- An inner `SpacingProvider` wrapper
+
+In the example below all the buttons are inside a spacing provider with margins rules for buttons, but some of them have their styles overridden using the above methods.
+
+```js
+import {
+  SpacingProvider,
+  TextInput,
+  Button,
+  Paragraph
+} from 'suomifi-ui-components';
+import { default as styled } from 'styled-components';
+
+const StyledButton = styled(Button)`
+  margin: 0;
+`;
+
+<div
+  style={{
+    border: '1px dotted blue',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    width: '100%'
+  }}
+>
+  <SpacingProvider
+    margins={{
+      button: { margin: 'm' }
+    }}
+  >
+    <Button>Button with global margins</Button>
+    <SpacingProvider margins={{ button: {} }}>
+      <Button>Margins overridden with nested provider</Button>
+    </SpacingProvider>
+    <Button>Button with global margins</Button>
+    <StyledButton>
+      Margins overridden using styled-components
+    </StyledButton>
+  </SpacingProvider>
+</div>;
+```
+
+### An example form
+
+With the provider developers can generate a margin ruleset once for a specific use case e.g. a form. The ruleset along with the `SpacingProvider` component can then be used to quickly create layouts in similar cases.
+
+```js
+import {
   Button,
   TextInput,
   Textarea,
-  SingleSelect,
-  StatusText,
-  TimeInput,
-  ToggleInput,
-  ToggleButton
+  Checkbox,
+  Paragraph,
+  Heading,
+  SpacingProvider
 } from 'suomifi-ui-components';
 
-const countries = [
-  {
-    labelText: 'Switzerland',
-    uniqueItemId: 'sw2435626'
-  },
-  {
-    labelText: 'France',
-    uniqueItemId: 'fr9823523'
-  },
-  {
-    labelText: 'Spain',
-    uniqueItemId: 'sp908293482'
-  }
-];
-
-<div>
+<div
+  style={{
+    border: '1px dotted blue',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start'
+  }}
+>
   <SpacingProvider
     margins={{
-      alert: { my: 'l' },
-      all: { ml: 'xl' },
-      button: { ml: 'xl', mb: 'm' },
-      textInput: { mb: 'm' },
-      singleSelect: { ml: 'xxl' },
-      statusText: { mt: 'xl' },
-      textarea: { ml: 'xxl' },
-      toggleInput: { ml: 'xxxl' },
-      toggleButton: { ml: 'xl' },
-      actionMenu: { mt: 'l' }
+      all: { margin: 'xl' },
+      button: { mb: 'xs' }
+      // textInput: { mb: 'm' },
+      // textarea: { mb: 'm' },
+      // heading: { my: 'm' },
+      // paragraph: { mb: 'm' }
     }}
   >
-    <Alert
-      closeText="Close"
-      onCloseButtonClick={() => setShowAlert(false)}
-    >
-      You are using a beta version of the service. It might contain
-      some bugs or glitches.
-    </Alert>
-    <Button>Testinappi</Button>
+    <Heading variant="h2">Feedback</Heading>
+    <Paragraph>Please tell us how we did.</Paragraph>
     <TextInput
       onBlur={(event) => console.log(event.target.value)}
-      labelText="TextInput with visible label"
-      statusText="Tietoa statuksesta"
+      labelText="Name"
     />
     <TextInput
+      type="email"
       onBlur={(event) => console.log(event.target.value)}
-      labelText="TextInput with visible label"
+      labelText="Email"
     />
-    <SpacingProvider margins={{ singleSelect: { ml: 'xs' } }}>
-      <SingleSelect
-        labelText="Country of residence"
-        hintText="Select your current country of residence. You can filter options by typing in the field."
-        clearButtonLabel="Clear selection"
-        items={countries}
-        visualPlaceholder="Choose country"
-        noItemsText="No items"
-        ariaOptionsAvailableTextFunction={(amount) =>
-          amount === 1 ? 'option available' : 'options available'
-        }
-      />
-    </SpacingProvider>
-    <Textarea labelText="Tekstikenttä" />
-    <TimeInput labelText="Opening time" />
-    <StatusText>Statusta</StatusText>
-    <ToggleButton onClick={(checked) => console.log(checked)}>
-      Airplane mode
-    </ToggleButton>
-    <ToggleInput onClick={(checked) => console.log(checked)}>
-      Another airplane mode (ToggleInput)
-    </ToggleInput>
-    <ActionMenu buttonText="Actions">
-      <ActionMenuItem onClick={() => console.log('Copy')}>
-        Copy
-      </ActionMenuItem>
-      <ActionMenuItem onClick={() => console.log('Edit')}>
-        Edit
-      </ActionMenuItem>
-      <ActionMenuItem onClick={() => console.log('Move')}>
-        Move
-      </ActionMenuItem>
-      <ActionMenuItem onClick={() => console.log('Remove')}>
-        Remove
-      </ActionMenuItem>
-    </ActionMenu>
+    <Textarea labelText="Your message" />
+    <Button>Submit</Button>
   </SpacingProvider>
 </div>;
 ```

--- a/.styleguidist/spacingprovider.md
+++ b/.styleguidist/spacingprovider.md
@@ -1,0 +1,27 @@
+Spacing provider is a wrapper component that allows giving its children margin rules to follow.
+
+```js
+import {
+  SpacingProvider,
+  Button,
+  TextInput
+} from 'suomifi-ui-components';
+<div>
+  <SpacingProvider
+    margins={{
+      button: { ml: 'xl', mb: 'm' },
+      textInput: { mb: 'm' }
+    }}
+  >
+    <Button>Testinappi</Button>
+    <TextInput
+      onBlur={(event) => console.log(event.target.value)}
+      labelText="TextInput with visible label"
+    />
+    <TextInput
+      onBlur={(event) => console.log(event.target.value)}
+      labelText="TextInput with visible label"
+    />
+  </SpacingProvider>
+</div>;
+```

--- a/.styleguidist/spacingprovider.md
+++ b/.styleguidist/spacingprovider.md
@@ -2,26 +2,103 @@ Spacing provider is a wrapper component that allows giving its children margin r
 
 ```js
 import {
+  ActionMenu,
+  Alert,
+  ActionMenuItem,
   SpacingProvider,
   Button,
-  TextInput
+  TextInput,
+  Textarea,
+  SingleSelect,
+  StatusText,
+  TimeInput,
+  ToggleInput,
+  ToggleButton
 } from 'suomifi-ui-components';
+
+const countries = [
+  {
+    labelText: 'Switzerland',
+    uniqueItemId: 'sw2435626'
+  },
+  {
+    labelText: 'France',
+    uniqueItemId: 'fr9823523'
+  },
+  {
+    labelText: 'Spain',
+    uniqueItemId: 'sp908293482'
+  }
+];
+
 <div>
   <SpacingProvider
     margins={{
+      alert: { my: 'l' },
+      all: { ml: 'xl' },
       button: { ml: 'xl', mb: 'm' },
-      textInput: { mb: 'm' }
+      textInput: { mb: 'm' },
+      singleSelect: { ml: 'xxl' },
+      statusText: { mt: 'xl' },
+      textarea: { ml: 'xxl' },
+      toggleInput: { ml: 'xxxl' },
+      toggleButton: { ml: 'xl' },
+      actionMenu: { mt: 'l' }
     }}
   >
+    <Alert
+      closeText="Close"
+      onCloseButtonClick={() => setShowAlert(false)}
+    >
+      You are using a beta version of the service. It might contain
+      some bugs or glitches.
+    </Alert>
     <Button>Testinappi</Button>
     <TextInput
       onBlur={(event) => console.log(event.target.value)}
       labelText="TextInput with visible label"
+      statusText="Tietoa statuksesta"
     />
     <TextInput
       onBlur={(event) => console.log(event.target.value)}
       labelText="TextInput with visible label"
     />
+    <SpacingProvider margins={{ singleSelect: { ml: 'xs' } }}>
+      <SingleSelect
+        labelText="Country of residence"
+        hintText="Select your current country of residence. You can filter options by typing in the field."
+        clearButtonLabel="Clear selection"
+        items={countries}
+        visualPlaceholder="Choose country"
+        noItemsText="No items"
+        ariaOptionsAvailableTextFunction={(amount) =>
+          amount === 1 ? 'option available' : 'options available'
+        }
+      />
+    </SpacingProvider>
+    <Textarea labelText="Tekstikenttä" />
+    <TimeInput labelText="Opening time" />
+    <StatusText>Statusta</StatusText>
+    <ToggleButton onClick={(checked) => console.log(checked)}>
+      Airplane mode
+    </ToggleButton>
+    <ToggleInput onClick={(checked) => console.log(checked)}>
+      Another airplane mode (ToggleInput)
+    </ToggleInput>
+    <ActionMenu buttonText="Actions">
+      <ActionMenuItem onClick={() => console.log('Copy')}>
+        Copy
+      </ActionMenuItem>
+      <ActionMenuItem onClick={() => console.log('Edit')}>
+        Edit
+      </ActionMenuItem>
+      <ActionMenuItem onClick={() => console.log('Move')}>
+        Move
+      </ActionMenuItem>
+      <ActionMenuItem onClick={() => console.log('Remove')}>
+        Remove
+      </ActionMenuItem>
+    </ActionMenu>
   </SpacingProvider>
 </div>;
 ```

--- a/.styleguidist/spacingprovider.md
+++ b/.styleguidist/spacingprovider.md
@@ -40,6 +40,7 @@ The global margins given via the provider are set as low specificity css styles,
 - CSS styles using class selectors
 - Styled-component with margin specified
 - An inner `SpacingProvider` wrapper
+- Component-specific margin props
 
 In the example below all the buttons are inside a spacing provider with margins rules for buttons, but some of them have their styles overridden using the above methods.
 
@@ -78,6 +79,8 @@ const StyledButton = styled(Button)`
     <StyledButton>
       Margins overridden using styled-components
     </StyledButton>
+    <Button>Button with global margins</Button>
+    <Button margin="0">Margins overridden with margin prop</Button>
   </SpacingProvider>
 </div>;
 ```

--- a/.styleguidist/spacingprovider.md
+++ b/.styleguidist/spacingprovider.md
@@ -8,8 +8,16 @@ The margin values can be given using the desired spacing token.
 import {
   SpacingProvider,
   TextInput,
-  Button
+  Button,
+  WizardNavigation,
+  WizardNavigationItem,
+  RouterLink
 } from 'suomifi-ui-components';
+
+const Comp = (props) => {
+  const { children, ...passProps } = props;
+  return <div {...passProps}>{props.children}</div>;
+};
 
 <SpacingProvider
   margins={{

--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -107,6 +107,10 @@ module.exports = {
               name: 'Tokens',
               content: './.styleguidist/spacingtokens.md',
             },
+            {
+              name: 'Global spacing',
+              content: './.styleguidist/spacingprovider.md',
+            },
           ],
         },
         {

--- a/src/core/ActionMenu/ActionMenu.baseStyles.tsx
+++ b/src/core/ActionMenu/ActionMenu.baseStyles.tsx
@@ -1,6 +1,8 @@
 import { css } from 'styled-components';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = () => css`
+export const baseStyles = (margins?: MarginProps) => css`
+  ${getCssMargins(margins)}
   &.fi-action-menu--full-width {
     width: 100%;
   }

--- a/src/core/ActionMenu/ActionMenu.baseStyles.tsx
+++ b/src/core/ActionMenu/ActionMenu.baseStyles.tsx
@@ -1,8 +1,8 @@
 import { css } from 'styled-components';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (margins?: MarginProps) => css`
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   &.fi-action-menu--full-width {
     width: 100%;
   }

--- a/src/core/ActionMenu/ActionMenu.baseStyles.tsx
+++ b/src/core/ActionMenu/ActionMenu.baseStyles.tsx
@@ -1,8 +1,12 @@
 import { css } from 'styled-components';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (margins?: MarginProps) => css`
-  ${buildSpacingCSS(margins)}
+export const baseStyles = (
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   &.fi-action-menu--full-width {
     width: 100%;
   }

--- a/src/core/ActionMenu/ActionMenu.test.tsx
+++ b/src/core/ActionMenu/ActionMenu.test.tsx
@@ -86,7 +86,7 @@ describe('Margin prop', () => {
     const { container } = render(
       TestActionMenu({ ...actionMenuProps, margin: 'xs' }),
     );
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overridden by style prop', async () => {

--- a/src/core/ActionMenu/ActionMenu.tsx
+++ b/src/core/ActionMenu/ActionMenu.tsx
@@ -26,7 +26,6 @@ import {
 } from '../Button/Button';
 import { HtmlDiv } from '../../reset';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -35,6 +34,7 @@ import { baseStyles } from './ActionMenu.baseStyles';
 import { ActionMenuItemProps } from './ActionMenuItem/ActionMenuItem';
 import { ActionMenuDividerProps } from './ActionMenuDivider/ActionMenuDivider';
 import { IconOptionsVertical } from 'suomifi-icons';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 const baseClassName = 'fi-action-menu';
 export const actionMenuClassNames = {
@@ -111,8 +111,7 @@ const BaseActionMenu = (props: ActionMenuProps) => {
     style,
     ...rest
   } = props;
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
 
   const openButtonRef = forwardedRef || useRef<HTMLButtonElement>(null);
   const [menuVisible, setMenuVisible] = useState<boolean>(false);
@@ -175,7 +174,7 @@ const BaseActionMenu = (props: ActionMenuProps) => {
       className={classnames(baseClassName, className, {
         [actionMenuClassNames.fullWidth]: fullWidth,
       })}
-      style={{ ...marginStyle, ...style }}
+      style={style}
     >
       <Button
         id={buttonId}
@@ -222,7 +221,14 @@ const StyledActionMenu = styled(
     <BaseActionMenu {...passProps} />
   ),
 )`
-  ${({ globalMargins }) => baseStyles(globalMargins?.actionMenu)}
+  ${({ globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.actionMenu,
+      marginProps,
+    );
+    return baseStyles(cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const ActionMenu = forwardRef<HTMLButtonElement, ActionMenuProps>(

--- a/src/core/ActionMenu/ActionMenu.tsx
+++ b/src/core/ActionMenu/ActionMenu.tsx
@@ -8,7 +8,11 @@ import React, {
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import {
   ActionMenuPopover,
   InitialActiveDescendant,
@@ -25,6 +29,7 @@ import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './ActionMenu.baseStyles';
 import { ActionMenuItemProps } from './ActionMenuItem/ActionMenuItem';
@@ -209,31 +214,40 @@ const BaseActionMenu = (props: ActionMenuProps) => {
 };
 
 const StyledActionMenu = styled(
-  ({ theme, ...passProps }: ActionMenuProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: ActionMenuProps & SuomifiThemeProp & GlobalMarginProps) => (
     <BaseActionMenu {...passProps} />
   ),
 )`
-  ${() => baseStyles()}
+  ${({ globalMargins }) => baseStyles(globalMargins?.actionMenu)}
 `;
 
 const ActionMenu = forwardRef<HTMLButtonElement, ActionMenuProps>(
   (props: ActionMenuProps, ref: React.RefObject<HTMLButtonElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledActionMenu
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledActionMenu
+                    theme={suomifiTheme}
+                    id={id}
+                    globalMargins={margins}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert.baseStyles.ts
@@ -36,9 +36,7 @@ export const baseStyles = (
         height: 40px;
         display: inline-block;
         padding: 7px;
-        margin-top: 7px;
-        margin-right: ${theme.spacing.xs};
-        margin-bottom: ${theme.spacing.insetM};
+        margin: 7px ${theme.spacing.xs} ${theme.spacing.insetM} 0;
         border: 1px solid transparent;
         border-radius: ${theme.radiuses.basic};
         white-space: nowrap;

--- a/src/core/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert.baseStyles.ts
@@ -2,11 +2,13 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
 import { transparentize } from 'polished';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   &.fi-alert {
     ${element(theme)}
     ${font(theme)('bodyTextSmall')}
+    ${getCssMargins(margins)};
     width: 100%;
 
     & .fi-alert_style-wrapper {

--- a/src/core/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert.baseStyles.ts
@@ -2,13 +2,13 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
 import { transparentize } from 'polished';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   &.fi-alert {
     ${element(theme)}
     ${font(theme)('bodyTextSmall')}
-    ${getCssMargins(margins)};
+    ${buildSpacingCSS(margins)};
     width: 100%;
 
     & .fi-alert_style-wrapper {

--- a/src/core/Alert/Alert.baseStyles.ts
+++ b/src/core/Alert/Alert.baseStyles.ts
@@ -4,11 +4,16 @@ import { element, font } from '../theme/reset';
 import { transparentize } from 'polished';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   &.fi-alert {
     ${element(theme)}
     ${font(theme)('bodyTextSmall')}
-    ${buildSpacingCSS(margins)};
+    ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)};
     width: 100%;
 
     & .fi-alert_style-wrapper {

--- a/src/core/Alert/Alert.test.tsx
+++ b/src/core/Alert/Alert.test.tsx
@@ -104,7 +104,7 @@ describe('props', () => {
   describe('margin prop', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<Alert closeText="Close" margin="xs" />);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin style overwritten from style', () => {

--- a/src/core/Alert/Alert.tsx
+++ b/src/core/Alert/Alert.tsx
@@ -10,11 +10,16 @@ import {
 } from '../../reset';
 import { AutoId } from '../utils/AutoId/AutoId';
 import { getConditionalAriaProp } from '../../utils/aria';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Alert.baseStyles';
 import { IconClose, IconError, IconInfo, IconWarning } from 'suomifi-icons';
@@ -139,31 +144,38 @@ class BaseAlert extends Component<AlertProps> {
   }
 }
 
-const StyledAlert = styled((props: AlertProps & SuomifiThemeProp) => {
-  const { theme, ...passProps } = props;
-  return <BaseAlert {...passProps} />;
-})`
-  ${({ theme }) => baseStyles(theme)}
+const StyledAlert = styled(
+  (props: AlertProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
+    return <BaseAlert {...passProps} />;
+  },
+)`
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.alert)}
 `;
 
 const Alert = forwardRef(
   (props: AlertProps, ref: React.RefObject<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledAlert
-                forwardedRef={ref}
-                theme={suomifiTheme}
-                id={id}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledAlert
+                    forwardedRef={ref}
+                    theme={suomifiTheme}
+                    globalMargins={margins}
+                    id={id}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Alert/Alert.tsx
+++ b/src/core/Alert/Alert.tsx
@@ -16,13 +16,13 @@ import {
   SpacingConsumer,
 } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Alert.baseStyles';
 import { IconClose, IconError, IconInfo, IconWarning } from 'suomifi-icons';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 const baseClassName = 'fi-alert';
 const alertClassNames = {
@@ -69,8 +69,7 @@ class BaseAlert extends Component<AlertProps> {
       closeButtonProps = {},
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     const {
       className: customCloseButtonClassName,
@@ -86,7 +85,7 @@ class BaseAlert extends Component<AlertProps> {
           [`${baseClassName}--${status}`]: !!status,
           [alertClassNames.smallScreen]: !!smallScreen,
         })}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
         ref={forwardedRef}
       >
         <HtmlDiv className={alertClassNames.styleWrapper}>
@@ -150,7 +149,14 @@ const StyledAlert = styled(
     return <BaseAlert {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.alert)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.alert,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Alert = forwardRef(

--- a/src/core/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/src/core/Alert/__snapshots__/Alert.test.tsx.snap
@@ -217,9 +217,7 @@ exports[`props children should match snapshot 1`] = `
   height: 40px;
   display: inline-block;
   padding: 7px;
-  margin-top: 7px;
-  margin-right: 10px;
-  margin-bottom: 8px;
+  margin: 7px 10px 8px 0;
   border: 1px solid transparent;
   border-radius: 2px;
   white-space: nowrap;

--- a/src/core/Block/Block.baseStyles.ts
+++ b/src/core/Block/Block.baseStyles.ts
@@ -7,10 +7,10 @@ import { SpacingProps, buildSpacingCSS } from '../theme/utils/spacing';
 export const baseStyles = (
   theme: SuomifiTheme,
   variant?: BlockVariant,
-  spacingProps?: SpacingProps,
+  margins?: SpacingProps,
 ) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   ${!!variant && variant === 'span' ? 'display: inline-block' : ''}
-  ${buildSpacingCSS(spacingProps)}
+  ${buildSpacingCSS(margins)};
 `;

--- a/src/core/Block/Block.baseStyles.ts
+++ b/src/core/Block/Block.baseStyles.ts
@@ -8,11 +8,11 @@ export const baseStyles = (
   theme: SuomifiTheme,
   variant?: BlockVariant,
   globalMargins?: SpacingProps,
-  propMargins?: SpacingProps,
+  propSpacing?: SpacingProps,
 ) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   ${!!variant && variant === 'span' ? 'display: inline-block' : ''}
   ${buildSpacingCSS(globalMargins)};
-  ${buildSpacingCSS(propMargins)};
+  ${buildSpacingCSS(propSpacing)};
 `;

--- a/src/core/Block/Block.baseStyles.ts
+++ b/src/core/Block/Block.baseStyles.ts
@@ -7,10 +7,12 @@ import { SpacingProps, buildSpacingCSS } from '../theme/utils/spacing';
 export const baseStyles = (
   theme: SuomifiTheme,
   variant?: BlockVariant,
-  margins?: SpacingProps,
+  globalMargins?: SpacingProps,
+  propMargins?: SpacingProps,
 ) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   ${!!variant && variant === 'span' ? 'display: inline-block' : ''}
-  ${buildSpacingCSS(margins)};
+  ${buildSpacingCSS(globalMargins)};
+  ${buildSpacingCSS(propMargins)};
 `;

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -5,7 +5,6 @@ import {
   GlobalMarginProps,
   SpacingProps,
   separateMarginAndPaddingProps,
-  separateMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Block.baseStyles';
 import { HtmlDivWithNativeRef, HtmlDivProps } from '../../reset';
@@ -73,12 +72,12 @@ const StyledBlock = styled(
   ),
 )`
   ${({ theme, globalMargins, variant, ...rest }) => {
-    const [marginProps, _passProps] = separateMarginProps(rest);
+    const [spacingProps, _passProps] = separateMarginAndPaddingProps(rest);
     const cleanedGlobalMargins = filterDuplicateKeys(
       globalMargins.textInput,
-      marginProps,
+      spacingProps,
     );
-    return baseStyles(theme, variant, cleanedGlobalMargins, marginProps);
+    return baseStyles(theme, variant, cleanedGlobalMargins, spacingProps);
   }}
 `;
 

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -2,12 +2,17 @@ import React, { Component, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import {
+  GlobalMarginProps,
   SpacingProps,
   separateMarginAndPaddingProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Block.baseStyles';
 import { HtmlDivWithNativeRef, HtmlDivProps } from '../../reset';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 
 const baseClassName = 'fi-block';
 
@@ -68,11 +73,20 @@ const StyledBlock = styled(
 `;
 
 const Block = forwardRef((props: BlockProps, ref: React.Ref<any>) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledBlock theme={suomifiTheme} forwardedRef={ref} {...props} />
+  <SpacingConsumer>
+    {({ margins }) => (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledBlock
+            theme={suomifiTheme}
+            globalMargin={margins}
+            forwardedRef={ref}
+            {...props}
+          />
+        )}
+      </SuomifiThemeConsumer>
     )}
-  </SuomifiThemeConsumer>
+  </SpacingConsumer>
 ));
 
 Block.displayName = 'Block';

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -79,7 +79,7 @@ const Block = forwardRef((props: BlockProps, ref: React.Ref<any>) => (
         {({ suomifiTheme }) => (
           <StyledBlock
             theme={suomifiTheme}
-            globalMargin={margins}
+            globalMargins={margins}
             forwardedRef={ref}
             {...props}
           />

--- a/src/core/Block/Block.tsx
+++ b/src/core/Block/Block.tsx
@@ -5,6 +5,7 @@ import {
   GlobalMarginProps,
   SpacingProps,
   separateMarginAndPaddingProps,
+  separateMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Block.baseStyles';
 import { HtmlDivWithNativeRef, HtmlDivProps } from '../../reset';
@@ -13,6 +14,7 @@ import {
   SuomifiThemeConsumer,
   SpacingConsumer,
 } from '../theme';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 const baseClassName = 'fi-block';
 
@@ -43,7 +45,7 @@ class SemanticBlock extends Component<BlockProps> {
   render() {
     const { className, variant, forwardedRef, ...rest } = this.props;
 
-    const [_, passProps] = separateMarginAndPaddingProps(rest);
+    const [_spacingProps, passProps] = separateMarginAndPaddingProps(rest);
 
     const ComponentVariant =
       !variant || variant === 'default' ? HtmlDivWithNativeRef : variant;
@@ -61,14 +63,22 @@ class SemanticBlock extends Component<BlockProps> {
 }
 
 const StyledBlock = styled(
-  ({ theme, variant, ...passProps }: BlockProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    variant,
+    globalMargins,
+    ...passProps
+  }: BlockProps & SuomifiThemeProp & GlobalMarginProps) => (
     <SemanticBlock variant={variant} {...passProps} />
   ),
 )`
-  ${(props) => {
-    const { theme, variant, ...rest } = props;
-    const [spacingProps] = separateMarginAndPaddingProps(rest);
-    return baseStyles(theme, variant, spacingProps);
+  ${({ theme, globalMargins, variant, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.textInput,
+      marginProps,
+    );
+    return baseStyles(theme, variant, cleanedGlobalMargins, marginProps);
   }}
 `;
 

--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { nav, list, listItem, font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${nav(theme)}
   ${font(theme)('bodyTextSmall')}
+  ${getCssMargins(margins)};
   height: 1.5em;
 
   & .fi-breadcrumb {

--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../../theme';
 import { nav, list, listItem, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${nav(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${buildSpacingCSS(margins)};
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)};
   height: 1.5em;
 
   & .fi-breadcrumb {

--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { nav, list, listItem, font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${nav(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${getCssMargins(margins)};
+  ${buildSpacingCSS(margins)};
   height: 1.5em;
 
   & .fi-breadcrumb {

--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.test.tsx
@@ -18,7 +18,7 @@ describe('margin prop', () => {
       <Breadcrumb aria-label="You are here" margin="xs" />,
     );
     const navigation = container.querySelector('nav');
-    expect(navigation).toHaveAttribute('style', 'margin: 10px;');
+    expect(navigation).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop style overwritten from style', () => {

--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.tsx
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.tsx
@@ -4,11 +4,16 @@ import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { HtmlLi, HtmlNav, HtmlNavProps, HtmlOl } from '../../../reset';
 import { baseStyles } from './Breadcrumb.baseStyles';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 
 const baseClassName = 'fi-breadcrumb';
@@ -31,9 +36,9 @@ const breadcrumbItems = (children: ReactNode) =>
     <HtmlLi className={itemClassName}>{child}</HtmlLi>
   ));
 
-class BaseBreadcrumb extends Component<BreadcrumbProps & SuomifiThemeProp> {
+class BaseBreadcrumb extends Component<BreadcrumbProps> {
   render() {
-    const { className, theme, children, ...rest } = this.props;
+    const { className, children, ...rest } = this.props;
     const [marginProps, passProps] = separateMarginProps(rest);
     const marginStyle = spacingStyles(marginProps);
 
@@ -49,22 +54,35 @@ class BaseBreadcrumb extends Component<BreadcrumbProps & SuomifiThemeProp> {
   }
 }
 
-const StyledBreadcrumb = styled(BaseBreadcrumb)`
-  ${({ theme }) => baseStyles(theme)}
+const StyledBreadcrumb = styled(
+  ({
+    globalMargins,
+    theme,
+    ...passProps
+  }: BreadcrumbProps & SuomifiThemeProp & GlobalMarginProps) => (
+    <BaseBreadcrumb {...passProps} />
+  ),
+)`
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.breadcrumb)}
 `;
 
 const Breadcrumb = (props: BreadcrumbProps) => {
   const { 'aria-label': ariaLabel, ...passProps } = props;
   return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledBreadcrumb
-          theme={suomifiTheme}
-          {...passProps}
-          {...getConditionalAriaProp('aria-label', [ariaLabel])}
-        />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledBreadcrumb
+              theme={suomifiTheme}
+              globalMargins={margins}
+              {...passProps}
+              {...getConditionalAriaProp('aria-label', [ariaLabel])}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   );
 };
 

--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.tsx
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.tsx
@@ -10,11 +10,11 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../../theme/utils/spacing';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const baseClassName = 'fi-breadcrumb';
 const listClassName = `${baseClassName}_list`;
@@ -39,14 +39,13 @@ const breadcrumbItems = (children: ReactNode) =>
 class BaseBreadcrumb extends Component<BreadcrumbProps> {
   render() {
     const { className, children, ...rest } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     return (
       <HtmlNav
         {...passProps}
         className={classnames(baseClassName, className)}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       >
         <HtmlOl className={listClassName}>{breadcrumbItems(children)}</HtmlOl>
       </HtmlNav>
@@ -63,7 +62,14 @@ const StyledBreadcrumb = styled(
     <BaseBreadcrumb {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.breadcrumb)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.breadcrumb,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Breadcrumb = (props: BreadcrumbProps) => {

--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -310,6 +310,7 @@ exports[`calling render with the same component on the same container does not r
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+  margin: 0;
 }
 
 .c5.fi-breadcrumb-link .fi-breadcrumb-link_link:hover,

--- a/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.baseStyles.ts
+++ b/src/core/Breadcrumb/BreadcrumbLink/BreadcrumbLink.baseStyles.ts
@@ -12,6 +12,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     & .fi-breadcrumb-link_link {
       ${font(theme)('bodyTextSmall')}
+      margin: 0;
 
       &:hover,
       &:active {

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -2,6 +2,7 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { button } from '../theme/reset';
 import { alphaHex } from '../../utils/css';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
 const invertedStyles = (theme: SuomifiTheme) => css`
   &.fi-button--inverted {
@@ -123,8 +124,9 @@ const secondaryLightStyles = (theme: SuomifiTheme) => css`
   }
 `;
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${button(theme)}
+  ${getCssMargins(margins)}
   padding: 9px ${theme.spacing.insetXxl};
   min-height: 40px;
   color: ${theme.colors.whiteBase};

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -2,7 +2,7 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { button } from '../theme/reset';
 import { alphaHex } from '../../utils/css';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 const invertedStyles = (theme: SuomifiTheme) => css`
   &.fi-button--inverted {
@@ -126,7 +126,7 @@ const secondaryLightStyles = (theme: SuomifiTheme) => css`
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${button(theme)}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   padding: 9px ${theme.spacing.insetXxl};
   min-height: 40px;
   color: ${theme.colors.whiteBase};

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -124,9 +124,14 @@ const secondaryLightStyles = (theme: SuomifiTheme) => css`
   }
 `;
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${button(theme)}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   padding: 9px ${theme.spacing.insetXxl};
   min-height: 40px;
   color: ${theme.colors.whiteBase};

--- a/src/core/Button/Button.md
+++ b/src/core/Button/Button.md
@@ -20,39 +20,11 @@ Examples:
 ### Basic use
 
 ```js
-import { Button, SpacingProvider } from 'suomifi-ui-components';
-import React from 'react';
+import { Button } from 'suomifi-ui-components';
 
-const exampleRef = React.createRef();
-
-<>
-  <Button onClick={() => console.log('Submitting form...')}>
-    Submit
-  </Button>
-
-  <SpacingProvider margins={{ button: { mt: 'xl' } }}>
-    <Button
-      className="my-button--test"
-      onClick={() => console.log('Test button click')}
-      type="submit"
-      mb="xxxl"
-    >
-      Button
-    </Button>
-
-    <Button disabled fullWidth>
-      Button disabled fullWidth
-    </Button>
-    <Button
-      ref={exampleRef}
-      onClick={() => {
-        console.log(exampleRef.current);
-      }}
-    >
-      Button with ref
-    </Button>
-  </SpacingProvider>
-</>;
+<Button onClick={() => console.log('Submitting form...')}>
+  Submit
+</Button>;
 ```
 
 ### Full width button

--- a/src/core/Button/Button.md
+++ b/src/core/Button/Button.md
@@ -20,11 +20,39 @@ Examples:
 ### Basic use
 
 ```js
-import { Button } from 'suomifi-ui-components';
+import { Button, SpacingProvider } from 'suomifi-ui-components';
+import React from 'react';
 
-<Button onClick={() => console.log('Submitting form...')}>
-  Submit
-</Button>;
+const exampleRef = React.createRef();
+
+<>
+  <Button onClick={() => console.log('Submitting form...')}>
+    Submit
+  </Button>
+
+  <SpacingProvider margins={{ button: { mt: 'xl' } }}>
+    <Button
+      className="my-button--test"
+      onClick={() => console.log('Test button click')}
+      type="submit"
+      mb="xxxl"
+    >
+      Button
+    </Button>
+
+    <Button disabled fullWidth>
+      Button disabled fullWidth
+    </Button>
+    <Button
+      ref={exampleRef}
+      onClick={() => {
+        console.log(exampleRef.current);
+      }}
+    >
+      Button with ref
+    </Button>
+  </SpacingProvider>
+</>;
 ```
 
 ### Full width button

--- a/src/core/Button/Button.test.tsx
+++ b/src/core/Button/Button.test.tsx
@@ -85,7 +85,7 @@ describe('Button variant', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<Button margin="xs">Test button</Button>);
       const button = container.querySelector('button');
-      expect(button).toHaveAttribute('style', 'margin: 10px;');
+      expect(button).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop style overwritten from style', () => {

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -102,7 +102,7 @@ const loadingButtonClassName = `${baseClassName}--loading`;
 const loadingButtonIconOnlyClassName = `${baseClassName}--loading-icon-only`;
 const loadingIconClassName = `${baseClassName}_loading-icon`;
 
-class BaseButton extends Component<InternalButtonProps> {
+class BaseButton extends Component<ButtonProps> {
   render() {
     const {
       fullWidth,
@@ -167,11 +167,15 @@ class BaseButton extends Component<InternalButtonProps> {
 }
 
 const StyledButton = styled(
-  ({ theme, ...passProps }: InternalButtonProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: ButtonProps & SuomifiThemeProp & { globalMargins: GlobalMargins }) => (
     <BaseButton {...passProps} />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.button)}
 `;
 
 const Button = forwardRef(
@@ -194,22 +198,12 @@ const Button = forwardRef(
 );
 
 export const InternalButton = forwardRef(
-  (props: InternalButtonProps, ref: React.RefObject<HTMLButtonElement>) => (
-    <SpacingConsumer>
-      {({ margins }) => (
-        <SuomifiThemeConsumer>
-          {({ suomifiTheme }) => (
-            <StyledButton
-              theme={suomifiTheme}
-              forwardedRef={ref}
-              globalMargins={margins}
-              ignoreGlobalMargins={true}
-              {...props}
-            />
-          )}
-        </SuomifiThemeConsumer>
+  (props: ButtonProps, ref: React.RefObject<HTMLButtonElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledButton theme={suomifiTheme} forwardedRef={ref} {...props} />
       )}
-    </SpacingConsumer>
+    </SuomifiThemeConsumer>
   ),
 );
 

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -5,7 +5,6 @@ import { baseStyles } from './Button.baseStyles';
 import { HtmlButton, HtmlButtonProps, HtmlSpan } from '../../reset';
 import { SuomifiThemeConsumer, SuomifiThemeProp } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMargins,
@@ -13,6 +12,7 @@ import {
 import { IconPreloader } from 'suomifi-icons';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { SpacingConsumer } from '../theme/SpacingProvider/SpacingProvider';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 export type ButtonVariant =
   | 'default'
@@ -120,8 +120,7 @@ class BaseButton extends Component<ButtonProps> {
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
     const onClickProp = !!disabled || !!ariaDisabled ? null : { onClick };
 
     return (
@@ -148,7 +147,7 @@ class BaseButton extends Component<ButtonProps> {
             [loadingButtonClassName]: loading,
             [loadingButtonIconOnlyClassName]: loading && !children,
           })}
-          style={{ ...marginStyle, ...style }}
+          style={style}
         >
           {loading && <IconPreloader className={loadingIconClassName} />}
           {!!icon && !loading && (
@@ -175,7 +174,14 @@ const StyledButton = styled(
     <BaseButton {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.button)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.button,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Button = forwardRef(

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -89,7 +89,9 @@ interface InternalButtonProps
 
 export type ButtonProps = InternalButtonProps &
   ForcedAccessibleNameProps &
-  LoadingProps;
+  LoadingProps & {
+    globalMargins?: GlobalMargins;
+  };
 
 const baseClassName = 'fi-button';
 const disabledClassName = `${baseClassName}--disabled`;
@@ -101,7 +103,7 @@ const loadingButtonClassName = `${baseClassName}--loading`;
 const loadingButtonIconOnlyClassName = `${baseClassName}--loading-icon-only`;
 const loadingIconClassName = `${baseClassName}_loading-icon`;
 
-class BaseButton extends Component<ButtonProps> {
+class BaseButton extends Component<InternalButtonProps> {
   render() {
     const {
       fullWidth,

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -8,9 +8,11 @@ import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMargins,
 } from '../theme/utils/spacing';
 import { IconPreloader } from 'suomifi-icons';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
+import { SpacingConsumer } from '../theme/SpacingProvider/SpacingProvider';
 
 export type ButtonVariant =
   | 'default'
@@ -82,6 +84,7 @@ interface InternalButtonProps
   onClick?: (event: React.MouseEvent) => void;
   /** Ref object is passed to the button element. Alternative to React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLButtonElement>;
+  globalMargins?: GlobalMargins;
 }
 
 export type ButtonProps = InternalButtonProps &
@@ -114,6 +117,7 @@ class BaseButton extends Component<ButtonProps> {
       forwardedRef,
       children,
       style,
+      globalMargins,
       ...rest
     } = this.props;
     const [marginProps, passProps] = separateMarginProps(rest);
@@ -172,11 +176,20 @@ const StyledButton = styled(
 
 const Button = forwardRef(
   (props: ButtonProps, ref: React.RefObject<HTMLButtonElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledButton theme={suomifiTheme} forwardedRef={ref} {...props} />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledButton
+              theme={suomifiTheme}
+              forwardedRef={ref}
+              globalMargins={margins}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Button/Button.tsx
+++ b/src/core/Button/Button.tsx
@@ -84,7 +84,6 @@ interface InternalButtonProps
   onClick?: (event: React.MouseEvent) => void;
   /** Ref object is passed to the button element. Alternative to React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLButtonElement>;
-  globalMargins?: GlobalMargins;
 }
 
 export type ButtonProps = InternalButtonProps &
@@ -119,7 +118,6 @@ class BaseButton extends Component<InternalButtonProps> {
       forwardedRef,
       children,
       style,
-      globalMargins,
       ...rest
     } = this.props;
     const [marginProps, passProps] = separateMarginProps(rest);
@@ -169,7 +167,7 @@ class BaseButton extends Component<InternalButtonProps> {
 }
 
 const StyledButton = styled(
-  ({ theme, ...passProps }: ButtonProps & SuomifiThemeProp) => (
+  ({ theme, ...passProps }: InternalButtonProps & SuomifiThemeProp) => (
     <BaseButton {...passProps} />
   ),
 )`
@@ -186,6 +184,26 @@ const Button = forwardRef(
               theme={suomifiTheme}
               forwardedRef={ref}
               globalMargins={margins}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
+      )}
+    </SpacingConsumer>
+  ),
+);
+
+export const InternalButton = forwardRef(
+  (props: InternalButtonProps, ref: React.RefObject<HTMLButtonElement>) => (
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledButton
+              theme={suomifiTheme}
+              forwardedRef={ref}
+              globalMargins={margins}
+              ignoreGlobalMargins={true}
               {...props}
             />
           )}

--- a/src/core/Chip/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip/Chip.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { baseChipBaseStyles } from '../BaseChip/BaseChip.baseStyles';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${baseChipBaseStyles(theme)}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   &.fi-chip--button {
     cursor: pointer;
     &:hover {

--- a/src/core/Chip/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip/Chip.baseStyles.tsx
@@ -3,9 +3,14 @@ import { SuomifiTheme } from '../../theme';
 import { baseChipBaseStyles } from '../BaseChip/BaseChip.baseStyles';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${baseChipBaseStyles(theme)}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   &.fi-chip--button {
     cursor: pointer;
     &:hover {

--- a/src/core/Chip/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip/Chip.baseStyles.tsx
@@ -1,9 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { baseChipBaseStyles } from '../BaseChip/BaseChip.baseStyles';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${baseChipBaseStyles(theme)}
+  ${getCssMargins(margins)}
   &.fi-chip--button {
     cursor: pointer;
     &:hover {

--- a/src/core/Chip/Chip/Chip.test.tsx
+++ b/src/core/Chip/Chip/Chip.test.tsx
@@ -101,7 +101,7 @@ describe('onClick', () => {
   describe('margin prop', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<Chip margin="xs">Test</Chip>);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop style overwritten from style', () => {

--- a/src/core/Chip/Chip/Chip.tsx
+++ b/src/core/Chip/Chip/Chip.tsx
@@ -8,6 +8,7 @@ import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import {
@@ -16,7 +17,11 @@ import {
   chipClassNames,
 } from '../BaseChip/BaseChip';
 import { baseStyles } from './Chip.baseStyles';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 
 const chipButtonClassNames = {
   removable: `${baseClassName}--removable`,
@@ -109,22 +114,35 @@ class DefaultChip extends Component<ChipProps> {
 }
 
 const StyledChip = styled(
-  ({ theme, ...passProps }: ChipProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: ChipProps & SuomifiThemeProp & GlobalMarginProps) => (
     <DefaultChip {...passProps} />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.chip)}
 `;
 
 const Chip = forwardRef(
   (props: ChipProps, ref: React.RefObject<HTMLButtonElement>) => {
     const { ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledChip theme={suomifiTheme} forwardedRef={ref} {...passProps} />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <StyledChip
+                theme={suomifiTheme}
+                globalMargins={margins}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Chip/Chip/Chip.tsx
+++ b/src/core/Chip/Chip/Chip.tsx
@@ -5,7 +5,6 @@ import { IconClose } from 'suomifi-icons';
 import { getLogger } from '../../../utils/log';
 import { HtmlButton, HtmlButtonProps, HtmlSpan } from '../../../reset';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -22,6 +21,7 @@ import {
   SuomifiThemeConsumer,
   SpacingConsumer,
 } from '../../theme';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const chipButtonClassNames = {
   removable: `${baseClassName}--removable`,
@@ -68,8 +68,7 @@ class DefaultChip extends Component<ChipProps> {
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     const onClickProp = !!disabled || !!ariaDisabled ? {} : { onClick };
 
@@ -94,7 +93,7 @@ class DefaultChip extends Component<ChipProps> {
         {...onClickProp}
         forwardedRef={forwardedRef}
         {...passProps}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlSpan className={chipClassNames.content}>{children}</HtmlSpan>
         {!!removable && (
@@ -122,7 +121,14 @@ const StyledChip = styled(
     <DefaultChip {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.chip)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.chip,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Chip = forwardRef(

--- a/src/core/Chip/ChipList/ChipList.baseStyles.tsx
+++ b/src/core/Chip/ChipList/ChipList.baseStyles.tsx
@@ -7,8 +7,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   padding-top: 5px;
 
   & .fi-chip-list_content_wrapper > * {
-    margin-right: 10px;
-    margin-top: 10px;
+    margin: 10px 10px 0 0;
     padding-right: -10px;
   }
 

--- a/src/core/Chip/StaticChip/StaticChip.baseStyles.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { SuomifiTheme } from '../../theme';
 import { css } from 'styled-components';
 import { baseChipBaseStyles } from '../BaseChip/BaseChip.baseStyles';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const staticChipBaseStyles = (
   theme: SuomifiTheme,
   margins?: MarginProps,
 ) => css`
   ${baseChipBaseStyles(theme)}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
 `;

--- a/src/core/Chip/StaticChip/StaticChip.baseStyles.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.baseStyles.tsx
@@ -1,7 +1,12 @@
 import { SuomifiTheme } from '../../theme';
 import { css } from 'styled-components';
 import { baseChipBaseStyles } from '../BaseChip/BaseChip.baseStyles';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const staticChipBaseStyles = (theme: SuomifiTheme) => css`
+export const staticChipBaseStyles = (
+  theme: SuomifiTheme,
+  margins?: MarginProps,
+) => css`
   ${baseChipBaseStyles(theme)}
+  ${getCssMargins(margins)}
 `;

--- a/src/core/Chip/StaticChip/StaticChip.baseStyles.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.baseStyles.tsx
@@ -5,8 +5,10 @@ import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const staticChipBaseStyles = (
   theme: SuomifiTheme,
-  margins?: MarginProps,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
 ) => css`
   ${baseChipBaseStyles(theme)}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
 `;

--- a/src/core/Chip/StaticChip/StaticChip.test.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.test.tsx
@@ -62,7 +62,7 @@ describe('classnames', () => {
   describe('margin prop', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<StaticChip margin="xs">Test</StaticChip>);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop style overwritten from style', () => {

--- a/src/core/Chip/StaticChip/StaticChip.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.tsx
@@ -8,11 +8,16 @@ import {
   chipClassNames,
 } from '../BaseChip/BaseChip';
 import { staticChipBaseStyles } from './StaticChip.baseStyles';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 
 export interface StaticChipProps
@@ -44,20 +49,34 @@ class BaseChip extends Component<StaticChipProps> {
 }
 
 const StyledChip = styled(
-  ({ theme, ...passProps }: StaticChipProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: StaticChipProps & SuomifiThemeProp & GlobalMarginProps) => (
     <BaseChip {...passProps} />
   ),
 )`
-  ${({ theme }) => staticChipBaseStyles(theme)}
+  ${({ theme, globalMargins }) =>
+    staticChipBaseStyles(theme, globalMargins?.staticChip)}
 `;
 
 const StaticChip = forwardRef(
   (props: StaticChipProps, ref: React.Ref<HTMLSpanElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledChip theme={suomifiTheme} forwardedRef={ref} {...props} />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledChip
+              theme={suomifiTheme}
+              globalMargins={margins}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Chip/StaticChip/StaticChip.tsx
+++ b/src/core/Chip/StaticChip/StaticChip.tsx
@@ -14,11 +14,11 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../../theme/utils/spacing';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 export interface StaticChipProps
   extends BaseChipProps,
@@ -31,8 +31,7 @@ export interface StaticChipProps
 class BaseChip extends Component<StaticChipProps> {
   render() {
     const { className, children, disabled = false, ...rest } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     return (
       <HtmlSpan
@@ -40,7 +39,7 @@ class BaseChip extends Component<StaticChipProps> {
           [chipClassNames.disabled]: !!disabled,
         })}
         {...passProps}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       >
         <HtmlSpan className={chipClassNames.content}>{children}</HtmlSpan>
       </HtmlSpan>
@@ -57,8 +56,14 @@ const StyledChip = styled(
     <BaseChip {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) =>
-    staticChipBaseStyles(theme, globalMargins?.staticChip)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.staticChip,
+      marginProps,
+    );
+    return staticChipBaseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const StaticChip = forwardRef(

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { element, input } from '../../theme/reset';
+import { element, fixInternalMargins, input } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (
@@ -11,6 +11,7 @@ export const baseStyles = (
   width: 290px;
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
+  ${fixInternalMargins()}
   .fi-dropdown_item-list {
     padding-top: 0;
   }

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, input } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   width: 290px;
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   .fi-dropdown_item-list {
     padding-top: 0;
   }

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -1,9 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, input } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   width: 290px;
+  ${getCssMargins(margins)}
   .fi-dropdown_item-list {
     padding-top: 0;
   }

--- a/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -3,9 +3,14 @@ import { SuomifiTheme } from '../../theme';
 import { element, input } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   width: 290px;
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   .fi-dropdown_item-list {
     padding-top: 0;
   }

--- a/src/core/Dropdown/Dropdown/Dropdown.test.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.test.tsx
@@ -323,7 +323,7 @@ describe('margin', () => {
     };
     const { baseElement } = render(TestDropdown(props));
     const div = baseElement.querySelector('.fi-dropdown');
-    expect(div).toHaveAttribute('style', 'margin: 10px;');
+    expect(div).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overwritten by style prop', () => {

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -14,11 +14,16 @@ import {
 import { Label, LabelMode } from '../../Form/Label/Label';
 import { DropdownItemProps } from '../DropdownItem/DropdownItem';
 import { baseStyles } from './Dropdown.baseStyles';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { forkRefs, getOwnerDocument } from '../../../utils/common/common';
 import { Popover } from '../../../core/Popover/Popover';
@@ -707,10 +712,13 @@ class BaseDropdown<T extends string = string> extends Component<
 const StyledDropdown = styled(
   <T extends string = string>({
     theme,
+    globalMargins,
     ...passProps
-  }: DropdownProps<T> & SuomifiThemeProp) => <BaseDropdown {...passProps} />,
+  }: DropdownProps<T> & SuomifiThemeProp & GlobalMarginProps) => (
+    <BaseDropdown {...passProps} />
+  ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.dropdown)}
 `;
 
 const DropdownInner = <T extends string = string>(
@@ -719,20 +727,25 @@ const DropdownInner = <T extends string = string>(
 ) => {
   const { id: propId, ...passProps } = props;
   return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledDropdown
-              theme={suomifiTheme}
-              id={id}
-              forwardedRef={ref}
-              {...passProps}
-            />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <AutoId id={propId}>
+              {(id) => (
+                <StyledDropdown
+                  theme={suomifiTheme}
+                  globalMargins={margins}
+                  id={id}
+                  forwardedRef={ref}
+                  {...passProps}
+                />
+              )}
+            </AutoId>
           )}
-        </AutoId>
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   );
 };
 

--- a/src/core/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Dropdown/Dropdown/Dropdown.tsx
@@ -20,12 +20,15 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../../theme/utils/spacing';
-import { forkRefs, getOwnerDocument } from '../../../utils/common/common';
+import {
+  filterDuplicateKeys,
+  forkRefs,
+  getOwnerDocument,
+} from '../../../utils/common/common';
 import { Popover } from '../../../core/Popover/Popover';
 import { SelectItemList } from '../../Form/Select/BaseSelect/SelectItemList/SelectItemList';
 import { HintText } from '../../Form/HintText/HintText';
@@ -538,8 +541,7 @@ class BaseDropdown<T extends string = string> extends Component<
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     if (React.Children.count(children) < 1) {
       getLogger().warn(`Dropdown '${labelText}' does not contain items`);
@@ -582,7 +584,7 @@ class BaseDropdown<T extends string = string> extends Component<
           [dropdownClassNames.fullWidth]: fullWidth,
         })}
         id={id}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <Label
           id={labelId}
@@ -718,7 +720,14 @@ const StyledDropdown = styled(
     <BaseDropdown {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.dropdown)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.dropdown,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const DropdownInner = <T extends string = string>(

--- a/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -338,6 +338,12 @@ exports[`Basic dropdown should match snapshot 1`] = `
   width: 290px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -1040,6 +1046,12 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   width: 290px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -1735,6 +1747,12 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   width: 290px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -2328,6 +2346,12 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 
 .c1 {
   width: 290px;
+}
+
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
 }
 
 .c1 .fi-dropdown_item-list {

--- a/src/core/Expander/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander/Expander.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   background-color: ${theme.colors.whiteBase};
   position: relative;
   padding: 0;

--- a/src/core/Expander/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander/Expander.baseStyles.tsx
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
+  ${getCssMargins(margins)}
   background-color: ${theme.colors.whiteBase};
   position: relative;
   padding: 0;

--- a/src/core/Expander/Expander/Expander.baseStyles.tsx
+++ b/src/core/Expander/Expander/Expander.baseStyles.tsx
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   background-color: ${theme.colors.whiteBase};
   position: relative;
   padding: 0;

--- a/src/core/Expander/Expander/Expander.test.tsx
+++ b/src/core/Expander/Expander/Expander.test.tsx
@@ -140,7 +140,7 @@ describe('margin prop', () => {
       </Expander>,
     );
     const div = getByTestId('expander-test');
-    expect(div).toHaveAttribute('style', 'margin: 10px;');
+    expect(div).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overridden by style prop', async () => {

--- a/src/core/Expander/Expander/Expander.tsx
+++ b/src/core/Expander/Expander/Expander.tsx
@@ -9,7 +9,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -19,6 +18,7 @@ import {
   ExpanderGroupProviderState,
 } from '../ExpanderGroup/ExpanderGroup';
 import { baseStyles } from './Expander.baseStyles';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const baseClassName = 'fi-expander';
 const openClassName = `${baseClassName}--open`;
@@ -168,8 +168,7 @@ class BaseExpander extends Component<BaseExpanderProps & SuomifiThemeProp> {
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
     const openState = open !== undefined ? !!open : this.state.openState;
 
     return (
@@ -179,7 +178,7 @@ class BaseExpander extends Component<BaseExpanderProps & SuomifiThemeProp> {
         className={classnames(className, baseClassName, {
           [openClassName]: !!openState,
         })}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <ExpanderProvider
           value={{
@@ -202,7 +201,14 @@ const StyledExpander = styled(
     return <BaseExpander {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.expander)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.dropdown,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 interface ExpanderState {

--- a/src/core/Expander/Expander/Expander.tsx
+++ b/src/core/Expander/Expander/Expander.tsx
@@ -3,11 +3,16 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../utils/AutoId/AutoId';
 import { HtmlDivWithRef, HtmlDivWithRefProps } from '../../../reset';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import {
   ExpanderGroupConsumer,
@@ -191,8 +196,13 @@ class BaseExpander extends Component<BaseExpanderProps & SuomifiThemeProp> {
   }
 }
 
-const StyledExpander = styled(BaseExpander)`
-  ${({ theme }) => baseStyles(theme)}
+const StyledExpander = styled(
+  (props: BaseExpanderProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { globalMargins, ...passProps } = props;
+    return <BaseExpander {...passProps} />;
+  },
+)`
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.expander)}
 `;
 
 interface ExpanderState {
@@ -203,25 +213,30 @@ const Expander = forwardRef(
   (props: ExpanderProps, ref: React.Ref<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <ExpanderGroupConsumer>
-                {(consumer) => (
-                  <StyledExpander
-                    theme={suomifiTheme}
-                    id={id}
-                    forwardedRef={ref}
-                    {...passProps}
-                    consumer={consumer}
-                  />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <ExpanderGroupConsumer>
+                    {(consumer) => (
+                      <StyledExpander
+                        theme={suomifiTheme}
+                        globalMargins={margins}
+                        id={id}
+                        forwardedRef={ref}
+                        {...passProps}
+                        consumer={consumer}
+                      />
+                    )}
+                  </ExpanderGroupConsumer>
                 )}
-              </ExpanderGroupConsumer>
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   width: 100%;
   max-width: 100%;
 

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -1,9 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
+  ${getCssMargins(margins)}
   width: 100%;
   max-width: 100%;
 

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.baseStyles.tsx
@@ -3,9 +3,14 @@ import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   width: 100%;
   max-width: 100%;
 

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.test.tsx
@@ -447,7 +447,7 @@ describe('margin prop', () => {
       </ExpanderGroup>,
     );
     const div = getByTestId('expander-group');
-    expect(div).toHaveAttribute('style', 'margin: 10px;');
+    expect(div).toHaveStyle('margin: 10px');
   });
 });
 

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -8,14 +8,16 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import { baseStyles } from './ExpanderGroup.baseStyles';
-import { HTMLAttributesIncludingDataAttributes } from 'utils/common/common';
+import {
+  HTMLAttributesIncludingDataAttributes,
+  filterDuplicateKeys,
+} from '../../../utils/common/common';
 
 const baseClassName = 'fi-expander-group';
 const openClassName = `${baseClassName}--open`;
@@ -174,8 +176,7 @@ class BaseExpanderGroup extends Component<
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
     const { expanderGroupOpenState, allOpen } = this.state;
     return (
       <HtmlDiv
@@ -183,7 +184,7 @@ class BaseExpanderGroup extends Component<
         className={classnames(className, baseClassName, {
           [openClassName]: this.openExpanderCount > 0,
         })}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         {!!showToggleAllButton && (
           <HtmlButton
@@ -226,8 +227,14 @@ const StyledExpanderGroup = styled(
     return <BaseExpanderGroup {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.expanderGroup)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.expanderGroup,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const ExpanderGroup = forwardRef(

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -2,11 +2,16 @@ import React, { Component, ReactNode, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv, HtmlButton, HtmlSpan, HtmlDivProps } from '../../../reset';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import { baseStyles } from './ExpanderGroup.baseStyles';
@@ -215,21 +220,32 @@ class BaseExpanderGroup extends Component<
   }
 }
 
-const StyledExpanderGroup = styled(BaseExpanderGroup)`
-  ${({ theme }) => baseStyles(theme)}
+const StyledExpanderGroup = styled(
+  (props: ExpanderGroupProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { globalMargins, ...passProps } = props;
+    return <BaseExpanderGroup {...passProps} />;
+  },
+)`
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.expanderGroup)}
 `;
 
 const ExpanderGroup = forwardRef(
   (props: ExpanderGroupProps, ref: React.Ref<HTMLButtonElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledExpanderGroup
-          theme={suomifiTheme}
-          forwardedRef={ref}
-          {...props}
-        />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledExpanderGroup
+              theme={suomifiTheme}
+              globalMargins={margins}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 /* stylelint-disable no-descending-specificity */
 const checkedStyles = (theme: SuomifiTheme) => css`
@@ -124,7 +124,7 @@ const largeVariantStyles = (theme: SuomifiTheme) => css`
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   
   & .fi-checkbox_label {
     position: relative;

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -121,10 +121,15 @@ const largeVariantStyles = (theme: SuomifiTheme) => css`
   }
 `;
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   
   & .fi-checkbox_label {
     position: relative;

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
 /* stylelint-disable no-descending-specificity */
 const checkedStyles = (theme: SuomifiTheme) => css`
@@ -120,9 +121,10 @@ const largeVariantStyles = (theme: SuomifiTheme) => css`
   }
 `;
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
+  ${getCssMargins(margins)}
   
   & .fi-checkbox_label {
     position: relative;

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { element, font } from '../../theme/reset';
+import { element, fixInternalMargins, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 /* stylelint-disable no-descending-specificity */
@@ -130,6 +130,7 @@ export const baseStyles = (
   ${font(theme)('bodyTextSmall')}
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
+  ${fixInternalMargins()}
   
   & .fi-checkbox_label {
     position: relative;

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -180,7 +180,7 @@ describe('props', () => {
   describe('margin', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<Checkbox margin="xs">Text</Checkbox>);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
   });
 

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -11,7 +11,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -22,6 +21,7 @@ import { HintText } from '../HintText/HintText';
 import { CheckboxGroupConsumer } from './CheckboxGroup';
 import { baseStyles } from './Checkbox.baseStyles';
 import { IconCheck } from 'suomifi-icons';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const baseClassName = 'fi-checkbox';
 
@@ -161,8 +161,7 @@ class BaseCheckbox extends Component<CheckboxProps> {
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     const { checkedState } = this.state;
 
@@ -197,7 +196,7 @@ class BaseCheckbox extends Component<CheckboxProps> {
             [checkboxClassNames.disabled]: !!disabled,
           },
         )}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlInput
           type="checkbox"
@@ -245,11 +244,19 @@ const StyledCheckbox = styled(
     theme,
     globalMargins,
     ...passProps
-  }: InternalCheckboxProps & SuomifiThemeProp & GlobalMarginProps) => (
-    <BaseCheckbox {...passProps} />
-  ),
+  }: InternalCheckboxProps &
+    SuomifiThemeProp &
+    GlobalMarginProps &
+    MarginProps) => <BaseCheckbox {...passProps} />,
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.checkbox)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.checkbox,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Checkbox = forwardRef(

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -5,11 +5,16 @@ import { InputStatus, StatusTextCommonProps } from '../types';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { HtmlLabel, HtmlDiv, HtmlInput, HtmlInputProps } from '../../../reset';
 import { StatusText } from '../StatusText/StatusText';
@@ -236,36 +241,45 @@ class BaseCheckbox extends Component<CheckboxProps> {
 }
 
 const StyledCheckbox = styled(
-  ({ theme, ...passProps }: InternalCheckboxProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: InternalCheckboxProps & SuomifiThemeProp & GlobalMarginProps) => (
     <BaseCheckbox {...passProps} />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.checkbox)}
 `;
 
 const Checkbox = forwardRef(
   (props: CheckboxProps, ref: React.RefObject<HTMLInputElement>) => {
     const { id: propId, status: propStatus, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <CheckboxGroupConsumer>
-                {({ status: groupStatus }) => (
-                  <StyledCheckbox
-                    theme={suomifiTheme}
-                    id={id}
-                    forwardedRef={ref}
-                    status={!!propStatus ? propStatus : groupStatus}
-                    {...passProps}
-                  />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <CheckboxGroupConsumer>
+                    {({ status: groupStatus }) => (
+                      <StyledCheckbox
+                        theme={suomifiTheme}
+                        id={id}
+                        forwardedRef={ref}
+                        globalMargins={margins}
+                        status={!!propStatus ? propStatus : groupStatus}
+                        {...passProps}
+                      />
+                    )}
+                  </CheckboxGroupConsumer>
                 )}
-              </CheckboxGroupConsumer>
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/Checkbox/CheckboxGroup.baseStyles.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.baseStyles.tsx
@@ -1,9 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
+  ${getCssMargins(margins)}
 
   & .fi-checkbox-group_legend {
     margin-bottom: 10px;

--- a/src/core/Form/Checkbox/CheckboxGroup.baseStyles.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
 
   & .fi-checkbox-group_legend {
     margin-bottom: 10px;

--- a/src/core/Form/Checkbox/CheckboxGroup.baseStyles.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.baseStyles.tsx
@@ -3,9 +3,14 @@ import { SuomifiTheme } from '../../theme';
 import { element } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
 
   & .fi-checkbox-group_legend {
     margin-bottom: 10px;

--- a/src/core/Form/Checkbox/CheckboxGroup.test.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.test.tsx
@@ -165,7 +165,7 @@ describe('props', () => {
     it('should have margin style from margin prop', () => {
       const { getByTestId } = render(Group);
       const div = getByTestId('group');
-      expect(div).toHaveAttribute('style', 'margin: 10px;');
+      expect(div).toHaveStyle('margin: 10px');
     });
 
     it('should have margin style overridden by style prop', async () => {

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -8,7 +8,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -28,6 +27,7 @@ import { CheckboxProps } from './Checkbox';
 import { baseStyles } from './CheckboxGroup.baseStyles';
 import { AutoId } from '../../utils/AutoId/AutoId';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const baseClassName = 'fi-checkbox-group';
 const checkboxGroupClassNames = {
@@ -103,8 +103,7 @@ class BaseCheckboxGroup extends Component<
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     const statusTextId = !!groupStatusText ? `${id}-statusText` : undefined;
 
@@ -113,7 +112,7 @@ class BaseCheckboxGroup extends Component<
         className={classnames(baseClassName, className)}
         id={id}
         {...passProps}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlFieldSet>
           <HtmlLegend className={checkboxGroupClassNames.legend}>
@@ -167,8 +166,14 @@ const StyledCheckboxGroup = styled(
     <BaseCheckboxGroup {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins.checkboxGroup)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.checkboxGroup,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const CheckboxGroup = forwardRef(

--- a/src/core/Form/Checkbox/CheckboxGroup.tsx
+++ b/src/core/Form/Checkbox/CheckboxGroup.tsx
@@ -2,11 +2,16 @@ import React, { Component, ReactNode, forwardRef, ReactElement } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import {
   HtmlDiv,
@@ -154,28 +159,41 @@ class BaseCheckboxGroup extends Component<
   }
 }
 
-const StyledCheckboxGroup = styled(BaseCheckboxGroup)`
-  ${({ theme }) => baseStyles(theme)}
+const StyledCheckboxGroup = styled(
+  ({
+    globalMargins,
+    ...passProps
+  }: CheckboxGroupProps & SuomifiThemeProp & GlobalMarginProps) => (
+    <BaseCheckboxGroup {...passProps} />
+  ),
+)`
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins.checkboxGroup)}
 `;
 
 const CheckboxGroup = forwardRef(
   (props: CheckboxGroupProps, ref: React.Ref<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledCheckboxGroup
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledCheckboxGroup
+                    theme={suomifiTheme}
+                    id={id}
+                    globalMargins={margins}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -169,6 +169,12 @@ exports[`props children has matching snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-checkbox_label {
   position: relative;
   display: block;

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -307,6 +307,12 @@ exports[`default, with only required props should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c7 .fi-label,
+.c7 .fi-hint-text,
+.c7 .fi-status-text {
+  margin: 0;
+}
+
 .c7 .fi-checkbox_label {
   position: relative;
   display: block;

--- a/src/core/Form/DateInput/DateInput.baseStyles.tsx
+++ b/src/core/Form/DateInput/DateInput.baseStyles.tsx
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
   width: 150px;
+  ${getCssMargins(margins)};
 
   &.fi-date-input--full-width {
     width: 100%;

--- a/src/core/Form/DateInput/DateInput.baseStyles.tsx
+++ b/src/core/Form/DateInput/DateInput.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
   width: 150px;
-  ${getCssMargins(margins)};
+  ${buildSpacingCSS(margins)};
 
   &.fi-date-input--full-width {
     width: 100%;

--- a/src/core/Form/DateInput/DateInput.baseStyles.tsx
+++ b/src/core/Form/DateInput/DateInput.baseStyles.tsx
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${font(theme)('bodyText')}
   width: 150px;
-  ${buildSpacingCSS(margins)};
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)};
 
   &.fi-date-input--full-width {
     width: 100%;

--- a/src/core/Form/DateInput/DateInput.baseStyles.tsx
+++ b/src/core/Form/DateInput/DateInput.baseStyles.tsx
@@ -1,6 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { input, containerIEFocus, font } from '../../theme/reset';
+import {
+  input,
+  containerIEFocus,
+  font,
+  fixInternalMargins,
+} from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (
@@ -12,6 +17,7 @@ export const baseStyles = (
   width: 150px;
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)};
+  ${fixInternalMargins()}
 
   &.fi-date-input--full-width {
     width: 100%;

--- a/src/core/Form/DateInput/DateInput.test.tsx
+++ b/src/core/Form/DateInput/DateInput.test.tsx
@@ -875,7 +875,7 @@ describe('props', () => {
           <DateInput labelText="Date" margin="xs" />,
         );
         const div = baseElement.querySelector('.fi-date-input');
-        expect(div).toHaveAttribute('style', 'margin: 10px;');
+        expect(div).toHaveStyle('margin: 10px');
       });
 
       it('has margin style overwritten by style prop', () => {

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -12,7 +12,11 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { IconCalendar } from 'suomifi-icons';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
@@ -49,6 +53,7 @@ import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMargins,
 } from '../../theme/utils/spacing';
 
 const baseClassName = 'fi-date-input';
@@ -477,31 +482,40 @@ const BaseDateInput = (props: DateInputProps) => {
 };
 
 const StyledDateInput = styled(
-  ({ theme, ...passProps }: DateInputProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: DateInputProps & SuomifiThemeProp & { globalMargins: GlobalMargins }) => (
     <BaseDateInput {...passProps} />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.dateInput)}
 `;
 
 const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
   (props: DateInputProps, ref: React.Ref<HTMLInputElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledDateInput
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledDateInput
+                    theme={suomifiTheme}
+                    id={id}
+                    forwardedRef={ref}
+                    globalMargins={margins}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -22,6 +22,7 @@ import { getConditionalAriaProp } from '../../../utils/aria';
 import { getLogger } from '../../../utils/log';
 import {
   HTMLAttributesIncludingDataAttributes,
+  filterDuplicateKeys,
   forkRefs,
 } from '../../../utils/common/common';
 import { HtmlInputProps, HtmlDiv, HtmlInput, HtmlButton } from '../../../reset';
@@ -50,7 +51,6 @@ import {
   cellDateAriaLabel,
 } from './dateUtils';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMargins,
@@ -259,8 +259,7 @@ const BaseDateInput = (props: DateInputProps) => {
     style,
     ...rest
   } = props;
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
 
   const hintTextId = `${id}-hintText`;
 
@@ -376,7 +375,7 @@ const BaseDateInput = (props: DateInputProps) => {
         [dateInputClassNames.fullWidth]: fullWidth,
         [dateInputClassNames.hasPicker]: datePickerEnabled,
       })}
-      style={{ ...marginStyle, ...style }}
+      style={style}
     >
       <HtmlDiv className={dateInputClassNames.styleWrapper}>
         <Label
@@ -490,7 +489,14 @@ const StyledDateInput = styled(
     <BaseDateInput {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.dateInput)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.dateInput,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const DateInput = forwardRef<HTMLInputElement, DateInputProps>(

--- a/src/core/Form/DateInput/DatePicker/DatePicker.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.baseStyles.tsx
@@ -1,14 +1,19 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
-import { font } from '../../../theme/reset';
+import { fixInternalMargins, font } from '../../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')};
+  ${fixInternalMargins()}
 
   &.fi-date-picker {
     background-color: ${theme.colors.whiteBase};
     box-shadow: ${theme.shadows.wideBoxShadow};
     border: 1px solid ${theme.colors.blackLight1};
+
+    & .fi-button {
+      margin: 0;
+    }
   }
 
   & .fi-date-picker_bottom-container {

--- a/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
@@ -13,6 +13,7 @@ export const baseStyles = (
   }
 
   & .fi-date-selectors_year-select {
+    margin: 0;
     margin-right: ${theme.spacing.xs};
     width: ${yearSelectWidth}px;
     .fi-dropdown_button {
@@ -21,6 +22,7 @@ export const baseStyles = (
   }
 
   & .fi-date-selectors_month-select {
+    margin: 0;
     margin-right: ${theme.spacing.xxs};
     width: ${monthSelectWidth}px;
     .fi-dropdown_button {

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -227,6 +227,12 @@ exports[`snapshots match date input error status with statustext 1`] = `
   width: 150px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-date-input--full-width {
   width: 100%;
 }
@@ -729,6 +735,12 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
   width: 150px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-date-input--full-width {
   width: 100%;
 }
@@ -1221,6 +1233,12 @@ exports[`snapshots match date input hint text 1`] = `
   width: 150px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-date-input--full-width {
   width: 100%;
 }
@@ -1698,6 +1716,12 @@ exports[`snapshots match date input minimal implementation 1`] = `
   width: 150px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-date-input--full-width {
   width: 100%;
 }
@@ -2166,6 +2190,12 @@ exports[`snapshots match date input optional text 1`] = `
   line-height: 1.5;
   font-weight: 400;
   width: 150px;
+}
+
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
 }
 
 .c1.fi-date-input--full-width {
@@ -2665,6 +2695,12 @@ exports[`snapshots match date input success status with statustext 1`] = `
   line-height: 1.5;
   font-weight: 400;
   width: 150px;
+}
+
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
 }
 
 .c1.fi-date-input--full-width {
@@ -3718,6 +3754,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   width: 290px;
 }
 
+.c12 .fi-label,
+.c12 .fi-hint-text,
+.c12 .fi-status-text {
+  margin: 0;
+}
+
 .c12 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -3907,6 +3949,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 }
 
 .c11 .fi-date-selectors_year-select {
+  margin: 0;
   margin-right: 10px;
   width: 0px;
 }
@@ -3916,6 +3959,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 }
 
 .c11 .fi-date-selectors_month-select {
+  margin: 0;
   margin-right: 5px;
   width: 0px;
 }
@@ -3961,10 +4005,20 @@ exports[`snapshots match date input with datepicker with controlled input value 
   font-weight: 400;
 }
 
+.c10 .fi-label,
+.c10 .fi-hint-text,
+.c10 .fi-status-text {
+  margin: 0;
+}
+
 .c10.fi-date-picker {
   background-color: hsl(0,0%,100%);
   box-shadow: 0px 4px 8px 0px hsla(0,0%,13%,0.14);
   border: 1px solid hsl(0,0%,42%);
+}
+
+.c10.fi-date-picker .fi-button {
+  margin: 0;
 }
 
 .c10 .fi-date-picker_bottom-container {
@@ -4113,6 +4167,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   line-height: 1.5;
   font-weight: 400;
   width: 150px;
+}
+
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
 }
 
 .c1.fi-date-input--full-width {
@@ -5960,6 +6020,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   width: 290px;
 }
 
+.c12 .fi-label,
+.c12 .fi-hint-text,
+.c12 .fi-status-text {
+  margin: 0;
+}
+
 .c12 .fi-dropdown_item-list {
   padding-top: 0;
 }
@@ -6149,6 +6215,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 }
 
 .c11 .fi-date-selectors_year-select {
+  margin: 0;
   margin-right: 10px;
   width: 0px;
 }
@@ -6158,6 +6225,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 }
 
 .c11 .fi-date-selectors_month-select {
+  margin: 0;
   margin-right: 5px;
   width: 0px;
 }
@@ -6203,10 +6271,20 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   font-weight: 400;
 }
 
+.c10 .fi-label,
+.c10 .fi-hint-text,
+.c10 .fi-status-text {
+  margin: 0;
+}
+
 .c10.fi-date-picker {
   background-color: hsl(0,0%,100%);
   box-shadow: 0px 4px 8px 0px hsla(0,0%,13%,0.14);
   border: 1px solid hsl(0,0%,42%);
+}
+
+.c10.fi-date-picker .fi-button {
+  margin: 0;
 }
 
 .c10 .fi-date-picker_bottom-container {
@@ -6355,6 +6433,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   line-height: 1.5;
   font-weight: 400;
   width: 150px;
+}
+
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
 }
 
 .c1.fi-date-input--full-width {

--- a/src/core/Form/ErrorSummary/ErrorSummary.tsx
+++ b/src/core/Form/ErrorSummary/ErrorSummary.tsx
@@ -5,11 +5,7 @@ import { HtmlDiv, HtmlDivWithRef, HtmlDivProps, hLevels } from '../../../reset';
 import { IconErrorFilled } from 'suomifi-icons';
 import { AutoId } from '../../utils/AutoId/AutoId';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
-import {
-  spacingStyles,
-  separateMarginProps,
-  MarginProps,
-} from '../../theme/utils/spacing';
+import { separateMarginProps, MarginProps } from '../../theme/utils/spacing';
 import { baseStyles } from './ErrorSummary.baseStyles';
 import { Heading } from '../../Heading/Heading';
 import { Link } from '../../Link';
@@ -77,8 +73,7 @@ const BaseErrorSummary = (props: ErrorSummaryProps) => {
     forwardedRef,
     ...rest
   } = props;
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
 
   const focusInput = (
     event: MouseEvent<HTMLAnchorElement>,
@@ -104,7 +99,7 @@ const BaseErrorSummary = (props: ErrorSummaryProps) => {
       className={classnames(baseClassName, className, {
         [inlineAlertClassNames.smallScreen]: !!smallScreen,
       })}
-      style={{ ...marginStyle, ...passProps?.style }}
+      style={{ ...passProps?.style }}
       ref={forwardedRef}
     >
       <HtmlDiv className={inlineAlertClassNames.styleWrapper}>

--- a/src/core/Form/HintText/HintText.baseStyles.tsx
+++ b/src/core/Form/HintText/HintText.baseStyles.tsx
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   color: ${theme.colors.blackBase};
   ${font(theme)('bodyTextSmall')};
+  ${getCssMargins(margins)}
 
   &.fi-hint-text {
     display: block;

--- a/src/core/Form/HintText/HintText.baseStyles.tsx
+++ b/src/core/Form/HintText/HintText.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   color: ${theme.colors.blackBase};
   ${font(theme)('bodyTextSmall')};
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
 
   &.fi-hint-text {
     display: block;

--- a/src/core/Form/HintText/HintText.baseStyles.tsx
+++ b/src/core/Form/HintText/HintText.baseStyles.tsx
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   color: ${theme.colors.blackBase};
   ${font(theme)('bodyTextSmall')};
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
 
   &.fi-hint-text {
     display: block;

--- a/src/core/Form/HintText/HintText.test.tsx
+++ b/src/core/Form/HintText/HintText.test.tsx
@@ -36,7 +36,7 @@ describe('props', () => {
   describe('margin', () => {
     it('should have margin style from margin prop', () => {
       const { getByText } = render(<HintText margin="xs">Test</HintText>);
-      expect(getByText('Test')).toHaveAttribute('style', 'margin: 10px;');
+      expect(getByText('Test')).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Form/HintText/HintText.tsx
+++ b/src/core/Form/HintText/HintText.tsx
@@ -2,11 +2,16 @@ import React, { forwardRef, ReactNode } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { baseStyles } from './HintText.baseStyles';
 
@@ -26,10 +31,11 @@ export interface HintTextProps extends HtmlSpanProps, MarginProps {
 const StyledHintText = styled(
   ({
     className,
+    globalMargins,
     theme,
     children,
     ...rest
-  }: HintTextProps & SuomifiThemeProp) => {
+  }: HintTextProps & SuomifiThemeProp & GlobalMarginProps) => {
     const [marginProps, passProps] = separateMarginProps(rest);
     const marginStyle = spacingStyles(marginProps);
     return (
@@ -43,7 +49,7 @@ const StyledHintText = styled(
     );
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.hintText)}
 `;
 
 const HintText = forwardRef(
@@ -53,17 +59,22 @@ const HintText = forwardRef(
       return null;
     }
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledHintText
-            forwardedRef={ref}
-            theme={suomifiTheme}
-            {...passProps}
-          >
-            {children}
-          </StyledHintText>
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <StyledHintText
+                forwardedRef={ref}
+                theme={suomifiTheme}
+                globalMargins={margins}
+                {...passProps}
+              >
+                {children}
+              </StyledHintText>
+            )}
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/HintText/HintText.tsx
+++ b/src/core/Form/HintText/HintText.tsx
@@ -8,12 +8,12 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { baseStyles } from './HintText.baseStyles';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const baseClassName = 'fi-hint-text';
 
@@ -36,20 +36,27 @@ const StyledHintText = styled(
     children,
     ...rest
   }: HintTextProps & SuomifiThemeProp & GlobalMarginProps) => {
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     return (
       <HtmlSpan
         {...passProps}
         className={classnames(className, baseClassName, {})}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       >
         {children}
       </HtmlSpan>
     );
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.hintText)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.hintText,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const HintText = forwardRef(

--- a/src/core/Form/Label/Label.baseStyles.tsx
+++ b/src/core/Form/Label/Label.baseStyles.tsx
@@ -1,8 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+  ${getCssMargins(margins)}
+
   &.fi-label {
     & .fi-label_label-span {
       ${font(theme)('actionElementInnerTextBold')};

--- a/src/core/Form/Label/Label.baseStyles.tsx
+++ b/src/core/Form/Label/Label.baseStyles.tsx
@@ -1,10 +1,10 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
 
   &.fi-label {
     & .fi-label_label-span {

--- a/src/core/Form/Label/Label.baseStyles.tsx
+++ b/src/core/Form/Label/Label.baseStyles.tsx
@@ -3,8 +3,13 @@ import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
-  ${buildSpacingCSS(margins)}
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
 
   &.fi-label {
     & .fi-label_label-span {

--- a/src/core/Form/Label/Label.test.tsx
+++ b/src/core/Form/Label/Label.test.tsx
@@ -67,7 +67,7 @@ describe('props', () => {
   describe('margin', () => {
     it('has margin style from margin prop', () => {
       const { container } = render(<Label margin="xs">Test text</Label>);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('has margin prop overwritten by style prop', () => {

--- a/src/core/Form/Label/Label.tsx
+++ b/src/core/Form/Label/Label.tsx
@@ -9,11 +9,16 @@ import React, {
 } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { baseStyles } from './Label.baseStyles';
 import { asPropType } from '../../../utils/typescript';
@@ -75,11 +80,12 @@ const StyledLabel = styled(
     style,
     children,
     asProp = 'label',
+    globalMargins,
     optionalText,
     tooltipComponent: tooltipComponentProp,
     forceTooltipRerender = false,
     ...rest
-  }: LabelProps & SuomifiThemeProp) => {
+  }: LabelProps & SuomifiThemeProp & GlobalMarginProps) => {
     const [marginProps, passProps] = separateMarginProps(rest);
     const marginStyle = spacingStyles(marginProps);
     const [wrapperRef, setWrapperRef] = useState<HTMLDivElement | null>(null);
@@ -136,13 +142,23 @@ const StyledLabel = styled(
     );
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.label)}
 `;
 
 const Label = (props: LabelProps) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => <StyledLabel theme={suomifiTheme} {...props} />}
-  </SuomifiThemeConsumer>
+  <SpacingConsumer>
+    {({ margins }) => (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledLabel
+            globalMargins={margins}
+            theme={suomifiTheme}
+            {...props}
+          />
+        )}
+      </SuomifiThemeConsumer>
+    )}
+  </SpacingConsumer>
 );
 
 Label.displayName = 'Label';

--- a/src/core/Form/Label/Label.tsx
+++ b/src/core/Form/Label/Label.tsx
@@ -15,7 +15,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -25,6 +24,7 @@ import { asPropType } from '../../../utils/typescript';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import { HtmlSpan, HtmlSpanProps, HtmlDivWithRef } from '../../../reset';
 import { TooltipProps } from '../../Tooltip/Tooltip';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 export type LabelMode = 'hidden' | 'visible';
 
@@ -86,8 +86,8 @@ const StyledLabel = styled(
     forceTooltipRerender = false,
     ...rest
   }: LabelProps & SuomifiThemeProp & GlobalMarginProps) => {
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     const [wrapperRef, setWrapperRef] = useState<HTMLDivElement | null>(null);
 
     function getTooltipComponent(
@@ -109,7 +109,7 @@ const StyledLabel = styled(
         forwardedRef={(ref: SetStateAction<HTMLDivElement | null>) =>
           setWrapperRef(ref)
         }
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         {labelMode === 'hidden' ? (
           <VisuallyHidden as={asProp} {...passProps}>
@@ -142,7 +142,14 @@ const StyledLabel = styled(
     );
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.label)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.label,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Label = (props: LabelProps) => (

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -70,11 +70,16 @@ const largeStyles = () => css`
   }
 `;
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   position: relative;
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
 
   &.fi-radio-button {
     & .fi-radio-button_hintText {

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -1,7 +1,7 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 const disabledStyles = (theme: SuomifiTheme) => css`
   &.fi-radio-button--disabled {
@@ -74,7 +74,7 @@ export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   position: relative;
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
 
   &.fi-radio-button {
     & .fi-radio-button_hintText {

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
 const disabledStyles = (theme: SuomifiTheme) => css`
   &.fi-radio-button--disabled {
@@ -69,10 +70,11 @@ const largeStyles = () => css`
   }
 `;
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   position: relative;
+  ${getCssMargins(margins)}
 
   &.fi-radio-button {
     & .fi-radio-button_hintText {

--- a/src/core/Form/RadioButton/RadioButton.test.tsx
+++ b/src/core/Form/RadioButton/RadioButton.test.tsx
@@ -147,7 +147,7 @@ describe('children', () => {
 describe('margin', () => {
   it('should have margin style from margin prop', () => {
     const { container } = render(<RadioButton value="value" margin="xs" />);
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overridden by style prop', async () => {

--- a/src/core/Form/RadioButton/RadioButton.tsx
+++ b/src/core/Form/RadioButton/RadioButton.tsx
@@ -10,11 +10,16 @@ import {
 } from '../../../reset';
 import { getLogger } from '../../../utils/log';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../theme';
+import {
+  SpacingConsumer,
+  SuomifiThemeConsumer,
+  SuomifiThemeProp,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { HintText } from '../HintText/HintText';
@@ -176,49 +181,60 @@ class BaseRadioButton extends Component<RadioButtonProps> {
 }
 
 const StyledRadioButton = styled(
-  ({ theme, ...passProps }: RadioButtonProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: RadioButtonProps & SuomifiThemeProp & GlobalMarginProps) => (
     <BaseRadioButton {...passProps} />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.radioButton)}
 `;
 
 const RadioButton = forwardRef(
   (props: RadioButtonProps, ref: React.RefObject<HTMLInputElement>) => {
     const { id: propId, onChange, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <RadioButtonGroupConsumer>
-                {({ onRadioButtonChange, selectedValue, name }) => (
-                  <StyledRadioButton
-                    theme={suomifiTheme}
-                    id={id}
-                    forwardedRef={ref}
-                    {...passProps}
-                    {...(!!onRadioButtonChange
-                      ? {
-                          checked: selectedValue === passProps.value,
-                          name,
-                        }
-                      : {})}
-                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                      if (!!onRadioButtonChange) {
-                        onRadioButtonChange(event.target.value);
-                      }
-                      if (!!onChange) {
-                        onChange(event);
-                      }
-                    }}
-                  />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <RadioButtonGroupConsumer>
+                    {({ onRadioButtonChange, selectedValue, name }) => (
+                      <StyledRadioButton
+                        theme={suomifiTheme}
+                        id={id}
+                        forwardedRef={ref}
+                        globalMargins={margins}
+                        {...passProps}
+                        {...(!!onRadioButtonChange
+                          ? {
+                              checked: selectedValue === passProps.value,
+                              name,
+                            }
+                          : {})}
+                        onChange={(
+                          event: React.ChangeEvent<HTMLInputElement>,
+                        ) => {
+                          if (!!onRadioButtonChange) {
+                            onRadioButtonChange(event.target.value);
+                          }
+                          if (!!onChange) {
+                            onChange(event);
+                          }
+                        }}
+                      />
+                    )}
+                  </RadioButtonGroupConsumer>
                 )}
-              </RadioButtonGroupConsumer>
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/RadioButton/RadioButton.tsx
+++ b/src/core/Form/RadioButton/RadioButton.tsx
@@ -16,7 +16,6 @@ import {
   SuomifiThemeProp,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -26,6 +25,7 @@ import { HintText } from '../HintText/HintText';
 import { RadioButtonGroupConsumer } from './RadioButtonGroup';
 import { baseStyles } from './RadioButton.baseStyles';
 import { IconRadioButton, IconRadioButtonLarge } from 'suomifi-icons';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const baseClassName = 'fi-radio-button';
 const radioButtonClassNames = {
@@ -117,8 +117,7 @@ class BaseRadioButton extends Component<RadioButtonProps> {
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     if (!children) {
       getLogger().error(
@@ -143,7 +142,7 @@ class BaseRadioButton extends Component<RadioButtonProps> {
             [radioButtonClassNames.checked]: checked,
           },
         )}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlInput
           className={radioButtonClassNames.input}
@@ -189,7 +188,14 @@ const StyledRadioButton = styled(
     <BaseRadioButton {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.radioButton)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.radioButton,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const RadioButton = forwardRef(

--- a/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
+  ${getCssMargins(margins)}
 
   &.fi-radio-button-group {
     & .fi-radio-button-group_legend {

--- a/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
 
   &.fi-radio-button-group {
     & .fi-radio-button-group_legend {

--- a/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
 
   &.fi-radio-button-group {
     & .fi-radio-button-group_legend {

--- a/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.baseStyles.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { element, font } from '../../theme/reset';
+import { element, fixInternalMargins, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (
@@ -12,6 +12,7 @@ export const baseStyles = (
   ${font(theme)('bodyText')}
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
+  ${fixInternalMargins()}
 
   &.fi-radio-button-group {
     & .fi-radio-button-group_legend {
@@ -39,6 +40,7 @@ export const baseStyles = (
 
   & .fi-radio-button-group_container {
     & > .fi-radio-button {
+      margin: 0;
       margin-bottom: ${theme.spacing.xs};
 
       &:last-child {

--- a/src/core/Form/RadioButton/RadioButtonGroup.test.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.test.tsx
@@ -222,7 +222,7 @@ describe('props', () => {
           <RadioButton value="" />
         </RadioButtonGroup>,
       );
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin style overridden by style prop', async () => {

--- a/src/core/Form/RadioButton/RadioButtonGroup.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.tsx
@@ -6,7 +6,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -24,6 +23,7 @@ import { RadioButtonProps } from './RadioButton';
 import { baseStyles } from './RadioButtonGroup.baseStyles';
 import { AutoId } from '../../utils/AutoId/AutoId';
 import classnames from 'classnames';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const baseClassName = 'fi-radio-button-group';
 const radioButtonGroupClassNames = {
@@ -127,15 +127,14 @@ class BaseRadioButtonGroup extends Component<
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     return (
       <HtmlDivWithRef
         className={classnames(baseClassName, className)}
         id={id}
         {...passProps}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlFieldSet>
           <HtmlLegend className={radioButtonGroupClassNames.legend}>
@@ -178,8 +177,14 @@ const StyledRadioButtonGroup = styled(
     <BaseRadioButtonGroup {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.radioButtonGroup)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.radioButtonGroup,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const RadioButtonGroup = forwardRef(

--- a/src/core/Form/RadioButton/RadioButtonGroup.tsx
+++ b/src/core/Form/RadioButton/RadioButtonGroup.tsx
@@ -1,10 +1,15 @@
 import React, { Component, forwardRef, ReactElement, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import {
   HtmlDiv,
@@ -165,28 +170,41 @@ class BaseRadioButtonGroup extends Component<
   }
 }
 
-const StyledRadioButtonGroup = styled(BaseRadioButtonGroup)`
-  ${({ theme }) => baseStyles(theme)}
+const StyledRadioButtonGroup = styled(
+  ({
+    globalMargins,
+    ...passProps
+  }: RadioButtonGroupProps & SuomifiThemeProp & GlobalMarginProps) => (
+    <BaseRadioButtonGroup {...passProps} />
+  ),
+)`
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.radioButtonGroup)}
 `;
 
 const RadioButtonGroup = forwardRef(
   (props: RadioButtonGroupProps, ref: React.RefObject<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledRadioButtonGroup
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledRadioButtonGroup
+                    theme={suomifiTheme}
+                    id={id}
+                    globalMargins={margins}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -243,6 +243,12 @@ exports[`default, with only required props should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_legend {
   margin-bottom: 10px;
 }
@@ -272,6 +278,7 @@ exports[`default, with only required props should match snapshot 1`] = `
 }
 
 .c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin: 0;
   margin-bottom: 10px;
 }
 
@@ -864,6 +871,12 @@ exports[`props className should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_legend {
   margin-bottom: 10px;
 }
@@ -893,6 +906,7 @@ exports[`props className should match snapshot 1`] = `
 }
 
 .c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin: 0;
   margin-bottom: 10px;
 }
 
@@ -1485,6 +1499,12 @@ exports[`props defaultValue should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_legend {
   margin-bottom: 10px;
 }
@@ -1514,6 +1534,7 @@ exports[`props defaultValue should match snapshot 1`] = `
 }
 
 .c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin: 0;
   margin-bottom: 10px;
 }
 
@@ -2128,6 +2149,12 @@ exports[`props hintText should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_legend {
   margin-bottom: 10px;
 }
@@ -2157,6 +2184,7 @@ exports[`props hintText should match snapshot 1`] = `
 }
 
 .c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin: 0;
   margin-bottom: 10px;
 }
 
@@ -2754,6 +2782,12 @@ exports[`props id should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_legend {
   margin-bottom: 10px;
 }
@@ -2783,6 +2817,7 @@ exports[`props id should match snapshot 1`] = `
 }
 
 .c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin: 0;
   margin-bottom: 10px;
 }
 
@@ -3375,6 +3410,12 @@ exports[`props label should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_legend {
   margin-bottom: 10px;
 }
@@ -3404,6 +3445,7 @@ exports[`props label should match snapshot 1`] = `
 }
 
 .c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin: 0;
   margin-bottom: 10px;
 }
 
@@ -4008,6 +4050,12 @@ exports[`props labelMode should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_legend {
   margin-bottom: 10px;
 }
@@ -4037,6 +4085,7 @@ exports[`props labelMode should match snapshot 1`] = `
 }
 
 .c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin: 0;
   margin-bottom: 10px;
 }
 
@@ -4629,6 +4678,12 @@ exports[`props name should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_legend {
   margin-bottom: 10px;
 }
@@ -4658,6 +4713,7 @@ exports[`props name should match snapshot 1`] = `
 }
 
 .c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin: 0;
   margin-bottom: 10px;
 }
 
@@ -5250,6 +5306,12 @@ exports[`props value should match snapshot 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-radio-button-group .fi-radio-button-group_legend {
   margin-bottom: 10px;
 }
@@ -5279,6 +5341,7 @@ exports[`props value should match snapshot 1`] = `
 }
 
 .c1 .fi-radio-button-group_container > .fi-radio-button {
+  margin: 0;
   margin-bottom: 10px;
 }
 

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -1,9 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
+  ${getCssMargins(margins)}
   width: 290px;
 
   & .fi-search-input {

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -3,9 +3,14 @@ import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   width: 290px;
 
   & .fi-search-input {

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   width: 290px;
 
   & .fi-search-input {

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -1,6 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { input, containerIEFocus, font } from '../../theme/reset';
+import {
+  input,
+  containerIEFocus,
+  font,
+  fixInternalMargins,
+} from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (
@@ -11,6 +16,7 @@ export const baseStyles = (
   ${font(theme)('bodyText')}
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
+  ${fixInternalMargins()}
   width: 290px;
 
   & .fi-search-input {

--- a/src/core/Form/SearchInput/SearchInput.test.tsx
+++ b/src/core/Form/SearchInput/SearchInput.test.tsx
@@ -72,7 +72,7 @@ describe('props', () => {
           margin="xs"
         />,
       );
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop overwritten by style prop', () => {

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -15,7 +15,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -37,6 +36,7 @@ import { IconSearch } from 'suomifi-icons';
 import { InputStatus, StatusTextCommonProps } from '../types';
 import { baseStyles } from './SearchInput.baseStyles';
 import { InputClearButton } from '../InputClearButton/InputClearButton';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 type SearchInputValue = string | number | undefined;
 
@@ -169,8 +169,8 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
       statusTextAriaLiveMode = 'assertive',
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     const statusTextId = `${id}-statusText`;
 
     const conditionalSetState = (newValue: SearchInputValue) => {
@@ -237,7 +237,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
           [searchInputClassNames.notEmpty]: !!this.state.value,
           [searchInputClassNames.fullWidth]: fullWidth,
         })}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlSpan className={searchInputClassNames.styleWrapper}>
           <Label
@@ -322,7 +322,14 @@ const StyledSearchInput = styled(
     <BaseSearchInput {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.searchInput)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.searchInput,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const SearchInput = forwardRef(

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -9,11 +9,16 @@ import React, {
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { Debounce } from '../../utils/Debounce/Debounce';
@@ -309,28 +314,40 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
   }
 }
 
-const StyledSearchInput = styled(BaseSearchInput)`
-  ${({ theme }) => baseStyles(theme)}
+const StyledSearchInput = styled(
+  ({
+    globalMargins,
+    ...passProps
+  }: SearchInputProps & SuomifiThemeProp & GlobalMarginProps) => (
+    <BaseSearchInput {...passProps} />
+  ),
+)`
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.searchInput)}
 `;
 
 const SearchInput = forwardRef(
   (props: SearchInputProps, ref: React.RefObject<HTMLInputElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledSearchInput
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledSearchInput
+                    theme={suomifiTheme}
+                    id={id}
+                    globalMargins={margins}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -378,6 +378,12 @@ exports[`snapshot should have matching default structure 1`] = `
   width: 290px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-search-input_wrapper {
   width: 100%;
   min-width: 105px;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../../theme';
 import { font } from '../../../../theme/reset';
+import { MarginProps, getCssMargins } from '../../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
   width: 290px;
+  ${getCssMargins(margins)}
 
   &.fi-multiselect {
     & .fi-filter-input_input-element-container {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../../../../theme';
 import { font } from '../../../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${font(theme)('bodyText')}
   width: 290px;
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
 
   &.fi-multiselect {
     & .fi-filter-input_input-element-container {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../../theme';
 import { font } from '../../../../theme/reset';
-import { MarginProps, getCssMargins } from '../../../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
   width: 290px;
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
 
   &.fi-multiselect {
     & .fi-filter-input_input-element-container {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../../theme';
-import { font } from '../../../../theme/reset';
+import { fixInternalMargins, font } from '../../../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../../../theme/utils/spacing';
 
 export const baseStyles = (
@@ -12,6 +12,8 @@ export const baseStyles = (
   width: 290px;
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
+  ${fixInternalMargins()}
+
 
   &.fi-multiselect {
     & .fi-filter-input_input-element-container {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
@@ -34,6 +34,6 @@ export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   }
 
   & .fi-multiselect_removeAllButton {
-    margin-top: 10px;
+    margin: 10px 0 0 0;
   }
 `;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -91,19 +91,24 @@ const countries = [
     ariaOptionsAvailableText="options available"
     ariaOptionChipRemovedText="removed"
   />
-  ;
-  <SpacingProvider margins={{ mt: 'xxxl' }}>
+  <SpacingProvider
+    margins={{
+      all: {mt: 'xxxl'}
+      textInput: { mt: 's', ml: 'l' },
+      button: { margin: 'l' }
+    }}
+  >
     <MultiSelect
-      labelText="Tools"
-      hintText="You can filter options by typing in the field"
-      items={tools}
+      labelText="Visited countries"
+      hintText="Select all countries you have visited during the past year. You can filter options by typing in the field"
+      items={countries}
       chipListVisible={true}
       ariaChipActionLabel="Remove"
       removeAllButtonLabel="Remove all selections"
-      visualPlaceholder="Choose your tools"
+      visualPlaceholder="Choose visited countries"
       noItemsText="No items"
       defaultSelectedItems={defaultSelectedTools}
-      ariaSelectedAmountText="tools selected"
+      ariaSelectedAmountText="countries selected"
       ariaOptionsAvailableText="options available"
       ariaOptionChipRemovedText="removed"
     />

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -91,28 +91,6 @@ const countries = [
     ariaOptionsAvailableText="options available"
     ariaOptionChipRemovedText="removed"
   />
-  <SpacingProvider
-    margins={{
-      all: {mt: 'xxxl'}
-      textInput: { mt: 's', ml: 'l' },
-      button: { margin: 'l' }
-    }}
-  >
-    <MultiSelect
-      labelText="Visited countries"
-      hintText="Select all countries you have visited during the past year. You can filter options by typing in the field"
-      items={countries}
-      chipListVisible={true}
-      ariaChipActionLabel="Remove"
-      removeAllButtonLabel="Remove all selections"
-      visualPlaceholder="Choose visited countries"
-      noItemsText="No items"
-      defaultSelectedItems={defaultSelectedTools}
-      ariaSelectedAmountText="countries selected"
-      ariaOptionsAvailableText="options available"
-      ariaOptionChipRemovedText="removed"
-    />
-  </SpacingProvider>
 </>;
 ```
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -77,19 +77,38 @@ const countries = [
   }
 ];
 
-<MultiSelect
-  labelText="Visited countries"
-  hintText="Select all countries you have visited during the past year. You can filter options by typing in the field"
-  items={countries}
-  chipListVisible
-  ariaChipActionLabel="Deselect"
-  removeAllButtonLabel="Remove all selections"
-  visualPlaceholder="Choose countries"
-  noItemsText="No items"
-  ariaSelectedAmountText="countries selected"
-  ariaOptionsAvailableText="options available"
-  ariaOptionChipRemovedText="removed"
-/>;
+<>
+  <MultiSelect
+    labelText="Visited countries"
+    hintText="Select all countries you have visited during the past year. You can filter options by typing in the field"
+    items={countries}
+    chipListVisible
+    ariaChipActionLabel="Deselect"
+    removeAllButtonLabel="Remove all selections"
+    visualPlaceholder="Choose countries"
+    noItemsText="No items"
+    ariaSelectedAmountText="countries selected"
+    ariaOptionsAvailableText="options available"
+    ariaOptionChipRemovedText="removed"
+  />
+  ;
+  <SpacingProvider margins={{ mt: 'xxxl' }}>
+    <MultiSelect
+      labelText="Tools"
+      hintText="You can filter options by typing in the field"
+      items={tools}
+      chipListVisible={true}
+      ariaChipActionLabel="Remove"
+      removeAllButtonLabel="Remove all selections"
+      visualPlaceholder="Choose your tools"
+      noItemsText="No items"
+      defaultSelectedItems={defaultSelectedTools}
+      ariaSelectedAmountText="tools selected"
+      ariaOptionsAvailableText="options available"
+      ariaOptionChipRemovedText="removed"
+    />
+  </SpacingProvider>
+</>;
 ```
 
 ### Default selected items

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -841,7 +841,7 @@ describe('margin', () => {
       />,
     );
 
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overridden by style prop', async () => {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -1,11 +1,16 @@
 import React, { Component, ReactNode, forwardRef, ReactElement } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMargins,
 } from '../../../../theme/utils/spacing';
 import { HtmlDiv, HtmlDivProps } from '../../../../../reset';
 import { getOwnerDocument } from '../../../../../utils/common';
@@ -241,7 +246,7 @@ interface MultiSelectState<T extends MultiSelectData> {
 }
 
 class BaseMultiSelect<T> extends Component<
-  MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp
+  MultiSelectProps<T & MultiSelectData>
 > {
   private popoverListRef: React.RefObject<HTMLUListElement>;
 
@@ -252,7 +257,7 @@ class BaseMultiSelect<T> extends Component<
   private chipRemovalAnnounceTimeOut: ReturnType<typeof setTimeout> | null =
     null;
 
-  constructor(props: MultiSelectProps<T & MultiSelectData> & SuomifiThemeProp) {
+  constructor(props: MultiSelectProps<T & MultiSelectData>) {
     super(props);
     this.popoverListRef = React.createRef();
 
@@ -622,7 +627,6 @@ class BaseMultiSelect<T> extends Component<
     const {
       id,
       className,
-      theme,
       labelText,
       optionalText,
       hintText,
@@ -965,8 +969,17 @@ class BaseMultiSelect<T> extends Component<
   }
 }
 
-const StyledMultiSelect = styled(BaseMultiSelect)`
-  ${({ theme }) => baseStyles(theme)}
+const StyledMultiSelect = styled(
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: MultiSelectProps<MultiSelectData> &
+    SuomifiThemeProp & { globalMargins?: GlobalMargins }) => (
+    <BaseMultiSelect {...passProps} />
+  ),
+)`
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.multiSelect)}
 `;
 
 function MultiSelectInner<T>(
@@ -975,20 +988,25 @@ function MultiSelectInner<T>(
 ) {
   const { id: propId, ...passProps } = props;
   return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledMultiSelect
-              theme={suomifiTheme}
-              id={id}
-              forwardedRef={ref}
-              {...passProps}
-            />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <AutoId id={propId}>
+              {(id) => (
+                <StyledMultiSelect
+                  theme={suomifiTheme}
+                  id={id}
+                  forwardedRef={ref}
+                  globalMargins={margins}
+                  {...passProps}
+                />
+              )}
+            </AutoId>
           )}
-        </AutoId>
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   );
 }
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -7,14 +7,16 @@ import {
   SpacingConsumer,
 } from '../../../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMargins,
 } from '../../../../theme/utils/spacing';
 import { HtmlDiv, HtmlDivProps } from '../../../../../reset';
 import { getOwnerDocument } from '../../../../../utils/common';
-import { HTMLAttributesIncludingDataAttributes } from '../../../../../utils/common/common';
+import {
+  HTMLAttributesIncludingDataAttributes,
+  filterDuplicateKeys,
+} from '../../../../../utils/common/common';
 import { AutoId } from '../../../../utils/AutoId/AutoId';
 import { Debounce } from '../../../../utils/Debounce/Debounce';
 import { Popover, PopoverConsumer } from '../../../../Popover/Popover';
@@ -665,8 +667,7 @@ class BaseMultiSelect<T> extends Component<
       fullWidth,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     const filteredItemsWithChecked: (T & MultiSelectData & CheckedProp)[] =
       filteredItems.map((item) => ({
@@ -690,7 +691,7 @@ class BaseMultiSelect<T> extends Component<
             [multiSelectClassNames.error]: status === 'error',
             [`${baseClassName}--full-width`]: fullWidth,
           })}
-          style={{ ...marginStyle, ...style }}
+          style={style}
         >
           <HtmlDiv
             className={classnames(multiSelectClassNames.content_wrapper, {})}
@@ -979,7 +980,14 @@ const StyledMultiSelect = styled(
     <BaseMultiSelect {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.multiSelect)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins?.multiSelect,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 function MultiSelectInner<T>(

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1245,7 +1245,7 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c1 .fi-multiselect_removeAllButton {
-  margin-top: 10px;
+  margin: 10px 0 0 0;
 }
 
 @media (forced-colors:active) {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -850,8 +850,7 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c12 .fi-chip-list_content_wrapper > * {
-  margin-right: 10px;
-  margin-top: 10px;
+  margin: 10px 10px 0 0;
   padding-right: -10px;
 }
 
@@ -1219,6 +1218,12 @@ exports[`has matching snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   width: 290px;
+}
+
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
 }
 
 .c1.fi-multiselect .fi-filter-input_input-element-container {

--- a/src/core/Form/Select/MultiSelect/MultiSelectRemoveAllButton/MultiSelectRemoveAllButton.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelectRemoveAllButton/MultiSelectRemoveAllButton.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { IconRemove } from 'suomifi-icons';
-import { Button } from '../../../../Button/Button';
+import { InternalButton } from '../../../../Button/Button';
 import { MultiSelectData } from '../MultiSelect/MultiSelect';
 
 export interface MultiSelectRemoveAllButtonProps<T extends MultiSelectData> {
@@ -33,14 +33,15 @@ export const MultiSelectRemoveAllButton = <T extends MultiSelectData>(
     Object.keys(selectedItems).length !== selectedAndEnabledKeysCount;
 
   return showRemoveAllButton ? (
-    <Button
+    <InternalButton
       className={className}
       variant="secondaryLight"
       icon={<IconRemove />}
       onClick={onClick}
+      ignoreGlobalMargins={true}
       {...passProps}
     >
       {children}
-    </Button>
+    </InternalButton>
   ) : null;
 };

--- a/src/core/Form/Select/MultiSelect/MultiSelectRemoveAllButton/MultiSelectRemoveAllButton.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelectRemoveAllButton/MultiSelectRemoveAllButton.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { IconRemove } from 'suomifi-icons';
-import { InternalButton } from '../../../../Button/Button';
+import { Button } from '../../../../Button/Button';
 import { MultiSelectData } from '../MultiSelect/MultiSelect';
 
 export interface MultiSelectRemoveAllButtonProps<T extends MultiSelectData> {
@@ -33,7 +33,7 @@ export const MultiSelectRemoveAllButton = <T extends MultiSelectData>(
     Object.keys(selectedItems).length !== selectedAndEnabledKeysCount;
 
   return showRemoveAllButton ? (
-    <InternalButton
+    <Button
       className={className}
       variant="secondaryLight"
       icon={<IconRemove />}
@@ -41,6 +41,6 @@ export const MultiSelectRemoveAllButton = <T extends MultiSelectData>(
       {...passProps}
     >
       {children}
-    </InternalButton>
+    </Button>
   ) : null;
 };

--- a/src/core/Form/Select/MultiSelect/MultiSelectRemoveAllButton/MultiSelectRemoveAllButton.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelectRemoveAllButton/MultiSelectRemoveAllButton.tsx
@@ -38,7 +38,6 @@ export const MultiSelectRemoveAllButton = <T extends MultiSelectData>(
       variant="secondaryLight"
       icon={<IconRemove />}
       onClick={onClick}
-      ignoreGlobalMargins={true}
       {...passProps}
     >
       {children}

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
 import { font } from '../../../theme/reset';
-import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   width: 290px;
 
   &.fi-single-select {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
-import { font } from '../../../theme/reset';
+import { fixInternalMargins, font } from '../../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
 export const baseStyles = (
@@ -11,6 +11,7 @@ export const baseStyles = (
   ${font(theme)('bodyText')}
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
+  ${fixInternalMargins()}
   width: 290px;
 
   &.fi-single-select {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -1,9 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
 import { font } from '../../../theme/reset';
+import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
+  ${getCssMargins(margins)}
   width: 290px;
 
   &.fi-single-select {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -3,9 +3,14 @@ import { SuomifiTheme } from '../../../theme';
 import { font } from '../../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   width: 290px;
 
   &.fi-single-select {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -668,7 +668,7 @@ describe('margin', () => {
         margin="xs"
       />,
     );
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overridden by style prop', async () => {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -7,11 +7,16 @@ import { HTMLAttributesIncludingDataAttributes } from '../../../../utils/common/
 import { AutoId } from '../../../utils/AutoId/AutoId';
 import { Debounce } from '../../../utils/Debounce/Debounce';
 import { Popover } from '../../../Popover/Popover';
-import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import {
+  SpacingConsumer,
+  SuomifiThemeConsumer,
+  SuomifiThemeProp,
+} from '../../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMargins,
 } from '../../../theme/utils/spacing';
 import { FilterInput, FilterInputStatus } from '../../FilterInput/FilterInput';
 import { LoadingSpinner } from '../../../LoadingSpinner/LoadingSpinner';
@@ -783,8 +788,17 @@ class BaseSingleSelect<T> extends Component<
   }
 }
 
-const StyledSingleSelect = styled(BaseSingleSelect)`
-  ${({ theme }) => baseStyles(theme)}
+const StyledSingleSelect = styled(
+  ({
+    globalMargins,
+    ...passProps
+  }: SingleSelectProps<SingleSelectData> &
+    SuomifiThemeProp & { globalMargins?: GlobalMargins }) => (
+    <BaseSingleSelect {...passProps} />
+  ),
+)`
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.singleSelect)}
 `;
 
 function SingleSelectInner<T>(
@@ -793,20 +807,25 @@ function SingleSelectInner<T>(
 ) {
   const { id: propId, ...passProps } = props;
   return (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <AutoId id={propId}>
-          {(id) => (
-            <StyledSingleSelect
-              theme={suomifiTheme}
-              id={id}
-              forwardedRef={ref}
-              {...passProps}
-            />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <AutoId id={propId}>
+              {(id) => (
+                <StyledSingleSelect
+                  theme={suomifiTheme}
+                  id={id}
+                  globalMargins={margins}
+                  forwardedRef={ref}
+                  {...passProps}
+                />
+              )}
+            </AutoId>
           )}
-        </AutoId>
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   );
 }
 

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -3,7 +3,10 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv, HtmlDivProps } from '../../../../reset';
 import { getOwnerDocument, escapeStringRegexp } from '../../../../utils/common';
-import { HTMLAttributesIncludingDataAttributes } from '../../../../utils/common/common';
+import {
+  HTMLAttributesIncludingDataAttributes,
+  filterDuplicateKeys,
+} from '../../../../utils/common/common';
 import { AutoId } from '../../../utils/AutoId/AutoId';
 import { Debounce } from '../../../utils/Debounce/Debounce';
 import { Popover } from '../../../Popover/Popover';
@@ -13,10 +16,9 @@ import {
   SuomifiThemeProp,
 } from '../../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
-  GlobalMargins,
+  GlobalMarginProps,
 } from '../../../theme/utils/spacing';
 import { FilterInput, FilterInputStatus } from '../../FilterInput/FilterInput';
 import { LoadingSpinner } from '../../../LoadingSpinner/LoadingSpinner';
@@ -559,8 +561,7 @@ class BaseSingleSelect<T> extends Component<
       fullWidth,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     const ariaActiveDescendant = focusedDescendantId
       ? `${id}-${focusedDescendantId}`
@@ -577,7 +578,7 @@ class BaseSingleSelect<T> extends Component<
           [singleSelectClassNames.error]: status === 'error',
           [singleSelectClassNames.fullWidth]: fullWidth,
         })}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <Debounce waitFor={debounce}>
           {(debouncer: Function) => (
@@ -793,12 +794,17 @@ const StyledSingleSelect = styled(
     globalMargins,
     ...passProps
   }: SingleSelectProps<SingleSelectData> &
-    SuomifiThemeProp & { globalMargins?: GlobalMargins }) => (
-    <BaseSingleSelect {...passProps} />
-  ),
+    SuomifiThemeProp &
+    GlobalMarginProps) => <BaseSingleSelect {...passProps} />,
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.singleSelect)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.singleSelect,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 function SingleSelectInner<T>(

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -846,6 +846,12 @@ exports[`has matching snapshot 1`] = `
   width: 290px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-single-select .fi-filter-input_input {
   padding-right: 36px;
 }

--- a/src/core/Form/StatusText/StatusText.baseStyles.tsx
+++ b/src/core/Form/StatusText/StatusText.baseStyles.tsx
@@ -1,14 +1,14 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodySemiBoldSmall')};
   color: ${theme.colors.blackBase};
   font-size: 14px;
   line-height: 20px;
-  ${getCssMargins(margins)};
+  ${buildSpacingCSS(margins)};
 
   &.fi-status-text {
     display: block;

--- a/src/core/Form/StatusText/StatusText.baseStyles.tsx
+++ b/src/core/Form/StatusText/StatusText.baseStyles.tsx
@@ -1,12 +1,14 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodySemiBoldSmall')};
   color: ${theme.colors.blackBase};
   font-size: 14px;
   line-height: 20px;
+  ${getCssMargins(margins)};
 
   &.fi-status-text {
     display: block;

--- a/src/core/Form/StatusText/StatusText.baseStyles.tsx
+++ b/src/core/Form/StatusText/StatusText.baseStyles.tsx
@@ -3,12 +3,17 @@ import { SuomifiTheme } from '../../theme';
 import { font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${font(theme)('bodySemiBoldSmall')};
   color: ${theme.colors.blackBase};
   font-size: 14px;
   line-height: 20px;
-  ${buildSpacingCSS(margins)};
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)};
 
   &.fi-status-text {
     display: block;

--- a/src/core/Form/StatusText/StatusText.test.tsx
+++ b/src/core/Form/StatusText/StatusText.test.tsx
@@ -72,7 +72,7 @@ describe('props', () => {
 describe('margin', () => {
   it('should have margin style from margin prop', () => {
     const { container } = render(<StatusText margin="xs" />);
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -8,7 +8,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -17,6 +16,7 @@ import { HtmlSpan, HtmlSpanProps } from '../../../reset';
 import { InputStatus, AriaLiveMode } from '../types';
 import { baseStyles } from './StatusText.baseStyles';
 import { IconErrorFilled, IconCheckCircleFilled } from 'suomifi-icons';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const baseClassName = 'fi-status-text';
 const statusTextClassNames = {
@@ -73,8 +73,8 @@ const StyledStatusText = styled(
     ariaLiveMode = 'polite',
     ...rest
   }: StatusTextProps & SuomifiThemeProp & GlobalMarginProps) => {
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     const ariaLiveProp = !disabled
       ? { 'aria-live': ariaLiveMode }
       : { 'aria-live': 'off' };
@@ -87,7 +87,7 @@ const StyledStatusText = styled(
           [statusTextClassNames.error]: status === 'error',
         })}
         aria-atomic="true"
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       >
         {!!children && getIcon(status, theme)}
         {children}
@@ -95,7 +95,14 @@ const StyledStatusText = styled(
     );
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.statusText)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.statusText,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const StatusText = forwardRef<HTMLSpanElement, StatusTextProps>(

--- a/src/core/Form/StatusText/StatusText.tsx
+++ b/src/core/Form/StatusText/StatusText.tsx
@@ -5,11 +5,13 @@ import {
   SuomifiThemeProp,
   SuomifiThemeConsumer,
   SuomifiTheme,
+  SpacingConsumer,
 } from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { HtmlSpan, HtmlSpanProps } from '../../../reset';
 import { InputStatus, AriaLiveMode } from '../types';
@@ -63,13 +65,14 @@ const getIcon = (status: InputStatus | undefined, theme: SuomifiTheme) => {
 const StyledStatusText = styled(
   ({
     className,
+    globalMargins,
     children,
     disabled,
     status,
     theme,
     ariaLiveMode = 'polite',
     ...rest
-  }: StatusTextProps & SuomifiThemeProp) => {
+  }: StatusTextProps & SuomifiThemeProp & GlobalMarginProps) => {
     const [marginProps, passProps] = separateMarginProps(rest);
     const marginStyle = spacingStyles(marginProps);
     const ariaLiveProp = !disabled
@@ -92,24 +95,29 @@ const StyledStatusText = styled(
     );
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.statusText)}
 `;
 
 const StatusText = forwardRef<HTMLSpanElement, StatusTextProps>(
   (props: StatusTextProps, ref: React.Ref<HTMLSpanElement>) => {
     const { children, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledStatusText
-            forwardedRef={ref}
-            theme={suomifiTheme}
-            {...passProps}
-          >
-            {children}
-          </StyledStatusText>
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <StyledStatusText
+                forwardedRef={ref}
+                globalMargins={margins}
+                theme={suomifiTheme}
+                {...passProps}
+              >
+                {children}
+              </StyledStatusText>
+            )}
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -1,6 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { input, containerIEFocus, font } from '../../theme/reset';
+import {
+  input,
+  containerIEFocus,
+  font,
+  fixInternalMargins,
+} from '../../theme/reset';
 import { math } from 'polished';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
@@ -13,6 +18,7 @@ export const baseStyles = (
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
   line-height: 0;
+  ${fixInternalMargins()}
 
   & .fi-text-input_character-counter {
     ${font(theme)('bodyTextSmall')};

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -9,7 +9,6 @@ export const baseStyles = (
   globalMargins?: MarginProps,
   propMargins?: MarginProps,
 ) => css`
-  ${font(theme)('bodyText')}
   width: 290px;
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -2,7 +2,7 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
 import { math } from 'polished';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (
   theme: SuomifiTheme,
@@ -11,9 +11,8 @@ export const baseStyles = (
 ) => css`
   ${font(theme)('bodyText')}
   width: 290px;
-  line-height: 0;
-  ${getCssMargins(margins)}
-  ${getCssMargins(importantMargins)}
+  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(importantMargins)}
 
   & .fi-text-input_character-counter {
     ${font(theme)('bodyTextSmall')};

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -12,7 +12,7 @@ export const baseStyles = (
   ${font(theme)('bodyText')}
   width: 290px;
   ${buildSpacingCSS(margins)}
-  ${buildSpacingCSS(importantMargins)}
+  ${buildSpacingCSS(importantMargins, true)}
 
   & .fi-text-input_character-counter {
     ${font(theme)('bodyTextSmall')};

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -2,9 +2,12 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { input, containerIEFocus, font } from '../../theme/reset';
 import { math } from 'polished';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+  ${font(theme)('bodyText')}
   width: 290px;
+  ${getCssMargins(margins)}
   line-height: 0;
 
   & .fi-text-input_character-counter {

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -4,11 +4,16 @@ import { input, containerIEFocus, font } from '../../theme/reset';
 import { math } from 'polished';
 import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  margins?: MarginProps,
+  importantMargins?: MarginProps,
+) => css`
   ${font(theme)('bodyText')}
   width: 290px;
-  ${getCssMargins(margins)}
   line-height: 0;
+  ${getCssMargins(margins)}
+  ${getCssMargins(importantMargins)}
 
   & .fi-text-input_character-counter {
     ${font(theme)('bodyTextSmall')};

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -6,13 +6,14 @@ import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (
   theme: SuomifiTheme,
-  margins?: MarginProps,
-  importantMargins?: MarginProps,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
 ) => css`
   ${font(theme)('bodyText')}
   width: 290px;
-  ${buildSpacingCSS(margins)}
-  ${buildSpacingCSS(importantMargins, true)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
+  line-height: 0;
 
   & .fi-text-input_character-counter {
     ${font(theme)('bodyTextSmall')};

--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -28,10 +28,65 @@ Examples:
 Provide a descriptive `labelText` for the input
 
 ```js
-import { TextInput } from 'suomifi-ui-components';
+import {
+  TextInput,
+  Tooltip,
+  Button,
+  Heading,
+  Text,
+  SpacingProvider
+} from 'suomifi-ui-components';
 import React from 'react';
 
-<TextInput labelText="First name" />;
+const exampleRef = React.createRef();
+
+const labelTextForTooltipExample = 'TextInput with a tooltip';
+
+<>
+  <TextInput labelText="First name" />;
+  <SpacingProvider
+    margins={{ textInput: { mb: 'xl' }, button: { margin: 's' } }}
+  >
+    <TextInput
+      onBlur={(event) => console.log(event.target.value)}
+      labelText="TextInput with visible label"
+    />
+    <TextInput
+      onBlur={(event) => console.log(event.target.value)}
+      labelText="Test TextInput with hidden label and a visual placeholder"
+      labelMode="hidden"
+      visualPlaceholder="This input has a hidden label"
+    />
+    <TextInput
+      onBlur={(event) => console.log(event.target.value)}
+      labelText="TextInput with hint text"
+      hintText="An example hint text"
+    />
+    <Button>Rapurapurallaa</Button>
+    <TextInput
+      labelText="TextInput with optional text and ref"
+      optionalText="optional"
+      ref={exampleRef}
+      onChange={() => {
+        console.log(exampleRef.current);
+      }}
+    />
+    <TextInput
+      labelText={labelTextForTooltipExample}
+      tooltipComponent={
+        <Tooltip
+          ariaToggleButtonLabelText={`${labelTextForTooltipExample}, additional information`}
+          ariaCloseButtonLabelText={`${labelTextForTooltipExample}, close additional information`}
+        >
+          <Heading variant="h5" as="h2">
+            Tooltip
+          </Heading>
+          <Text>Text content for the tooltip</Text>
+        </Tooltip>
+      }
+    />
+  </SpacingProvider>
+</>;
 ```
 
 ### Hint text

--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -77,7 +77,7 @@ describe('props', () => {
   describe('margin', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<TextInput labelText="" margin="xs" />);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop overwritten by style prop', () => {

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -199,8 +199,6 @@ const BaseTextInput = (props: InternalTextInputProps) => {
 
   const definedRef = forwardedRef || null;
 
-  const globalMarginStyle = spacingStyles(globalMargins?.textInput);
-
   const hintTextId = `${id}-hintText`;
   const statusTextId = `${id}-statusText`;
   return (
@@ -212,7 +210,7 @@ const BaseTextInput = (props: InternalTextInputProps) => {
         [textInputClassNames.success]: status === 'success',
         [textInputClassNames.fullWidth]: fullWidth,
       })}
-      style={{ ...globalMarginStyle, ...marginStyle, ...style }}
+      style={{ ...marginStyle, ...style }}
     >
       <HtmlSpan className={textInputClassNames.styleWrapper}>
         <Label
@@ -283,11 +281,14 @@ const BaseTextInput = (props: InternalTextInputProps) => {
 };
 
 const StyledTextInput = styled(
-  ({ theme, ...passProps }: TextInputProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    ...passProps
+  }: TextInputProps & SuomifiThemeProp & { globalMargins: GlobalMargins }) => (
     <BaseTextInput {...passProps} />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.textInput)}
 `;
 
 const TextInput = forwardRef<HTMLInputElement, TextInputProps>(

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -16,7 +16,9 @@ import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMargins,
 } from '../../theme/utils/spacing';
+import { SpacingConsumer } from '../../theme/SpacingProvider/SpacingProvider';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { forkRefs } from '../../../utils/common/common';
@@ -107,7 +109,11 @@ interface BaseTextInputProps
 
 export type TextInputProps = characterCounterProps & BaseTextInputProps;
 
-const BaseTextInput = (props: TextInputProps) => {
+type InternalTextInputProps = TextInputProps & {
+  globalMargins?: GlobalMargins;
+};
+
+const BaseTextInput = (props: InternalTextInputProps) => {
   const [charCount, setCharCount] = useState(0);
   const [characterCounterAriaText, setCharacterCounterAriaText] = useState('');
   const [typingTimer, setTypingTimer] = useState<ReturnType<
@@ -139,6 +145,7 @@ const BaseTextInput = (props: TextInputProps) => {
     fullWidth,
     icon,
     forwardedRef,
+    globalMargins,
     debounce,
     statusTextAriaLiveMode = 'assertive',
     'aria-describedby': ariaDescribedBy,
@@ -192,6 +199,8 @@ const BaseTextInput = (props: TextInputProps) => {
 
   const definedRef = forwardedRef || null;
 
+  const globalMarginStyle = spacingStyles(globalMargins?.textInput);
+
   const hintTextId = `${id}-hintText`;
   const statusTextId = `${id}-statusText`;
   return (
@@ -203,7 +212,7 @@ const BaseTextInput = (props: TextInputProps) => {
         [textInputClassNames.success]: status === 'success',
         [textInputClassNames.fullWidth]: fullWidth,
       })}
-      style={{ ...marginStyle, ...style }}
+      style={{ ...globalMarginStyle, ...marginStyle, ...style }}
     >
       <HtmlSpan className={textInputClassNames.styleWrapper}>
         <Label
@@ -285,20 +294,25 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   (props: TextInputProps, ref: React.Ref<HTMLInputElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledTextInput
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledTextInput
+                    theme={suomifiTheme}
+                    id={id}
+                    forwardedRef={ref}
+                    globalMargins={margins}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -13,7 +13,6 @@ import classnames from 'classnames';
 import { AutoId } from '../../utils/AutoId/AutoId';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMargins,
@@ -21,7 +20,7 @@ import {
 import { SpacingConsumer } from '../../theme/SpacingProvider/SpacingProvider';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
-import { forkRefs } from '../../../utils/common/common';
+import { forkRefs, filterDuplicateKeys } from '../../../utils/common/common';
 import { HtmlInputProps, HtmlDiv, HtmlSpan, HtmlInput } from '../../../reset';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import { Label, LabelMode } from '../Label/Label';
@@ -155,8 +154,7 @@ const BaseTextInput = (props: InternalTextInputProps) => {
     ariaCharactersExceededText,
     ...rest
   } = props;
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
 
   useEffect(() => {
     if (characterLimit !== undefined && inputRef.current?.value.length) {
@@ -210,7 +208,7 @@ const BaseTextInput = (props: InternalTextInputProps) => {
         [textInputClassNames.success]: status === 'success',
         [textInputClassNames.fullWidth]: fullWidth,
       })}
-      style={{ ...marginStyle, ...style }}
+      style={style}
     >
       <HtmlSpan className={textInputClassNames.styleWrapper}>
         <Label
@@ -288,7 +286,14 @@ const StyledTextInput = styled(
     <BaseTextInput {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.textInput)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.textInput,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const TextInput = forwardRef<HTMLInputElement, TextInputProps>(

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -215,6 +215,12 @@ exports[`snapshots match error status with statustext 1`] = `
   line-height: 0;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-text-input_character-counter {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -689,6 +695,12 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   line-height: 0;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-text-input_character-counter {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1130,6 +1142,12 @@ exports[`snapshots match minimal implementation 1`] = `
 .c1 {
   width: 290px;
   line-height: 0;
+}
+
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
 }
 
 .c1 .fi-text-input_character-counter {

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -5,13 +5,13 @@ import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (
   theme: SuomifiTheme,
-  margins?: MarginProps,
-  importantMargins?: MarginProps,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
 ) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)}
-  ${buildSpacingCSS(importantMargins, true)};
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)};
   color: ${theme.colors.blackBase};
   width: 290px;
 

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
+  ${getCssMargins(margins)};
   color: ${theme.colors.blackBase};
   width: 290px;
 

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  margins?: MarginProps,
+  importantMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)};
+  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(importantMargins, true)};
   color: ${theme.colors.blackBase};
   width: 290px;
 

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { element, font } from '../../theme/reset';
+import { element, fixInternalMargins, font } from '../../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (
@@ -12,6 +12,7 @@ export const baseStyles = (
   ${font(theme)('bodyText')}
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)};
+  ${fixInternalMargins()}
   color: ${theme.colors.blackBase};
   width: 290px;
 

--- a/src/core/Form/Textarea/Textarea.baseStyles.tsx
+++ b/src/core/Form/Textarea/Textarea.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${getCssMargins(margins)};
+  ${buildSpacingCSS(margins)};
   color: ${theme.colors.blackBase};
   width: 290px;
 

--- a/src/core/Form/Textarea/Textarea.test.tsx
+++ b/src/core/Form/Textarea/Textarea.test.tsx
@@ -280,7 +280,7 @@ describe('props', () => {
   describe('margin', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<Textarea labelText="" margin="xs" />);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop overwritten from containerProps', () => {

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -18,7 +18,7 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import { HtmlTextarea, HtmlTextareaProps, HtmlDiv } from '../../../reset';
-import { forkRefs } from '../../../utils/common/common';
+import { filterDuplicateKeys, forkRefs } from '../../../utils/common/common';
 import { Label } from '../Label/Label';
 import { HintText } from '../HintText/HintText';
 import { StatusText } from '../StatusText/StatusText';
@@ -30,7 +30,6 @@ import {
 import { baseStyles } from './Textarea.baseStyles';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -141,8 +140,7 @@ const BaseTextarea = (props: TextareaProps) => {
     ariaCharactersExceededText,
     ...rest
   } = props;
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
   const [charCount, setCharCount] = useState(0);
   const [characterCounterAriaText, setCharacterCounterAriaText] = useState('');
   const [typingTimer, setTypingTimer] = useState<ReturnType<
@@ -208,7 +206,7 @@ const BaseTextarea = (props: TextareaProps) => {
         [textareaClassNames.error]: status === 'error' && !disabled,
         [textareaClassNames.fullWidth]: fullWidth,
       })}
-      style={{ ...marginStyle, ...style }}
+      style={style}
     >
       <Label
         htmlFor={id}
@@ -281,7 +279,14 @@ const StyledTextarea = styled(
     <BaseTextarea {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.textarea)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.textarea,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Textarea = forwardRef(

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -12,7 +12,11 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import { HtmlTextarea, HtmlTextareaProps, HtmlDiv } from '../../../reset';
 import { forkRefs } from '../../../utils/common/common';
 import { Label } from '../Label/Label';
@@ -29,6 +33,7 @@ import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 
 const baseClassName = 'fi-textarea';
@@ -268,31 +273,40 @@ const BaseTextarea = (props: TextareaProps) => {
 };
 
 const StyledTextarea = styled(
-  ({ theme, ...passProps }: TextareaProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: TextareaProps & SuomifiThemeProp & GlobalMarginProps) => (
     <BaseTextarea {...passProps} />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.textarea)}
 `;
 
 const Textarea = forwardRef(
   (props: TextareaProps, ref: React.Ref<HTMLTextAreaElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledTextarea
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledTextarea
+                    theme={suomifiTheme}
+                    id={id}
+                    globalMargins={margins}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/core/Form/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -205,6 +205,12 @@ exports[`snapshot default structure should match snapshot 1`] = `
   width: 290px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-textarea {
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
+++ b/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
@@ -1,6 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { element, containerIEFocus, font } from '../../theme/reset';
+import {
+  element,
+  containerIEFocus,
+  font,
+  fixInternalMargins,
+} from '../../theme/reset';
 import { math } from 'polished';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
@@ -12,6 +17,7 @@ export const baseStyles = (
   ${font(theme)('bodyText')}
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
+  ${fixInternalMargins()}
   max-width: 290px;
 
   & .fi-time-input_character-counter {

--- a/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
+++ b/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
@@ -4,9 +4,14 @@ import { element, containerIEFocus, font } from '../../theme/reset';
 import { math } from 'polished';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   max-width: 290px;
 
   & .fi-time-input_character-counter {

--- a/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
+++ b/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
@@ -2,9 +2,11 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, containerIEFocus, font } from '../../theme/reset';
 import { math } from 'polished';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
+  ${getCssMargins(margins)}
   max-width: 290px;
 
   & .fi-time-input_character-counter {

--- a/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
+++ b/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
@@ -2,11 +2,11 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, containerIEFocus, font } from '../../theme/reset';
 import { math } from 'polished';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   max-width: 290px;
 
   & .fi-time-input_character-counter {

--- a/src/core/Form/TimeInput/TimeInput.test.tsx
+++ b/src/core/Form/TimeInput/TimeInput.test.tsx
@@ -88,7 +88,7 @@ describe('props', () => {
   describe('margin', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<TimeInput labelText="" margin="xs" />);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop overwritten from wrapperProps', () => {

--- a/src/core/Form/TimeInput/TimeInput.tsx
+++ b/src/core/Form/TimeInput/TimeInput.tsx
@@ -9,7 +9,11 @@ import React, {
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
 import { autocompleteTimeString, forkRefs } from '../../../utils/common/common';
@@ -17,6 +21,7 @@ import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { HtmlInputProps, HtmlDiv, HtmlSpan, HtmlInput } from '../../../reset';
 import { Label, LabelMode } from '../Label/Label';
@@ -212,31 +217,40 @@ const BaseTimeInput = (props: TimeInputProps) => {
 };
 
 const StyledTimeInput = styled(
-  ({ theme, ...passProps }: TimeInputProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: TimeInputProps & SuomifiThemeProp & GlobalMarginProps) => (
     <BaseTimeInput {...passProps} />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.timeInput)}
 `;
 
 const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
   (props: TimeInputProps, ref: React.Ref<HTMLInputElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledTimeInput
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledTimeInput
+                    theme={suomifiTheme}
+                    id={id}
+                    globalMargins={margins}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/TimeInput/TimeInput.tsx
+++ b/src/core/Form/TimeInput/TimeInput.tsx
@@ -16,9 +16,12 @@ import {
 } from '../../theme';
 import { Debounce } from '../../utils/Debounce/Debounce';
 import { getConditionalAriaProp } from '../../../utils/aria';
-import { autocompleteTimeString, forkRefs } from '../../../utils/common/common';
 import {
-  spacingStyles,
+  autocompleteTimeString,
+  filterDuplicateKeys,
+  forkRefs,
+} from '../../../utils/common/common';
+import {
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -125,8 +128,7 @@ const BaseTimeInput = (props: TimeInputProps) => {
     tooltipComponent,
     ...rest
   } = props;
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
 
   const [inputValue, setInputValue] = useState(defaultValue || '');
 
@@ -157,7 +159,7 @@ const BaseTimeInput = (props: TimeInputProps) => {
         [timeInputClassNames.error]: status === 'error',
         [timeInputClassNames.success]: status === 'success',
       })}
-      style={{ ...marginStyle, ...style }}
+      style={style}
     >
       <HtmlSpan className={timeInputClassNames.styleWrapper}>
         <Label
@@ -225,7 +227,14 @@ const StyledTimeInput = styled(
     <BaseTimeInput {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.timeInput)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.timeInput,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(

--- a/src/core/Form/TimeInput/__snapshots__/TimeInput.test.tsx.snap
+++ b/src/core/Form/TimeInput/__snapshots__/TimeInput.test.tsx.snap
@@ -227,6 +227,12 @@ exports[`snapshots match error status with statustext 1`] = `
   max-width: 290px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-time-input_character-counter {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -710,6 +716,12 @@ exports[`snapshots match hidden label 1`] = `
   max-width: 290px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-time-input_character-counter {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1183,6 +1195,12 @@ exports[`snapshots match hint text 1`] = `
   max-width: 290px;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1 .fi-time-input_character-counter {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1644,6 +1662,12 @@ exports[`snapshots match minimal implementation 1`] = `
   line-height: 1.5;
   font-weight: 400;
   max-width: 290px;
+}
+
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
 }
 
 .c1 .fi-time-input_character-counter {

--- a/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
@@ -28,5 +28,8 @@ export const baseStyles = (
         }
       }
     }
+    & .fi-text {
+      margin: 0;
+    }
   }
 `;

--- a/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
@@ -4,9 +4,11 @@ import {
   toggleBaseStyles,
   focusOverrides,
 } from '../ToggleBase/Toggle.baseStyles';
+import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${toggleBaseStyles(theme)}
+  ${getCssMargins(margins)};
   &.fi-toggle--disabled > button {
     cursor: not-allowed;
   }

--- a/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
@@ -4,11 +4,11 @@ import {
   toggleBaseStyles,
   focusOverrides,
 } from '../ToggleBase/Toggle.baseStyles';
-import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${toggleBaseStyles(theme)}
-  ${getCssMargins(margins)};
+  ${buildSpacingCSS(margins)};
   &.fi-toggle--disabled > button {
     cursor: not-allowed;
   }

--- a/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggeButton.baseStyles.tsx
@@ -6,9 +6,14 @@ import {
 } from '../ToggleBase/Toggle.baseStyles';
 import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${toggleBaseStyles(theme)}
-  ${buildSpacingCSS(margins)};
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)};
   &.fi-toggle--disabled > button {
     cursor: not-allowed;
   }

--- a/src/core/Form/Toggle/ToggleButton/ToggleButton.test.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggleButton.test.tsx
@@ -64,7 +64,7 @@ describe('Basic ToggleButton', () => {
 describe('margin', () => {
   it('should have margin style from margin prop', () => {
     const { container } = render(<ToggleButton margin="xs">Test</ToggleButton>);
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten by style prop', () => {

--- a/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
@@ -18,6 +18,7 @@ import {
   MarginProps,
   GlobalMarginProps,
 } from '../../../theme/utils/spacing';
+import { filterDuplicateKeys } from '../../../../utils/common/common';
 
 const toggleClassNames = {
   disabled: `${baseClassName}--disabled`,
@@ -118,13 +119,19 @@ class BaseToggleButton extends Component<ToggleButtonProps> {
 }
 
 const StyledToggleButton = styled(
-  (props: ToggleBaseProps & SuomifiThemeProp & GlobalMarginProps) => {
+  (props: ToggleButtonProps & SuomifiThemeProp & GlobalMarginProps) => {
     const { theme, globalMargins, ...passProps } = props;
     return <BaseToggleButton {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.toggleButton)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.toggleButton,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const ToggleButton = forwardRef(

--- a/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
@@ -8,11 +8,16 @@ import { HtmlSpan, HtmlButtonProps, HtmlButton } from '../../../../reset';
 import { ToggleBaseProps, baseClassName } from '../ToggleBase/ToggleBase';
 import { ToggleIcon } from '../ToggleBase/ToggleIcon';
 import { baseStyles } from './ToggeButton.baseStyles';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../../theme/utils/spacing';
 
 const toggleClassNames = {
@@ -114,32 +119,38 @@ class BaseToggleButton extends Component<ToggleButtonProps> {
 }
 
 const StyledToggleButton = styled(
-  (props: ToggleBaseProps & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (props: ToggleBaseProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseToggleButton {...passProps} />;
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.toggleButton)}
 `;
 
 const ToggleButton = forwardRef(
   (props: ToggleButtonProps, ref: React.RefObject<HTMLButtonElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledToggleButton
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledToggleButton
+                    theme={suomifiTheme}
+                    id={id}
+                    globalMargins={margins}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
+++ b/src/core/Form/Toggle/ToggleButton/ToggleButton.tsx
@@ -14,7 +14,6 @@ import {
   SpacingConsumer,
 } from '../../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -81,8 +80,8 @@ class BaseToggleButton extends Component<ToggleButtonProps> {
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     const { toggleState } = this.state;
 
     return (
@@ -96,7 +95,7 @@ class BaseToggleButton extends Component<ToggleButtonProps> {
           },
           toggleClassNames.label,
         )}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlButton
           {...passProps}

--- a/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -315,6 +315,10 @@ exports[`Basic ToggleButton should match snapshot 1`] = `
   outline: 3px solid transparent;
 }
 
+.c1.fi-toggle--button > button .fi-text {
+  margin: 0;
+}
+
 <span
   class="c0 c1 fi-toggle fi-toggle--button fi-toggle_label"
 >

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
@@ -7,11 +7,11 @@ import {
   iconHeight,
   focusOverrides,
 } from '../ToggleBase/Toggle.baseStyles';
-import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${toggleBaseStyles(theme)}
-  ${getCssMargins(margins)};
+  ${buildSpacingCSS(margins)};
   &.fi-toggle--input {
     &:focus-within {
       outline: 0;

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
@@ -9,9 +9,14 @@ import {
 } from '../ToggleBase/Toggle.baseStyles';
 import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${toggleBaseStyles(theme)}
-  ${buildSpacingCSS(margins)};
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)};
   &.fi-toggle--input {
     &:focus-within {
       outline: 0;

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
@@ -28,6 +28,9 @@ export const baseStyles = (
         }
       }
     }
+    & .fi-text {
+      margin: 0;
+    }
   }
 
   & .fi-toggle_input-element {

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.baseStyles.tsx
@@ -7,9 +7,11 @@ import {
   iconHeight,
   focusOverrides,
 } from '../ToggleBase/Toggle.baseStyles';
+import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${toggleBaseStyles(theme)}
+  ${getCssMargins(margins)};
   &.fi-toggle--input {
     &:focus-within {
       outline: 0;

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.test.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.test.tsx
@@ -75,7 +75,7 @@ describe('name', () => {
 describe('margin', () => {
   it('should have margin style from margin prop', () => {
     const { container } = render(<ToggleInput margin="xs" />);
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten by style prop', () => {

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
@@ -8,7 +8,6 @@ import {
   SpacingConsumer,
 } from '../../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -24,6 +23,7 @@ import {
 import { ToggleIcon } from '../ToggleBase/ToggleIcon';
 import { ToggleBaseProps, baseClassName } from '../ToggleBase/ToggleBase';
 import { baseStyles } from './ToggleInput.baseStyles';
+import { filterDuplicateKeys } from '../../../../utils/common/common';
 
 const toggleClassNames = {
   disabled: `${baseClassName}--disabled`,
@@ -91,8 +91,8 @@ class BaseToggleInput extends Component<ToggleInputProps> {
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     const { toggleState } = this.state;
 
     return (
@@ -105,7 +105,7 @@ class BaseToggleInput extends Component<ToggleInputProps> {
             [toggleClassNames.disabled]: !!disabled,
           },
         )}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlLabel className={toggleClassNames.label} htmlFor={id}>
           <HtmlInput
@@ -131,12 +131,19 @@ class BaseToggleInput extends Component<ToggleInputProps> {
 }
 
 const StyledToggleInput = styled(
-  (props: ToggleBaseProps & SuomifiThemeProp & GlobalMarginProps) => {
+  (props: ToggleInputProps & SuomifiThemeProp & GlobalMarginProps) => {
     const { theme, globalMargins, ...passProps } = props;
     return <BaseToggleInput {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.toggleInput)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.toggleButton,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const ToggleInput = forwardRef(

--- a/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
+++ b/src/core/Form/Toggle/ToggleInput/ToggleInput.tsx
@@ -2,11 +2,16 @@ import React, { Component, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../../../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../../theme/utils/spacing';
 import { getConditionalAriaProp } from '../../../../utils/aria';
 import { Text } from '../../../Text/Text';
@@ -126,32 +131,37 @@ class BaseToggleInput extends Component<ToggleInputProps> {
 }
 
 const StyledToggleInput = styled(
-  (props: ToggleBaseProps & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (props: ToggleBaseProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseToggleInput {...passProps} />;
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.toggleInput)}
 `;
 
 const ToggleInput = forwardRef(
   (props: ToggleInputProps, ref: React.RefObject<HTMLInputElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledToggleInput
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledToggleInput
+                    theme={suomifiTheme}
+                    id={id}
+                    globalMargins={margins}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
+++ b/src/core/Form/Toggle/ToggleInput/__snapshots__/ToggleInput.test.tsx.snap
@@ -316,6 +316,10 @@ exports[`Basic ToggleInput should match snapshot 1`] = `
   outline: 3px solid transparent;
 }
 
+.c1.fi-toggle--input .fi-text {
+  margin: 0;
+}
+
 .c1 .fi-toggle_input-element {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;

--- a/src/core/Heading/Heading.baseStyles.ts
+++ b/src/core/Heading/Heading.baseStyles.ts
@@ -2,13 +2,15 @@ import { css } from 'styled-components';
 import { SuomifiThemeProp } from '../theme';
 import { element, font } from '../theme/reset';
 import { HeadingProps } from './Heading';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = ({
-  color,
-  theme,
-}: HeadingProps & SuomifiThemeProp) => css`
+export const baseStyles = (
+  { color, theme }: HeadingProps & SuomifiThemeProp,
+  margins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
+  ${getCssMargins(margins)}
   color: ${!!color && color in theme.colors
     ? theme.colors[color]
     : theme.colors.blackBase};

--- a/src/core/Heading/Heading.baseStyles.ts
+++ b/src/core/Heading/Heading.baseStyles.ts
@@ -2,7 +2,7 @@ import { css } from 'styled-components';
 import { SuomifiThemeProp } from '../theme';
 import { element, font } from '../theme/reset';
 import { HeadingProps } from './Heading';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (
   { color, theme }: HeadingProps & SuomifiThemeProp,
@@ -10,7 +10,7 @@ export const baseStyles = (
 ) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   color: ${!!color && color in theme.colors
     ? theme.colors[color]
     : theme.colors.blackBase};

--- a/src/core/Heading/Heading.baseStyles.ts
+++ b/src/core/Heading/Heading.baseStyles.ts
@@ -1,16 +1,18 @@
 import { css } from 'styled-components';
-import { SuomifiThemeProp } from '../theme';
+import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
-import { HeadingProps } from './Heading';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (
-  { color, theme }: HeadingProps & SuomifiThemeProp,
-  margins?: MarginProps,
+  theme: SuomifiTheme,
+  color?: keyof SuomifiTheme['colors'],
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
 ) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   color: ${!!color && color in theme.colors
     ? theme.colors[color]
     : theme.colors.blackBase};

--- a/src/core/Heading/Heading.test.tsx
+++ b/src/core/Heading/Heading.test.tsx
@@ -46,7 +46,7 @@ describe('Margin prop', () => {
         Test
       </Heading>,
     );
-    expect(getByText('Test')).toHaveAttribute('style', 'margin: 10px;');
+    expect(getByText('Test')).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -10,13 +10,13 @@ import {
   SpacingConsumer,
 } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Heading.baseStyles';
 import { HtmlH, HtmlHProps, hLevels } from '../../reset';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 const baseClassName = 'fi-heading';
 const smallScreenClassName = `${baseClassName}--small-screen`;
@@ -64,8 +64,8 @@ const StyledHeading = styled(
     asProp,
     ...rest
   }: InternalHeadingProps & GlobalMarginProps) => {
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     return (
       <HtmlH
         {...passProps}
@@ -78,12 +78,19 @@ const StyledHeading = styled(
           },
         )}
         as={!!asProp ? asProp : getSemanticVariant(variant)}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       />
     );
   },
 )`
-  ${(props) => baseStyles(props, props.globalMargins?.heading)}
+  ${({ theme, color, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.button,
+      marginProps,
+    );
+    return baseStyles(theme, color, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Heading = forwardRef(

--- a/src/core/Heading/Heading.tsx
+++ b/src/core/Heading/Heading.tsx
@@ -3,11 +3,17 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { asPropType } from '../../utils/typescript';
 import { getLogger } from '../../utils/log';
-import { ColorProp, SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  ColorProp,
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Heading.baseStyles';
 import { HtmlH, HtmlHProps, hLevels } from '../../reset';
@@ -51,12 +57,13 @@ const StyledHeading = styled(
   ({
     smallScreen,
     className,
+    globalMargins,
     theme,
     variant,
     color,
     asProp,
     ...rest
-  }: InternalHeadingProps) => {
+  }: InternalHeadingProps & GlobalMarginProps) => {
     const [marginProps, passProps] = separateMarginProps(rest);
     const marginStyle = spacingStyles(marginProps);
     return (
@@ -76,7 +83,7 @@ const StyledHeading = styled(
     );
   },
 )`
-  ${(props) => baseStyles(props)}
+  ${(props) => baseStyles(props, props.globalMargins?.heading)}
 `;
 
 const Heading = forwardRef(
@@ -89,17 +96,22 @@ const Heading = forwardRef(
       return null;
     }
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledHeading
-            theme={suomifiTheme}
-            forwardedRef={ref}
-            asProp={as}
-            {...passProps}
-            variant={variant}
-          />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <StyledHeading
+                theme={suomifiTheme}
+                globalMargins={margins}
+                forwardedRef={ref}
+                asProp={as}
+                {...passProps}
+                variant={variant}
+              />
+            )}
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/InlineAlert/InlineAlert.baseStyles.ts
@@ -2,13 +2,13 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
 import { transparentize } from 'polished';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   &.fi-inline-alert {
     ${element(theme)}
     ${font(theme)('bodyTextSmall')}
-    ${getCssMargins(margins)}
+    ${buildSpacingCSS(margins)}
     width: 100%;
     padding: 5px 0px 4px 0px;
     border: 1px solid;

--- a/src/core/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/InlineAlert/InlineAlert.baseStyles.ts
@@ -4,11 +4,16 @@ import { element, font } from '../theme/reset';
 import { transparentize } from 'polished';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   &.fi-inline-alert {
     ${element(theme)}
     ${font(theme)('bodyTextSmall')}
-    ${buildSpacingCSS(margins)}
+    ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
     width: 100%;
     padding: 5px 0px 4px 0px;
     border: 1px solid;

--- a/src/core/InlineAlert/InlineAlert.baseStyles.ts
+++ b/src/core/InlineAlert/InlineAlert.baseStyles.ts
@@ -2,11 +2,13 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
 import { transparentize } from 'polished';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   &.fi-inline-alert {
     ${element(theme)}
     ${font(theme)('bodyTextSmall')}
+    ${getCssMargins(margins)}
     width: 100%;
     padding: 5px 0px 4px 0px;
     border: 1px solid;

--- a/src/core/InlineAlert/InlineAlert.test.tsx
+++ b/src/core/InlineAlert/InlineAlert.test.tsx
@@ -33,7 +33,7 @@ describe('props', () => {
   describe('Margin', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<InlineAlert margin="xs">Test</InlineAlert>);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop overwritten from style prop', () => {

--- a/src/core/InlineAlert/InlineAlert.tsx
+++ b/src/core/InlineAlert/InlineAlert.tsx
@@ -4,11 +4,16 @@ import classnames from 'classnames';
 import { HtmlDiv, HtmlDivWithRef, HtmlDivProps } from '../../reset';
 import { IconError, IconWarning } from 'suomifi-icons';
 import { AutoId } from '../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './InlineAlert.baseStyles';
 
@@ -105,32 +110,37 @@ class BaseInlineAlert extends Component<InlineAlertProps> {
 }
 
 const StyledInlineAlert = styled(
-  (props: InlineAlertProps & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (props: InlineAlertProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseInlineAlert {...passProps} />;
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.inlineAlert)}
 `;
 
 const InlineAlert = forwardRef<HTMLDivElement, InlineAlertProps>(
   (props: InlineAlertProps, ref: React.RefObject<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledInlineAlert
-                forwardedRef={ref}
-                theme={suomifiTheme}
-                id={id}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledInlineAlert
+                    forwardedRef={ref}
+                    theme={suomifiTheme}
+                    globalMargins={margins}
+                    id={id}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/InlineAlert/InlineAlert.tsx
+++ b/src/core/InlineAlert/InlineAlert.tsx
@@ -10,12 +10,12 @@ import {
   SpacingConsumer,
 } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './InlineAlert.baseStyles';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 const baseClassName = 'fi-inline-alert';
 const inlineAlertClassNames = {
@@ -60,8 +60,8 @@ class BaseInlineAlert extends Component<InlineAlertProps> {
       forwardedRef,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     return (
       <HtmlDivWithRef
         as="section"
@@ -70,7 +70,7 @@ class BaseInlineAlert extends Component<InlineAlertProps> {
           [`${baseClassName}--${status}`]: !!status,
           [inlineAlertClassNames.smallScreen]: !!smallScreen,
         })}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
         ref={forwardedRef}
       >
         <HtmlDiv className={inlineAlertClassNames.styleWrapper}>
@@ -115,7 +115,14 @@ const StyledInlineAlert = styled(
     return <BaseInlineAlert {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.inlineAlert)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.inlineAlert,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const InlineAlert = forwardRef<HTMLDivElement, InlineAlertProps>(

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -3,9 +3,14 @@ import { SuomifiTheme } from '../theme';
 import { element } from '../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
 
   &.fi-language-menu {
     .fi-language-menu_button {

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -1,11 +1,13 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element } from '../theme/reset';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+  ${element(theme)}
+  ${getCssMargins(margins)}
+
   &.fi-language-menu {
-    ${element(theme)}
-
     .fi-language-menu_button {
       ${element(theme)}
       ${theme.typography.actionElementInnerTextBold}

--- a/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element } from '../theme/reset';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
 
   &.fi-language-menu {
     .fi-language-menu_button {

--- a/src/core/LanguageMenu/LanguageMenu.test.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.test.tsx
@@ -133,7 +133,7 @@ describe('props', () => {
           margin: 'xs',
         }),
       );
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin prop overwritten by style prop', () => {

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -9,11 +9,16 @@ import React, {
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { AutoId } from '../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import {
   LanguageMenuPopover,
@@ -191,31 +196,41 @@ const BaseLanguageMenu = (props: LanguageMenuProps) => {
 };
 
 const StyledLanguageMenu = styled(
-  ({ theme, ...passProps }: LanguageMenuProps & SuomifiThemeProp) => (
+  ({
+    theme,
+    globalMargins,
+    ...passProps
+  }: LanguageMenuProps & SuomifiThemeProp & GlobalMarginProps) => (
     <BaseLanguageMenu {...passProps} />
   ),
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.languageMenu)}
 `;
 
 const LanguageMenu = forwardRef<HTMLButtonElement, LanguageMenuProps>(
   (props: LanguageMenuProps, ref: React.RefObject<HTMLButtonElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledLanguageMenu
-                theme={suomifiTheme}
-                id={id}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledLanguageMenu
+                    theme={suomifiTheme}
+                    globalMargins={margins}
+                    id={id}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/LanguageMenu/LanguageMenu.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.tsx
@@ -15,7 +15,6 @@ import {
   SpacingConsumer,
 } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -29,6 +28,7 @@ import { getConditionalAriaProp } from '../../utils/aria';
 import { baseStyles } from './LanguageMenu.baseStyles';
 import { LanguageMenuItemProps } from './LanguageMenuItem/LanguageMenuItem';
 import { IconChevronUp, IconChevronDown } from 'suomifi-icons';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 const baseClassName = 'fi-language-menu';
 export const languageMenuClassNames = {
@@ -92,8 +92,8 @@ const BaseLanguageMenu = (props: LanguageMenuProps) => {
     'aria-label': ariaLabel,
     ...rest
   } = props;
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
+
   const openButtonRef = forwardedRef || useRef<HTMLButtonElement>(null);
   const [menuVisible, setMenuVisible] = useState<boolean>(false);
   const [ariaExpanded, setAriaExpanded] = useState<boolean>(false);
@@ -151,10 +151,7 @@ const BaseLanguageMenu = (props: LanguageMenuProps) => {
   };
 
   return (
-    <HtmlDiv
-      className={classnames(baseClassName, className)}
-      style={{ ...marginStyle, ...style }}
-    >
+    <HtmlDiv className={classnames(baseClassName, className)} style={style}>
       <HtmlButton
         id={buttonId}
         aria-expanded={ariaExpanded}
@@ -204,8 +201,14 @@ const StyledLanguageMenu = styled(
     <BaseLanguageMenu {...passProps} />
   ),
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.languageMenu)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.languageMenu,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const LanguageMenu = forwardRef<HTMLButtonElement, LanguageMenuProps>(

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -236,7 +236,7 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
   cursor: inherit;
 }
 
-.c1.fi-language-menu {
+.c1 {
   color: hsl(0,0%,13%);
 }
 
@@ -678,7 +678,7 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
   cursor: inherit;
 }
 
-.c1.fi-language-menu {
+.c1 {
   color: hsl(0,0%,13%);
 }
 

--- a/src/core/Link/ExternalLink/ExternalLink.baseStyles.ts
+++ b/src/core/Link/ExternalLink/ExternalLink.baseStyles.ts
@@ -1,9 +1,14 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { baseStyles } from '../BaseLink/BaseLink.baseStyles';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const ExternalLinkStyles = (theme: SuomifiTheme) => css`
+export const ExternalLinkStyles = (
+  theme: SuomifiTheme,
+  margins?: MarginProps,
+) => css`
   ${baseStyles(theme)}
+  ${getCssMargins(margins)}
   & .fi-link_icon {
     margin: 0;
     padding-left: ${theme.spacing.insetXs};

--- a/src/core/Link/ExternalLink/ExternalLink.baseStyles.ts
+++ b/src/core/Link/ExternalLink/ExternalLink.baseStyles.ts
@@ -5,10 +5,12 @@ import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const ExternalLinkStyles = (
   theme: SuomifiTheme,
-  margins?: MarginProps,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
 ) => css`
   ${baseStyles(theme)}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   & .fi-link_icon {
     margin: 0;
     padding-left: ${theme.spacing.insetXs};

--- a/src/core/Link/ExternalLink/ExternalLink.baseStyles.ts
+++ b/src/core/Link/ExternalLink/ExternalLink.baseStyles.ts
@@ -1,14 +1,14 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { baseStyles } from '../BaseLink/BaseLink.baseStyles';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const ExternalLinkStyles = (
   theme: SuomifiTheme,
   margins?: MarginProps,
 ) => css`
   ${baseStyles(theme)}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   & .fi-link_icon {
     margin: 0;
     padding-left: ${theme.spacing.insetXs};

--- a/src/core/Link/ExternalLink/ExternalLink.test.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.test.tsx
@@ -22,7 +22,7 @@ describe('margin', () => {
       </ExternalLink>,
     );
     const link = container.querySelector('a');
-    expect(link).toHaveAttribute('style', 'margin: 10px;');
+    expect(link).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -76,7 +76,6 @@ class BaseExternalLink extends Component<ExternalLinkProps & SuomifiThemeProp> {
         target={!!toNewWindow ? '_blank' : undefined}
         rel={!!toNewWindow ? 'noopener' : undefined}
         as={asProp}
-        style={{ ...passProps?.style }}
       >
         {variant === 'accent' && (
           <IconChevronRight

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -7,7 +7,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -21,6 +20,7 @@ import {
   baseClassName,
   linkClassNames,
 } from '../BaseLink/BaseLink';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const iconClassName = 'fi-link_icon';
 const externalClassName = 'fi-link--external';
@@ -63,8 +63,8 @@ class BaseExternalLink extends Component<ExternalLinkProps & SuomifiThemeProp> {
       underline = 'hover',
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     return (
       <HtmlA
         {...passProps}
@@ -76,7 +76,7 @@ class BaseExternalLink extends Component<ExternalLinkProps & SuomifiThemeProp> {
         target={!!toNewWindow ? '_blank' : undefined}
         rel={!!toNewWindow ? 'noopener' : undefined}
         as={asProp}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       >
         {variant === 'accent' && (
           <IconChevronRight
@@ -98,8 +98,14 @@ const StyledExternalLink = styled(
     return <BaseExternalLink theme={theme} {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) =>
-    ExternalLinkStyles(theme, globalMargins?.externalLink)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.externalLink,
+      marginProps,
+    );
+    return ExternalLinkStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const ExternalLink = forwardRef(

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -1,11 +1,16 @@
 import React, { Component, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { IconChevronRight, IconLinkExternal } from 'suomifi-icons';
 import { VisuallyHidden } from '../../VisuallyHidden/VisuallyHidden';
@@ -88,25 +93,31 @@ class BaseExternalLink extends Component<ExternalLinkProps & SuomifiThemeProp> {
 }
 
 const StyledExternalLink = styled(
-  (props: ExternalLinkProps & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (props: ExternalLinkProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseExternalLink theme={theme} {...passProps} />;
   },
 )`
-  ${({ theme }) => ExternalLinkStyles(theme)}
+  ${({ theme, globalMargins }) =>
+    ExternalLinkStyles(theme, globalMargins?.externalLink)}
 `;
 
 const ExternalLink = forwardRef(
   (props: ExternalLinkProps, ref: React.Ref<HTMLAnchorElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledExternalLink
-          theme={suomifiTheme}
-          forwardedRef={ref}
-          {...props}
-        />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledExternalLink
+              theme={suomifiTheme}
+              globalMargins={margins}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Link/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link/Link.baseStyles.ts
@@ -1,7 +1,9 @@
 import { SuomifiTheme } from '../../theme';
 import { css } from 'styled-components';
 import { baseStyles } from '../BaseLink/BaseLink.baseStyles';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const LinkStyles = (theme: SuomifiTheme) => css`
+export const LinkStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+  ${getCssMargins(margins)}
   ${baseStyles(theme)}
 `;

--- a/src/core/Link/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link/Link.baseStyles.ts
@@ -1,9 +1,9 @@
 import { SuomifiTheme } from '../../theme';
 import { css } from 'styled-components';
 import { baseStyles } from '../BaseLink/BaseLink.baseStyles';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const LinkStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   ${baseStyles(theme)}
 `;

--- a/src/core/Link/Link/Link.baseStyles.ts
+++ b/src/core/Link/Link/Link.baseStyles.ts
@@ -3,7 +3,12 @@ import { css } from 'styled-components';
 import { baseStyles } from '../BaseLink/BaseLink.baseStyles';
 import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const LinkStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
-  ${buildSpacingCSS(margins)}
+export const LinkStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   ${baseStyles(theme)}
 `;

--- a/src/core/Link/Link/Link.test.tsx
+++ b/src/core/Link/Link/Link.test.tsx
@@ -24,7 +24,7 @@ describe('margin', () => {
       </Link>,
     );
     const link = container.querySelector('a');
-    expect(link).toHaveAttribute('style', 'margin: 10px;');
+    expect(link).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -9,7 +9,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -20,6 +19,7 @@ import {
   baseClassName,
   linkClassNames,
 } from '../BaseLink/BaseLink';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 export interface LinkProps extends BaseLinkProps, MarginProps {
   /** Ref is forwarded to the anchor element. Alternative to React `ref` attribute. */
@@ -38,8 +38,8 @@ const StyledLink = styled(
     underline = 'hover',
     ...rest
   }: LinkProps & SuomifiThemeProp & GlobalMarginProps) => {
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     return (
       <HtmlA
         {...passProps}
@@ -49,7 +49,7 @@ const StyledLink = styled(
           [linkClassNames.small]: smallScreen,
         })}
         as={asProp}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       >
         {variant === 'accent' && (
           <IconChevronRight
@@ -62,7 +62,14 @@ const StyledLink = styled(
     );
   },
 )`
-  ${({ theme, globalMargins }) => LinkStyles(theme, globalMargins?.link)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.button,
+      marginProps,
+    );
+    return LinkStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Link = forwardRef(

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -3,11 +3,16 @@ import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { IconChevronRight } from 'suomifi-icons';
 import { LinkStyles } from '../Link/Link.baseStyles';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { HtmlA } from '../../../reset';
 import {
@@ -27,11 +32,12 @@ const StyledLink = styled(
     className,
     smallScreen,
     theme,
+    globalMargins,
     variant = 'default',
     children,
     underline = 'hover',
     ...rest
-  }: LinkProps & SuomifiThemeProp) => {
+  }: LinkProps & SuomifiThemeProp & GlobalMarginProps) => {
     const [marginProps, passProps] = separateMarginProps(rest);
     const marginStyle = spacingStyles(marginProps);
     return (
@@ -56,16 +62,25 @@ const StyledLink = styled(
     );
   },
 )`
-  ${({ theme }) => LinkStyles(theme)}
+  ${({ theme, globalMargins }) => LinkStyles(theme, globalMargins?.link)}
 `;
 
 const Link = forwardRef(
   (props: LinkProps, ref: React.Ref<HTMLAnchorElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledLink theme={suomifiTheme} forwardedRef={ref} {...props} />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledLink
+              theme={suomifiTheme}
+              globalMargins={margins}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Link/LinkList/LinkList.baseStyles.ts
+++ b/src/core/Link/LinkList/LinkList.baseStyles.ts
@@ -1,8 +1,13 @@
 import { SuomifiTheme } from 'core/theme';
 import { css } from 'styled-components';
 import { font } from '../../theme/reset';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const LinkListStyles = (theme: SuomifiTheme) => css`
+export const LinkListStyles = (
+  theme: SuomifiTheme,
+  margins?: MarginProps,
+) => css`
+  ${getCssMargins(margins)}
   &.fi-link-list {
     padding: 0;
     margin: 5px 0 0 0;

--- a/src/core/Link/LinkList/LinkList.baseStyles.ts
+++ b/src/core/Link/LinkList/LinkList.baseStyles.ts
@@ -1,13 +1,13 @@
 import { SuomifiTheme } from 'core/theme';
 import { css } from 'styled-components';
 import { font } from '../../theme/reset';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const LinkListStyles = (
   theme: SuomifiTheme,
   margins?: MarginProps,
 ) => css`
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   &.fi-link-list {
     padding: 0;
     margin: 5px 0 0 0;

--- a/src/core/Link/LinkList/LinkList.baseStyles.ts
+++ b/src/core/Link/LinkList/LinkList.baseStyles.ts
@@ -5,9 +5,11 @@ import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const LinkListStyles = (
   theme: SuomifiTheme,
-  margins?: MarginProps,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
 ) => css`
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   &.fi-link-list {
     padding: 0;
     margin: 5px 0 0 0;

--- a/src/core/Link/LinkList/LinkList.test.tsx
+++ b/src/core/Link/LinkList/LinkList.test.tsx
@@ -38,7 +38,7 @@ describe('Simple link list with one item', () => {
 describe('Margin prop', () => {
   it('should have margin style from margin prop', () => {
     const { container } = render(<LinkList ariaLabelledBy="" margin="xs" />);
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Link/LinkList/LinkList.test.tsx
+++ b/src/core/Link/LinkList/LinkList.test.tsx
@@ -37,8 +37,8 @@ describe('Simple link list with one item', () => {
 
 describe('Margin prop', () => {
   it('should have margin style from margin prop', () => {
-    const { container } = render(<LinkList ariaLabelledBy="" margin="xs" />);
-    expect(container.firstChild).toHaveStyle('margin: 10px');
+    const { baseElement } = render(<LinkList ariaLabelledBy="" margin="xs" />);
+    expect(baseElement).toMatchSnapshot();
   });
 
   it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Link/LinkList/LinkList.tsx
+++ b/src/core/Link/LinkList/LinkList.tsx
@@ -8,13 +8,13 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { HtmlUlProps, HtmlUlWithRef } from '../../../reset';
 import { getConditionalAriaProp } from '../../../utils/aria';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 const LinkListClassName = 'fi-link-list';
 const SmallScreenClassName = 'fi-link-list--small';
@@ -39,8 +39,8 @@ const StyledLinkList = styled(
     forwardedRef,
     ...rest
   }: LinkListProps & SuomifiThemeProp & GlobalMarginProps) => {
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     return (
       <HtmlUlWithRef
         ref={forwardedRef}
@@ -49,15 +49,21 @@ const StyledLinkList = styled(
           [SmallScreenClassName]: smallScreen,
         })}
         {...getConditionalAriaProp('aria-labelledby', [ariaLabelledBy])}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       >
         {children}
       </HtmlUlWithRef>
     );
   },
 )`
-  ${({ theme, globalMargins }) =>
-    LinkListStyles(theme, globalMargins?.linkList)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.linkList,
+      marginProps,
+    );
+    return LinkListStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const LinkList = forwardRef(

--- a/src/core/Link/LinkList/LinkList.tsx
+++ b/src/core/Link/LinkList/LinkList.tsx
@@ -2,11 +2,16 @@ import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { LinkListStyles } from './LinkList.baseStyles';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import { HtmlUlProps, HtmlUlWithRef } from '../../../reset';
 import { getConditionalAriaProp } from '../../../utils/aria';
@@ -30,9 +35,10 @@ const StyledLinkList = styled(
     children,
     smallScreen,
     ariaLabelledBy,
+    globalMargins,
     forwardedRef,
     ...rest
-  }: LinkListProps & SuomifiThemeProp) => {
+  }: LinkListProps & SuomifiThemeProp & GlobalMarginProps) => {
     const [marginProps, passProps] = separateMarginProps(rest);
     const marginStyle = spacingStyles(marginProps);
     return (
@@ -50,16 +56,26 @@ const StyledLinkList = styled(
     );
   },
 )`
-  ${({ theme }) => LinkListStyles(theme)}
+  ${({ theme, globalMargins }) =>
+    LinkListStyles(theme, globalMargins?.linkList)}
 `;
 
 const LinkList = forwardRef(
   (props: LinkListProps, ref: React.Ref<HTMLUListElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledLinkList theme={suomifiTheme} forwardedRef={ref} {...props} />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledLinkList
+              theme={suomifiTheme}
+              globalMargins={margins}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
+++ b/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
@@ -1,5 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Margin prop should have margin style from margin prop 1`] = `
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: block;
+  list-style-type: decimal;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 40px;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c1 {
+  margin: 10px !important;
+}
+
+.c1.fi-link-list {
+  padding: 0;
+  margin: 5px 0 0 0;
+}
+
+.c1.fi-link-list--small .fi-link-list-item_icon .fi-icon {
+  -webkit-transform: translateY(0.15em);
+  -ms-transform: translateY(0.15em);
+  transform: translateY(0.15em);
+}
+
+.c1.fi-link-list--small .fi-link {
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+<body>
+  <div>
+    <ul
+      class="c0 c1 fi-link-list"
+    />
+  </div>
+</body>
+`;
+
 exports[`Simple link list with one item should match snapshot 1`] = `
 .c5 {
   vertical-align: baseline;

--- a/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
+++ b/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
@@ -257,6 +257,10 @@ exports[`Simple link list with one item should match snapshot 1`] = `
   fill: hsl(23,82%,50%);
 }
 
+.c3.fi-link-list-item .fi-link {
+  margin: 0;
+}
+
 .c1.fi-link-list {
   padding: 0;
   margin: 5px 0 0 0;

--- a/src/core/Link/LinkListItem/LinkListItem.baseStyles.ts
+++ b/src/core/Link/LinkListItem/LinkListItem.baseStyles.ts
@@ -18,5 +18,8 @@ export const LinkListItemStyles = (theme: SuomifiTheme) => css`
         }
       }
     }
+    & .fi-link {
+      margin: 0;
+    }
   }
 `;

--- a/src/core/Link/RouterLink/RouterLink.baseStyles.ts
+++ b/src/core/Link/RouterLink/RouterLink.baseStyles.ts
@@ -1,9 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
-import { font } from '../../theme/reset';
 import { baseStyles } from '../BaseLink/BaseLink.baseStyles';
+import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
 
-export const RouterLinkStyles = (theme: SuomifiTheme) => css`
+export const RouterLinkStyles = (
+  theme: SuomifiTheme,
+  margins?: MarginProps,
+) => css`
+  ${getCssMargins(margins)}
   ${baseStyles(theme)}
-  ${font(theme)('bodyText')}
 `;

--- a/src/core/Link/RouterLink/RouterLink.baseStyles.ts
+++ b/src/core/Link/RouterLink/RouterLink.baseStyles.ts
@@ -5,8 +5,10 @@ import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const RouterLinkStyles = (
   theme: SuomifiTheme,
-  margins?: MarginProps,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
 ) => css`
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   ${baseStyles(theme)}
 `;

--- a/src/core/Link/RouterLink/RouterLink.baseStyles.ts
+++ b/src/core/Link/RouterLink/RouterLink.baseStyles.ts
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { baseStyles } from '../BaseLink/BaseLink.baseStyles';
-import { MarginProps, getCssMargins } from '../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
 export const RouterLinkStyles = (
   theme: SuomifiTheme,
   margins?: MarginProps,
 ) => css`
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   ${baseStyles(theme)}
 `;

--- a/src/core/Link/RouterLink/RouterLink.test.tsx
+++ b/src/core/Link/RouterLink/RouterLink.test.tsx
@@ -43,7 +43,7 @@ describe('margin', () => {
       </RouterLink>,
     );
     const link = container.querySelector('a');
-    expect(link).toHaveAttribute('style', 'margin: 10px;');
+    expect(link).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -3,11 +3,16 @@ import React, { forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import { RouterLinkStyles } from './RouterLink.baseStyles';
 import { IconChevronRight } from 'suomifi-icons';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../theme/utils/spacing';
 import {
   baseClassName,
@@ -116,6 +121,7 @@ const PolymorphicLink = <C extends React.ElementType>(
 ) => {
   const {
     asComponent,
+    globalMargins, // destructured out here to make typescript happy on styled level
     children,
     className,
     smallScreen,
@@ -165,19 +171,36 @@ const PolymorphicLink = <C extends React.ElementType>(
   );
 };
 
-const StyledRouterLink = styled(PolymorphicLink)`
-  ${({ theme }) => RouterLinkStyles(theme)}
+const StyledRouterLink = styled(
+  <C extends React.ElementType>(
+    props: RouterLinkProps<C> & SuomifiThemeProp & GlobalMarginProps,
+  ) => {
+    const { ...passProps } = props;
+    return <PolymorphicLink {...passProps} />;
+  },
+)`
+  ${({ theme, globalMargins }) =>
+    RouterLinkStyles(theme, globalMargins?.routerLink)}
 `;
 
 const RouterLinkInner = <C extends React.ElementType = 'a'>(
   props: RouterLinkProps<C>,
   ref?: PolymorphicRef<C>,
 ) => (
-  <SuomifiThemeConsumer>
-    {({ suomifiTheme }) => (
-      <StyledRouterLink theme={suomifiTheme} forwardedRef={ref} {...props} />
+  <SpacingConsumer>
+    {({ margins }) => (
+      <SuomifiThemeConsumer>
+        {({ suomifiTheme }) => (
+          <StyledRouterLink
+            theme={suomifiTheme}
+            globalMargins={margins}
+            forwardedRef={ref}
+            {...props}
+          />
+        )}
+      </SuomifiThemeConsumer>
     )}
-  </SuomifiThemeConsumer>
+  </SpacingConsumer>
 );
 
 // Type assertion is needed to set the function signature with generic type C.

--- a/src/core/Link/RouterLink/RouterLink.tsx
+++ b/src/core/Link/RouterLink/RouterLink.tsx
@@ -9,7 +9,6 @@ import {
   SpacingConsumer,
 } from '../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -21,6 +20,7 @@ import {
 } from '../BaseLink/BaseLink';
 import classnames from 'classnames';
 import { HtmlA } from '../../../reset';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 
 //
 // Source: https://www.benmvp.com/blog/polymorphic-react-components-typescript/
@@ -131,8 +131,8 @@ const PolymorphicLink = <C extends React.ElementType>(
     forwardedRef,
     ...rest
   } = props;
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
+
   const Component = asComponent || HtmlA;
 
   const classNames = classnames(baseClassName, routerLinkClassName, className, {
@@ -148,7 +148,7 @@ const PolymorphicLink = <C extends React.ElementType>(
         className={classNames}
         ref={forwardedRef}
         {...passProps}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       >
         {variant === 'accent' && (
           <IconChevronRight color={theme.colors.accentBase} />
@@ -164,7 +164,7 @@ const PolymorphicLink = <C extends React.ElementType>(
       className={classNames}
       forwardedRef={forwardedRef}
       {...passProps}
-      style={{ ...marginStyle, ...passProps?.style }}
+      style={{ ...passProps?.style }}
     >
       {children}
     </Component>
@@ -179,8 +179,14 @@ const StyledRouterLink = styled(
     return <PolymorphicLink {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) =>
-    RouterLinkStyles(theme, globalMargins?.routerLink)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.routerLink,
+      marginProps,
+    );
+    return RouterLinkStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const RouterLinkInner = <C extends React.ElementType = 'a'>(

--- a/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
+++ b/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
@@ -53,19 +53,6 @@ exports[`calling render with the same component on the same container does not r
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
 }
 
 .c1.fi-link {

--- a/src/core/LoadingSpinner/LoadingSpinner.baseStyles.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.baseStyles.tsx
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
+  ${getCssMargins(margins)}
   line-height: 1;
   &.fi-loadingSpinner {
     display: block;

--- a/src/core/LoadingSpinner/LoadingSpinner.baseStyles.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   line-height: 1;
   &.fi-loadingSpinner {
     display: block;

--- a/src/core/LoadingSpinner/LoadingSpinner.baseStyles.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.baseStyles.tsx
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   line-height: 1;
   &.fi-loadingSpinner {
     display: block;

--- a/src/core/LoadingSpinner/LoadingSpinner.test.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.test.tsx
@@ -62,7 +62,7 @@ describe('props', () => {
   describe('margin', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(<LoadingSpinner text="Test" margin="xs" />);
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin style overridden by style prop', async () => {

--- a/src/core/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.tsx
@@ -2,11 +2,16 @@ import React, { Component, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { baseStyles } from './LoadingSpinner.baseStyles';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { HtmlDiv, HtmlDivProps, HtmlDivWithRef } from '../../reset';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
@@ -112,26 +117,32 @@ class BaseLoadingSpinner extends Component<LoadingSpinnerProps> {
   }
 }
 const StyledLoadingSpinner = styled(
-  (props: LoadingSpinnerProps & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (props: LoadingSpinnerProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseLoadingSpinner {...passProps} />;
   },
 )`
-  ${({ theme }) => baseStyles(theme)};
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.loadingSpinner)};
 `;
 const LoadingSpinner = forwardRef(
   (props: LoadingSpinnerProps, ref: React.Ref<HTMLDivElement>) => {
     const { ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledLoadingSpinner
-            forwardedRef={ref}
-            theme={suomifiTheme}
-            {...passProps}
-          />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <StyledLoadingSpinner
+                forwardedRef={ref}
+                theme={suomifiTheme}
+                globalMargins={margins}
+                {...passProps}
+              />
+            )}
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/core/LoadingSpinner/LoadingSpinner.tsx
@@ -8,7 +8,6 @@ import {
   SpacingConsumer,
 } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -20,6 +19,7 @@ import {
   IconErrorFilled,
   IconPreloader,
 } from 'suomifi-icons';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 export type LoadingSpinnerStatus = 'loading' | 'success' | 'failed';
 export interface LoadingSpinnerProps extends MarginProps, HtmlDivProps {
@@ -79,8 +79,7 @@ class BaseLoadingSpinner extends Component<LoadingSpinnerProps> {
       forwardedRef,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     return (
       <HtmlDivWithRef
@@ -95,7 +94,7 @@ class BaseLoadingSpinner extends Component<LoadingSpinnerProps> {
         id={id}
         ref={forwardedRef}
         {...passProps}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         {status === 'loading' && (
           <IconPreloader className={loadingSpinnerClassNames.icon} />
@@ -122,8 +121,14 @@ const StyledLoadingSpinner = styled(
     return <BaseLoadingSpinner {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.loadingSpinner)};
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.loadingSpinner,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 const LoadingSpinner = forwardRef(
   (props: LoadingSpinnerProps, ref: React.Ref<HTMLDivElement>) => {

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -1,9 +1,11 @@
 import { font } from '../../../theme/reset';
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
+import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
+  ${getCssMargins(margins)}
   &.fi-service-navigation {
     &--small-screen {
       background: ${theme.colors.highlightLight3};

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { font } from '../../../theme/reset';
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
-import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   &.fi-service-navigation {
     &--small-screen {
       background: ${theme.colors.highlightLight3};

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.baseStyles.tsx
@@ -3,9 +3,14 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
 import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   &.fi-service-navigation {
     &--small-screen {
       background: ${theme.colors.highlightLight3};

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.test.tsx
@@ -84,7 +84,7 @@ describe('margin', () => {
         <ServiceNavigationItem>Test</ServiceNavigationItem>
       </ServiceNavigation>,
     );
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overridden by style prop', async () => {

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -15,7 +15,6 @@ import {
   SuomifiThemeProp,
 } from '../../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -23,6 +22,7 @@ import {
 import { getConditionalAriaProp } from '../../../../utils/aria';
 import { baseStyles } from './ServiceNavigation.baseStyles';
 import classnames from 'classnames';
+import { filterDuplicateKeys } from '../../../../utils/common/common';
 
 export interface ServiceNavigationProps extends MarginProps, HtmlDivProps {
   /** Use `<ServiceNavigationItem>` components as children */
@@ -67,8 +67,8 @@ const BaseServiceNavigation = ({
   style,
   ...rest
 }: ServiceNavigationProps) => {
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
+
   const initiallyExpandedValue =
     initiallyExpanded !== undefined ? initiallyExpanded : true;
   const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
@@ -80,7 +80,7 @@ const BaseServiceNavigation = ({
       className={classnames(baseClassName, className, {
         [smallScreenClassName]: variant === 'smallScreen',
       })}
-      style={{ ...marginStyle, ...style }}
+      style={style}
       {...passProps}
     >
       {variant === 'smallScreen' && (
@@ -117,8 +117,14 @@ const StyledServiceNavigation = styled(
     return <BaseServiceNavigation {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.serviceNavigation)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.serviceNavigation,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const ServiceNavigation = forwardRef(

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/ServiceNavigation.tsx
@@ -9,11 +9,16 @@ import {
 } from '../../../../reset';
 import styled from 'styled-components';
 import { IconChevronDown, IconChevronRight } from 'suomifi-icons';
-import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import {
+  SpacingConsumer,
+  SuomifiThemeConsumer,
+  SuomifiThemeProp,
+} from '../../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../../theme/utils/spacing';
 import { getConditionalAriaProp } from '../../../../utils/aria';
 import { baseStyles } from './ServiceNavigation.baseStyles';
@@ -107,25 +112,31 @@ const BaseServiceNavigation = ({
 };
 
 const StyledServiceNavigation = styled(
-  (props: ServiceNavigationProps & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (props: ServiceNavigationProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseServiceNavigation {...passProps} />;
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.serviceNavigation)}
 `;
 
 const ServiceNavigation = forwardRef(
   (props: ServiceNavigationProps, ref: React.Ref<HTMLElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledServiceNavigation
-          theme={suomifiTheme}
-          forwardedRef={ref}
-          {...props}
-        />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledServiceNavigation
+              theme={suomifiTheme}
+              globalMargins={margins}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -554,19 +554,6 @@ exports[`should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
 }
 
 .c7.fi-link {

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
@@ -1,11 +1,11 @@
 import { font } from '../../../theme/reset';
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
-import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   &.fi-side-navigation {
     .fi-side-navigation_divider {
       height: 1px;

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
@@ -3,9 +3,14 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
 import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   &.fi-side-navigation {
     .fi-side-navigation_divider {
       height: 1px;

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.baseStyles.tsx
@@ -1,9 +1,11 @@
 import { font } from '../../../theme/reset';
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
+import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${font(theme)('bodyText')}
+  ${getCssMargins(margins)}
   &.fi-side-navigation {
     .fi-side-navigation_divider {
       height: 1px;

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.test.tsx
@@ -102,7 +102,7 @@ describe('margin', () => {
         <SideNavigationItem content="" subLevel={1} />
       </SideNavigation>,
     );
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overridden by style prop', async () => {

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
@@ -14,7 +14,6 @@ import {
   SuomifiThemeProp,
 } from '../../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -23,6 +22,7 @@ import { baseStyles } from './SideNavigation.baseStyles';
 import classnames from 'classnames';
 import { getConditionalAriaProp } from '../../../../utils/aria';
 import { IconChevronDown, IconChevronUp } from 'suomifi-icons';
+import { filterDuplicateKeys } from '../../../../utils/common/common';
 
 export interface SideNavigationProps extends MarginProps, HtmlDivProps {
   /** Use `<SideNavigationItem>` components as children */
@@ -71,8 +71,8 @@ const BaseSideNavigation = ({
   style,
   ...rest
 }: SideNavigationProps) => {
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
+
   const initiallyExpandedValue =
     initiallyExpanded !== undefined ? initiallyExpanded : true;
   const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
@@ -83,7 +83,7 @@ const BaseSideNavigation = ({
       className={classnames(baseClassName, className, {
         [smallScreenClassName]: variant === 'smallScreen',
       })}
-      style={{ ...marginStyle, ...style }}
+      style={style}
       {...passProps}
     >
       {variant === 'smallScreen' ? (
@@ -127,8 +127,14 @@ const StyledSideNavigation = styled(
     return <BaseSideNavigation {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.sideNavigation)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.sideNavigation,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const SideNavigation = forwardRef(

--- a/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
+++ b/src/core/Navigation/SideNavigation/SideNavigation/SideNavigation.tsx
@@ -8,11 +8,16 @@ import {
   HtmlUl,
 } from '../../../../reset';
 import styled from 'styled-components';
-import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import {
+  SpacingConsumer,
+  SuomifiThemeConsumer,
+  SuomifiThemeProp,
+} from '../../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../../theme/utils/spacing';
 import { baseStyles } from './SideNavigation.baseStyles';
 import classnames from 'classnames';
@@ -117,25 +122,31 @@ const BaseSideNavigation = ({
 };
 
 const StyledSideNavigation = styled(
-  (props: SideNavigationProps & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (props: SideNavigationProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseSideNavigation {...passProps} />;
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.sideNavigation)}
 `;
 
 const SideNavigation = forwardRef(
   (props: SideNavigationProps, ref: React.Ref<HTMLElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledSideNavigation
-          theme={suomifiTheme}
-          forwardedRef={ref}
-          {...props}
-        />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledSideNavigation
+              theme={suomifiTheme}
+              globalMargins={margins}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -670,19 +670,6 @@ exports[`calling render with the same component on the same container does not r
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
 }
 
 .c9.fi-link {

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
@@ -3,8 +3,13 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
 import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
-  ${buildSpacingCSS(margins)}
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   &.fi-wizard-navigation {
     .fi-wizard-navigation_heading {
       margin-left: ${theme.spacing.m};

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
@@ -1,8 +1,10 @@
 import { font } from '../../../theme/reset';
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
+import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+  ${getCssMargins(margins)}
   &.fi-wizard-navigation {
     .fi-wizard-navigation_heading {
       margin-left: ${theme.spacing.m};

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.baseStyles.tsx
@@ -1,10 +1,10 @@
 import { font } from '../../../theme/reset';
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
-import { MarginProps, getCssMargins } from '../../../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../../../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   &.fi-wizard-navigation {
     .fi-wizard-navigation_heading {
       margin-left: ${theme.spacing.m};

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
@@ -62,7 +62,7 @@ describe('margin', () => {
         <WizardNavigationItem status="current">Test</WizardNavigationItem>
       </WizardNavigation>,
     );
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overridden by style prop', async () => {

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -9,11 +9,16 @@ import {
   HtmlNav,
   HtmlUl,
 } from '../../../../reset';
-import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
+import {
+  SpacingConsumer,
+  SuomifiThemeConsumer,
+  SuomifiThemeProp,
+} from '../../../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../../../theme/utils/spacing';
 import { getConditionalAriaProp } from '../../../../utils/aria';
 import { baseStyles } from './WizardNavigation.baseStyles';
@@ -107,25 +112,31 @@ const BaseWizardNavigation = ({
 };
 
 const StyledWizardNavigation = styled(
-  (props: WizardNavigationProps & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (props: WizardNavigationProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseWizardNavigation {...passProps} />;
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.wizardNavigation)}
 `;
 
 const WizardNavigation = forwardRef(
   (props: WizardNavigationProps, ref: React.Ref<HTMLElement>) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledWizardNavigation
-          theme={suomifiTheme}
-          forwardedRef={ref}
-          {...props}
-        />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledWizardNavigation
+              theme={suomifiTheme}
+              globalMargins={margins}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.tsx
@@ -15,13 +15,13 @@ import {
   SuomifiThemeProp,
 } from '../../../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../../../theme/utils/spacing';
 import { getConditionalAriaProp } from '../../../../utils/aria';
 import { baseStyles } from './WizardNavigation.baseStyles';
+import { filterDuplicateKeys } from '../../../../utils/common/common';
 
 export interface WizardNavigationProps extends MarginProps, HtmlDivProps {
   /** Use `<WizardNavigationItem>` components as children */
@@ -66,8 +66,8 @@ const BaseWizardNavigation = ({
   style,
   ...rest
 }: WizardNavigationProps) => {
-  const [marginProps, passProps] = separateMarginProps(rest);
-  const marginStyle = spacingStyles(marginProps);
+  const [_marginProps, passProps] = separateMarginProps(rest);
+
   const initiallyExpandedValue =
     initiallyExpanded !== undefined ? initiallyExpanded : true;
   const [smallScreenNavOpen, setSmallScreenNavOpen] = useState(
@@ -79,7 +79,7 @@ const BaseWizardNavigation = ({
       className={classnames(baseClassName, className, {
         [smallScreenClassName]: variant === 'smallScreen',
       })}
-      style={{ ...marginStyle, ...style }}
+      style={style}
       {...passProps}
     >
       {variant === 'smallScreen' ? (
@@ -117,8 +117,14 @@ const StyledWizardNavigation = styled(
     return <BaseWizardNavigation {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.wizardNavigation)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.wizardNavigation,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const WizardNavigation = forwardRef(

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -763,19 +763,6 @@ exports[`calling render with the same component on the same container does not r
   font-size: 18px;
   line-height: 1.5;
   font-weight: 400;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 400;
 }
 
 .c8.fi-link {

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};
   border-radius: 4px;

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
+  ${getCssMargins(margins)}
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};
   border-radius: 4px;

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};
   border-radius: 4px;

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -55,13 +55,13 @@ export const baseStyles = (
     }
     & .fi-notification_heading {
       ${font(theme)('bodySemiBold')}
+      margin: 0;
       margin-bottom: ${theme.spacing.xxs};
     }
     & .fi-notification_action-element-wrapper {
       padding: 20px 26px 19px 84px;
       & .fi-button {
-        margin-top: ${theme.spacing.xs};
-        margin-right: ${theme.spacing.s};
+        margin: ${theme.spacing.xs} ${theme.spacing.s} 0 0;
       }
       & .fi-button:first-child {
         margin-top: 0;
@@ -71,6 +71,7 @@ export const baseStyles = (
     & .fi-notification_close-button {
       height: 40px;
       padding: 7px ${theme.spacing.insetL};
+      margin: 0;
       margin-top: 6px;
       border: 1px solid transparent;
       white-space: nowrap;

--- a/src/core/Notification/Notification.test.tsx
+++ b/src/core/Notification/Notification.test.tsx
@@ -96,7 +96,7 @@ describe('props', () => {
           Test
         </Notification>,
       );
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
   });
 

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -14,12 +14,12 @@ import {
   SpacingConsumer,
 } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Notification.baseStyles';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 export const baseClassName = 'fi-notification';
 export const notificationClassNames = {
@@ -107,8 +107,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
       showCloseButton = true,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     const {
       className: customCloseButtonClassName,
@@ -132,7 +131,7 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
             [notificationClassNames.smallScreen]: !!smallScreen,
           },
         )}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlDiv className={notificationClassNames.styleWrapper} style={style}>
           <HtmlDiv className={notificationClassNames.iconWrapper}>
@@ -210,8 +209,14 @@ const StyledNotification = styled(
     return <BaseNotification {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) =>
-    baseStyles(theme, globalMargins?.notification)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.notification,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Notification = forwardRef(

--- a/src/core/Notification/Notification.tsx
+++ b/src/core/Notification/Notification.tsx
@@ -8,11 +8,16 @@ import { getConditionalAriaProp } from '../../utils/aria';
 import { Heading } from '../Heading/Heading';
 import { AutoId } from '../utils/AutoId/AutoId';
 import { Button, ButtonProps, LoadingProps } from '../Button/Button';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Notification.baseStyles';
 
@@ -198,32 +203,40 @@ class BaseNotification extends Component<NotificationProps & InnerRef> {
 }
 
 const StyledNotification = styled(
-  (props: NotificationProps & InnerRef & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (
+    props: NotificationProps & InnerRef & SuomifiThemeProp & GlobalMarginProps,
+  ) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseNotification {...passProps} />;
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) =>
+    baseStyles(theme, globalMargins?.notification)}
 `;
 
 const Notification = forwardRef(
   (props: NotificationProps, ref: React.RefObject<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledNotification
-                forwardedRef={ref}
-                theme={suomifiTheme}
-                id={id}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledNotification
+                    forwardedRef={ref}
+                    theme={suomifiTheme}
+                    globalMargins={margins}
+                    id={id}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -887,6 +887,7 @@ exports[`props children should match snapshot 1`] = `
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
+  margin: 0;
   margin-bottom: 5px;
 }
 
@@ -895,8 +896,7 @@ exports[`props children should match snapshot 1`] = `
 }
 
 .c1.fi-notification .fi-notification_action-element-wrapper .fi-button {
-  margin-top: 10px;
-  margin-right: 15px;
+  margin: 10px 15px 0 0;
 }
 
 .c1.fi-notification .fi-notification_action-element-wrapper .fi-button:first-child {
@@ -906,6 +906,7 @@ exports[`props children should match snapshot 1`] = `
 .c1.fi-notification .fi-notification_close-button {
   height: 40px;
   padding: 7px 10px;
+  margin: 0;
   margin-top: 6px;
   border: 1px solid transparent;
   white-space: nowrap;

--- a/src/core/Pagination/Pagination.baseStyles.ts
+++ b/src/core/Pagination/Pagination.baseStyles.ts
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   &.fi-pagination {
     & .fi-pagination_style-wrapper {
       display: inline-flex;

--- a/src/core/Pagination/Pagination.baseStyles.ts
+++ b/src/core/Pagination/Pagination.baseStyles.ts
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   &.fi-pagination {
     & .fi-pagination_style-wrapper {
       display: inline-flex;

--- a/src/core/Pagination/Pagination.baseStyles.ts
+++ b/src/core/Pagination/Pagination.baseStyles.ts
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
-import { font, element } from '../theme/reset';
+import { font, element, fixInternalMargins } from '../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (
@@ -12,6 +12,7 @@ export const baseStyles = (
   ${font(theme)('bodyTextSmall')}
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
+  ${fixInternalMargins()}
   &.fi-pagination {
     & .fi-pagination_style-wrapper {
       display: inline-flex;
@@ -27,6 +28,7 @@ export const baseStyles = (
         width: 40px;
         padding-left: 0;
         padding-right: 0;
+        margin: 0;
 
         & > .fi-button_icon > .fi-icon {
           margin-right: auto;

--- a/src/core/Pagination/Pagination.baseStyles.ts
+++ b/src/core/Pagination/Pagination.baseStyles.ts
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
+  ${getCssMargins(margins)}
   &.fi-pagination {
     & .fi-pagination_style-wrapper {
       display: inline-flex;

--- a/src/core/Pagination/Pagination.test.tsx
+++ b/src/core/Pagination/Pagination.test.tsx
@@ -63,7 +63,7 @@ describe('props', () => {
   describe('margin', () => {
     it('should have margin style from margin prop', () => {
       const { container } = render(TestPagination({ margin: 'xs' }));
-      expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+      expect(container.firstChild).toHaveStyle('margin: 10px');
     });
 
     it('should have margin style overridden by style prop', async () => {

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -8,7 +8,6 @@ import {
   SpacingConsumer,
 } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -19,6 +18,7 @@ import { PageInput, PageInputValue } from './PageInput/PageInput';
 import { Button } from '../Button/Button';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
 import { AutoId } from '../utils/AutoId/AutoId';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 export interface PageInputProps {
   /** Page input action button label for screen readers  */
@@ -173,8 +173,8 @@ class BasePagination extends Component<PaginationProps> {
       ...rest
     } = this.props;
 
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     const pageInputId = `${id}-pageInput`;
 
     return (
@@ -183,7 +183,7 @@ class BasePagination extends Component<PaginationProps> {
         className={classnames(baseClassName, className, {
           [paginationClassNames.smallScreen]: !!smallScreen,
         })}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlDiv className={paginationClassNames.styleWrapper}>
           <HtmlDiv className={paginationClassNames.buttonsWrapper}>
@@ -246,7 +246,14 @@ const StyledPagination = styled(
     return <BasePagination {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.pagination)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.pagination,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Pagination = forwardRef(

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -2,11 +2,16 @@ import React, { Component, forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { IconArrowLeft, IconArrowRight } from 'suomifi-icons';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Pagination.baseStyles';
 import { HtmlSpan, HtmlNav, HtmlDiv, HtmlNavProps } from '../../reset';
@@ -235,31 +240,38 @@ class BasePagination extends Component<PaginationProps> {
   }
 }
 
-const StyledPagination = styled((props: PaginationProps & SuomifiThemeProp) => {
-  const { theme, ...passProps } = props;
-  return <BasePagination {...passProps} />;
-})`
-  ${({ theme }) => baseStyles(theme)}
+const StyledPagination = styled(
+  (props: PaginationProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
+    return <BasePagination {...passProps} />;
+  },
+)`
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.pagination)}
 `;
 
 const Pagination = forwardRef(
   (props: PaginationProps, ref: React.RefObject<HTMLElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledPagination
-                id={id}
-                theme={suomifiTheme}
-                forwardedRef={ref}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledPagination
+                    id={id}
+                    theme={suomifiTheme}
+                    globalMargins={margins}
+                    forwardedRef={ref}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -891,6 +891,12 @@ exports[`snapshot should have matching default structure 1`] = `
   font-weight: 400;
 }
 
+.c1 .fi-label,
+.c1 .fi-hint-text,
+.c1 .fi-status-text {
+  margin: 0;
+}
+
 .c1.fi-pagination .fi-pagination_style-wrapper {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -915,6 +921,7 @@ exports[`snapshot should have matching default structure 1`] = `
   width: 40px;
   padding-left: 0;
   padding-right: 0;
+  margin: 0;
 }
 
 .c1.fi-pagination .fi-pagination_buttons-wrapper .fi-pagination_arrow-button > .fi-button_icon > .fi-icon {

--- a/src/core/Paragraph/Paragraph.baseStyles.ts
+++ b/src/core/Paragraph/Paragraph.baseStyles.ts
@@ -1,11 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   margin: 0;
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
 `;

--- a/src/core/Paragraph/Paragraph.baseStyles.ts
+++ b/src/core/Paragraph/Paragraph.baseStyles.ts
@@ -3,9 +3,14 @@ import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   margin: 0;
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
 `;

--- a/src/core/Paragraph/Paragraph.baseStyles.ts
+++ b/src/core/Paragraph/Paragraph.baseStyles.ts
@@ -1,9 +1,11 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
   margin: 0;
+  ${getCssMargins(margins)}
 `;

--- a/src/core/Paragraph/Paragraph.test.tsx
+++ b/src/core/Paragraph/Paragraph.test.tsx
@@ -13,7 +13,7 @@ const TestParagraph = (
 describe('margin', () => {
   it('should have margin style from margin prop', () => {
     const { container } = render(<Paragraph margin="xs">Test</Paragraph>);
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -33,14 +32,13 @@ const StyledParagraph = styled(
     globalMargins,
     ...rest
   }: ParagraphProps & SuomifiThemeProp & GlobalMarginProps) => {
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     return (
       <HtmlP
         className={classnames(baseClassName, className)}
         {...passProps}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       />
     );
   },

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -14,6 +14,7 @@ import {
 } from '../theme';
 import { baseStyles } from './Paragraph.baseStyles';
 import { HtmlP, HtmlPProps } from '../../reset/HtmlP/HtmlP';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 const baseClassName = 'fi-paragraph';
 
@@ -43,7 +44,14 @@ const StyledParagraph = styled(
     );
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.paragraph)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.paragraph,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Paragraph = forwardRef<HTMLParagraphElement, ParagraphProps>(

--- a/src/core/Paragraph/Paragraph.tsx
+++ b/src/core/Paragraph/Paragraph.tsx
@@ -5,8 +5,14 @@ import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
-import { ColorProp, SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  ColorProp,
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import { baseStyles } from './Paragraph.baseStyles';
 import { HtmlP, HtmlPProps } from '../../reset/HtmlP/HtmlP';
 
@@ -20,7 +26,13 @@ export interface ParagraphProps extends HtmlPProps, MarginProps {
 }
 
 const StyledParagraph = styled(
-  ({ className, theme, style, ...rest }: ParagraphProps & SuomifiThemeProp) => {
+  ({
+    className,
+    theme,
+    style,
+    globalMargins,
+    ...rest
+  }: ParagraphProps & SuomifiThemeProp & GlobalMarginProps) => {
     const [marginProps, passProps] = separateMarginProps(rest);
     const marginStyle = spacingStyles(marginProps);
 
@@ -33,16 +45,25 @@ const StyledParagraph = styled(
     );
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins?.paragraph)}
 `;
 
 const Paragraph = forwardRef<HTMLParagraphElement, ParagraphProps>(
   (props, ref) => (
-    <SuomifiThemeConsumer>
-      {({ suomifiTheme }) => (
-        <StyledParagraph theme={suomifiTheme} forwardedRef={ref} {...props} />
+    <SpacingConsumer>
+      {({ margins }) => (
+        <SuomifiThemeConsumer>
+          {({ suomifiTheme }) => (
+            <StyledParagraph
+              theme={suomifiTheme}
+              globalMargins={margins}
+              forwardedRef={ref}
+              {...props}
+            />
+          )}
+        </SuomifiThemeConsumer>
       )}
-    </SuomifiThemeConsumer>
+    </SpacingConsumer>
   ),
 );
 

--- a/src/core/Text/Text.baseStyles.ts
+++ b/src/core/Text/Text.baseStyles.ts
@@ -1,17 +1,18 @@
 import { css } from 'styled-components';
-import { SuomifiThemeProp } from '../theme';
+import { SuomifiTheme } from '../theme';
 import { element, font } from '../theme/reset';
-import { TextProps } from './Text';
-import { GlobalMarginProps, buildSpacingCSS } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = ({
-  theme,
-  color,
-  globalMargins,
-}: TextProps & SuomifiThemeProp & GlobalMarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  color?: keyof SuomifiTheme['colors'],
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${buildSpacingCSS(globalMargins?.text)} 
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   color: ${!!color ? theme.colors[color] : theme.colors.blackBase};
 
   &.fi-text {

--- a/src/core/Text/Text.baseStyles.ts
+++ b/src/core/Text/Text.baseStyles.ts
@@ -2,13 +2,16 @@ import { css } from 'styled-components';
 import { SuomifiThemeProp } from '../theme';
 import { element, font } from '../theme/reset';
 import { TextProps } from './Text';
+import { GlobalMarginProps, getCssMargins } from '../theme/utils/spacing';
 
 export const baseStyles = ({
   theme,
   color,
-}: TextProps & SuomifiThemeProp) => css`
+  globalMargins,
+}: TextProps & SuomifiThemeProp & GlobalMarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
+  ${getCssMargins(globalMargins?.text)} 
   color: ${!!color ? theme.colors[color] : theme.colors.blackBase};
 
   &.fi-text {

--- a/src/core/Text/Text.baseStyles.ts
+++ b/src/core/Text/Text.baseStyles.ts
@@ -2,7 +2,7 @@ import { css } from 'styled-components';
 import { SuomifiThemeProp } from '../theme';
 import { element, font } from '../theme/reset';
 import { TextProps } from './Text';
-import { GlobalMarginProps, getCssMargins } from '../theme/utils/spacing';
+import { GlobalMarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = ({
   theme,
@@ -11,7 +11,7 @@ export const baseStyles = ({
 }: TextProps & SuomifiThemeProp & GlobalMarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyText')}
-  ${getCssMargins(globalMargins?.text)} 
+  ${buildSpacingCSS(globalMargins?.text)} 
   color: ${!!color ? theme.colors[color] : theme.colors.blackBase};
 
   &.fi-text {

--- a/src/core/Text/Text.test.tsx
+++ b/src/core/Text/Text.test.tsx
@@ -35,7 +35,7 @@ test('should not have basic accessibility issues', axeTest(TestTexts));
 describe('margin', () => {
   it('should have margin style from margin prop', () => {
     const { container } = render(<Text margin="xs">Test</Text>);
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin prop overwritten from style prop', () => {

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -8,13 +8,13 @@ import {
   SuomifiThemeProp,
 } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Text.baseStyles';
 import { HtmlSpan, HtmlSpanProps } from '../../reset';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 const baseClassName = 'fi-text';
 const smallScreenClassName = `${baseClassName}--small-screen`;
@@ -43,8 +43,7 @@ const StyledText = styled(
     color,
     ...rest
   }: TextProps & SuomifiThemeProp & GlobalMarginProps) => {
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     return (
       <HtmlSpan
@@ -57,13 +56,20 @@ const StyledText = styled(
             [smallScreenClassName]: smallScreen,
           },
         )}
-        style={{ ...marginStyle, ...passProps?.style }}
+        style={{ ...passProps?.style }}
       />
     );
   },
   // Component specific margins extracted within styles to minimize changes to surrounding code
 )`
-  ${(props) => baseStyles(props)}
+  ${({ theme, color, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.button,
+      marginProps,
+    );
+    return baseStyles(theme, color, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Text = forwardRef<HTMLSpanElement, TextProps>(

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -1,11 +1,17 @@
 import React, { forwardRef } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
-import { ColorProp, SuomifiThemeConsumer, SuomifiThemeProp } from '../theme';
+import {
+  ColorProp,
+  SpacingConsumer,
+  SuomifiThemeConsumer,
+  SuomifiThemeProp,
+} from '../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Text.baseStyles';
 import { HtmlSpan, HtmlSpanProps } from '../../reset';
@@ -31,11 +37,12 @@ const StyledText = styled(
   ({
     variant = 'body',
     smallScreen,
+    globalMargins,
     className,
     theme,
     color,
     ...rest
-  }: TextProps & SuomifiThemeProp) => {
+  }: TextProps & SuomifiThemeProp & GlobalMarginProps) => {
     const [marginProps, passProps] = separateMarginProps(rest);
     const marginStyle = spacingStyles(marginProps);
 
@@ -54,6 +61,7 @@ const StyledText = styled(
       />
     );
   },
+  // Component specific margins extracted within styles to minimize changes to surrounding code
 )`
   ${(props) => baseStyles(props)}
 `;
@@ -62,11 +70,20 @@ const Text = forwardRef<HTMLSpanElement, TextProps>(
   (props: TextProps, ref: React.Ref<HTMLSpanElement>) => {
     const { ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledText theme={suomifiTheme} forwardedRef={ref} {...passProps} />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <StyledText
+                theme={suomifiTheme}
+                globalMargins={margins}
+                forwardedRef={ref}
+                {...passProps}
+              />
+            )}
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Text/Text.tsx
+++ b/src/core/Text/Text.tsx
@@ -56,7 +56,6 @@ const StyledText = styled(
             [smallScreenClassName]: smallScreen,
           },
         )}
-        style={{ ...passProps?.style }}
       />
     );
   },

--- a/src/core/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/core/Text/__snapshots__/Text.test.tsx.snap
@@ -49,6 +49,25 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c2 {
+  color: hsl(0,0%,13%);
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  margin: 0;
+  margin-bottom: 15px !important;
+}
+
+.c3 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -72,12 +91,12 @@ exports[`calling render with the same component on the same container does not r
   white-space: normal;
 }
 
-.c2::before,
-.c2::after {
+.c3::before,
+.c3::after {
   box-sizing: border-box;
 }
 
-.c3 {
+.c4 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -95,7 +114,7 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(0,0%,13%);
 }
 
-.c3.fi-text--bold {
+.c4.fi-text--bold {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -111,7 +130,7 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 600;
 }
 
-.c3.fi-text--lead {
+.c4.fi-text--lead {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -127,7 +146,7 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
-.c3.fi-text--small-screen {
+.c4.fi-text--small-screen {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -143,7 +162,7 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 400;
 }
 
-.c3.fi-text--small-screen.fi-text--bold {
+.c4.fi-text--small-screen.fi-text--bold {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -159,7 +178,7 @@ exports[`calling render with the same component on the same container does not r
   font-weight: 600;
 }
 
-.c3.fi-text--small-screen.fi-text--lead {
+.c4.fi-text--small-screen.fi-text--lead {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -184,11 +203,10 @@ exports[`calling render with the same component on the same container does not r
     Paragraph text
   </p>
   <p
-    class="c0 fi-paragraph c1"
-    style="margin-bottom: 15px;"
+    class="c0 fi-paragraph c2"
   >
     <span
-      class="c2 fi-text c3 fi-text--lead"
+      class="c3 fi-text c4 fi-text--lead"
     >
       Leading text
     </span>
@@ -197,12 +215,12 @@ exports[`calling render with the same component on the same container does not r
     class="c0 fi-paragraph c1"
   >
     <span
-      class="c2 fi-text c3 fi-text--body"
+      class="c3 fi-text c4 fi-text--body"
     >
       Body text
     </span>
     <span
-      class="c2 fi-text c3 fi-text--bold"
+      class="c3 fi-text c4 fi-text--bold"
     >
       Bold text
     </span>
@@ -211,12 +229,12 @@ exports[`calling render with the same component on the same container does not r
     class="c0 fi-paragraph c1"
   >
     <span
-      class="c2 fi-text c3 fi-text--body fi-text--small-screen"
+      class="c3 fi-text c4 fi-text--body fi-text--small-screen"
     >
       Body text
     </span>
     <span
-      class="c2 fi-text c3 fi-text--bold fi-text--small-screen"
+      class="c3 fi-text c4 fi-text--bold fi-text--small-screen"
     >
       Bold text
     </span>

--- a/src/core/Toast/Toast.baseStyles.tsx
+++ b/src/core/Toast/Toast.baseStyles.tsx
@@ -1,10 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
+import { MarginProps, getCssMargins } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
+  ${getCssMargins(margins)}
   border-top: 4px solid ${theme.colors.successBase};
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};

--- a/src/core/Toast/Toast.baseStyles.tsx
+++ b/src/core/Toast/Toast.baseStyles.tsx
@@ -3,10 +3,15 @@ import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
 import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${buildSpacingCSS(margins)}
+  ${buildSpacingCSS(globalMargins)}
+  ${buildSpacingCSS(propMargins, true)}
   border-top: 4px solid ${theme.colors.successBase};
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};

--- a/src/core/Toast/Toast.baseStyles.tsx
+++ b/src/core/Toast/Toast.baseStyles.tsx
@@ -1,12 +1,12 @@
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../theme';
 import { font, element } from '../theme/reset';
-import { MarginProps, getCssMargins } from '../theme/utils/spacing';
+import { MarginProps, buildSpacingCSS } from '../theme/utils/spacing';
 
 export const baseStyles = (theme: SuomifiTheme, margins?: MarginProps) => css`
   ${element(theme)}
   ${font(theme)('bodyTextSmall')}
-  ${getCssMargins(margins)}
+  ${buildSpacingCSS(margins)}
   border-top: 4px solid ${theme.colors.successBase};
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};

--- a/src/core/Toast/Toast.test.tsx
+++ b/src/core/Toast/Toast.test.tsx
@@ -89,7 +89,7 @@ describe('props', () => {
 describe('margin', () => {
   it('should have margin style from margin prop', () => {
     const { container } = render(<Toast margin="xs" />);
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 
   it('should have margin style overridden by style prop', async () => {

--- a/src/core/Toast/Toast.tsx
+++ b/src/core/Toast/Toast.tsx
@@ -2,11 +2,16 @@ import React, { Component, forwardRef, ReactNode } from 'react';
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { baseStyles } from './Toast.baseStyles';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../theme';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../theme';
 import {
   spacingStyles,
   separateMarginProps,
   MarginProps,
+  GlobalMarginProps,
 } from '../theme/utils/spacing';
 import { IconCheckCircle } from 'suomifi-icons';
 import { Heading } from '../Heading/Heading';
@@ -88,22 +93,33 @@ class BaseToast extends Component<ToastProps> {
     );
   }
 }
-const StyledToast = styled((props: ToastProps & SuomifiThemeProp) => {
-  const { theme, ...passProps } = props;
-  return <BaseToast {...passProps} />;
-})`
-  ${({ theme }) => baseStyles(theme)};
+const StyledToast = styled(
+  (props: ToastProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
+    return <BaseToast {...passProps} />;
+  },
+)`
+  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins.toast)};
 `;
 
 const Toast = forwardRef(
   (props: ToastProps, ref: React.Ref<HTMLDivElement>) => {
     const { ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <StyledToast forwardedRef={ref} theme={suomifiTheme} {...passProps} />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <StyledToast
+                forwardedRef={ref}
+                theme={suomifiTheme}
+                globalMargins={margins}
+                {...passProps}
+              />
+            )}
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Toast/Toast.tsx
+++ b/src/core/Toast/Toast.tsx
@@ -8,7 +8,6 @@ import {
   SpacingConsumer,
 } from '../theme';
 import {
-  spacingStyles,
   separateMarginProps,
   MarginProps,
   GlobalMarginProps,
@@ -17,6 +16,7 @@ import { IconCheckCircle } from 'suomifi-icons';
 import { Heading } from '../Heading/Heading';
 import { HtmlDiv, HtmlDivWithRef, HtmlDivWithRefProps } from '../../reset';
 import { hLevels } from '../../reset/HtmlH/HtmlH';
+import { filterDuplicateKeys } from '../../utils/common/common';
 
 export interface ToastProps extends MarginProps, HtmlDivWithRefProps {
   /** Sets aria-live mode for the Toast text content and label.
@@ -59,14 +59,14 @@ class BaseToast extends Component<ToastProps> {
       style,
       ...rest
     } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
+
     return (
       <HtmlDivWithRef
         className={classnames(baseClassName, className)}
         as="section"
         {...passProps}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <HtmlDiv className={toastClassNames.styleWrapper}>
           <HtmlDiv className={toastClassNames.iconWrapper}>
@@ -99,7 +99,14 @@ const StyledToast = styled(
     return <BaseToast {...passProps} />;
   },
 )`
-  ${({ theme, globalMargins }) => baseStyles(theme, globalMargins.toast)};
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.toast,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const Toast = forwardRef(

--- a/src/core/Tooltip/Tooltip.test.tsx
+++ b/src/core/Tooltip/Tooltip.test.tsx
@@ -171,6 +171,6 @@ describe('margin', () => {
         Test
       </Tooltip>,
     );
-    expect(container.firstChild).toHaveStyle('margin: 10px');
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/core/Tooltip/Tooltip.test.tsx
+++ b/src/core/Tooltip/Tooltip.test.tsx
@@ -171,6 +171,6 @@ describe('margin', () => {
         Test
       </Tooltip>,
     );
-    expect(container.firstChild).toHaveAttribute('style', 'margin: 10px;');
+    expect(container.firstChild).toHaveStyle('margin: 10px');
   });
 });

--- a/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
+++ b/src/core/Tooltip/TooltipContent/TooltipContent.baseStyles.tsx
@@ -5,8 +5,7 @@ export const baseStyles = (arrowOffsetPx: number, theme: SuomifiTheme) => css`
   ${theme.typography.bodyTextSmall};
 
   &.fi-tooltip_content {
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin: 10px 0;
     position: relative;
     border: 1px solid ${theme.colors.depthDark2};
     border-radius: ${theme.radiuses.basic};

--- a/src/core/Tooltip/TooltipToggleButton/TooltipToggleButton.tsx
+++ b/src/core/Tooltip/TooltipToggleButton/TooltipToggleButton.tsx
@@ -2,11 +2,7 @@ import React, { Component, forwardRef } from 'react';
 import classnames from 'classnames';
 import { default as styled } from 'styled-components';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
-import {
-  spacingStyles,
-  separateMarginProps,
-  MarginProps,
-} from '../../theme/utils/spacing';
+import { separateMarginProps, MarginProps } from '../../theme/utils/spacing';
 import { HtmlButton, HtmlButtonProps } from '../../../reset';
 import { baseStyles } from './TooltipToggleButton.baseStyles';
 import { IconInfoFilled } from 'suomifi-icons';
@@ -29,15 +25,14 @@ class BaseTooltipToggleButton extends Component<
 > {
   render() {
     const { className, 'aria-label': ariaLabel, style, ...rest } = this.props;
-    const [marginProps, passProps] = separateMarginProps(rest);
-    const marginStyle = spacingStyles(marginProps);
+    const [_marginProps, passProps] = separateMarginProps(rest);
 
     return (
       <HtmlButton
         className={classnames(className, tooltipClassNames.toggleButton)}
         aria-label={ariaLabel}
         {...passProps}
-        style={{ ...marginStyle, ...style }}
+        style={style}
       >
         <IconInfoFilled className={tooltipClassNames.toggleButtonIcon} />
       </HtmlButton>

--- a/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -139,8 +139,7 @@ exports[`Basic tooltip should match snapshot 1`] = `
 }
 
 .c4.fi-tooltip_content {
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin: 10px 0;
   position: relative;
   border: 1px solid hsl(201,7%,46%);
   border-radius: 2px;

--- a/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -323,3 +323,143 @@ exports[`Basic tooltip should match snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`margin should have margin style from margin prop 1`] = `
+.c2 {
+  vertical-align: baseline;
+}
+
+.c2.fi-icon {
+  display: inline-block;
+}
+
+.c2 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c2 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c2.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c2.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c0 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  display: inline-block;
+  max-width: 100%;
+  cursor: pointer;
+}
+
+.c0:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+.c0::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+.c0::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+.c0::-webkit-inner-spin-button {
+  height: auto;
+}
+
+.c0::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.c0::before,
+.c0::after {
+  box-sizing: border-box;
+}
+
+.c1 {
+  display: inline;
+  height: 16px;
+  width: 16px;
+  margin-left: 5px;
+  vertical-align: middle;
+}
+
+.c1:focus-visible {
+  outline: 3px solid transparent;
+  position: relative;
+}
+
+.c1:focus-visible:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0,0%,100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196,77%,44%);
+  z-index: 9999;
+}
+
+.c1 .fi-tooltip_toggle-button_icon {
+  height: 100%;
+  width: 100%;
+  color: hsl(212,63%,45%);
+}
+
+<div>
+  <button
+    aria-expanded="false"
+    aria-label=""
+    class="c0 c1 fi-tooltip fi-tooltip_toggle-button"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="fi-icon c2 fi-tooltip_toggle-button_icon"
+      focusable="false"
+      height="1em"
+      viewBox="0 0 24 24"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        class="fi-icon-base-fill"
+        d="M11.996 0c3.207 0 6.22 1.248 8.487 3.514A11.917 11.917 0 0 1 24 12a11.92 11.92 0 0 1-3.517 8.486A11.927 11.927 0 0 1 11.996 24c-3.207 0-6.221-1.249-8.487-3.514-4.679-4.68-4.679-12.292 0-16.972A11.923 11.923 0 0 1 11.996 0Zm.007 10H10a1 1 0 0 0 0 2h1v5h-1a1 1 0 0 0 0 2h4.003a1 1 0 0 0 0-2h-1v-6a1 1 0 0 0-1-1Zm-.501-5a1.5 1.5 0 1 0-.002 3h.002l.145-.006A1.5 1.5 0 0 0 11.502 5Z"
+        fill="#222"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </button>
+</div>
+`;

--- a/src/core/theme/SpacingProvider/SpacingProvider.tsx
+++ b/src/core/theme/SpacingProvider/SpacingProvider.tsx
@@ -14,13 +14,80 @@ export interface SpacingProviderProps {
 export const SpacingProvider = (props: SpacingProviderProps) => {
   const spacingContext = useContext(SpacingContext);
 
-  const mergedMargins = { ...spacingContext.margins, ...props.margins };
+  const contextMargins: GlobalMargins = spacingContext.margins;
+  const propMargins: GlobalMargins = props.margins;
+
+  const allMargins = {
+    ...(contextMargins.all || {}),
+    ...(propMargins.all || {}),
+  };
+
+  const mergedMargins: GlobalMargins = {
+    ...contextMargins,
+    ...propMargins,
+  };
+
+  const allGlobalMarginKeys = {
+    all: null,
+    alert: null,
+    actionMenu: null,
+    block: null,
+    button: null,
+    breadcrumb: null,
+    checkbox: null,
+    checkboxGroup: null,
+    chip: null,
+    dateInput: null,
+    dropdown: null,
+    expander: null,
+    expanderGroup: null,
+    externalLink: null,
+    heading: null,
+    hintText: null,
+    inlineAlert: null,
+    label: null,
+    languageMenu: null,
+    link: null,
+    linkList: null,
+    loadingSpinner: null,
+    multiSelect: null,
+    notification: null,
+    pagination: null,
+    paragraph: null,
+    radioButton: null,
+    radioButtonGroup: null,
+    routerLink: null,
+    searchInput: null,
+    serviceNavigation: null,
+    sideNavigation: null,
+    singleSelect: null,
+    staticChip: null,
+    statusText: null,
+    text: null,
+    textarea: null,
+    textInput: null,
+    timeInput: null,
+    toast: null,
+    toggleInput: null,
+    toggleButton: null,
+    tooltip: null,
+    wizardNavigation: null,
+  };
+
+  // Apply the 'all' margins for each component and override with component specific margins if provided
+  Object.keys(allGlobalMarginKeys).forEach((key) => {
+    mergedMargins[key as keyof GlobalMargins] = {
+      ...allMargins,
+      ...(contextMargins[key as keyof GlobalMargins] || {}),
+      ...(propMargins[key as keyof GlobalMargins] || {}),
+    };
+  });
 
   const globalMargins = useMemo(
     () => ({
       margins: mergedMargins,
     }),
-    [mergedMargins, spacingContext.margins],
+    [mergedMargins],
   );
 
   if (!props.children) {

--- a/src/core/theme/SpacingProvider/SpacingProvider.tsx
+++ b/src/core/theme/SpacingProvider/SpacingProvider.tsx
@@ -14,11 +14,13 @@ export interface SpacingProviderProps {
 export const SpacingProvider = (props: SpacingProviderProps) => {
   const spacingContext = useContext(SpacingContext);
 
+  const mergedMargins = { ...spacingContext.margins, ...props.margins };
+
   const globalMargins = useMemo(
     () => ({
-      margins: props.margins,
+      margins: mergedMargins,
     }),
-    [props.margins, spacingContext.margins],
+    [mergedMargins, spacingContext.margins],
   );
 
   if (!props.children) {

--- a/src/core/theme/SpacingProvider/SpacingProvider.tsx
+++ b/src/core/theme/SpacingProvider/SpacingProvider.tsx
@@ -1,0 +1,32 @@
+import React, { useMemo, useContext, ReactNode } from 'react';
+import { GlobalMargins } from '../utils/spacing';
+
+export const SpacingContext = React.createContext({ margins: {} });
+
+export const SpacingConsumer = SpacingContext.Consumer;
+
+export interface SpacingProviderProps {
+  margins: GlobalMargins;
+  /** Children, returns null if no children are provided */
+  children?: ReactNode;
+}
+
+export const SpacingProvider = (props: SpacingProviderProps) => {
+  const spacingContext = useContext(SpacingContext);
+
+  const globalMargins = useMemo(
+    () => ({
+      margins: props.margins,
+    }),
+    [props.margins, spacingContext.margins],
+  );
+
+  if (!props.children) {
+    return null;
+  }
+  return (
+    <SpacingContext.Provider value={globalMargins}>
+      {props.children}
+    </SpacingContext.Provider>
+  );
+};

--- a/src/core/theme/index.ts
+++ b/src/core/theme/index.ts
@@ -24,3 +24,9 @@ export {
   SpacingProps,
   SpacingWithoutInsetProp,
 } from './utils/spacing';
+export {
+  SpacingProvider,
+  SpacingProviderProps,
+  SpacingConsumer,
+} from './SpacingProvider/SpacingProvider';
+export { GlobalMargins } from './utils/spacing';

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -45,6 +45,14 @@ export const containerIEFocus = (theme: SuomifiTheme) => css`
   }
 `;
 
+export const fixInternalMargins = () => css`
+  & .fi-label,
+  & .fi-hint-text,
+  & .fi-status-text {
+    margin: 0;
+  }
+`;
+
 export const inputButton = (theme: SuomifiTheme) => css`
   ${input(theme)}
 `;

--- a/src/core/theme/utils/spacing.test.ts
+++ b/src/core/theme/utils/spacing.test.ts
@@ -1,7 +1,7 @@
 import {
+  spacingStyles,
   MarginProps,
   SpacingProps,
-  spacingStyles,
   separateMarginProps,
   separateMarginAndPaddingProps,
 } from './spacing';

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -91,11 +91,13 @@ export type GlobalMargins = {
   singleSelect?: MarginProps;
   staticChip?: MarginProps;
   statusText?: MarginProps;
+  text?: MarginProps;
   textarea?: MarginProps;
   textInput?: MarginProps;
   timeInput?: MarginProps;
   toggleInput?: MarginProps;
   toggleButton?: MarginProps;
+  wizardNavigation?: MarginProps;
 };
 
 export interface SpacingProps extends PaddingProps, MarginProps {}

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -76,6 +76,8 @@ export type GlobalMargins = {
   inlineAlert?: MarginProps;
   label?: MarginProps;
   languageMenu?: MarginProps;
+  link?: MarginProps;
+  linkList?: MarginProps;
   multiSelect?: MarginProps;
   radioButton?: MarginProps;
   radioButtonGroup?: MarginProps;

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -114,7 +114,7 @@ export const spacingStyles = (props: SpacingProps | undefined) => {
 };
 
 export const buildSpacingCSS = (
-  spacing: SpacingProps | undefined,
+  spacing?: SpacingProps,
   important?: boolean,
 ): string => {
   if (!spacing) return '';

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -54,6 +54,12 @@ export interface MarginProps {
   my?: SpacingWithoutInsetProp;
 }
 
+export type GlobalMargins = {
+  button: MarginProps;
+  textInput: MarginProps;
+  checkbox: MarginProps;
+};
+
 export interface SpacingProps extends PaddingProps, MarginProps {}
 
 export const spacingStyles = (props: SpacingProps | undefined) => {

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -59,6 +59,7 @@ export type GlobalMargins = {
   button?: MarginProps;
   textInput?: MarginProps;
   checkbox?: MarginProps;
+  multiSelect?: MarginProps;
 };
 
 export interface SpacingProps extends PaddingProps, MarginProps {}

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -55,9 +55,10 @@ export interface MarginProps {
 }
 
 export type GlobalMargins = {
-  button: MarginProps;
-  textInput: MarginProps;
-  checkbox: MarginProps;
+  all?: MarginProps;
+  button?: MarginProps;
+  textInput?: MarginProps;
+  checkbox?: MarginProps;
 };
 
 export interface SpacingProps extends PaddingProps, MarginProps {}

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -73,7 +73,9 @@ export type GlobalMargins = {
   externalLink?: MarginProps;
   heading?: MarginProps;
   hintText?: MarginProps;
+  inlineAlert?: MarginProps;
   label?: MarginProps;
+  languageMenu?: MarginProps;
   multiSelect?: MarginProps;
   radioButton?: MarginProps;
   radioButtonGroup?: MarginProps;

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -67,6 +67,7 @@ export type GlobalMargins = {
   multiSelect?: MarginProps;
   radioButton?: MarginProps;
   radioButtonGroup?: MarginProps;
+  searchInput?: MarginProps;
   textInput?: MarginProps;
 };
 

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -68,6 +68,8 @@ export type GlobalMargins = {
   chip?: MarginProps;
   dateInput?: MarginProps;
   dropdown?: MarginProps;
+  expander?: MarginProps;
+  expanderGroup?: MarginProps;
   hintText?: MarginProps;
   label?: MarginProps;
   multiSelect?: MarginProps;

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -65,6 +65,8 @@ export type GlobalMargins = {
   hintText?: MarginProps;
   label?: MarginProps;
   multiSelect?: MarginProps;
+  radioButton?: MarginProps;
+  radioButtonGroup?: MarginProps;
   textInput?: MarginProps;
 };
 

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -58,17 +58,30 @@ export interface MarginProps {
 
 export type GlobalMargins = {
   all?: MarginProps;
+  alert?: MarginProps;
+  actionMenu?: MarginProps;
+  block?: MarginProps;
   button?: MarginProps;
+  breadcrumb?: MarginProps;
   checkbox?: MarginProps;
   checkboxGroup?: MarginProps;
+  chip?: MarginProps;
   dateInput?: MarginProps;
+  dropdown?: MarginProps;
   hintText?: MarginProps;
   label?: MarginProps;
   multiSelect?: MarginProps;
   radioButton?: MarginProps;
   radioButtonGroup?: MarginProps;
   searchInput?: MarginProps;
+  singleSelect?: MarginProps;
+  staticChip?: MarginProps;
+  statusText?: MarginProps;
+  textarea?: MarginProps;
   textInput?: MarginProps;
+  timeInput?: MarginProps;
+  toggleInput?: MarginProps;
+  toggleButton?: MarginProps;
 };
 
 export interface SpacingProps extends PaddingProps, MarginProps {}

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -95,8 +95,10 @@ export type GlobalMargins = {
   textarea?: MarginProps;
   textInput?: MarginProps;
   timeInput?: MarginProps;
+  toast?: MarginProps;
   toggleInput?: MarginProps;
   toggleButton?: MarginProps;
+  tooltip?: MarginProps;
   wizardNavigation?: MarginProps;
 };
 

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -78,7 +78,9 @@ export type GlobalMargins = {
   languageMenu?: MarginProps;
   link?: MarginProps;
   linkList?: MarginProps;
+  loadingSpinner?: MarginProps;
   multiSelect?: MarginProps;
+  notification?: MarginProps;
   radioButton?: MarginProps;
   radioButtonGroup?: MarginProps;
   searchInput?: MarginProps;

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -81,8 +81,10 @@ export type GlobalMargins = {
   loadingSpinner?: MarginProps;
   multiSelect?: MarginProps;
   notification?: MarginProps;
+  pagination?: MarginProps;
   radioButton?: MarginProps;
   radioButtonGroup?: MarginProps;
+  routerLink?: MarginProps;
   searchInput?: MarginProps;
   singleSelect?: MarginProps;
   staticChip?: MarginProps;

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -82,6 +82,7 @@ export type GlobalMargins = {
   multiSelect?: MarginProps;
   notification?: MarginProps;
   pagination?: MarginProps;
+  paragraph?: MarginProps;
   radioButton?: MarginProps;
   radioButtonGroup?: MarginProps;
   routerLink?: MarginProps;

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -16,6 +16,8 @@ export type SpacingWithoutInsetProp =
   | 'xxxxl'
   | '0';
 
+export type GlobalMarginProps = { globalMargins: GlobalMargins };
+
 const spaceVal = (theme: SuomifiTheme) => (val?: SpacingProp) => {
   if (val === '0') return '0';
   return !!val ? theme.spacing[val] : '';
@@ -57,9 +59,13 @@ export interface MarginProps {
 export type GlobalMargins = {
   all?: MarginProps;
   button?: MarginProps;
-  textInput?: MarginProps;
   checkbox?: MarginProps;
+  checkboxGroup?: MarginProps;
+  dateInput?: MarginProps;
+  hintText?: MarginProps;
+  label?: MarginProps;
   multiSelect?: MarginProps;
+  textInput?: MarginProps;
 };
 
 export interface SpacingProps extends PaddingProps, MarginProps {}

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -86,6 +86,8 @@ export type GlobalMargins = {
   radioButtonGroup?: MarginProps;
   routerLink?: MarginProps;
   searchInput?: MarginProps;
+  serviceNavigation?: MarginProps;
+  sideNavigation?: MarginProps;
   singleSelect?: MarginProps;
   staticChip?: MarginProps;
   statusText?: MarginProps;

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -113,12 +113,20 @@ export const spacingStyles = (props: SpacingProps | undefined) => {
   return Object.assign({}, ...array);
 };
 
-export const buildSpacingCSS = (props: SpacingProps | undefined): string => {
-  if (!props) return '';
+export const buildSpacingCSS = (
+  spacing: SpacingProps | undefined,
+  important?: boolean,
+): string => {
+  if (!spacing) return '';
 
-  const cssStyles = Object.entries(props)
+  const cssStyles = Object.entries(spacing)
     .map(([key, value]) =>
-      getCSSSpacing(defaultSuomifiTheme, key as keyof SpacingProps, value),
+      getCSSSpacing(
+        defaultSuomifiTheme,
+        key as keyof SpacingProps,
+        value,
+        important,
+      ),
     )
     .join('');
 
@@ -186,19 +194,21 @@ const getCSSSpacing = (
   theme: SuomifiTheme,
   key: keyof SpacingProps,
   value: SpacingProp,
+  important: boolean = false,
 ) => {
   const amount = spaceVal(theme)(value);
+  const importantValue = important ? '!important' : '';
   switch (key) {
     case 'mx':
-      return `margin-right: ${amount}; margin-left: ${amount};`;
+      return `margin-right: ${amount} ${importantValue}; margin-left: ${amount} ${importantValue};`;
     case 'my':
-      return `margin-top: ${amount}; margin-bottom: ${amount};`;
+      return `margin-top: ${amount} ${importantValue}; margin-bottom: ${amount} ${importantValue};`;
     case 'px':
-      return `padding-right: ${amount}; padding-left: ${amount};`;
+      return `padding-right: ${amount} ${importantValue}; padding-left: ${amount} ${importantValue};`;
     case 'py':
-      return `padding-top: ${amount}; padding-bottom: ${amount};`;
+      return `padding-top: ${amount} ${importantValue}; padding-bottom: ${amount} ${importantValue};`;
     default:
-      return `${[cssSelector[key]]}: ${amount};`;
+      return `${cssSelector[key]}: ${amount} ${importantValue};`;
   }
 };
 

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -70,6 +70,8 @@ export type GlobalMargins = {
   dropdown?: MarginProps;
   expander?: MarginProps;
   expanderGroup?: MarginProps;
+  externalLink?: MarginProps;
+  heading?: MarginProps;
   hintText?: MarginProps;
   label?: MarginProps;
   multiSelect?: MarginProps;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -170,6 +170,12 @@ export {
   SpacingProps,
   SpacingWithoutInsetProp,
 } from './core/theme';
+export {
+  SpacingProvider,
+  SpacingProviderProps,
+  SpacingConsumer,
+  GlobalMargins,
+} from './core/theme';
 export { getLogger, setLogger, Logger } from './utils/log/logger';
 export { autocompleteTimeString } from './utils/common';
 export {

--- a/src/utils/common/common.ts
+++ b/src/utils/common/common.ts
@@ -26,6 +26,26 @@ export const getOwnerDocument = (elementRef: React.RefObject<any>) => {
   return null;
 };
 
+/**
+ * This function takes an object and removes all properties that are present in the filterObject.
+ * Used in cleaning up generated style properties
+ */
+export function filterDuplicateKeys<T extends object, U extends object>(
+  mainObject?: T,
+  filterObject?: U,
+): Partial<T> {
+  if (!mainObject) {
+    return {};
+  }
+  return mainObject && filterObject
+    ? (Object.fromEntries(
+        Object.entries(mainObject).filter(
+          ([key]) => !Object.prototype.hasOwnProperty.call(filterObject, key),
+        ),
+      ) as Partial<T>)
+    : {};
+}
+
 export const escapeStringRegexp = (string: String) =>
   string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/-/g, '\\x2d');
 


### PR DESCRIPTION
## Description
This PR contains two changes / additions to the spacing utilities of the library:

1. It changes the `margin` props implementation so that instead of inline styles they are applied using `!important` CSS styles
2. It introduces a `SpacingProvider` HOC, which allows developers to give context-specific spacing rules to easily create layouts and spacing rulesets for repeating use cases.

## Motivation and Context
The margin prop implementation needed to be changed due to strict content security policies having issues with inline styles. The spacing provider pattern is a general quality of life improvement for certain use cases.

## How Has This Been Tested?
Mostly in styleguidist on chrome to make sure the changes and additions work as intended and don't cause any unwanted side effects. Also tested briefly on a React + Vite project to detect any obvious typescript issues.

## Release notes
### General
- **Breaking change:** Margin props are now implemented using `!important` CSS styles instead of style attributes
### SpacingProvider
- Introduce `SpacingProvider` HOC for providing context or even site-specific spacing rules.
