### PR TITLE
[Fix] Windows high contrast mode issues

### DIFF
--- a/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
+++ b/src/core/Chip/BaseChip/BaseChip.baseStyles.tsx
@@ -40,6 +40,9 @@ export const baseChipBaseStyles = (theme: SuomifiTheme) => css`
       &:active {
         background: ${theme.colors.depthBase};
       }
+      @media screen and (forced-colors: active) {
+        color: GrayText;
+      }
     }
   }
 `;

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -188,6 +188,12 @@ exports[`children should match snapshot 1`] = `
   cursor: not-allowed;
 }
 
+@media screen and (forced-colors:active) {
+  .c1.fi-chip--disabled.fi-chip {
+    color: GrayText;
+  }
+}
+
 <div>
   <button
     aria-disabled="false"
@@ -395,6 +401,12 @@ exports[`classnames should match snapshot 1`] = `
   cursor: not-allowed;
 }
 
+@media screen and (forced-colors:active) {
+  .c1.fi-chip--disabled.fi-chip {
+    color: GrayText;
+  }
+}
+
 <div>
   <button
     aria-disabled="false"
@@ -596,6 +608,12 @@ exports[`disabled should match snapshot 1`] = `
 
 .c1.fi-chip--removable.fi-chip--disabled .fi-chip--icon {
   cursor: not-allowed;
+}
+
+@media screen and (forced-colors:active) {
+  .c1.fi-chip--disabled.fi-chip {
+    color: GrayText;
+  }
 }
 
 <div>

--- a/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
+++ b/src/core/Chip/StaticChip/__snapshots__/StaticChip.test.tsx.snap
@@ -95,6 +95,12 @@ exports[`children should match snapshot 1`] = `
   background: hsl(202,7%,67%);
 }
 
+@media screen and (forced-colors:active) {
+  .c1.fi-chip--disabled.fi-chip {
+    color: GrayText;
+  }
+}
+
 <div>
   <span
     class="c0 fi-chip c1"
@@ -207,6 +213,12 @@ exports[`classnames should match snapshot 1`] = `
   background: hsl(202,7%,67%);
 }
 
+@media screen and (forced-colors:active) {
+  .c1.fi-chip--disabled.fi-chip {
+    color: GrayText;
+  }
+}
+
 <div>
   <span
     class="c0 fi-chip c1 custom-class"
@@ -313,6 +325,12 @@ exports[`disabled should match snapshot 1`] = `
 .c1.fi-chip--disabled.fi-chip:hover,
 .c1.fi-chip--disabled.fi-chip:active {
   background: hsl(202,7%,67%);
+}
+
+@media screen and (forced-colors:active) {
+  .c1.fi-chip--disabled.fi-chip {
+    color: GrayText;
+  }
 }
 
 <div>

--- a/src/core/Form/DateInput/DatePicker/MonthDay/MonthDay.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/MonthDay/MonthDay.baseStyles.tsx
@@ -83,4 +83,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       font-weight: 400;
     }
   }
+
+  @media screen and (forced-colors: active) {
+    [aria-disabled='true'] {
+      color: GrayText;
+    }
+  }
 `;

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -4344,6 +4344,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
   }
 }
 
+@media screen and (forced-colors:active) {
+  .c17 [aria-disabled='true'] {
+    color: GrayText;
+  }
+}
+
 <body>
   <div>
     <div
@@ -6577,6 +6583,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   .c13.fi-loadingSpinner.fi-loadingSpinner--loading .fi-loadingSpinner_icon {
     -webkit-animation: rotation 10s infinite linear;
     animation: rotation 10s infinite linear;
+  }
+}
+
+@media screen and (forced-colors:active) {
+  .c17 [aria-disabled='true'] {
+    color: GrayText;
   }
 }
 

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -163,6 +163,20 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       pointer-events: all;
     }
 
+    & .fi-search-input_button-clear {
+      clip: auto;
+      overflow: visible;
+      height: 20px;
+      width: 20px;
+      margin: 10px;
+
+      & .fi-icon-base-fill {
+        @media (forced-colors: active) {
+          fill: ButtonText;
+        }
+      }
+    }
+
     & .fi-search-input_button-search {
       background: ${theme.gradients.highlightBaseToHighlightDark1};
 
@@ -191,13 +205,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
           fill: ButtonText;
         }
       }
-    }
-    & .fi-search-input_button-clear {
-      clip: auto;
-      overflow: visible;
-      height: 20px;
-      width: 20px;
-      margin: 10px;
     }
   }
 `;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -613,6 +613,15 @@ exports[`snapshot should have matching default structure 1`] = `
   pointer-events: all;
 }
 
+.c1.fi-search-input--not-empty .fi-search-input_button-clear {
+  -webkit-clip: auto;
+  clip: auto;
+  overflow: visible;
+  height: 20px;
+  width: 20px;
+  margin: 10px;
+}
+
 .c1.fi-search-input--not-empty .fi-search-input_button-search {
   background: linear-gradient(0deg,hsl(212,63%,37%) 0%,hsl(212,63%,45%) 100%);
 }
@@ -649,13 +658,10 @@ exports[`snapshot should have matching default structure 1`] = `
   fill: hsl(0,0%,100%);
 }
 
-.c1.fi-search-input--not-empty .fi-search-input_button-clear {
-  -webkit-clip: auto;
-  clip: auto;
-  overflow: visible;
-  height: 20px;
-  width: 20px;
-  margin: 10px;
+@media (forced-colors:active) {
+  .c1.fi-search-input--not-empty .fi-search-input_button-clear .fi-icon-base-fill {
+    fill: ButtonText;
+  }
 }
 
 @media (forced-colors:active) {

--- a/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
@@ -15,6 +15,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-select-item--query_highlight {
       background-color: transparent;
       font-weight: bold;
+
+      @media (forced-colors: active) {
+        background-color: Highlight;
+      }
     }
 
     & .fi-select-item_icon {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1245,6 +1245,12 @@ exports[`has matching snapshot 1`] = `
 }
 
 @media (forced-colors:active) {
+  .c20.fi-select-item .fi-select-item--query_highlight {
+    background-color: Highlight;
+  }
+}
+
+@media (forced-colors:active) {
   .c20.fi-select-item--hasKeyboardFocus {
     background-color: Highlight;
   }

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1286,6 +1286,12 @@ exports[`has matching snapshot 1`] = `
   }
 }
 
+@media screen and (forced-colors:active) {
+  .c13.fi-chip--disabled.fi-chip {
+    color: GrayText;
+  }
+}
+
 @media (prefers-reduced-motion) {
   .c15.fi-loadingSpinner.fi-loadingSpinner--loading .fi-loadingSpinner_icon {
     -webkit-animation: rotation 10s infinite linear;

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -861,6 +861,12 @@ exports[`has matching snapshot 1`] = `
 }
 
 @media (forced-colors:active) {
+  .c18.fi-select-item .fi-select-item--query_highlight {
+    background-color: Highlight;
+  }
+}
+
+@media (forced-colors:active) {
   .c18.fi-select-item--hasKeyboardFocus {
     background-color: Highlight;
   }

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -700,6 +700,12 @@ exports[`should match snapshot 1`] = `
   background: hsl(202,7%,67%);
 }
 
+@media screen and (forced-colors:active) {
+  .c9.fi-chip--disabled.fi-chip {
+    color: GrayText;
+  }
+}
+
 <div
   class="c0 fi-service-navigation c1"
 >


### PR DESCRIPTION
## Description
This PR fixes addresses issues where components were not fully accessible or didn't behave optimally when using Windows high contrast mode. Issues fixed:
- DatePicker disabled dates are now better distinguishable from enabled ones
- Multiselect highlighted text in list is now visible
- Disabled Chip is now distinguishable from an enabled one

## Related Issue
Closes #744 

## Motivation and Context
These are accessibility issues that needed to be tackled in order to meet our accessibility goals.

## How Has This Been Tested?
Tested by running on styleguidist on Chrome with Windows high contrast mode on.

## Screenshots (if appropriate):
### Datepicker
Before:
![dapicker before](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/fa01b4ac-8f94-4d77-8598-bce3b3685982)
After:
![datepicker after](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/b0aab3f8-0039-4d76-8ad5-6b36a641450a)
### Chip
Before: 
![chip_before](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/cdd6fbb6-d11c-4a31-99cb-e9d0ab592ab3)
After:
![chip](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/4b746896-9762-4faa-b70e-e554d410a815)
### MultiSelect
Before:
![land_before](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/21c1fc57-49ef-44c5-b608-6216b6c4fdab)
After:
![land_after](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/5df87c4f-2212-4083-96eb-0a5a120c2cde)



## Release notes
### MultiSelect, Chip, DateInput
- Fix accessibility issues related to Windows high contrast mode
