### PR TITLE
[Feature] Date picker position prop

### DIFF
--- a/src/core/Form/DateInput/DateInput.md
+++ b/src/core/Form/DateInput/DateInput.md
@@ -97,7 +97,7 @@ import { DateInput } from 'suomifi-ui-components';
 
 ### Date picker position
 
-Use `datePickerPosition` prop to change the position of the date picker popover in relation to the calendar button. The date picker will also automatically adjust its position, both vertically and horizontally, based on available space.
+Use `datePickerPosition` prop to change the position of the date picker popover in relation to the calendar button. The date picker will also automatically adjust its position, both vertically and horizontally, based on available space. The possible values are `left`, `right` and `center` with `left` being the default.
 
 ```js
 import { DateInput } from 'suomifi-ui-components';

--- a/src/core/Form/DateInput/DateInput.md
+++ b/src/core/Form/DateInput/DateInput.md
@@ -6,6 +6,7 @@ Examples:
 - [Default value](./#/Components/DateInput?id=default-value)
 - [Controlled value](./#/Components/DateInput?id=controlled-value)
 - [Date picker](./#/Components/DateInput?id=date-picker)
+- [Date picker position](./#/Components/DateInput?id=date-picker-position)
 - [MinDate & maxDate](./#/Components/DateInput?id=mindate--maxdate)
 - [Validation](./#/Components/DateInput?id=validation)
 - [Initial focused date in date picker](./#/Components/DateInput?id=initial-focused-date-in-date-picker)

--- a/src/core/Form/DateInput/DateInput.md
+++ b/src/core/Form/DateInput/DateInput.md
@@ -94,6 +94,21 @@ import { DateInput } from 'suomifi-ui-components';
 />;
 ```
 
+### Date picker position
+
+Use `datePickerPosition` prop to change the position of the date picker popover in relation to the calendar button. The date picker will also automatically adjust its position, both vertically and horizontally, based on available space.
+
+```js
+import { DateInput } from 'suomifi-ui-components';
+
+<DateInput
+  labelText="Beginning date"
+  hintText="Use format D.M.YYYY"
+  datePickerEnabled
+  datePickerPosition="center"
+/>;
+```
+
 ### MinDate & maxDate
 
 Use the `minDate` and `maxDate` props to control the available dates in the date picker calendar.

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -86,7 +86,7 @@ export interface DatePickerProps {
     'onChange' | 'style' | 'aria-hidden' | 'ref'
   >;
   /**
-   * Alignment of the date picker relative to the date picker button.
+   * Alignment of the date picker relative to the date picker button. Possible values are 'center', 'left' and 'right'.
    * @default 'left'
    */
   datePickerPosition?: datePickerAlignment;

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -71,6 +71,8 @@ export const dateInputClassNames = {
   statusTextHasContent: `${baseClassName}_statusText--has-content`,
 };
 
+export type datePickerAlignment = 'center' | 'left' | 'right';
+
 export interface DatePickerProps {
   /** Enables date picker for date input.
    * @default false
@@ -83,6 +85,12 @@ export interface DatePickerProps {
     HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
     'onChange' | 'style' | 'aria-hidden' | 'ref'
   >;
+  /**
+   * Alignment of the date picker relative to the date picker button.
+   * e.g. 'left' aligns the left edge of the date picker with the left edge of the button.
+   * @default 'left'
+   */
+  datePickerPosition?: datePickerAlignment;
   /**
    * Enables small screen version of calendar
    * @default false
@@ -234,6 +242,7 @@ const BaseDateInput = (props: DateInputProps) => {
     value,
     datePickerEnabled = false,
     datePickerProps: customDatePickerProps,
+    datePickerPosition = 'left',
     smallScreen = false,
     datePickerTexts = undefined,
     language = defaultLanguage,
@@ -447,6 +456,7 @@ const BaseDateInput = (props: DateInputProps) => {
                 maxDate={maxDate}
                 smallScreen={smallScreen}
                 userProps={customDatePickerProps}
+                position={datePickerPosition}
               />
             </HtmlDiv>
           )}

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -87,7 +87,6 @@ export interface DatePickerProps {
   >;
   /**
    * Alignment of the date picker relative to the date picker button.
-   * e.g. 'left' aligns the left edge of the date picker with the left edge of the button.
    * @default 'left'
    */
   datePickerPosition?: datePickerAlignment;

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 import { useEnhancedEffect } from '../../../../utils/common';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../theme';
 import { HtmlDiv, HtmlDivWithRef } from '../../../../reset';
-import { DatePickerProps } from '../DateInput';
+import { DatePickerProps, datePickerAlignment } from '../DateInput';
 import { InternalDatePickerTextProps } from '../datePickerTexts';
 import { baseStyles } from './DatePicker.baseStyles';
 import { Button } from '../../../Button/Button';
@@ -66,6 +66,7 @@ export interface InternalDatePickerProps
     HTMLAttributesIncludingDataAttributes<HTMLDivElement>,
     'onChange' | 'style' | 'aria-hidden' | 'ref'
   >;
+  position: datePickerAlignment;
 }
 
 export const BaseDatePicker = (props: InternalDatePickerProps) => {
@@ -305,6 +306,9 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
     return null;
   };
 
+  const datePickerOffset =
+    props.position === 'right' ? 322 : props.position === 'center' ? 160 : 0;
+
   const { styles, attributes } = usePopper(
     openButtonRef.current,
     dialogElement,
@@ -318,7 +322,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
         {
           name: 'offset',
           options: {
-            offset: [0, 10],
+            offset: [datePickerOffset, 10],
           },
         },
         {


### PR DESCRIPTION
## Description
This PR adds the option to change the alignment of the date picker in relation to the date picker button in the date input.

## Motivation and Context
This feature was a request from services using the component and was fairly simple to implement.


## How Has This Been Tested?
By running locally in styleguidist on Chrome and in a react + vite test project on Chrome and Firefox

## Release notes
### Dateinput
- Allow custom date picker positioning via new `datePickerPosition` prop
