### PR TITLE
[Feature] SingleSelect and MultiSelect fullWidth prop

### DIFF
--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
@@ -13,6 +13,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     & .fi-filter-input_input {
       padding-right: 36px;
     }
+    &--full-width {
+      width: 100%;
+    }
   }
 
   & .fi-multiselect_content_wrapper {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.md
@@ -13,6 +13,7 @@ Examples:
 - [Disabled](./#/Components/MultiSelect?id=disabled)
 - [Formatting accessibility texts](./#/Components/MultiSelect?id=formatting-accessibility-texts)
 - [Loading indicator](./#/Components/MultiSelect?id=loading-indicator)
+- [Full width](./#/Components/MultiSelect?id=full-width)
 - [Tooltip](./#/Components/MultiSelect?id=tooltip)
 
 <div style="margin-bottom: 40px">
@@ -698,6 +699,68 @@ const simulateBackendCall = (searchStr) => {
       setLoading(true);
     }
   }}
+/>;
+```
+
+### Full width
+
+You can make the component span the entire width of the parent by using the `fullWidth` prop
+
+```js
+import { MultiSelect } from 'suomifi-ui-components';
+
+const countries = [
+  {
+    labelText: 'Switzerland',
+    uniqueItemId: 'sw2435626'
+  },
+  {
+    labelText: 'France',
+    uniqueItemId: 'fr9823523'
+  },
+  {
+    labelText: 'Spain',
+    uniqueItemId: 'sp908293482'
+  },
+  {
+    labelText: 'Bulgaria',
+    uniqueItemId: 'bg82502335'
+  },
+  {
+    labelText: 'Slovenia',
+    uniqueItemId: 'sl9081231'
+  },
+  {
+    labelText: 'Norway',
+    uniqueItemId: 'no05111511'
+  },
+  {
+    labelText: 'Germany',
+    uniqueItemId: 'ge3451261'
+  },
+  {
+    labelText: 'Finland',
+    uniqueItemId: 'fi09282626'
+  },
+  {
+    labelText: 'Poland',
+    uniqueItemId: 'po6126266'
+  }
+];
+
+<MultiSelect
+  labelText="Visited countries"
+  hintText="Select all countries you have visited during the past year. You can filter options by typing in the field"
+  items={countries}
+  chipListVisible
+  ariaChipActionLabel="Deselect"
+  removeAllButtonLabel="Remove all selections"
+  visualPlaceholder="Choose countries"
+  noItemsText="No items"
+  ariaSelectedAmountText="countries selected"
+  ariaOptionsAvailableText="options available"
+  ariaOptionChipRemovedText="removed"
+  fullWidth
 />;
 ```
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -573,6 +573,22 @@ test('visualPlaceholder: has the given text as placeholder attribute', () => {
   expect(inputfield).toHaveAttribute('placeholder', 'Select item(s)');
 });
 
+test('fullWidth: has the corresponding style and class', () => {
+  const { container } = render(
+    <MultiSelect
+      labelText="MultiSelect"
+      items={[]}
+      noItemsText="No items"
+      fullWidth={true}
+      ariaSelectedAmountText=""
+      ariaOptionsAvailableText=""
+      ariaOptionChipRemovedText=""
+    />,
+  );
+  expect(container.firstChild).toHaveClass('fi-multiselect--full-width');
+  expect(container.firstChild).toHaveStyle('width: 100%;');
+});
+
 test('id: has the given id', () => {
   const { getByRole } = render(
     <MultiSelect

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -32,6 +32,7 @@ const baseClassName = 'fi-multiselect';
 const multiSelectClassNames = {
   open: `${baseClassName}--open`,
   error: `${baseClassName}--error`,
+  fullWidth: `${baseClassName}--full-width`,
   content_wrapper: `${baseClassName}_content_wrapper`,
   removeAllButton: `${baseClassName}_removeAllButton`,
 };
@@ -194,6 +195,8 @@ interface InternalMultiSelectProps<T extends MultiSelectData> {
   forwardedRef?: React.RefObject<HTMLInputElement>;
   /** Props passed to unordered list element inside the popover. For example data-attributes */
   listProps?: HTMLAttributesIncludingDataAttributes<HTMLUListElement>;
+  /** Sets component's width to 100% of its parent */
+  fullWidth?: boolean;
 }
 
 type AllowItemAdditionProps =
@@ -655,6 +658,7 @@ class BaseMultiSelect<T> extends Component<
       forwardedRef, // Only destructured away so it doesn't end up in the DOM
       listProps,
       style,
+      fullWidth,
       ...rest
     } = this.props;
     const [marginProps, passProps] = separateMarginProps(rest);
@@ -680,6 +684,7 @@ class BaseMultiSelect<T> extends Component<
           className={classnames(baseClassName, className, {
             [multiSelectClassNames.open]: showPopover,
             [multiSelectClassNames.error]: status === 'error',
+            [`${baseClassName}--full-width`]: fullWidth,
           })}
           style={{ ...marginStyle, ...style }}
         >

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1229,6 +1229,10 @@ exports[`has matching snapshot 1`] = `
   padding-right: 36px;
 }
 
+.c1.fi-multiselect--full-width {
+  width: 100%;
+}
+
 .c1 .fi-multiselect_content_wrapper {
   display: inline-block;
   width: 100%;

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -16,6 +16,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         padding-right: 73px;
       }
     }
+
+    &--full-width {
+      width: 100%;
+    }
   }
 
   &.fi-single-select--open {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -14,6 +14,7 @@ Examples:
 - [Controlled state with custom option enabled](./#/Components/SingleSelect?id=controlled-state-with-custom-option-enabled)
 - [Disabled](./#/Components/SingleSelect?id=disabled)
 - [Loading indicator](./#/Components/SingleSelect?id=loading-indicator)
+- [Full width](./#/Components/SingleSelect?id=full-width)
 - [Tooltip](./#/Components/SingleSelect?id=tooltip)
 
 <div style="margin-bottom: 40px">
@@ -594,6 +595,66 @@ const simulateBackendCall = (searchStr) => {
       setLoading(true);
     }
   }}
+/>;
+```
+
+### Full width
+
+You can make the component span the entire width of its parent via the `fullWidth` prop.
+
+```js
+import { SingleSelect } from 'suomifi-ui-components';
+
+const countries = [
+  {
+    labelText: 'Switzerland',
+    uniqueItemId: 'sw2435626'
+  },
+  {
+    labelText: 'France',
+    uniqueItemId: 'fr9823523'
+  },
+  {
+    labelText: 'Spain',
+    uniqueItemId: 'sp908293482'
+  },
+  {
+    labelText: 'Bulgaria',
+    uniqueItemId: 'bg82502335'
+  },
+  {
+    labelText: 'Slovenia',
+    uniqueItemId: 'sl9081231'
+  },
+  {
+    labelText: 'Norway',
+    uniqueItemId: 'no05111511'
+  },
+  {
+    labelText: 'Germany',
+    uniqueItemId: 'ge3451261'
+  },
+  {
+    labelText: 'Finland',
+    uniqueItemId: 'fi09282626'
+  },
+  {
+    labelText: 'Poland',
+    uniqueItemId: 'po6126266'
+  }
+];
+
+<SingleSelect
+  labelText="Country of residence"
+  hintText="Select your current country of residence. You can filter options by typing in the field."
+  clearButtonLabel="Clear selection"
+  items={countries}
+  visualPlaceholder="Choose country"
+  noItemsText="No items"
+  ariaOptionsAvailableTextFunction={(amount) =>
+    amount === 1 ? 'option available' : 'options available'
+  }
+  fullWidth
 />;
 ```
 

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -393,6 +393,24 @@ describe('status', () => {
   });
 });
 
+describe('fullWidth', () => {
+  it('should have full width classname', () => {
+    const { container } = render(
+      <SingleSelect
+        labelText="SingleSelect"
+        clearButtonLabel="Clear selection"
+        items={[]}
+        noItemsText="No items"
+        visualPlaceholder="Select item"
+        fullWidth={true}
+        ariaOptionsAvailableText="Options available"
+      />,
+    );
+    expect(container.firstChild).toHaveClass('fi-single-select--full-width');
+    expect(container.firstChild).toHaveStyle('width: 100%;');
+  });
+});
+
 describe('disabled', () => {
   it('should not be interactive while disabled', async () => {
     const { getByRole, getAllByRole } = render(

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -31,6 +31,7 @@ const singleSelectClassNames = {
   open: `${baseClassName}--open`,
   error: `${baseClassName}--error`,
   queryHighlight: `${baseClassName}-item--query_highlight`,
+  fullWidth: `${baseClassName}--full-width`,
 };
 
 export interface SingleSelectData {
@@ -128,6 +129,8 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
   forwardedRef?: React.RefObject<HTMLInputElement>;
   /** Props passed to the unordered list element inside the popover. For example data-attributes */
   listProps?: HTMLAttributesIncludingDataAttributes<HTMLUListElement>;
+  /** Sets component's width to 100% of its parent */
+  fullWidth?: boolean;
 }
 
 type LoadingProps =
@@ -548,6 +551,7 @@ class BaseSingleSelect<T> extends Component<
       forwardedRef, // Only destructured away so it doesn't end up in the DOM
       listProps,
       style,
+      fullWidth,
       ...rest
     } = this.props;
     const [marginProps, passProps] = separateMarginProps(rest);
@@ -566,6 +570,7 @@ class BaseSingleSelect<T> extends Component<
           [singleSelectClassNames.valueSelected]: !!selectedItem,
           [singleSelectClassNames.open]: showPopover,
           [singleSelectClassNames.error]: status === 'error',
+          [singleSelectClassNames.fullWidth]: fullWidth,
         })}
         style={{ ...marginStyle, ...style }}
       >

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -854,6 +854,10 @@ exports[`has matching snapshot 1`] = `
   padding-right: 73px;
 }
 
+.c1.fi-single-select--full-width {
+  width: 100%;
+}
+
 .c1.fi-single-select--open .fi-filter-input_input {
   border-bottom: 0;
   border-bottom-left-radius: 0;


### PR DESCRIPTION
## Description
This PR adds the `fullWidth` prop to SingleSelect and MultiSelect. It should provide the same functionality as in other form components, namely, to set the component's width to 100%.

## Motivation and Context
This addition was requested by developers and made sense since the option is available in other form components.

## How Has This Been Tested?
Tested by running locally on styleguidist on Chrome and Firefox.

## Screenshots (if appropriate):
![image](https://github.com/vrk-kpa/suomifi-ui-components/assets/54316341/f88baff3-7924-4e16-9e6c-bdb14453a28a)


## Release notes
### SingleSelect
- Add `fullWidth` prop

### MultiSelect
- Add `fullWidth` prop
