### PR TITLE
[Fix] TextInput examples

### DIFF
--- a/src/core/Form/TextInput/TextInput.md
+++ b/src/core/Form/TextInput/TextInput.md
@@ -28,65 +28,10 @@ Examples:
 Provide a descriptive `labelText` for the input
 
 ```js
-import {
-  TextInput,
-  Tooltip,
-  Button,
-  Heading,
-  Text,
-  SpacingProvider
-} from 'suomifi-ui-components';
+import { TextInput } from 'suomifi-ui-components';
 import React from 'react';
 
-const exampleRef = React.createRef();
-
-const labelTextForTooltipExample = 'TextInput with a tooltip';
-
-<>
-  <TextInput labelText="First name" />;
-  <SpacingProvider
-    margins={{ textInput: { mb: 'xl' }, button: { margin: 's' } }}
-  >
-    <TextInput
-      onBlur={(event) => console.log(event.target.value)}
-      labelText="TextInput with visible label"
-    />
-    <TextInput
-      onBlur={(event) => console.log(event.target.value)}
-      labelText="Test TextInput with hidden label and a visual placeholder"
-      labelMode="hidden"
-      visualPlaceholder="This input has a hidden label"
-    />
-    <TextInput
-      onBlur={(event) => console.log(event.target.value)}
-      labelText="TextInput with hint text"
-      hintText="An example hint text"
-    />
-    <Button>Rapurapurallaa</Button>
-    <TextInput
-      labelText="TextInput with optional text and ref"
-      optionalText="optional"
-      ref={exampleRef}
-      onChange={() => {
-        console.log(exampleRef.current);
-      }}
-    />
-    <TextInput
-      labelText={labelTextForTooltipExample}
-      tooltipComponent={
-        <Tooltip
-          ariaToggleButtonLabelText={`${labelTextForTooltipExample}, additional information`}
-          ariaCloseButtonLabelText={`${labelTextForTooltipExample}, close additional information`}
-        >
-          <Heading variant="h5" as="h2">
-            Tooltip
-          </Heading>
-          <Text>Text content for the tooltip</Text>
-        </Tooltip>
-      }
-    />
-  </SpacingProvider>
-</>;
+<TextInput labelText="First name" />;
 ```
 
 ### Hint text


### PR DESCRIPTION
## Description
Some testing content from spacing provider branch got accidentally applied to development branch. This PR removes it and returns TextInput examples to their earlier state.

## Motivation and Context
A clear oversight and unwanted content that needs to be corrected.

## How Has This Been Tested?
Locally on styleguidist on chrome

