### PR TITLE
[Bugfix] SingleSelect input value in controlled state

### DIFF
--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -264,7 +264,9 @@ class BaseSingleSelect<T> extends Component<
         );
         if (matchingItem) {
           resolvedInputValue =
-            matchingItem.labelText || prevState.filterInputValue;
+            matchingItem.labelText && !prevState.filterMode
+              ? matchingItem.labelText
+              : prevState.filterInputValue;
         }
       }
 


### PR DESCRIPTION
## Description
SingleSelect input value didn't behave correctly when both `onInputValueChange` and `onChange` were given and onchange altered the parent component state. The input value could not be modified in this case.

This PR provides a suggested solution to the issue.

## Related Issue
Closes #857

## Motivation and Context
This was a bug reported by users and  a service developer

## How Has This Been Tested?
Tested by running locally on styleguidist with modified examples.

## Release notes
### SingleSelect
- Fix an issue where input value could not be updated in a certain controlled state situation