### PR TITLE
FileInput: Fix multifile list separator CSS

### DIFF
--- a/src/core/Form/FileInput/FileInput.baseStyles.tsx
+++ b/src/core/Form/FileInput/FileInput.baseStyles.tsx
@@ -69,7 +69,7 @@ export const baseStyles = (
       .fi-file-input_file-item-outer-wrapper {
         padding: ${theme.spacing.xxs};
 
-        :not(:last-child) {
+        &:not(:last-child) {
           border-bottom: 1px solid ${theme.colors.depthLight2};
         }
       }


### PR DESCRIPTION
## Description

PR fixes a cosmetic issue in FileInput multifile list. The horizontal line separating the items was not correct. 

## How Has This Been Tested?

Styleguidist (where the issue did not manifest in the first place for some reason...) and a separate CRA project

## Screenshots

Before
<img width="648" alt="image" src="https://github.com/user-attachments/assets/feae9851-393b-4837-aa3f-d10d929daf2c">

After
<img width="665" alt="image" src="https://github.com/user-attachments/assets/a7f1ff14-d675-4e41-b32c-1f28aff95e8c">


## Release notes

### FileInput
- Fix multifile list styles

