### PR TITLE
[Fix] Details varied content example accessibility

### DIFF
--- a/src/core/Details/Details.md
+++ b/src/core/Details/Details.md
@@ -32,27 +32,20 @@ import { Details } from 'suomifi-ui-components';
 The details component accepts practically any content, and thus its contents can be structured in whatever way suits the purpose
 
 ```js
-import { Details, Heading, Paragraph } from 'suomifi-ui-components';
-
-const DetailsContent = () => (
-  <div style={{ display: 'flex' }}>
-    <div style={{ flex: 1 }}>
-      <Heading variant="h4">Some info</Heading>
-      <Paragraph>
-        This is some relevant information regarding a topic
-      </Paragraph>
-    </div>
-    <div style={{ flex: 1 }}>
-      <Heading variant="h4">Some other info</Heading>
-      <Paragraph>
-        This is relevant information concerning another topic
-      </Paragraph>
-    </div>
-  </div>
-);
+import {
+  Details,
+  ExternalLink,
+  Paragraph,
+  Block
+} from 'suomifi-ui-components';
 
 <Details summaryLabel="Additional information on the topic">
-  <DetailsContent />
+  <Paragraph>
+    This is some relevant information regarding a topic
+  </Paragraph>
+  <ExternalLink href="#">
+    For more information refer to this page
+  </ExternalLink>
 </Details>;
 ```
 

--- a/src/core/Details/Details.md
+++ b/src/core/Details/Details.md
@@ -35,8 +35,7 @@ The details component accepts practically any content, and thus its contents can
 import {
   Details,
   ExternalLink,
-  Paragraph,
-  Block
+  Paragraph
 } from 'suomifi-ui-components';
 
 <Details summaryLabel="Additional information on the topic">


### PR DESCRIPTION
## Description
Thre was a small accessibility issue in the varied content example of `Details` component documentation. Details content shouldn't contain headings. This PR changes simplifies the varied content example and fixes the accessibility issue in the process.

## Motivation and Context
This came up in the accessibility validation and needed to be fixed.

## How Has This Been Tested?
Locally on styleguidist
