### PR TITLE
[Fix] Adjust FileInput accessibility

### DIFF
--- a/src/core/Form/FileInput/FileInput.baseStyles.tsx
+++ b/src/core/Form/FileInput/FileInput.baseStyles.tsx
@@ -121,13 +121,6 @@ export const baseStyles = (
     }
 
     .fi-file-input_input-outer-wrapper {
-      &.appears-focused {
-        position: relative;
-        ${theme.focuses.highContrastFocus}
-        &:after {
-          ${theme.focuses.absoluteFocus}
-        }
-      }
       .fi-file-input_drag-area {
         width: 100%;
         background: ${theme.colors.highlightLight4};

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -75,7 +75,7 @@ const BaseFileItem = (props: FileItemProps) => {
   return (
     <HtmlDiv
       className={fileInputClassNames.fileItemOuterWrapper}
-      role="listitem"
+      role={multiFile ? 'listitem' : undefined}
     >
       <HtmlDiv className={fileInputClassNames.fileItem}>
         <HtmlDiv className={fileInputClassNames.fileInfo}>
@@ -101,7 +101,6 @@ const BaseFileItem = (props: FileItemProps) => {
             </Link>
           ) : (
             <HtmlDivWithRef
-              tabIndex={multiFile ? 0 : -1}
               forwardedRef={
                 fileItemRefs.fileNameRef as React.RefObject<HTMLDivElement>
               }
@@ -141,6 +140,7 @@ const BaseFileItem = (props: FileItemProps) => {
             metaData?.buttonText ? metaData.buttonText : removeFileText
           } ${file.name}`}
           className={fileInputClassNames.removeFileButton}
+          ref={fileItemRefs.removeButtonRef}
         >
           {getButtonText()}
         </Button>

--- a/src/core/Form/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/src/core/Form/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snapshots match error status with statustext 1`] = `
-.c4 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -25,8 +25,8 @@ exports[`snapshots match error status with statustext 1`] = `
   white-space: normal;
 }
 
-.c4::before,
-.c4::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
@@ -59,7 +59,7 @@ exports[`snapshots match error status with statustext 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -83,12 +83,37 @@ exports[`snapshots match error status with statustext 1`] = `
   white-space: normal;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
 .c2::before,
 .c2::after {
   box-sizing: border-box;
 }
 
-.c5 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -111,17 +136,17 @@ exports[`snapshots match error status with statustext 1`] = `
   max-width: 100%;
 }
 
-.c5::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c5::before,
-.c5::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c6 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -141,12 +166,37 @@ exports[`snapshots match error status with statustext 1`] = `
   max-width: 100%;
 }
 
-.c6::before,
-.c6::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -165,42 +215,42 @@ exports[`snapshots match error status with statustext 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c3.fi-label .fi-label_label-span .fi-tooltip {
+.c5.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
-.c8 {
+.c10 {
   vertical-align: baseline;
 }
 
-.c8.fi-icon {
+.c10.fi-icon {
   display: inline-block;
 }
 
-.c8 .fi-icon-base-fill {
+.c10 .fi-icon-base-fill {
   fill: currentColor;
 }
 
-.c8 .fi-icon-base-stroke {
+.c10 .fi-icon-base-stroke {
   stroke: currentColor;
 }
 
-.c8.fi-icon--cursor-pointer {
+.c10.fi-icon--cursor-pointer {
   cursor: pointer;
 }
 
-.c8.fi-icon--cursor-pointer * {
+.c10.fi-icon--cursor-pointer * {
   cursor: inherit;
 }
 
-.c7 {
+.c9 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -219,15 +269,15 @@ exports[`snapshots match error status with statustext 1`] = `
   line-height: 20px;
 }
 
-.c7.fi-status-text {
+.c9.fi-status-text {
   display: block;
 }
 
-.c7.fi-status-text.fi-status-text--error {
+.c9.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
 }
 
-.c7.fi-status-text .fi-icon {
+.c9.fi-status-text .fi-icon {
   vertical-align: middle;
   -webkit-transform: translateY(-0.1em);
   -ms-transform: translateY(-0.1em);
@@ -390,27 +440,6 @@ exports[`snapshots match error status with statustext 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-}
-
-.c1.fi-file-input .fi-file-input_input-outer-wrapper.appears-focused {
-  position: relative;
-  outline: 3px solid transparent;
-}
-
-.c1.fi-file-input .fi-file-input_input-outer-wrapper.appears-focused:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area {
@@ -608,77 +637,85 @@ exports[`snapshots match error status with statustext 1`] = `
 <div
   class="c0 fi-file-input c1 fi-file-input--error"
 >
-  <div
-    class="c2 c3 fi-file-input_label--visible fi-label"
+  <fieldset
+    class="c2"
   >
-    <label
-      class="c4 fi-label_label-span"
-      id="5-label"
-    >
-      Resume
-    </label>
-  </div>
-  <div
-    class="c0 fi-file-input_input-outer-wrapper"
-  >
-    <div
-      class="c2 fi-file-input_drag-area"
+    <legend
+      class="c3"
     >
       <div
-        class="c0 fi-file-input_input-wrapper"
+        class="c4 c5 fi-file-input_label--visible fi-label"
       >
-        <input
-          aria-describedby="5-statusText"
-          aria-invalid="true"
-          aria-labelledby="5-label"
-          class="c5 fi-file-input_input-element"
-          data-testid="file-input"
-          id="5"
-          type="file"
-        />
-        <label
-          class="c6 fi-file-input_input-label"
-          for="5"
+        <span
+          class="c6 fi-label_label-span"
+          id="5-label"
         >
-          Choose file
-        </label>
+          Resume
+        </span>
+      </div>
+    </legend>
+    <div
+      class="c0 fi-file-input_input-outer-wrapper"
+    >
+      <div
+        class="c4 fi-file-input_drag-area"
+      >
         <div
-          class="c0 fi-file-input_drag-text-container"
+          class="c0 fi-file-input_input-wrapper"
         >
-          Drag and drop files here
+          <input
+            aria-describedby="5-statusText"
+            aria-invalid="true"
+            class="c7 fi-file-input_input-element"
+            data-testid="file-input"
+            id="5"
+            tabindex="0"
+            type="file"
+          />
+          <label
+            class="c8 fi-file-input_input-label"
+            for="5"
+          >
+            Choose file
+          </label>
+          <div
+            class="c0 fi-file-input_drag-text-container"
+          >
+            Drag and drop files here
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <span
-    aria-atomic="true"
-    aria-live="assertive"
-    class="c4 c7 fi-file-input_statusText--has-content fi-status-text fi-status-text--error"
-    id="5-statusText"
-  >
-    <svg
-      aria-hidden="true"
-      class="fi-icon c8"
-      focusable="false"
-      height="1em"
-      viewBox="0 0 24 24"
-      width="1em"
-      xmlns="http://www.w3.org/2000/svg"
+    <span
+      aria-atomic="true"
+      aria-live="assertive"
+      class="c6 c9 fi-file-input_statusText--has-content fi-status-text fi-status-text--error"
+      id="5-statusText"
     >
-      <path
-        class="fi-icon-base-fill"
-        d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0Zm.71 17.29c-.38-.37-1.05-.37-1.42 0-.181.19-.29.44-.29.71 0 .26.109.52.29.71.189.18.45.29.71.29.26 0 .52-.11.71-.29.18-.19.29-.45.29-.71 0-.27-.11-.52-.29-.71ZM12 5a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V6a1 1 0 0 0-1-1Z"
-        fill="#222"
-        fill-rule="evenodd"
-      />
-    </svg>
-    This is a status text
-  </span>
+      <svg
+        aria-hidden="true"
+        class="fi-icon c10"
+        focusable="false"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          class="fi-icon-base-fill"
+          d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0Zm.71 17.29c-.38-.37-1.05-.37-1.42 0-.181.19-.29.44-.29.71 0 .26.109.52.29.71.189.18.45.29.71.29.26 0 .52-.11.71-.29.18-.19.29-.45.29-.71 0-.27-.11-.52-.29-.71ZM12 5a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V6a1 1 0 0 0-1-1Z"
+          fill="#222"
+          fill-rule="evenodd"
+        />
+      </svg>
+      This is a status text
+    </span>
+  </fieldset>
 </div>
 `;
 
 exports[`snapshots match hidden label 1`] = `
-.c7 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -702,12 +739,12 @@ exports[`snapshots match hidden label 1`] = `
   white-space: normal;
 }
 
-.c7::before,
-.c7::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
-.c4 {
+.c6 {
   position: absolute;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -748,7 +785,7 @@ exports[`snapshots match hidden label 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -772,12 +809,37 @@ exports[`snapshots match hidden label 1`] = `
   white-space: normal;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
 .c2::before,
 .c2::after {
   box-sizing: border-box;
 }
 
-.c5 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -800,17 +862,17 @@ exports[`snapshots match hidden label 1`] = `
   max-width: 100%;
 }
 
-.c5::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c5::before,
-.c5::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c6 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -830,12 +892,37 @@ exports[`snapshots match hidden label 1`] = `
   max-width: 100%;
 }
 
-.c6::before,
-.c6::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -854,18 +941,18 @@ exports[`snapshots match hidden label 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c3.fi-label .fi-label_label-span .fi-tooltip {
+.c5.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
-.c8 {
+.c10 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -884,15 +971,15 @@ exports[`snapshots match hidden label 1`] = `
   line-height: 20px;
 }
 
-.c8.fi-status-text {
+.c10.fi-status-text {
   display: block;
 }
 
-.c8.fi-status-text.fi-status-text--error {
+.c10.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
 }
 
-.c8.fi-status-text .fi-icon {
+.c10.fi-status-text .fi-icon {
   vertical-align: middle;
   -webkit-transform: translateY(-0.1em);
   -ms-transform: translateY(-0.1em);
@@ -1055,27 +1142,6 @@ exports[`snapshots match hidden label 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-}
-
-.c1.fi-file-input .fi-file-input_input-outer-wrapper.appears-focused {
-  position: relative;
-  outline: 3px solid transparent;
-}
-
-.c1.fi-file-input .fi-file-input_input-outer-wrapper.appears-focused:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area {
@@ -1273,58 +1339,66 @@ exports[`snapshots match hidden label 1`] = `
 <div
   class="c0 fi-file-input c1"
 >
-  <div
-    class="c2 c3 fi-label"
+  <fieldset
+    class="c2"
   >
-    <label
-      class="c4 fi-visually-hidden"
-      id="4-label"
-    >
-      Resume
-    </label>
-  </div>
-  <div
-    class="c0 fi-file-input_input-outer-wrapper"
-  >
-    <div
-      class="c2 fi-file-input_drag-area"
+    <legend
+      class="c3"
     >
       <div
-        class="c0 fi-file-input_input-wrapper"
+        class="c4 c5 fi-label"
       >
-        <input
-          aria-invalid="false"
-          aria-labelledby="4-label"
-          class="c5 fi-file-input_input-element"
-          data-testid="file-input"
-          id="4"
-          type="file"
-        />
-        <label
-          class="c6 fi-file-input_input-label"
-          for="4"
+        <span
+          class="c6 fi-visually-hidden"
+          id="4-label"
         >
-          Choose file
-        </label>
+          Resume
+        </span>
+      </div>
+    </legend>
+    <div
+      class="c0 fi-file-input_input-outer-wrapper"
+    >
+      <div
+        class="c4 fi-file-input_drag-area"
+      >
         <div
-          class="c0 fi-file-input_drag-text-container"
+          class="c0 fi-file-input_input-wrapper"
         >
-          Drag and drop files here
+          <input
+            aria-invalid="false"
+            class="c7 fi-file-input_input-element"
+            data-testid="file-input"
+            id="4"
+            tabindex="0"
+            type="file"
+          />
+          <label
+            class="c8 fi-file-input_input-label"
+            for="4"
+          >
+            Choose file
+          </label>
+          <div
+            class="c0 fi-file-input_drag-text-container"
+          >
+            Drag and drop files here
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <span
-    aria-atomic="true"
-    aria-live="assertive"
-    class="c7 c8 fi-status-text"
-    id="4-statusText"
-  />
+    <span
+      aria-atomic="true"
+      aria-live="assertive"
+      class="c9 c10 fi-status-text"
+      id="4-statusText"
+    />
+  </fieldset>
 </div>
 `;
 
 exports[`snapshots match hint text 1`] = `
-.c4 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1348,8 +1422,8 @@ exports[`snapshots match hint text 1`] = `
   white-space: normal;
 }
 
-.c4::before,
-.c4::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
@@ -1382,7 +1456,7 @@ exports[`snapshots match hint text 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1406,12 +1480,37 @@ exports[`snapshots match hint text 1`] = `
   white-space: normal;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
 .c2::before,
 .c2::after {
   box-sizing: border-box;
 }
 
-.c6 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1434,17 +1533,17 @@ exports[`snapshots match hint text 1`] = `
   max-width: 100%;
 }
 
-.c6::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c6::before,
-.c6::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c7 {
+.c9 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -1464,12 +1563,37 @@ exports[`snapshots match hint text 1`] = `
   max-width: 100%;
 }
 
-.c7::before,
-.c7::after {
+.c9::before,
+.c9::after {
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1488,18 +1612,18 @@ exports[`snapshots match hint text 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c3.fi-label .fi-label_label-span .fi-tooltip {
+.c5.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
-.c5 {
+.c7 {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
@@ -1516,11 +1640,11 @@ exports[`snapshots match hint text 1`] = `
   font-weight: 400;
 }
 
-.c5.fi-hint-text {
+.c7.fi-hint-text {
   display: block;
 }
 
-.c8 {
+.c10 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -1539,15 +1663,15 @@ exports[`snapshots match hint text 1`] = `
   line-height: 20px;
 }
 
-.c8.fi-status-text {
+.c10.fi-status-text {
   display: block;
 }
 
-.c8.fi-status-text.fi-status-text--error {
+.c10.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
 }
 
-.c8.fi-status-text .fi-icon {
+.c10.fi-status-text .fi-icon {
   vertical-align: middle;
   -webkit-transform: translateY(-0.1em);
   -ms-transform: translateY(-0.1em);
@@ -1710,27 +1834,6 @@ exports[`snapshots match hint text 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-}
-
-.c1.fi-file-input .fi-file-input_input-outer-wrapper.appears-focused {
-  position: relative;
-  outline: 3px solid transparent;
-}
-
-.c1.fi-file-input .fi-file-input_input-outer-wrapper.appears-focused:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area {
@@ -1930,67 +2033,75 @@ exports[`snapshots match hint text 1`] = `
     <div
       class="c0 fi-file-input c1"
     >
-      <div
-        class="c2 c3 fi-file-input_label--visible fi-label"
+      <fieldset
+        class="c2"
       >
-        <label
-          class="c4 fi-label_label-span"
-          id="3-label"
-        >
-          Resume
-        </label>
-      </div>
-      <span
-        class="c4 c5 fi-hint-text"
-        id="3-hintText"
-      >
-        Maximum file size is 1 MB
-      </span>
-      <div
-        class="c0 fi-file-input_input-outer-wrapper"
-      >
-        <div
-          class="c2 fi-file-input_drag-area"
+        <legend
+          class="c3"
         >
           <div
-            class="c0 fi-file-input_input-wrapper"
+            class="c4 c5 fi-file-input_label--visible fi-label"
           >
-            <input
-              aria-describedby="3-hintText"
-              aria-invalid="false"
-              aria-labelledby="3-label"
-              class="c6 fi-file-input_input-element"
-              data-testid="file-input"
-              id="3"
-              type="file"
-            />
-            <label
-              class="c7 fi-file-input_input-label"
-              for="3"
+            <span
+              class="c6 fi-label_label-span"
+              id="3-label"
             >
-              Choose file
-            </label>
+              Resume
+            </span>
+          </div>
+        </legend>
+        <span
+          class="c6 c7 fi-hint-text"
+          id="3-hintText"
+        >
+          Maximum file size is 1 MB
+        </span>
+        <div
+          class="c0 fi-file-input_input-outer-wrapper"
+        >
+          <div
+            class="c4 fi-file-input_drag-area"
+          >
             <div
-              class="c0 fi-file-input_drag-text-container"
+              class="c0 fi-file-input_input-wrapper"
             >
-              Drag and drop files here
+              <input
+                aria-describedby="3-hintText"
+                aria-invalid="false"
+                class="c8 fi-file-input_input-element"
+                data-testid="file-input"
+                id="3"
+                tabindex="0"
+                type="file"
+              />
+              <label
+                class="c9 fi-file-input_input-label"
+                for="3"
+              >
+                Choose file
+              </label>
+              <div
+                class="c0 fi-file-input_drag-text-container"
+              >
+                Drag and drop files here
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <span
-        aria-atomic="true"
-        aria-live="assertive"
-        class="c4 c8 fi-status-text"
-        id="3-statusText"
-      />
+        <span
+          aria-atomic="true"
+          aria-live="assertive"
+          class="c6 c10 fi-status-text"
+          id="3-statusText"
+        />
+      </fieldset>
     </div>
   </div>
 </body>
 `;
 
 exports[`snapshots match minimal implementation 1`] = `
-.c4 {
+.c6 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2014,8 +2125,8 @@ exports[`snapshots match minimal implementation 1`] = `
   white-space: normal;
 }
 
-.c4::before,
-.c4::after {
+.c6::before,
+.c6::after {
   box-sizing: border-box;
 }
 
@@ -2048,7 +2159,7 @@ exports[`snapshots match minimal implementation 1`] = `
   box-sizing: border-box;
 }
 
-.c2 {
+.c4 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2072,12 +2183,37 @@ exports[`snapshots match minimal implementation 1`] = `
   white-space: normal;
 }
 
+.c4::before,
+.c4::after {
+  box-sizing: border-box;
+}
+
+.c2 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
 .c2::before,
 .c2::after {
   box-sizing: border-box;
 }
 
-.c5 {
+.c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2100,17 +2236,17 @@ exports[`snapshots match minimal implementation 1`] = `
   max-width: 100%;
 }
 
-.c5::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: inherit;
   opacity: 0.54;
 }
 
-.c5::before,
-.c5::after {
+.c7::before,
+.c7::after {
   box-sizing: border-box;
 }
 
-.c6 {
+.c8 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -2130,12 +2266,37 @@ exports[`snapshots match minimal implementation 1`] = `
   max-width: 100%;
 }
 
-.c6::before,
-.c6::after {
+.c8::before,
+.c8::after {
   box-sizing: border-box;
 }
 
-.c3.fi-label .fi-label_label-span {
+.c3 {
+  line-height: 1.15;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  box-sizing: border-box;
+  font: 100% inherit;
+  line-height: 1;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: baseline;
+  color: inherit;
+  background: none;
+  cursor: inherit;
+  max-width: 100%;
+}
+
+.c3::before,
+.c3::after {
+  box-sizing: border-box;
+}
+
+.c5.fi-label .fi-label_label-span {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2154,18 +2315,18 @@ exports[`snapshots match minimal implementation 1`] = `
   color: hsl(0,0%,13%);
 }
 
-.c3.fi-label .fi-label_label-span .fi-label_optional-text {
+.c5.fi-label .fi-label_label-span .fi-label_optional-text {
   font-family: 'Source Sans Pro','Helvetica Neue','Arial',sans-serif;
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
 }
 
-.c3.fi-label .fi-label_label-span .fi-tooltip {
+.c5.fi-label .fi-label_label-span .fi-tooltip {
   margin-left: 6px;
 }
 
-.c7 {
+.c9 {
   -webkit-letter-spacing: 0;
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
@@ -2184,15 +2345,15 @@ exports[`snapshots match minimal implementation 1`] = `
   line-height: 20px;
 }
 
-.c7.fi-status-text {
+.c9.fi-status-text {
   display: block;
 }
 
-.c7.fi-status-text.fi-status-text--error {
+.c9.fi-status-text.fi-status-text--error {
   color: hsl(3,59%,43%);
 }
 
-.c7.fi-status-text .fi-icon {
+.c9.fi-status-text .fi-icon {
   vertical-align: middle;
   -webkit-transform: translateY(-0.1em);
   -ms-transform: translateY(-0.1em);
@@ -2355,27 +2516,6 @@ exports[`snapshots match minimal implementation 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-}
-
-.c1.fi-file-input .fi-file-input_input-outer-wrapper.appears-focused {
-  position: relative;
-  outline: 3px solid transparent;
-}
-
-.c1.fi-file-input .fi-file-input_input-outer-wrapper.appears-focused:after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
-  border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0,0%,100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196,77%,44%);
-  z-index: 9999;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area {
@@ -2573,52 +2713,60 @@ exports[`snapshots match minimal implementation 1`] = `
 <div
   class="c0 fi-file-input c1"
 >
-  <div
-    class="c2 c3 fi-file-input_label--visible fi-label"
+  <fieldset
+    class="c2"
   >
-    <label
-      class="c4 fi-label_label-span"
-      id="1-label"
-    >
-      Resume
-    </label>
-  </div>
-  <div
-    class="c0 fi-file-input_input-outer-wrapper"
-  >
-    <div
-      class="c2 fi-file-input_drag-area"
+    <legend
+      class="c3"
     >
       <div
-        class="c0 fi-file-input_input-wrapper"
+        class="c4 c5 fi-file-input_label--visible fi-label"
       >
-        <input
-          aria-invalid="false"
-          aria-labelledby="1-label"
-          class="c5 fi-file-input_input-element"
-          data-testid="file-input"
-          id="1"
-          type="file"
-        />
-        <label
-          class="c6 fi-file-input_input-label"
-          for="1"
+        <span
+          class="c6 fi-label_label-span"
+          id="1-label"
         >
-          Choose file
-        </label>
+          Resume
+        </span>
+      </div>
+    </legend>
+    <div
+      class="c0 fi-file-input_input-outer-wrapper"
+    >
+      <div
+        class="c4 fi-file-input_drag-area"
+      >
         <div
-          class="c0 fi-file-input_drag-text-container"
+          class="c0 fi-file-input_input-wrapper"
         >
-          Drag and drop files here
+          <input
+            aria-invalid="false"
+            class="c7 fi-file-input_input-element"
+            data-testid="file-input"
+            id="1"
+            tabindex="0"
+            type="file"
+          />
+          <label
+            class="c8 fi-file-input_input-label"
+            for="1"
+          >
+            Choose file
+          </label>
+          <div
+            class="c0 fi-file-input_drag-text-container"
+          >
+            Drag and drop files here
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  <span
-    aria-atomic="true"
-    aria-live="assertive"
-    class="c4 c7 fi-status-text"
-    id="1-statusText"
-  />
+    <span
+      aria-atomic="true"
+      aria-live="assertive"
+      class="c6 c9 fi-status-text"
+      id="1-statusText"
+    />
+  </fieldset>
 </div>
 `;


### PR DESCRIPTION
## Description

PR fixes various a11y related issues in the `<FileInput>` component as discussed in ticket https://jira.dvv.fi/browse/SFIDS-974 

- The component's structure now has a HTML fieldset + legend at the top level to limit the number of `<label>` elements
- In single file mode, the actual input is not focusable after a file has been selected. Focus moves to the "Remove" button instead
- File names are not focusable anymore when `filePreview` is not used
- Fixed redundant role=listitem when using single file mode

## How Has This Been Tested?

Styleguidist on macOS Chrome + Safari

## Release notes

### FileInput
- Fix various accessibility related issues
