### PR TITLE
[Fix] TimeInput redundant fullWidth prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suomifi-ui-components",
-  "version": "15.0.0-beta.2",
+  "version": "15.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suomifi-ui-components",
-      "version": "15.0.0-beta.2",
+      "version": "15.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.23.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suomifi-ui-components",
-  "version": "15.0.0-beta.0",
+  "version": "15.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suomifi-ui-components",
-      "version": "15.0.0-beta.0",
+      "version": "15.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.23.5",

--- a/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
+++ b/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
@@ -72,13 +72,6 @@ export const baseStyles = (
     }
   }
 
-  &.fi-time-input--full-width {
-    width: 100%;
-    & .fi-time-input_input-element-container {
-      width: 100%;
-    }
-  }
-
   & .fi-time-input_input {
     ${element(theme)}
     ${font(theme)('actionElementInnerText')}

--- a/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
+++ b/src/core/Form/TimeInput/TimeInput.baseStyles.tsx
@@ -74,6 +74,9 @@ export const baseStyles = (
 
   &.fi-time-input--full-width {
     width: 100%;
+    & .fi-time-input_input-element-container {
+      width: 100%;
+    }
   }
 
   & .fi-time-input_input {

--- a/src/core/Form/TimeInput/TimeInput.tsx
+++ b/src/core/Form/TimeInput/TimeInput.tsx
@@ -39,7 +39,6 @@ export const timeInputClassNames = {
   disabled: `${baseClassName}--disabled`,
   error: `${baseClassName}--error`,
   success: `${baseClassName}--success`,
-  fullWidth: `${baseClassName}--full-width`,
   labelIsVisible: `${baseClassName}_label--visible`,
   inputElementContainer: `${baseClassName}_input-element-container`,
   inputElement: `${baseClassName}_input`,
@@ -96,8 +95,6 @@ export interface TimeInputProps
   defaultValue?: string;
   /** Controlled value */
   value?: string;
-  /** Sets component's width to 100% of its parent */
-  fullWidth?: boolean;
   /** Text to mark the field optional. Will be wrapped in parentheses and shown after `labelText` */
   optionalText?: string;
   /** Debounce time in milliseconds for onChange function. No debounce is applied if no value is given. */
@@ -123,7 +120,6 @@ const BaseTimeInput = (props: TimeInputProps) => {
     value: controlledValue,
     defaultValue,
     forwardedRef,
-    fullWidth,
     debounce,
     statusTextAriaLiveMode = 'assertive',
     'aria-describedby': ariaDescribedBy,
@@ -160,7 +156,6 @@ const BaseTimeInput = (props: TimeInputProps) => {
         [timeInputClassNames.disabled]: !!passProps.disabled,
         [timeInputClassNames.error]: status === 'error',
         [timeInputClassNames.success]: status === 'success',
-        [timeInputClassNames.fullWidth]: !!fullWidth,
       })}
       style={style}
     >

--- a/src/core/Form/TimeInput/TimeInput.tsx
+++ b/src/core/Form/TimeInput/TimeInput.tsx
@@ -39,6 +39,7 @@ export const timeInputClassNames = {
   disabled: `${baseClassName}--disabled`,
   error: `${baseClassName}--error`,
   success: `${baseClassName}--success`,
+  fullWidth: `${baseClassName}--full-width`,
   labelIsVisible: `${baseClassName}_label--visible`,
   inputElementContainer: `${baseClassName}_input-element-container`,
   inputElement: `${baseClassName}_input`,
@@ -122,6 +123,7 @@ const BaseTimeInput = (props: TimeInputProps) => {
     value: controlledValue,
     defaultValue,
     forwardedRef,
+    fullWidth,
     debounce,
     statusTextAriaLiveMode = 'assertive',
     'aria-describedby': ariaDescribedBy,
@@ -158,6 +160,7 @@ const BaseTimeInput = (props: TimeInputProps) => {
         [timeInputClassNames.disabled]: !!passProps.disabled,
         [timeInputClassNames.error]: status === 'error',
         [timeInputClassNames.success]: status === 'success',
+        [timeInputClassNames.fullWidth]: !!fullWidth,
       })}
       style={style}
     >

--- a/src/core/Form/TimeInput/__snapshots__/TimeInput.test.tsx.snap
+++ b/src/core/Form/TimeInput/__snapshots__/TimeInput.test.tsx.snap
@@ -339,10 +339,6 @@ exports[`snapshots match error status with statustext 1`] = `
   z-index: 9999;
 }
 
-.c1.fi-time-input--full-width {
-  width: 100%;
-}
-
 .c1 .fi-time-input_input {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -828,10 +824,6 @@ exports[`snapshots match hidden label 1`] = `
   z-index: 9999;
 }
 
-.c1.fi-time-input--full-width {
-  width: 100%;
-}
-
 .c1 .fi-time-input_input {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -1307,10 +1299,6 @@ exports[`snapshots match hint text 1`] = `
   z-index: 9999;
 }
 
-.c1.fi-time-input--full-width {
-  width: 100%;
-}
-
 .c1 .fi-time-input_input {
   color: hsl(0,0%,13%);
   -webkit-letter-spacing: 0;
@@ -1774,10 +1762,6 @@ exports[`snapshots match minimal implementation 1`] = `
   box-sizing: border-box;
   box-shadow: 0 0 0 2px hsl(196,77%,44%);
   z-index: 9999;
-}
-
-.c1.fi-time-input--full-width {
-  width: 100%;
 }
 
 .c1 .fi-time-input_input {


### PR DESCRIPTION
## Description
This PR removes the non-functioning `fullWidth` prop from `TimeInput` altogether. It is not useful since the input entry length is limited anyway, and there are no use cases where the input value needs to be longer.

## Motivation and Context
This was a redundant entry in the components API with no real implementation behind it.

## Release notes
### TimeInput
**Breaking change:** Remove redundant `fullWidth` prop
