### PR TITLE
[Hotfix] Dropdown, SingleSelect & MultiSelect screen reader a11y 

### DIFF
--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -4514,10 +4514,10 @@ exports[`snapshots match date input with datepicker with controlled input value 
             class="c0 fi-dropdown_input-wrapper"
           >
             <button
+              aria-controls="16-popover"
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="16-displayValue 16-label"
-              aria-owns="16-popover"
               class="c6 fi-dropdown_button"
               id="16_button"
               tabindex="0"
@@ -4562,10 +4562,10 @@ exports[`snapshots match date input with datepicker with controlled input value 
             class="c0 fi-dropdown_input-wrapper"
           >
             <button
+              aria-controls="17-popover"
               aria-expanded="false"
               aria-haspopup="listbox"
               aria-labelledby="17-displayValue 17-label"
-              aria-owns="17-popover"
               class="c6 fi-dropdown_button"
               id="17_button"
               tabindex="0"
@@ -6789,10 +6789,10 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               class="c0 fi-dropdown_input-wrapper"
             >
               <button
+                aria-controls="9-popover"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="9-displayValue 9-label"
-                aria-owns="9-popover"
                 class="c6 fi-dropdown_button"
                 id="9_button"
                 tabindex="0"
@@ -6837,10 +6837,10 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
               class="c0 fi-dropdown_input-wrapper"
             >
               <button
+                aria-controls="10-popover"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="10-displayValue 10-label"
-                aria-owns="10-popover"
                 class="c6 fi-dropdown_button"
                 id="10_button"
                 tabindex="0"

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
@@ -619,7 +619,7 @@ class BaseDropdown<T extends string = string> extends Component<
               statusTextId,
               hintTextId,
             ])}
-            aria-owns={popoverItemListId}
+            aria-controls={popoverItemListId}
             aria-expanded={ariaExpanded}
             onClick={() => {
               if (!showPopover) {

--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -285,18 +285,14 @@ exports[`Basic dropdown should match snapshot 1`] = `
   border-bottom-right-radius: 2px;
   margin: 0;
   padding: 4px 0 0 0;
+  display: block;
+  width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c9:focus {
   outline: none;
-}
-
-.c9 .fi-select-item-list_content_wrapper {
-  display: block;
-  width: 100%;
-  max-height: inherit;
-  overflow-y: auto;
-  overflow-x: hidden;
 }
 
 .c7 {
@@ -607,10 +603,10 @@ exports[`Basic dropdown should match snapshot 1`] = `
         class="c0 fi-dropdown_input-wrapper"
       >
         <button
+          aria-controls="test-id-popover"
           aria-expanded="true"
           aria-haspopup="listbox"
           aria-labelledby="test-id-displayValue test-id-label"
-          aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
           id="test-id_button"
           tabindex="0"
@@ -648,36 +644,31 @@ exports[`Basic dropdown should match snapshot 1`] = `
       class="c2"
     >
       <ul
-        aria-activedescendant="test-id-item-1"
         class="c8 fi-select-item-list c9 fi-dropdown_item-list"
         id="test-id-popover"
         role="listbox"
         tabindex="0"
       >
-        <div
-          class="c2 fi-select-item-list_content_wrapper"
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c10 c11 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
+          id="test-id-item-1"
+          role="option"
+          tabindex="0"
         >
-          <li
-            aria-disabled="false"
-            aria-selected="false"
-            class="c10 c11 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
-            id="test-id-item-1"
-            role="option"
-            tabindex="0"
-          >
-            Item 1
-          </li>
-          <li
-            aria-disabled="false"
-            aria-selected="false"
-            class="c10 c11 fi-dropdown_item"
-            id="test-id-item-2"
-            role="option"
-            tabindex="-1"
-          >
-            Item 2
-          </li>
-        </div>
+          Item 1
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c10 c11 fi-dropdown_item"
+          id="test-id-item-2"
+          role="option"
+          tabindex="-1"
+        >
+          Item 2
+        </li>
       </ul>
     </div>
   </div>
@@ -969,18 +960,14 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   border-bottom-right-radius: 2px;
   margin: 0;
   padding: 4px 0 0 0;
+  display: block;
+  width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c9:focus {
   outline: none;
-}
-
-.c9 .fi-select-item-list_content_wrapper {
-  display: block;
-  width: 100%;
-  max-height: inherit;
-  overflow-y: auto;
-  overflow-x: hidden;
 }
 
 .c12 {
@@ -1315,10 +1302,10 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
         class="c0 fi-dropdown_input-wrapper"
       >
         <button
+          aria-controls="test-id-popover"
           aria-expanded="true"
           aria-haspopup="listbox"
           aria-labelledby="test-id-displayValue test-id-label"
-          aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
           id="test-id_button"
           tabindex="0"
@@ -1357,52 +1344,47 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
       class="c2"
     >
       <ul
-        aria-activedescendant="test-id-item-2"
         class="c8 fi-select-item-list c9 fi-dropdown_item-list"
         id="test-id-popover"
         role="listbox"
         tabindex="0"
       >
-        <div
-          class="c2 fi-select-item-list_content_wrapper"
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c10 c11 fi-dropdown_item"
+          id="test-id-item-1"
+          role="option"
+          tabindex="-1"
         >
-          <li
-            aria-disabled="false"
-            aria-selected="false"
-            class="c10 c11 fi-dropdown_item"
-            id="test-id-item-1"
-            role="option"
-            tabindex="-1"
+          Item 1
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="true"
+          class="c10 c11 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus fi-dropdown_item--selected"
+          id="test-id-item-2"
+          role="option"
+          tabindex="0"
+        >
+          Item 2
+          <svg
+            aria-hidden="true"
+            class="fi-icon c12 fi-dropdown_item_icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 20 20"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            Item 1
-          </li>
-          <li
-            aria-disabled="false"
-            aria-selected="true"
-            class="c10 c11 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus fi-dropdown_item--selected"
-            id="test-id-item-2"
-            role="option"
-            tabindex="0"
-          >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="fi-icon c12 fi-dropdown_item_icon"
-              focusable="false"
-              height="1em"
-              viewBox="0 0 20 20"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                class="fi-icon-base-fill"
-                d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
-                fill="#222"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </li>
-        </div>
+            <path
+              class="fi-icon-base-fill"
+              d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+              fill="#222"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </li>
       </ul>
     </div>
   </div>
@@ -1694,18 +1676,14 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   border-bottom-right-radius: 2px;
   margin: 0;
   padding: 4px 0 0 0;
+  display: block;
+  width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c9:focus {
   outline: none;
-}
-
-.c9 .fi-select-item-list_content_wrapper {
-  display: block;
-  width: 100%;
-  max-height: inherit;
-  overflow-y: auto;
-  overflow-x: hidden;
 }
 
 .c7 {
@@ -2016,10 +1994,10 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
         class="c0 fi-dropdown_input-wrapper"
       >
         <button
+          aria-controls="test-id-popover"
           aria-expanded="true"
           aria-haspopup="listbox"
           aria-labelledby="test-id-displayValue additional-label-id test-id-label"
-          aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
           id="test-id_button"
           tabindex="0"
@@ -2057,36 +2035,31 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
       class="c2"
     >
       <ul
-        aria-activedescendant="test-id-item-1"
         class="c8 fi-select-item-list c9 fi-dropdown_item-list"
         id="test-id-popover"
         role="listbox"
         tabindex="0"
       >
-        <div
-          class="c2 fi-select-item-list_content_wrapper"
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c10 c11 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
+          id="test-id-item-1"
+          role="option"
+          tabindex="0"
         >
-          <li
-            aria-disabled="false"
-            aria-selected="false"
-            class="c10 c11 fi-dropdown_item fi-dropdown_item--hasKeyboardFocus"
-            id="test-id-item-1"
-            role="option"
-            tabindex="0"
-          >
-            Item 1
-          </li>
-          <li
-            aria-disabled="false"
-            aria-selected="false"
-            class="c10 c11 fi-dropdown_item"
-            id="test-id-item-2"
-            role="option"
-            tabindex="-1"
-          >
-            Item 2
-          </li>
-        </div>
+          Item 1
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c10 c11 fi-dropdown_item"
+          id="test-id-item-2"
+          role="option"
+          tabindex="-1"
+        >
+          Item 2
+        </li>
       </ul>
     </div>
   </div>
@@ -2551,10 +2524,10 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
         class="c0 fi-dropdown_input-wrapper"
       >
         <button
+          aria-controls="test-id-popover"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="test-id-displayValue test-id-label"
-          aria-owns="test-id-popover"
           class="c5 fi-dropdown_button"
           id="test-id_button"
           tabindex="0"

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
@@ -16,15 +16,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   margin: 0;
   padding: 4px 0 0 0;
 
+  display: block;
+  width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+
   &:focus {
     outline: none;
-  }
-
-  & .fi-select-item-list_content_wrapper {
-    display: block;
-    width: 100%;
-    max-height: inherit;
-    overflow-y: auto;
-    overflow-x: hidden;
   }
 `;

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
@@ -9,14 +9,11 @@ import React, {
 import { default as styled } from 'styled-components';
 import classnames from 'classnames';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../../theme';
-import { HtmlDivWithRef, HtmlUlWithRef } from '../../../../../reset';
+import { HtmlUlWithRef } from '../../../../../reset';
+import { forkRefs } from '../../../../../utils/common/common';
 import { baseStyles } from './SelectItemList.baseStyles';
 
 const baseClassName = 'fi-select-item-list';
-
-const selectItemListClassNames = {
-  content_wrapper: `${baseClassName}_content_wrapper`,
-};
 
 export interface SelectItemListProps {
   /** SelectItemList container div class name for custom styling. */
@@ -36,12 +33,12 @@ export interface SelectItemListProps {
 }
 
 interface InnerRef {
-  forwardedRef: RefObject<HTMLUListElement>;
+  forwardedRef: React.Ref<HTMLUListElement>;
 }
 class BaseSelectItemList extends Component<
   SelectItemListProps & InnerRef & SuomifiThemeProp
 > {
-  private wrapperRef: RefObject<HTMLDivElement>;
+  private wrapperRef: RefObject<HTMLUListElement>;
 
   constructor(props: SelectItemListProps & InnerRef & SuomifiThemeProp) {
     super(props);
@@ -104,24 +101,19 @@ class BaseSelectItemList extends Component<
       preventScrolling,
       ...passProps
     } = this.props;
+
     return (
       <HtmlUlWithRef
         id={id}
         tabIndex={0}
-        forwardRef={forwardedRef}
+        forwardRef={forkRefs(this.wrapperRef, forwardedRef)}
         className={classnames(baseClassName, className, {})}
         {...passProps}
         role="listbox"
         onBlur={onBlur}
-        aria-activedescendant={focusedDescendantId}
         onKeyDown={onKeyDown}
       >
-        <HtmlDivWithRef
-          forwardedRef={this.wrapperRef}
-          className={selectItemListClassNames.content_wrapper}
-        >
-          {children}
-        </HtmlDivWithRef>
+        {children}
       </HtmlUlWithRef>
     );
   }

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -501,6 +501,7 @@ class BaseMultiSelect<T> extends Component<
 
     switch (event.key) {
       case 'ArrowDown': {
+        event.preventDefault();
         this.setState({ showPopover: true });
         const nextItem =
           this.props.allowItemAddition &&
@@ -519,6 +520,7 @@ class BaseMultiSelect<T> extends Component<
       }
 
       case 'ArrowUp': {
+        event.preventDefault();
         this.setState({ showPopover: true });
         const previousItem =
           this.props.allowItemAddition &&
@@ -791,7 +793,7 @@ class BaseMultiSelect<T> extends Component<
                       aria-multiselectable="true"
                       {...listProps}
                     >
-                      <HtmlDiv>
+                      <>
                         {!loading &&
                           filteredItemsWithChecked.length > 0 &&
                           filteredItemsWithChecked.map((item) => {
@@ -861,7 +863,7 @@ class BaseMultiSelect<T> extends Component<
                             />
                           </SelectEmptyItem>
                         )}
-                      </HtmlDiv>
+                      </>
                     </SelectItemList>
                   )}
                 </PopoverConsumer>

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -624,18 +624,14 @@ exports[`has matching snapshot 1`] = `
   border-bottom-right-radius: 2px;
   margin: 0;
   padding: 4px 0 0 0;
+  display: block;
+  width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c18:focus {
   outline: none;
-}
-
-.c18 .fi-select-item-list_content_wrapper {
-  display: block;
-  width: 100%;
-  max-height: inherit;
-  overflow-y: auto;
-  overflow-x: hidden;
 }
 
 .c20 {
@@ -1574,159 +1570,150 @@ exports[`has matching snapshot 1`] = `
       class="c3"
     >
       <ul
-        aria-activedescendant=""
         aria-multiselectable="true"
         class="c17 fi-select-item-list c18"
         id="3-popover"
         role="listbox"
         tabindex="0"
       >
-        <div
-          class="c3 fi-select-item-list_content_wrapper"
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c19 fi-select-item c20"
+          id="3-jh2435626"
+          role="option"
+          tabindex="-1"
         >
-          <div
-            class="c0"
+          Jackhammer
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="true"
+          class="c19 fi-select-item c20 fi-select-item--selected"
+          id="3-h9823523"
+          role="option"
+          tabindex="-1"
+        >
+          Hammer
+          <svg
+            aria-hidden="true"
+            class="fi-icon c21 fi-select-item_icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 20 20"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c19 fi-select-item c20"
-              id="3-jh2435626"
-              role="option"
-              tabindex="-1"
-            >
-              Jackhammer
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="true"
-              class="c19 fi-select-item c20 fi-select-item--selected"
-              id="3-h9823523"
-              role="option"
-              tabindex="-1"
-            >
-              Hammer
-              <svg
-                aria-hidden="true"
-                class="fi-icon c21 fi-select-item_icon"
-                focusable="false"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  class="fi-icon-base-fill"
-                  d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
-                  fill="#222"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c19 fi-select-item c20"
-              id="3-sh908293482"
-              role="option"
-              tabindex="-1"
-            >
-              Sledgehammer
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c19 fi-select-item c20"
-              id="3-s82502335"
-              role="option"
-              tabindex="-1"
-            >
-              Spade
-            </li>
-            <li
-              aria-disabled="true"
-              aria-selected="true"
-              class="c19 fi-select-item c20 fi-select-item--selected fi-select-item--disabled"
-              id="3-ps9081231"
-              role="option"
-              tabindex="-1"
-            >
-              Powersaw
-              <svg
-                aria-hidden="true"
-                class="fi-icon c21 fi-select-item_icon"
-                focusable="false"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  class="fi-icon-base-fill"
-                  d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
-                  fill="#222"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c19 fi-select-item c20"
-              id="3-s05111511"
-              role="option"
-              tabindex="-1"
-            >
-              Shovel
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c19 fi-select-item c20"
-              id="3-is3451261"
-              role="option"
-              tabindex="-1"
-            >
-              Iron stick
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="true"
-              class="c19 fi-select-item c20 fi-select-item--selected"
-              id="3-r09282626"
-              role="option"
-              tabindex="-1"
-            >
-              Rake
-              <svg
-                aria-hidden="true"
-                class="fi-icon c21 fi-select-item_icon"
-                focusable="false"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  class="fi-icon-base-fill"
-                  d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
-                  fill="#222"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </li>
-            <li
-              aria-disabled="true"
-              aria-selected="false"
-              class="c19 fi-select-item c20 fi-select-item--disabled"
-              id="3-ms6126266"
-              role="option"
-              tabindex="-1"
-            >
-              Motorsaw
-            </li>
-          </div>
-        </div>
+            <path
+              class="fi-icon-base-fill"
+              d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+              fill="#222"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c19 fi-select-item c20"
+          id="3-sh908293482"
+          role="option"
+          tabindex="-1"
+        >
+          Sledgehammer
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c19 fi-select-item c20"
+          id="3-s82502335"
+          role="option"
+          tabindex="-1"
+        >
+          Spade
+        </li>
+        <li
+          aria-disabled="true"
+          aria-selected="true"
+          class="c19 fi-select-item c20 fi-select-item--selected fi-select-item--disabled"
+          id="3-ps9081231"
+          role="option"
+          tabindex="-1"
+        >
+          Powersaw
+          <svg
+            aria-hidden="true"
+            class="fi-icon c21 fi-select-item_icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 20 20"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              class="fi-icon-base-fill"
+              d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+              fill="#222"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c19 fi-select-item c20"
+          id="3-s05111511"
+          role="option"
+          tabindex="-1"
+        >
+          Shovel
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c19 fi-select-item c20"
+          id="3-is3451261"
+          role="option"
+          tabindex="-1"
+        >
+          Iron stick
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="true"
+          class="c19 fi-select-item c20 fi-select-item--selected"
+          id="3-r09282626"
+          role="option"
+          tabindex="-1"
+        >
+          Rake
+          <svg
+            aria-hidden="true"
+            class="fi-icon c21 fi-select-item_icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 20 20"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              class="fi-icon-base-fill"
+              d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+              fill="#222"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </li>
+        <li
+          aria-disabled="true"
+          aria-selected="false"
+          class="c19 fi-select-item c20 fi-select-item--disabled"
+          id="3-ms6126266"
+          role="option"
+          tabindex="-1"
+        >
+          Motorsaw
+        </li>
       </ul>
     </div>
   </div>

--- a/src/core/Form/Select/SingleSelect/SingleSelect.md
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.md
@@ -146,7 +146,9 @@ const defaultSelection = {
   visualPlaceholder="Choose country"
   noItemsText="No items"
   ariaOptionsAvailableTextFunction={(amount) =>
-    amount === 1 ? 'option available' : 'options available'
+    amount === 1
+      ? '1 option available'
+      : `${amount} options available`
   }
 />;
 ```
@@ -208,7 +210,9 @@ const [error, setError] = useState(true);
   visualPlaceholder="Choose country"
   noItemsText="No items"
   ariaOptionsAvailableTextFunction={(amount) =>
-    amount === 1 ? 'option available' : 'options available'
+    amount === 1
+      ? '1 option available'
+      : `${amount} options available`
   }
   status={error ? 'error' : 'default'}
   statusText={error ? 'This field is required' : ''}
@@ -274,7 +278,9 @@ const countries = [
   visualPlaceholder="Choose country"
   noItemsText="No items"
   ariaOptionsAvailableTextFunction={(amount) =>
-    amount === 1 ? 'option available' : 'options available'
+    amount === 1
+      ? '1 option available'
+      : `${amount} options available`
   }
   allowItemAddition
   itemAdditionHelpText="Add another country"
@@ -340,7 +346,9 @@ const countries = [
   visualPlaceholder="Choose country"
   noItemsText="No items"
   ariaOptionsAvailableTextFunction={(amount) =>
-    amount === 1 ? 'option available' : 'options available'
+    amount === 1
+      ? '1 option available'
+      : `${amount} options available`
   }
   selectedItem={selectedCountry}
   onItemSelectionChange={(newItem) => setSelectedCountry(newItem)}
@@ -423,7 +431,9 @@ const handleSelection = (newSelectedItem) => {
   visualPlaceholder="Choose country"
   noItemsText="No items"
   ariaOptionsAvailableTextFunction={(amount) =>
-    amount === 1 ? 'option available' : 'options available'
+    amount === 1
+      ? '1 option available'
+      : `${amount} options available`
   }
   allowItemAddition
   itemAdditionHelpText="Add another country"
@@ -498,7 +508,9 @@ const countries = [
     visualPlaceholder="Choose country"
     noItemsText="No items"
     ariaOptionsAvailableTextFunction={(amount) =>
-      amount === 1 ? 'option available' : 'options available'
+      amount === 1
+        ? '1 option available'
+        : `${amount} options available`
     }
   />
 </>;
@@ -584,7 +596,9 @@ const simulateBackendCall = (searchStr) => {
   visualPlaceholder="Choose country"
   noItemsText="No items"
   ariaOptionsAvailableTextFunction={(amount) =>
-    amount === 1 ? 'option available' : 'options available'
+    amount === 1
+      ? '1 option available'
+      : `${amount} options available`
   }
   debounce={1000}
   loading={loading}
@@ -652,7 +666,9 @@ const countries = [
   visualPlaceholder="Choose country"
   noItemsText="No items"
   ariaOptionsAvailableTextFunction={(amount) =>
-    amount === 1 ? 'option available' : 'options available'
+    amount === 1
+      ? '1 option available'
+      : `${amount} options available`
   }
   fullWidth
 />;
@@ -723,7 +739,9 @@ const labelText = 'Country of residence';
   visualPlaceholder="Choose country"
   noItemsText="No items"
   ariaOptionsAvailableTextFunction={(amount) =>
-    amount === 1 ? 'option available' : 'options available'
+    amount === 1
+      ? '1 option available'
+      : `${amount} options available`
   }
   tooltipComponent={
     <Tooltip

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -426,6 +426,7 @@ class BaseSingleSelect<T> extends Component<
 
     switch (event.key) {
       case 'ArrowDown': {
+        event.preventDefault();
         if (!this.state.showPopover) {
           this.setState({ showPopover: true });
         }
@@ -446,6 +447,7 @@ class BaseSingleSelect<T> extends Component<
       }
 
       case 'ArrowUp': {
+        event.preventDefault();
         if (!this.state.showPopover) {
           this.setState({ showPopover: true });
         }
@@ -699,7 +701,7 @@ class BaseSingleSelect<T> extends Component<
               focusedDescendantId={ariaActiveDescendant}
               {...listProps}
             >
-              <HtmlDiv>
+              <>
                 {popoverItems.length > 0 &&
                   !loading &&
                   popoverItems.map((item) => {
@@ -766,7 +768,7 @@ class BaseSingleSelect<T> extends Component<
                       {filterInputValue}
                     </SelectItemAddition>
                   )}
-              </HtmlDiv>
+              </>
             </SelectItemList>
           </Popover>
         )}

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -683,18 +683,14 @@ exports[`has matching snapshot 1`] = `
   border-bottom-right-radius: 2px;
   margin: 0;
   padding: 4px 0 0 0;
+  display: block;
+  width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c16:focus {
   outline: none;
-}
-
-.c16 .fi-select-item-list_content_wrapper {
-  display: block;
-  width: 100%;
-  max-height: inherit;
-  overflow-y: auto;
-  overflow-x: hidden;
 }
 
 .c18 {
@@ -1059,126 +1055,117 @@ exports[`has matching snapshot 1`] = `
       class="c3"
     >
       <ul
-        aria-activedescendant=""
         class="c15 fi-select-item-list c16"
         id="2-popover"
         role="listbox"
         tabindex="0"
       >
-        <div
-          class="c3 fi-select-item-list_content_wrapper"
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c17 fi-select-item c18"
+          id="2-jh2435626"
+          role="option"
+          tabindex="-1"
         >
-          <div
-            class="c0"
+          Jackhammer
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="true"
+          class="c17 fi-select-item c18 fi-select-item--selected"
+          id="2-h9823523"
+          role="option"
+          tabindex="-1"
+        >
+          Hammer
+          <svg
+            aria-hidden="true"
+            class="fi-icon c19 fi-select-item_icon"
+            focusable="false"
+            height="1em"
+            viewBox="0 0 20 20"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c17 fi-select-item c18"
-              id="2-jh2435626"
-              role="option"
-              tabindex="-1"
-            >
-              Jackhammer
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="true"
-              class="c17 fi-select-item c18 fi-select-item--selected"
-              id="2-h9823523"
-              role="option"
-              tabindex="-1"
-            >
-              Hammer
-              <svg
-                aria-hidden="true"
-                class="fi-icon c19 fi-select-item_icon"
-                focusable="false"
-                height="1em"
-                viewBox="0 0 20 20"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  class="fi-icon-base-fill"
-                  d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
-                  fill="#222"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c17 fi-select-item c18"
-              id="2-sh908293482"
-              role="option"
-              tabindex="-1"
-            >
-              Sledgehammer
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c17 fi-select-item c18"
-              id="2-s82502335"
-              role="option"
-              tabindex="-1"
-            >
-              Spade
-            </li>
-            <li
-              aria-disabled="true"
-              aria-selected="false"
-              class="c17 fi-select-item c18 fi-select-item--disabled"
-              id="2-ps9081231"
-              role="option"
-              tabindex="-1"
-            >
-              Powersaw
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c17 fi-select-item c18"
-              id="2-s05111511"
-              role="option"
-              tabindex="-1"
-            >
-              Shovel
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c17 fi-select-item c18"
-              id="2-is3451261"
-              role="option"
-              tabindex="-1"
-            >
-              Iron stick
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="c17 fi-select-item c18"
-              id="2-r09282626"
-              role="option"
-              tabindex="-1"
-            >
-              Rake
-            </li>
-            <li
-              aria-disabled="true"
-              aria-selected="false"
-              class="c17 fi-select-item c18 fi-select-item--disabled"
-              id="2-ms6126266"
-              role="option"
-              tabindex="-1"
-            >
-              Motorsaw
-            </li>
-          </div>
-        </div>
+            <path
+              class="fi-icon-base-fill"
+              d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+              fill="#222"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c17 fi-select-item c18"
+          id="2-sh908293482"
+          role="option"
+          tabindex="-1"
+        >
+          Sledgehammer
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c17 fi-select-item c18"
+          id="2-s82502335"
+          role="option"
+          tabindex="-1"
+        >
+          Spade
+        </li>
+        <li
+          aria-disabled="true"
+          aria-selected="false"
+          class="c17 fi-select-item c18 fi-select-item--disabled"
+          id="2-ps9081231"
+          role="option"
+          tabindex="-1"
+        >
+          Powersaw
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c17 fi-select-item c18"
+          id="2-s05111511"
+          role="option"
+          tabindex="-1"
+        >
+          Shovel
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c17 fi-select-item c18"
+          id="2-is3451261"
+          role="option"
+          tabindex="-1"
+        >
+          Iron stick
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="c17 fi-select-item c18"
+          id="2-r09282626"
+          role="option"
+          tabindex="-1"
+        >
+          Rake
+        </li>
+        <li
+          aria-disabled="true"
+          aria-selected="false"
+          class="c17 fi-select-item c18 fi-select-item--disabled"
+          id="2-ms6126266"
+          role="option"
+          tabindex="-1"
+        >
+          Motorsaw
+        </li>
       </ul>
     </div>
   </div>

--- a/src/reset/HtmlUl/HtmlUl.tsx
+++ b/src/reset/HtmlUl/HtmlUl.tsx
@@ -29,7 +29,7 @@ export const HtmlUl = styled(Ul)`
 const UlWithRef = ({
   forwardRef,
   ...passProps
-}: HtmlUlProps & { forwardRef: React.RefObject<HTMLUListElement> }) => (
+}: HtmlUlProps & { forwardRef: React.Ref<HTMLUListElement> }) => (
   <ul {...passProps} ref={forwardRef} />
 );
 


### PR DESCRIPTION
## Description

PR contains fixes for the Dropdown, SingleSelect & MultiSelect components. The changes to the Select components are mainly pre-emptive in nature and deal with the extra divs in the popover list. 

Dropdown, on the other hand, needs a hotfix since the component is currently not working in the latest macOS version with Safari + VoiceOver. The fix is, fortunately, very simple: Just replace `aria-owns` with `aria-controls` in the dropdown button.

## Motivation and Context

The issues were reported to us by an accessibility specialist.

## How Has This Been Tested?

Styleguidist: macOS 15 with Safari + VO, Chrome + VO

## Release notes

### Dropdown
- Fix screen reader accessibility which manifested when browsing the popover list

### SingleSelect, MultiSelect
- Remove redundant divs from the popover list (between `<ul>` and `<li>`)
- Fix `ariaOptionsAvailableTextFunction` documentation examples 
