### PR TITLE
[Fix] FileInput & FileItem circular dependency

### DIFF
--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -40,7 +40,7 @@ import { StatusText } from '../StatusText/StatusText';
 import { FileItem } from './FileItem';
 
 const baseClassName = 'fi-file-input';
-export const fileInputClassNames = {
+const fileInputClassNames = {
   fullWidth: `${baseClassName}--full-width`,
   inputOuterWrapper: `${baseClassName}_input-outer-wrapper`,
   dragArea: `${baseClassName}_drag-area`,
@@ -57,16 +57,7 @@ export const fileInputClassNames = {
   statusTextHasContent: `${baseClassName}_statusText--has-content`,
   hiddenUnderFile: `${baseClassName}_label--hidden-under-file`,
   dragAreaHasFile: `${baseClassName}_drag-area--has-file`,
-  fileItemOuterWrapper: `${baseClassName}_file-item-outer-wrapper`,
-  fileItem: `${baseClassName}_file-item`,
-  fileInfo: `${baseClassName}_file-info`,
-  fileName: `${baseClassName}_file-name`,
-  fileSize: `${baseClassName}_file-size`,
-  removeFileButton: `${baseClassName}_remove-file-button`,
   smallScreen: `${baseClassName}--small-screen`,
-  errorIcon: `${baseClassName}_error-icon`,
-  loadingIcon: `${baseClassName}_loading-icon`,
-  fileItemErrorText: `${baseClassName}_file-item-error-text`,
 };
 
 interface BaseFileInputProps

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -1,9 +1,5 @@
 import React, { ReactNode } from 'react';
-import {
-  ControlledFileItem,
-  FileItemRefs,
-  fileInputClassNames,
-} from './FileInput';
+import { ControlledFileItem, FileItemRefs } from './FileInput';
 import { Button } from '../../Button/Button';
 import { HtmlDiv, HtmlDivWithRef } from '../../../reset/HtmlDiv/HtmlDiv';
 import {
@@ -29,6 +25,19 @@ interface FileItemProps {
   smallScreen: boolean;
   metaData?: ControlledFileItem;
 }
+
+const baseClassName = 'fi-file-input';
+const fileItemClassNames = {
+  fileItemOuterWrapper: `${baseClassName}_file-item-outer-wrapper`,
+  fileItem: `${baseClassName}_file-item`,
+  fileInfo: `${baseClassName}_file-info`,
+  fileName: `${baseClassName}_file-name`,
+  fileSize: `${baseClassName}_file-size`,
+  removeFileButton: `${baseClassName}_remove-file-button`,
+  errorIcon: `${baseClassName}_error-icon`,
+  loadingIcon: `${baseClassName}_loading-icon`,
+  fileItemErrorText: `${baseClassName}_file-item-error-text`,
+};
 
 const BaseFileItem = (props: FileItemProps) => {
   const {
@@ -74,16 +83,16 @@ const BaseFileItem = (props: FileItemProps) => {
 
   return (
     <HtmlDiv
-      className={fileInputClassNames.fileItemOuterWrapper}
+      className={fileItemClassNames.fileItemOuterWrapper}
       role={multiFile ? 'listitem' : undefined}
     >
-      <HtmlDiv className={fileInputClassNames.fileItem}>
-        <HtmlDiv className={fileInputClassNames.fileInfo}>
+      <HtmlDiv className={fileItemClassNames.fileItem}>
+        <HtmlDiv className={fileItemClassNames.fileInfo}>
           {metaData?.status === 'error' && (
-            <IconErrorFilled className={fileInputClassNames.errorIcon} />
+            <IconErrorFilled className={fileItemClassNames.errorIcon} />
           )}
           {metaData?.status === 'loading' && (
-            <IconPreloader className={fileInputClassNames.loadingIcon} />
+            <IconPreloader className={fileItemClassNames.loadingIcon} />
           )}
           {!metaData?.status && <IconGenericFile />}
           {filePreview ? (
@@ -92,7 +101,7 @@ const BaseFileItem = (props: FileItemProps) => {
                 fileItemRefs.fileNameRef as React.RefObject<HTMLAnchorElement>
               }
               href={URL.createObjectURL(file)}
-              className={classnames(fileInputClassNames.fileName, 'is-link')}
+              className={classnames(fileItemClassNames.fileName, 'is-link')}
               target="_blank"
               aria-label={getFileAriaLabel()}
               aria-describedby={fileItemRefs.fileSizeElementId}
@@ -104,7 +113,7 @@ const BaseFileItem = (props: FileItemProps) => {
               forwardedRef={
                 fileItemRefs.fileNameRef as React.RefObject<HTMLDivElement>
               }
-              className={fileInputClassNames.fileName}
+              className={fileItemClassNames.fileName}
               aria-label={getFileAriaLabel()}
               aria-describedby={fileItemRefs.fileSizeElementId}
             >
@@ -112,7 +121,7 @@ const BaseFileItem = (props: FileItemProps) => {
             </HtmlDivWithRef>
           )}
           <HtmlDiv
-            className={fileInputClassNames.fileSize}
+            className={fileItemClassNames.fileSize}
             id={filePreview ? fileItemRefs.fileSizeElementId : undefined}
           >
             {`(${getFileSizeText()})`}
@@ -139,14 +148,14 @@ const BaseFileItem = (props: FileItemProps) => {
           aria-label={`${
             metaData?.buttonText ? metaData.buttonText : removeFileText
           } ${file.name}`}
-          className={fileInputClassNames.removeFileButton}
+          className={fileItemClassNames.removeFileButton}
           ref={fileItemRefs.removeButtonRef}
         >
           {getButtonText()}
         </Button>
       </HtmlDiv>
       {metaData?.errorText && (
-        <HtmlDiv className={fileInputClassNames.fileItemErrorText}>
+        <HtmlDiv className={fileItemClassNames.fileItemErrorText}>
           {metaData.errorText}
         </HtmlDiv>
       )}


### PR DESCRIPTION
## Description
Upon building there was a warning about a circular dependency between `FileInput` and `FileItem`. It seemed to have originated from the shared class name object. Separating FileItem classes to reside in the correct file seems to have fixed the issue.

## How Has This Been Tested?
Tested by building locally and checking that the warning message no longer appears upon building. 

## Release notes
### FileItem, FileInput
- Fix circular dependency between FileInput and FileItem
