### PR TITLE
[Feature] Add HtmlMark component

### DIFF
--- a/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.tsx
@@ -6,6 +6,7 @@ import { escapeStringRegexp } from '../../../../../utils/common';
 import { HtmlLi } from '../../../../../reset';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../../theme';
 import { baseStyles } from './SelectItem.baseStyles';
+import { HtmlMark } from '../../../../../reset/HtmlMark/HtmlMark';
 
 const baseClassName = 'fi-select-item';
 
@@ -47,9 +48,9 @@ class BaseSelectItem extends Component<SelectItemProps & SuomifiThemeProp> {
         if (isMatch) {
           return (
             // eslint-disable-next-line react/no-array-index-key
-            <mark className={selectItemClassNames.queryHighlight} key={i}>
+            <HtmlMark className={selectItemClassNames.queryHighlight} key={i}>
               {substring}
-            </mark>
+            </HtmlMark>
           );
         }
         // eslint-disable-next-line react/no-array-index-key

--- a/src/reset/HtmlMark/HtmlMark.tsx
+++ b/src/reset/HtmlMark/HtmlMark.tsx
@@ -1,0 +1,21 @@
+import React, { HTMLProps } from 'react';
+import { default as styled, css } from 'styled-components';
+import { resets } from '../utils';
+
+export interface HtmlMarkProps extends HTMLProps<HTMLElement> {}
+
+const spanResets = css`
+  ${resets.normalize.html}
+  ${resets.common}
+  display: inline;
+  max-width: 100%;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+`;
+
+const Mark = (props: HtmlMarkProps) => <mark {...props} />;
+
+export const HtmlMark = styled(Mark)`
+  ${spanResets}
+`;

--- a/src/reset/HtmlMark/HtmlMark.tsx
+++ b/src/reset/HtmlMark/HtmlMark.tsx
@@ -1,10 +1,10 @@
-import React, { HTMLProps } from 'react';
+import { HTMLProps } from 'react';
 import { default as styled, css } from 'styled-components';
 import { resets } from '../utils';
 
 export interface HtmlMarkProps extends HTMLProps<HTMLElement> {}
 
-const spanResets = css`
+const markResets = css`
   ${resets.normalize.html}
   ${resets.common}
   display: inline;
@@ -14,8 +14,6 @@ const spanResets = css`
   white-space: normal;
 `;
 
-const Mark = (props: HtmlMarkProps) => <mark {...props} />;
-
-export const HtmlMark = styled(Mark)`
-  ${spanResets}
+export const HtmlMark = styled.mark<HtmlMarkProps>`
+  ${markResets}
 `;


### PR DESCRIPTION
## Description
This PR adds style reset version of the html `<mark>` component to the library and replaces existing instances of `<mark>` with the new component, `<HtmlMark>`.

## Motivation and Context
Previously `SelectItem` used the native html `<mark>` component, and apparently some default bootstrap styles broke the styles of the component. Thus a reset version was needed. 

## How Has This Been Tested?
Tested by running locally on styleguidist on Win + Chrome. Still needs to be tested in a test project where the existing issue can be reproduced and thus test the fix properly.

## Release notes
### General
* Reset styles for `<mark>` components inside the library
