### PR TITLE
[Fix] DatePicker escape key event propagation

### DIFF
--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -213,12 +213,12 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   };
 
   const globalKeyDownHandler = (event: KeyboardEvent) => {
-    event.stopPropagation();
     if (
       event.key === 'Escape' &&
       !(yearSelectRef.current?.getAttribute('aria-expanded') === 'true') &&
       !(monthSelectRef.current?.getAttribute('aria-expanded') === 'true')
     ) {
+      event.stopPropagation();
       handleClose(true);
     }
 

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -213,6 +213,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   };
 
   const globalKeyDownHandler = (event: KeyboardEvent) => {
+    event.stopPropagation();
     if (
       event.key === 'Escape' &&
       !(yearSelectRef.current?.getAttribute('aria-expanded') === 'true') &&


### PR DESCRIPTION
## Description
This PR fixes an issue where an escape key press in `DatePicker` would propagate outside the component, causing unwanted side effects. One example of a side effect is when a `DateInput` with `DatePicker` is used inside a modal. Before this fix, pressing escape to close the date picker would also close the containing modal.

## Motivation and Context
This was a bug reported by a service using the library.

## How Has This Been Tested?
Tested by placing a DateInput inside of a modal and checking the behavior before and after the fix.

## Release notes
### DateInput
* Stop event propagation of escape keypress
