### PR TITLE
[Fix] Table fixes

### DIFF
--- a/src/core/Table/Table.baseStyles.tsx
+++ b/src/core/Table/Table.baseStyles.tsx
@@ -59,21 +59,28 @@ export const baseStyles = (
 
       .fi-table_th,
       .fi-table_td {
-        padding: ${theme.spacing.m};
-
+        padding: 12px 20px;
+        line-height: 2;
         .fi-link {
           font-size: 16px;
+          line-height: 1;
         }
         .fi-checkbox {
-          height: 18px;
+          height: 19px;
           width: 5px;
+        }
+
+        .fi-radio-button {
+          width: 3px;
+          .fi-radio-button_input + .fi-radio-button_icon_wrapper {
+            top: 4px;
+          }
         }
       }
 
       .fi-table_th {
         background-color: ${theme.colors.brandBase};
         color: ${theme.colors.whiteBase};
-        line-height: 1.5;
 
         &.checkbox-header {
           padding: 0;
@@ -145,7 +152,7 @@ export const baseStyles = (
       &.fi-table--condensed {
         .fi-table_th,
         .fi-table_td {
-          padding: ${theme.spacing.s} ${theme.spacing.m};
+          padding: ${theme.spacing.xs} ${theme.spacing.m};
         }
       }
     }

--- a/src/core/Table/Table.md
+++ b/src/core/Table/Table.md
@@ -217,7 +217,9 @@ const data = [
 
 Use the `enableRowSelection` to allow row selection via Checkboxes on the left hand side. Use the `onSelectedRowsChange()` prop to detect selection changes. The function returns the `id`s of selected rows.
 
-Also provide a `rowSelectionCheckboxLabel` to each row object to give an accessible label to the selection checkbox.
+Alternatively, you can use the `enableSingleRowSelection` prop to allow single row selection via RadioButton.
+
+Also provide a `rowSelectionCheckboxLabel` to each row object to give an accessible label to the selection Checkbox/RadioButton.
 
 You can control the selected rows programmatically by using the `controlledSelectedRowIds` prop as shown in the second example below.
 
@@ -310,6 +312,15 @@ const [controlledSelectedRowIds, setControlledSelectedRowIds] =
     columns={columns}
     data={data}
     enableRowSelection
+    onSelectedRowsChange={(rowIds) => console.log(rowIds)}
+    mb="xxxl"
+  />
+
+  <Table
+    caption="People in the project"
+    columns={columns}
+    data={data}
+    enableSingleRowSelection
     onSelectedRowsChange={(rowIds) => console.log(rowIds)}
     mb="xxxl"
   />

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -37,6 +37,7 @@ import {
 import { getConditionalAriaProp } from '../../utils/aria';
 import { Checkbox } from '../Form/Checkbox/Checkbox';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden';
+import { RadioButton } from '../Form/RadioButton/RadioButton';
 
 const baseClassName = 'fi-table';
 
@@ -98,6 +99,8 @@ export interface BaseTableProps<TColumns extends readonly TableColumn[]>
    * @default false
    */
   enableRowSelection?: boolean;
+  /** Enables selection of a single row via a radiobutton */
+  enableSingleRowSelection?: boolean;
   /** Callback fired when selected rows change */
   onSelectedRowsChange?: (selectedRowIds: string[]) => void;
   /** Controlled array */
@@ -136,6 +139,7 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
     caption,
     condensed,
     enableRowSelection,
+    enableSingleRowSelection,
     onSelectedRowsChange,
     tableSortedAriaLiveText,
     controlledSelectedRowIds,
@@ -196,10 +200,15 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
   };
 
   const handleRowSelection = (rowId: string, operation: 'add' | 'remove') => {
-    const newSelectedRowIds =
-      operation === 'add'
-        ? [...selectedRowIds, rowId]
-        : selectedRowIds.filter((rid) => rid !== rowId);
+    let newSelectedRowIds = [];
+    if (enableSingleRowSelection) {
+      newSelectedRowIds = [rowId];
+    } else {
+      newSelectedRowIds =
+        operation === 'add'
+          ? [...selectedRowIds, rowId]
+          : selectedRowIds.filter((rid) => rid !== rowId);
+    }
     if (controlledSelectedRowIds === undefined) {
       setSelectedRowIds(newSelectedRowIds);
     }
@@ -235,7 +244,7 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
         )}
         <HtmlTableHeader className={tableClassNames.thead}>
           <HtmlTableRow>
-            {enableRowSelection && (
+            {(enableRowSelection || enableSingleRowSelection) && (
               <HtmlTableCell className={classnames(tableClassNames.th)} />
             )}
             {columns.map((col) => (
@@ -300,6 +309,21 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
                       {row.rowSelectionCheckboxLabel}
                     </VisuallyHidden>
                   </Checkbox>
+                </HtmlTableCell>
+              )}
+              {enableSingleRowSelection && (
+                <HtmlTableCell className={classnames(tableClassNames.td)}>
+                  <RadioButton
+                    value={`radiobutton-${row.id}`}
+                    checked={selectedRowIds.includes(row.id)}
+                    onChange={(newValue) =>
+                      handleRowSelection(row.id, newValue ? 'add' : 'remove')
+                    }
+                  >
+                    <VisuallyHidden>
+                      {row.rowSelectionCheckboxLabel}
+                    </VisuallyHidden>
+                  </RadioButton>
                 </HtmlTableCell>
               )}
               {columns.map((col) => (

--- a/src/core/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/core/Table/__snapshots__/Table.test.tsx.snap
@@ -357,24 +357,35 @@ exports[`Table functionalities matches snapshot 1`] = `
 
 .c1.fi-table .fi-table_table .fi-table_th,
 .c1.fi-table .fi-table_table .fi-table_td {
-  padding: 20px;
+  padding: 12px 20px;
+  line-height: 2;
 }
 
 .c1.fi-table .fi-table_table .fi-table_th .fi-link,
 .c1.fi-table .fi-table_table .fi-table_td .fi-link {
   font-size: 16px;
+  line-height: 1;
 }
 
 .c1.fi-table .fi-table_table .fi-table_th .fi-checkbox,
 .c1.fi-table .fi-table_table .fi-table_td .fi-checkbox {
-  height: 18px;
+  height: 19px;
   width: 5px;
+}
+
+.c1.fi-table .fi-table_table .fi-table_th .fi-radio-button,
+.c1.fi-table .fi-table_table .fi-table_td .fi-radio-button {
+  width: 3px;
+}
+
+.c1.fi-table .fi-table_table .fi-table_th .fi-radio-button .fi-radio-button_input+.fi-radio-button_icon_wrapper,
+.c1.fi-table .fi-table_table .fi-table_td .fi-radio-button .fi-radio-button_input+.fi-radio-button_icon_wrapper {
+  top: 4px;
 }
 
 .c1.fi-table .fi-table_table .fi-table_th {
   background-color: hsl(214, 100%, 24%);
   color: hsl(0, 0%, 100%);
-  line-height: 1.5;
 }
 
 .c1.fi-table .fi-table_table .fi-table_th.checkbox-header {
@@ -460,7 +471,7 @@ exports[`Table functionalities matches snapshot 1`] = `
 
 .c1.fi-table .fi-table_table.fi-table--condensed .fi-table_th,
 .c1.fi-table .fi-table_table.fi-table--condensed .fi-table_td {
-  padding: 15px 20px;
+  padding: 10px 20px;
 }
 
 .c1.fi-table .fi-table_toolbar {


### PR DESCRIPTION
## Description

PR adds `enableSingleRowSelection` prop to Table to allow a single row to be selected via radio buttons.

Also fix some vertical alignment issues (mainly Safari) by increasing cell line height to 2 and decreasing padding.

## How Has This Been Tested?

Styleguidist macOS Chrome + Safari

## Release notes

### Table
- Add `enableSingleRowSelection` prop
- Fix cell height and alignment issues


