### PR TITLE
[Bugfix] Missing Link theme object

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,19 +16,27 @@ const typesTsConfig = {
 
 const output = {
   js: [
-    { dir: 'dist/cjs', format: 'cjs', preserveModules: true, sourcemap: true },
+    {
+      dir: 'dist/cjs',
+      format: 'cjs',
+      preserveModules: true,
+      sourcemap: true,
+      interop: 'auto',
+    },
     {
       dir: 'dist/esm',
       format: 'es',
       preserveModules: true,
       exports: 'named',
       sourcemap: true,
+      interop: 'auto',
     },
   ],
   types: [
     {
       file: 'dist/tmp/index.js',
       format: 'cjs',
+      interop: 'auto',
     },
   ],
   css: [{}],

--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -261,6 +261,10 @@ exports[`calling render with the same component on the same container does not r
   transform: translateY(0.15em);
 }
 
+.c7.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c7.fi-link.fi-link--small {
   font-size: 16px;
 }

--- a/src/core/Form/ErrorSummary/__snapshots__/ErrorSummary.test.tsx.snap
+++ b/src/core/Form/ErrorSummary/__snapshots__/ErrorSummary.test.tsx.snap
@@ -404,6 +404,10 @@ exports[`snapshots match minimal implementation 1`] = `
   transform: translateY(0.15em);
 }
 
+.c7.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c7.fi-link.fi-link--small {
   font-size: 16px;
 }
@@ -980,6 +984,10 @@ exports[`snapshots match smallScreen styles 1`] = `
   margin-left: -3px;
   margin-right: 2px;
   transform: translateY(0.15em);
+}
+
+.c7.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
 }
 
 .c7.fi-link.fi-link--small {

--- a/src/core/Link/BaseLink/BaseLink.baseStyles.ts
+++ b/src/core/Link/BaseLink/BaseLink.baseStyles.ts
@@ -48,6 +48,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         margin-left: -3px;
         margin-right: 2px;
         transform: translateY(0.15em);
+        & .fi-icon-base-fill {
+          fill: ${theme.colors.accentBase};
+        }
       }
     }
     &.fi-link--small {

--- a/src/core/Link/ExternalLink/ExternalLink.tsx
+++ b/src/core/Link/ExternalLink/ExternalLink.tsx
@@ -78,10 +78,7 @@ class BaseExternalLink extends Component<ExternalLinkProps & SuomifiThemeProp> {
         as={asProp}
       >
         {variant === 'accent' && (
-          <IconChevronRight
-            color={theme.colors.accentBase}
-            className={linkClassNames.accentIcon}
-          />
+          <IconChevronRight className={linkClassNames.accentIcon} />
         )}
         {children}
         {toNewWindow && <VisuallyHidden>{labelNewWindow}</VisuallyHidden>}

--- a/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
+++ b/src/core/Link/ExternalLink/__snapshots__/ExternalLink.test.tsx.snap
@@ -165,6 +165,10 @@ exports[`matches snapshot 1`] = `
   transform: translateY(0.15em);
 }
 
+.c1.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c1.fi-link.fi-link--small {
   font-size: 16px;
 }

--- a/src/core/Link/Link/Link.tsx
+++ b/src/core/Link/Link/Link.tsx
@@ -52,10 +52,7 @@ const StyledLink = styled(
         style={{ ...passProps?.style }}
       >
         {variant === 'accent' && (
-          <IconChevronRight
-            color={theme.colors.accentBase}
-            className={linkClassNames.accentIcon}
-          />
+          <IconChevronRight className={linkClassNames.accentIcon} />
         )}
         {children}
       </HtmlA>

--- a/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/core/Link/Link/__snapshots__/Link.test.tsx.snap
@@ -102,6 +102,10 @@ exports[`calling render with the same component on the same container does not r
   transform: translateY(0.15em);
 }
 
+.c1.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c1.fi-link.fi-link--small {
   font-size: 16px;
 }

--- a/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
+++ b/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
@@ -329,6 +329,10 @@ exports[`Simple link list with one item should match snapshot 1`] = `
   transform: translateY(0.15em);
 }
 
+.c7.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c7.fi-link.fi-link--small {
   font-size: 16px;
 }

--- a/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
+++ b/src/core/Link/RouterLink/__snapshots__/RouterLink.test.tsx.snap
@@ -102,6 +102,10 @@ exports[`calling render with the same component on the same container does not r
   transform: translateY(0.15em);
 }
 
+.c1.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c1.fi-link.fi-link--small {
   font-size: 16px;
 }

--- a/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
+++ b/src/core/Link/SkipLink/__snapshots__/SkipLink.test.tsx.snap
@@ -102,6 +102,10 @@ exports[`should match snapshot 1`] = `
   transform: translateY(0.15em);
 }
 
+.c1.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c1.fi-link.fi-link--small {
   font-size: 16px;
 }
@@ -170,6 +174,10 @@ exports[`should match snapshot 1`] = `
   margin-left: -3px;
   margin-right: 2px;
   transform: translateY(0.15em);
+}
+
+.c2.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
 }
 
 .c2.fi-link.fi-link--small {

--- a/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
+++ b/src/core/Navigation/ServiceNavigation/ServiceNavigation/__snapshots__/ServiceNavigation.test.tsx.snap
@@ -452,6 +452,10 @@ exports[`should match snapshot 1`] = `
   transform: translateY(0.15em);
 }
 
+.c10.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c10.fi-link.fi-link--small {
   font-size: 16px;
 }
@@ -527,6 +531,10 @@ exports[`should match snapshot 1`] = `
   margin-left: -3px;
   margin-right: 2px;
   transform: translateY(0.15em);
+}
+
+.c7.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
 }
 
 .c7.fi-link.fi-link--small {

--- a/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
+++ b/src/core/Navigation/SideNavigation/SideNavigation/__snapshots__/SideNavigation.test.tsx.snap
@@ -565,6 +565,10 @@ exports[`calling render with the same component on the same container does not r
   transform: translateY(0.15em);
 }
 
+.c11.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c11.fi-link.fi-link--small {
   font-size: 16px;
 }
@@ -640,6 +644,10 @@ exports[`calling render with the same component on the same container does not r
   margin-left: -3px;
   margin-right: 2px;
   transform: translateY(0.15em);
+}
+
+.c9.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
 }
 
 .c9.fi-link.fi-link--small {

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -692,6 +692,10 @@ exports[`calling render with the same component on the same container does not r
   transform: translateY(0.15em);
 }
 
+.c8.fi-link.fi-link--accent .fi-link--accent_icon .fi-icon-base-fill {
+  fill: hsl(23, 82%, 50%);
+}
+
 .c8.fi-link.fi-link--small {
   font-size: 16px;
 }

--- a/src/reset/HtmlMark/HtmlMark.tsx
+++ b/src/reset/HtmlMark/HtmlMark.tsx
@@ -1,5 +1,5 @@
 import { HTMLProps } from 'react';
-import { default as styled, css } from 'styled-components';
+import { styled, css } from 'styled-components';
 import { resets } from '../utils';
 
 export interface HtmlMarkProps extends HTMLProps<HTMLElement> {}


### PR DESCRIPTION
## Description
After updating dependencies, an issue appeared, where project builds would fail with an error referring to a missing theme object. It seems that somehow updating styled-components broke passing theme object down from the `styled` level of the components to the underlying JSX code. Link components used the theme to provide a color for the accent icon when used which caused the error.

This PR changes the styling of the icons to use CSS instead, which seems to fix the issue.

In addition, this PR fixes the styled import syntax on recently added HtmlMark component  and adds an `interop: 'auto'` setting to the rollup config to improve CJS compatibility.

## Motivation and Context
This was a major bug which needed to be fixed.

## How Has This Been Tested?
Tested locally on styleguidist on chrome, on DS-site where this error manifested without the fix. Also tested by a third party project where this issue was found.

## Release notes
### General
- Improve commonJS support
### Link, LinkExternal, RouterLink
- Set accent icon color in CSS instead of JSX
