### PR TITLE
[Feature] FileInput controlled state without file data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ version: 2.1
 executors:
   build-executor:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:20.18.2 # This is a workaround before node 22 support is sorted
 
 commands:
   checkout_and_cache:
     steps:
       - checkout
-      - run: 
+      - run:
           name: Node version
           command: node --version
       - restore_cache: # special step to restore the dependency cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   build-executor:
     docker:
-      - image: cimg/node:20.18.2 # This is a workaround before node 22 support is sorted
+      - image: cimg/node:lts
 
 commands:
   checkout_and_cache:

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -339,7 +339,7 @@ const mockedItems = [
 
 If you want to handle the file data without saving it to the component state, you can opt to provide only the necessary metadata to show the file in the component/list. You can then handle the file data as you want when saving the form.
 
-Provide at least `fileName`, `fileType` and `fileSize` as the metadata of the controlled value object. File previews can also be handled either by providing a `fileURL` in the metadata or a `filePreviewOnClick` in the `ControlledFileItem` object.
+Provide at least `fileName`, `fileType` and `fileSize` as the metadata of the controlled value object. File previews can also be handled either by providing a `fileURL` or a `filePreviewOnClick` in the `ControlledFileItem` object.
 
 The interface for the metadata is as follows:
 
@@ -440,6 +440,7 @@ const customSaveFunction = (files) => {
     value={controlledValue}
     filePreview
     multiFile
+    multiFileListHeadingText="Added files"
   />
 </div>;
 ```

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -407,7 +407,7 @@ const customSaveFunction = (files) => {
         fileSize: file.size,
         fileType: file.type
       },
-      buttonOnClick: (file) => {
+      buttonOnClick: () => {
         // Filter out the item based on id
         setControlledValue((prevValue) =>
           prevValue.filter(

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -332,6 +332,79 @@ const mockedItems = [
 </div>;
 ```
 
+### Controlled items with custom data handling
+
+If you want to handle the file data without saving it to the component state, you can opt to provide only the necessary metadata to show the file in the component/list. You can then handle the file data as you want when saving the form. File previews can also be handled either by providing a `fileURL` or `filePreviewCallback` in the metadata.
+
+```jsx
+import { FileInput } from 'suomifi-ui-components';
+import React, { useState } from 'react';
+
+const [statusText, setStatusText] = useState('');
+const [status, setStatus] = useState('default');
+const [controlledValue, setControlledValue] = useState([]);
+
+const validateFiles = (newFileList) => {
+  console.log(newFileList);
+  const filesAsArray = Array.from(newFileList);
+  let invalidFileFound = false;
+  let errorText = '';
+  if (filesAsArray.length > 0) {
+    // TODO: apply for multiple files
+    const file = filesAsArray[0];
+    if (file.size > 1000000) {
+      errorText += 'File size must be less than 1 megabytes.';
+      invalidFileFound = true;
+    }
+  }
+  if (invalidFileFound) {
+    setStatus('error');
+    setStatusText(errorText);
+  } else {
+    setStatus('default');
+    setStatusText('');
+    filesAsArray.length > 0
+      ? customSaveFunction(filesAsArray)
+      : setControlledValue([]);
+  }
+};
+
+const customSaveFunction = (files) => {
+  const pseudoFiles = [];
+  files.forEach((file) => {
+    const fileMetaData = {
+      metadata: {
+        fileName: file.name,
+        fileSize: file.size,
+        fileType: file.type,
+        filePreviewCallBack: () =>
+          // Fetch the file from wherever you store it
+          console.log(`Fetching file ${file.name} from backend`)
+      }
+    };
+    pseudoFiles.push(fileMetaData);
+    // Save actual file data however you want
+  });
+  setControlledValue(pseudoFiles);
+};
+
+<div style={{ width: 600 }}>
+  <FileInput
+    labelText="Resume"
+    inputButtonText="Choose file"
+    dragAreaText="Choose file or drag and drop here"
+    removeFileText="Remove"
+    addedFileAriaText="Added file: "
+    hintText="Use the pdf file format. Maximum file size is 1 MB"
+    status={status}
+    statusText={statusText}
+    onChange={validateFiles}
+    value={controlledValue}
+    filePreview
+  />
+</div>;
+```
+
 ### Accessing the input with ref
 
 The component's ref points to the underlying `<input type="file">` element and can thus be used to access the component's value as well as setting focus to it.

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -349,7 +349,6 @@ const [status, setStatus] = useState('default');
 const [controlledValue, setControlledValue] = useState([]);
 
 const validateFiles = (newFileList) => {
-  console.log(newFileList);
   const filesArray = Array.from(newFileList);
   let invalidFileFound = false;
   let errorText = '';
@@ -375,17 +374,26 @@ const validateFiles = (newFileList) => {
 const customSaveFunction = (files) => {
   const pseudoFiles = [];
   files.forEach((file) => {
-    const fileMetaData = {
+    const fileItemData = {
       metadata: {
+        id: `${Math.random().toString(36).substring(2, 15)}`,
         fileName: file.name,
         fileSize: file.size,
         fileType: file.type,
         filePreviewCallBack: () =>
           // Fetch the file from wherever you store it
           console.log(`Fetching file ${file.name} from backend`)
+      },
+      buttonOnClick: (file) => {
+        // Filter out the item based on id
+        setControlledValue((prevValue) =>
+          prevValue.filter(
+            (item) => item.metadata.id !== fileItemData.metadata.id
+          )
+        );
       }
     };
-    pseudoFiles.push(fileMetaData);
+    pseudoFiles.push(fileItemData);
     // Save actual file data however you want
   });
   setControlledValue(pseudoFiles);
@@ -404,6 +412,7 @@ const customSaveFunction = (files) => {
     onChange={validateFiles}
     value={controlledValue}
     filePreview
+    multiFile
   />
 </div>;
 ```

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -373,6 +373,7 @@ const [status, setStatus] = useState('default');
 const [controlledValue, setControlledValue] = useState([]);
 
 const validateFiles = (newFileList) => {
+  if (newFileList.length === 0) return;
   const filesArray = Array.from(newFileList);
   let invalidFileFound = false;
   let errorText = 'File size must be less than 1 megabytes ';
@@ -418,14 +419,10 @@ const customSaveFunction = (files) => {
         // Fetch the file from wherever you store it
         console.log(`Fetching file ${file.name} from backend`)
     };
-    pseudoFiles.push(
-      controlledValue.find(
-        (item) => item.metadata.fileName === file.name
-      ) || fileItemData
-    );
+    pseudoFiles.push(fileItemData);
     // Save actual file data however you want
   });
-  setControlledValue(pseudoFiles);
+  setControlledValue((prevValue) => [...prevValue, ...pseudoFiles]);
 };
 
 <div style={{ width: 600 }}>

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -182,6 +182,8 @@ interface ControlledFileItem {
   buttonIcon?: ReactElement;
   // Override default remove button behavior
   buttonOnClick?: (file) => void;
+  // File metadata for when you want to save the file outside the component state
+  metadata: Metadata;
 }
 ```
 
@@ -334,7 +336,9 @@ const mockedItems = [
 
 ### Controlled items with custom data handling
 
-If you want to handle the file data without saving it to the component state, you can opt to provide only the necessary metadata to show the file in the component/list. You can then handle the file data as you want when saving the form. File previews can also be handled either by providing a `fileURL` or `filePreviewCallback` in the metadata.
+If you want to handle the file data without saving it to the component state, you can opt to provide only the necessary metadata to show the file in the component/list. You can then handle the file data as you want when saving the form.
+
+Provide at least `fileName`, `fileType` and `fileSize` as the metadata of the controlled value object. File previews can also be handled either by providing a `fileURL` or `filePreviewCallback` in the metadata.
 
 ```jsx
 import { FileInput } from 'suomifi-ui-components';
@@ -346,12 +350,11 @@ const [controlledValue, setControlledValue] = useState([]);
 
 const validateFiles = (newFileList) => {
   console.log(newFileList);
-  const filesAsArray = Array.from(newFileList);
+  const filesArray = Array.from(newFileList);
   let invalidFileFound = false;
   let errorText = '';
-  if (filesAsArray.length > 0) {
-    // TODO: apply for multiple files
-    const file = filesAsArray[0];
+  if (filesArray.length > 0) {
+    const file = filesArray[0];
     if (file.size > 1000000) {
       errorText += 'File size must be less than 1 megabytes.';
       invalidFileFound = true;
@@ -363,8 +366,8 @@ const validateFiles = (newFileList) => {
   } else {
     setStatus('default');
     setStatusText('');
-    filesAsArray.length > 0
-      ? customSaveFunction(filesAsArray)
+    filesArray.length > 0
+      ? customSaveFunction(filesArray)
       : setControlledValue([]);
   }
 };

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -8,7 +8,8 @@ Examples:
 - [Small screen](./#/Components/FileInput?id=small-screen)
 - [Non-controlled validation](./#/Components/FileInput?id=non-controlled-validation)
 - [Controlled state](./#/Components/FileInput?id=controlled-state)
-- [Controlled items metadata](./#/Components/FileInput?id=controlled-items-metadata)
+- [Controlled items status](./#/Components/FileInput?id=controlled-items-status)
+- [Controlled items with custom data handling](./#/FileInput?id=controlled-items-with-custom-data-handling)
 - [Accessing the input with ref](./#/Components/FileInput?id=accessing-the-input-with-ref)
 - [Full width](./#/Components/FileInput?id=full-width)
 - [Hidden label](./#/Components/FileInput?id=hidden-label)
@@ -239,7 +240,7 @@ const validateFiles = (newFileList) => {
 </div>;
 ```
 
-### Controlled items metadata
+### Controlled items status
 
 Below is a static example of the different, more granularly controlled items that can be provided as controlled value.
 
@@ -338,7 +339,34 @@ const mockedItems = [
 
 If you want to handle the file data without saving it to the component state, you can opt to provide only the necessary metadata to show the file in the component/list. You can then handle the file data as you want when saving the form.
 
-Provide at least `fileName`, `fileType` and `fileSize` as the metadata of the controlled value object. File previews can also be handled either by providing a `fileURL` or `filePreviewCallback` in the metadata.
+Provide at least `fileName`, `fileType` and `fileSize` as the metadata of the controlled value object. File previews can also be handled either by providing a `fileURL` in the metadata or a `filePreviewOnClick` in the `ControlledFileItem` object.
+
+The interface for the metadata is as follows:
+
+```jsx static
+export interface Metadata {
+  /**
+   * The size of the file in bytes.
+   */
+  fileSize: number;
+  /**
+   * The name of the file.
+   */
+  fileName: string;
+  /**
+   * The type of the file
+   */
+  fileType: string;
+  /**
+   * URL to the file
+   */
+  fileURL?: string;
+  /**
+   * id of the file
+   */
+  id?: string;
+}
+```
 
 ```jsx
 import { FileInput } from 'suomifi-ui-components';
@@ -380,10 +408,7 @@ const customSaveFunction = (files) => {
         id: `${Math.random().toString(36).substring(2, 15)}`,
         fileName: file.name,
         fileSize: file.size,
-        fileType: file.type,
-        filePreviewCallBack: () =>
-          // Fetch the file from wherever you store it
-          console.log(`Fetching file ${file.name} from backend`)
+        fileType: file.type
       },
       buttonOnClick: (file) => {
         // Filter out the item based on id
@@ -392,7 +417,10 @@ const customSaveFunction = (files) => {
             (item) => item.metadata.id !== fileItemData.metadata.id
           )
         );
-      }
+      },
+      filePreviewOnClick: () =>
+        // Fetch the file from wherever you store it
+        console.log(`Fetching file ${file.name} from backend`)
     };
     pseudoFiles.push(
       controlledValue.find(

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -416,9 +416,7 @@ const customSaveFunction = (files) => {
       },
       filePreviewOnClick: () =>
         // Fetch the file from wherever you store it
-        console.log(`Fetching file ${file.name} from backend`),
-      wrapperRef:
-        files.indexOf(file) === files.length - 1 ? testRef : undefined
+        console.log(`Fetching file ${file.name} from backend`)
     };
     pseudoFiles.push(
       controlledValue.find(

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -358,10 +358,6 @@ export interface Metadata {
    */
   fileType: string;
   /**
-   * URL to the file
-   */
-  fileURL?: string;
-  /**
    * id of the file
    */
   id?: string;
@@ -420,7 +416,9 @@ const customSaveFunction = (files) => {
       },
       filePreviewOnClick: () =>
         // Fetch the file from wherever you store it
-        console.log(`Fetching file ${file.name} from backend`)
+        console.log(`Fetching file ${file.name} from backend`),
+      wrapperRef:
+        files.indexOf(file) === files.length - 1 ? testRef : undefined
     };
     pseudoFiles.push(
       controlledValue.find(

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -400,6 +400,7 @@ const validateFiles = (newFileList) => {
 const customSaveFunction = (files) => {
   const pseudoFiles = [];
   files.forEach((file) => {
+    // Create a metadata object based on file
     const fileItemData = {
       metadata: {
         id: `${Math.random().toString(36).substring(2, 15)}`,

--- a/src/core/Form/FileInput/FileInput.md
+++ b/src/core/Form/FileInput/FileInput.md
@@ -351,14 +351,15 @@ const [controlledValue, setControlledValue] = useState([]);
 const validateFiles = (newFileList) => {
   const filesArray = Array.from(newFileList);
   let invalidFileFound = false;
-  let errorText = '';
-  if (filesArray.length > 0) {
-    const file = filesArray[0];
+  let errorText = 'File size must be less than 1 megabytes ';
+
+  filesArray.forEach((file) => {
     if (file.size > 1000000) {
-      errorText += 'File size must be less than 1 megabytes.';
+      errorText += `(${file.name}) `;
       invalidFileFound = true;
     }
-  }
+  });
+
   if (invalidFileFound) {
     setStatus('error');
     setStatusText(errorText);
@@ -393,7 +394,11 @@ const customSaveFunction = (files) => {
         );
       }
     };
-    pseudoFiles.push(fileItemData);
+    pseudoFiles.push(
+      controlledValue.find(
+        (item) => item.metadata.fileName === file.name
+      ) || fileItemData
+    );
     // Save actual file data however you want
   });
   setControlledValue(pseudoFiles);

--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -280,7 +280,7 @@ const BaseFileInput = (props: InternalFileInputProps) => {
         const blob = new Blob([], { type: fileType });
         const file = new File([blob], fileName, {
           type: fileType,
-          lastModified: Date.now(),
+          lastModified: -1,
         });
         newFileList.items.add(file);
       }
@@ -346,7 +346,13 @@ const BaseFileInput = (props: InternalFileInputProps) => {
       setFilesToStateAndInput(newFileList.files);
     }
     if (propOnChange) {
-      propOnChange(newFileList.files || new FileList());
+      const filteredFiles = Array.from(newFileList.files).filter(
+        (file) => file.lastModified !== -1,
+      );
+      const filteredFileList = new DataTransfer();
+      filteredFiles.forEach((file) => filteredFileList.items.add(file));
+      console.log('Changed files:', filteredFileList.files);
+      propOnChange(filteredFileList.files || new FileList());
     }
   };
 
@@ -474,38 +480,47 @@ const BaseFileInput = (props: InternalFileInputProps) => {
   const handleOnChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newFileList = new DataTransfer();
     const filesFromEvent = event.target.files;
-    if (!controlledValue) {
-      if (multiFile) {
-        const previousAndNewFiles = Array.from(files || []).concat(
-          Array.from(filesFromEvent || []),
+
+    if (filesFromEvent && filesFromEvent.length > 0) {
+      if (!controlledValue) {
+        if (multiFile) {
+          const previousAndNewFiles = Array.from(files || []).concat(
+            Array.from(filesFromEvent || []),
+          );
+          previousAndNewFiles.forEach((file) => {
+            newFileList.items.add(file);
+          });
+        } else {
+          const filesFromEventArr = Array.from(filesFromEvent || []);
+          filesFromEventArr.forEach((file) => {
+            newFileList.items.add(file);
+          });
+        }
+        setFilesToStateAndInput(newFileList.files);
+      } else if (inputRef.current) {
+        const controlledValueAsArray = Array.from(
+          buildFileListFromControlledValueObjects(controlledValue) || [],
         );
-        previousAndNewFiles.forEach((file) => {
+        const controlledFileList = new DataTransfer();
+        controlledValueAsArray.forEach((file) => {
+          controlledFileList.items.add(file);
           newFileList.items.add(file);
         });
-      } else {
+        inputRef.current.files = controlledFileList.files;
         const filesFromEventArr = Array.from(filesFromEvent || []);
         filesFromEventArr.forEach((file) => {
           newFileList.items.add(file);
         });
       }
-      setFilesToStateAndInput(newFileList.files);
-    } else if (inputRef.current) {
-      const controlledValueAsArray = Array.from(
-        buildFileListFromControlledValueObjects(controlledValue) || [],
-      );
-      const controlledFileList = new DataTransfer();
-      controlledValueAsArray.forEach((file) => {
-        controlledFileList.items.add(file);
-        newFileList.items.add(file);
-      });
-      inputRef.current.files = controlledFileList.files;
-      const filesFromEventArr = Array.from(filesFromEvent || []);
-      filesFromEventArr.forEach((file) => {
-        newFileList.items.add(file);
-      });
-    }
-    if (propOnChange) {
-      propOnChange(newFileList.files);
+      if (propOnChange) {
+        const filteredFiles = Array.from(newFileList.files).filter(
+          (file) => file.lastModified !== -1,
+        );
+        const filteredFileList = new DataTransfer();
+        filteredFiles.forEach((file) => filteredFileList.items.add(file));
+        console.log('Changed files:', filteredFileList.files);
+        propOnChange(filteredFileList.files);
+      }
     }
   };
 

--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -191,13 +191,17 @@ type Metadata = {
    */
   fileName: string;
   /**
+   * The type of the file
+   */
+  fileType: string;
+  /**
    * URL to the file
    */
   fileURL?: string;
   /**
-   * The type of the file
+   * id of the file
    */
-  fileType: string;
+  id?: string;
   /**
    * Callback for when file preview link is clicked
    */

--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -150,7 +150,11 @@ export interface ControlledFileItem {
   /**
    * The actual file object.
    */
-  file: File;
+  file?: File;
+  /**
+   * Additional metadata for the file.
+   */
+  metadata?: MetaData;
   /**
    * Status of the element. Affects styling.
    */
@@ -174,8 +178,23 @@ export interface ControlledFileItem {
   /**
    * Override default remove button behavior.
    */
-  buttonOnClick?: (file: File) => void;
+  buttonOnClick?: (file: any) => void;
 }
+
+type MetaData = {
+  /**
+   * The size of the file in bytes.
+   */
+  fileSize: number;
+  /**
+   * The name of the file.
+   */
+  fileName: string;
+  /**
+   * URL to the file
+   */
+  fileURL: string;
+};
 
 type InternalFileInputProps = FileInputProps & GlobalMarginProps;
 
@@ -237,7 +256,9 @@ const BaseFileInput = (props: InternalFileInputProps) => {
   ) => {
     const newFileList = new DataTransfer();
     controlledValueObjects.forEach((fileItem) => {
-      newFileList.items.add(fileItem.file);
+      if (fileItem.file) {
+        newFileList.items.add(fileItem.file);
+      }
     });
     return newFileList.files;
   };
@@ -549,7 +570,7 @@ const BaseFileInput = (props: InternalFileInputProps) => {
                   removeFileText={removeFileText}
                   removeFile={removeFile}
                   smallScreen={smallScreen}
-                  metaData={controlledValue && controlledValue[0]}
+                  fileItemProps={controlledValue && controlledValue[0]}
                 />
               </HtmlDiv>
             )}
@@ -584,7 +605,7 @@ const BaseFileInput = (props: InternalFileInputProps) => {
                   removeFileText={removeFileText}
                   removeFile={removeFile}
                   smallScreen={smallScreen}
-                  metaData={controlledValue && controlledValue[index]}
+                  fileItemProps={controlledValue && controlledValue[index]}
                 />
               ))}
             </HtmlDiv>

--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -185,7 +185,7 @@ export interface ControlledFileItem {
   filePreviewOnClick?: () => void;
 }
 
-type Metadata = {
+export interface Metadata {
   /**
    * The size of the file in bytes.
    */
@@ -206,7 +206,7 @@ type Metadata = {
    * id of the file
    */
   id?: string;
-};
+}
 
 type InternalFileInputProps = FileInputProps & GlobalMarginProps;
 

--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -183,6 +183,10 @@ export interface ControlledFileItem {
    * Callback for when file preview link is clicked
    */
   filePreviewOnClick?: () => void;
+  /**
+   * URL to the file. Used in the file preview link. Secondary to `filePreviewOnClick`
+   */
+  fileURL?: string;
 }
 
 export interface Metadata {

--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -351,7 +351,6 @@ const BaseFileInput = (props: InternalFileInputProps) => {
       );
       const filteredFileList = new DataTransfer();
       filteredFiles.forEach((file) => filteredFileList.items.add(file));
-      console.log('Changed files:', filteredFileList.files);
       propOnChange(filteredFileList.files || new FileList());
     }
   };
@@ -518,7 +517,6 @@ const BaseFileInput = (props: InternalFileInputProps) => {
         );
         const filteredFileList = new DataTransfer();
         filteredFiles.forEach((file) => filteredFileList.items.add(file));
-        console.log('Changed files:', filteredFileList.files);
         propOnChange(filteredFileList.files);
       }
     }

--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -154,7 +154,7 @@ export interface ControlledFileItem {
   /**
    * Additional metadata for the file.
    */
-  metadata?: MetaData;
+  metadata?: Metadata;
   /**
    * Status of the element. Affects styling.
    */
@@ -178,10 +178,10 @@ export interface ControlledFileItem {
   /**
    * Override default remove button behavior.
    */
-  buttonOnClick?: (file: any) => void;
+  buttonOnClick?: () => void;
 }
 
-type MetaData = {
+type Metadata = {
   /**
    * The size of the file in bytes.
    */
@@ -587,7 +587,7 @@ const BaseFileInput = (props: InternalFileInputProps) => {
                   removeFileText={removeFileText}
                   removeFile={removeFile}
                   smallScreen={smallScreen}
-                  fileItemProps={controlledValue && controlledValue[0]}
+                  fileItemDetails={controlledValue && controlledValue[0]}
                 />
               </HtmlDiv>
             )}
@@ -622,7 +622,7 @@ const BaseFileInput = (props: InternalFileInputProps) => {
                   removeFileText={removeFileText}
                   removeFile={removeFile}
                   smallScreen={smallScreen}
-                  fileItemProps={controlledValue && controlledValue[index]}
+                  fileItemDetails={controlledValue && controlledValue[index]}
                 />
               ))}
             </HtmlDiv>

--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -179,6 +179,10 @@ export interface ControlledFileItem {
    * Override default remove button behavior.
    */
   buttonOnClick?: () => void;
+  /**
+   * Callback for when file preview link is clicked
+   */
+  filePreviewOnClick?: () => void;
 }
 
 type Metadata = {
@@ -202,10 +206,6 @@ type Metadata = {
    * id of the file
    */
   id?: string;
-  /**
-   * Callback for when file preview link is clicked
-   */
-  filePreviewCallBack?: () => void;
 };
 
 type InternalFileInputProps = FileInputProps & GlobalMarginProps;

--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -193,7 +193,15 @@ type MetaData = {
   /**
    * URL to the file
    */
-  fileURL: string;
+  fileURL?: string;
+  /**
+   * The type of the file
+   */
+  fileType: string;
+  /**
+   * Callback for when file preview link is clicked
+   */
+  filePreviewCallBack?: () => void;
 };
 
 type InternalFileInputProps = FileInputProps & GlobalMarginProps;
@@ -258,6 +266,15 @@ const BaseFileInput = (props: InternalFileInputProps) => {
     controlledValueObjects.forEach((fileItem) => {
       if (fileItem.file) {
         newFileList.items.add(fileItem.file);
+      } else if (fileItem.metadata) {
+        // Create a new mock file from metadata
+        const { fileName, fileType } = fileItem.metadata;
+        const blob = new Blob([], { type: fileType });
+        const file = new File([blob], fileName, {
+          type: fileType,
+          lastModified: Date.now(),
+        });
+        newFileList.items.add(file);
       }
     });
     return newFileList.files;

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -21,7 +21,7 @@ interface FileItemProps {
   fileItemRefs: FileItemRefs;
   addedFileAriaText: string;
   removeFileText: ReactNode;
-  removeFile: (file: any) => void;
+  removeFile: (file: File) => void;
   smallScreen: boolean;
   fileItemDetails?: ControlledFileItem;
 }
@@ -168,8 +168,8 @@ const BaseFileItem = (props: FileItemProps) => {
           onClick={() => {
             if (fileItemDetails?.buttonOnClick) {
               fileItemDetails.buttonOnClick();
-            } else {
-              removeFile(file || fileItemDetails?.metadata);
+            } else if (file) {
+              removeFile(file);
             }
           }}
           aria-label={`${

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -53,8 +53,8 @@ const BaseFileItem = (props: FileItemProps) => {
   } = props;
 
   const {
-    fileName: metaDataFileName,
-    fileSize: metaDataFileSize,
+    fileName: metadataFileName,
+    fileSize: metadataFileSize,
     fileURL: metadataFileURL,
     filePreviewCallBack: metadataFilePreviewCallBack,
   } = fileItemDetails?.metadata || {};
@@ -66,11 +66,8 @@ const BaseFileItem = (props: FileItemProps) => {
     return '';
   };
 
-  console.log('fileItemDetails', fileItemDetails);
-  console.log('file: ', file);
-
   const getFileSizeText = () => {
-    const fileSize = file?.size || metaDataFileSize;
+    const fileSize = file?.size || metadataFileSize;
     if (!fileSize) {
       return '';
     }
@@ -97,12 +94,12 @@ const BaseFileItem = (props: FileItemProps) => {
       fileItemDetails?.status !== 'loading' &&
       !fileItemDetails?.ariaLoadingText
     ) {
-      return `${addedFileAriaText} ${file?.name || metaDataFileName} ${
+      return `${addedFileAriaText} ${file?.name || metadataFileName} ${
         fileItemDetails?.errorText ? fileItemDetails.errorText : ''
       }`;
     }
     return `${fileItemDetails?.ariaLoadingText} ${
-      file?.name || metaDataFileName
+      file?.name || metadataFileName
     }`;
   };
 
@@ -137,7 +134,7 @@ const BaseFileItem = (props: FileItemProps) => {
                 }
               }}
             >
-              {file?.name || metaDataFileName}
+              {file?.name || metadataFileName}
             </Link>
           ) : (
             <HtmlDivWithRef
@@ -148,7 +145,7 @@ const BaseFileItem = (props: FileItemProps) => {
               aria-label={getFileAriaLabel()}
               aria-describedby={fileItemRefs.fileSizeElementId}
             >
-              {file?.name || metaDataFileName}
+              {file?.name || metadataFileName}
             </HtmlDivWithRef>
           )}
           <HtmlDiv
@@ -180,7 +177,7 @@ const BaseFileItem = (props: FileItemProps) => {
             fileItemDetails?.buttonText
               ? fileItemDetails.buttonText
               : removeFileText
-          } ${file?.name || metaDataFileName}`}
+          } ${file?.name || metadataFileName}`}
           className={fileItemClassNames.removeFileButton}
           ref={fileItemRefs.removeButtonRef}
         >

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -53,12 +53,21 @@ const BaseFileItem = (props: FileItemProps) => {
   } = props;
 
   const {
-    fileSize: metaDataFileName,
+    fileName: metaDataFileName,
     fileSize: metaDataFileSize,
     fileURL: metadataFileURL,
+    filePreviewCallBack: metadataFilePreviewCallBack,
   } = fileItemProps?.metadata || {};
 
+  const getPreviewLinkHref = () => {
+    if (metadataFilePreviewCallBack) return '';
+    if (metadataFileURL) return metadataFileURL;
+    if (file) return URL.createObjectURL(file);
+    return '';
+  };
+
   console.log('fileItemProps', fileItemProps);
+  console.log('file: ', file);
 
   const getFileSizeText = () => {
     const fileSize = file?.size || metaDataFileSize;
@@ -113,14 +122,18 @@ const BaseFileItem = (props: FileItemProps) => {
           {!fileItemProps?.status && <IconGenericFile />}
           {filePreview ? (
             <Link
+              asProp={metadataFilePreviewCallBack ? 'button' : undefined}
               ref={
                 fileItemRefs.fileNameRef as React.RefObject<HTMLAnchorElement>
               }
-              href={file ? URL.createObjectURL(file) : metadataFileURL || ''}
+              href={getPreviewLinkHref()}
               className={classnames(fileItemClassNames.fileName, 'is-link')}
               target="_blank"
               aria-label={getFileAriaLabel()}
               aria-describedby={fileItemRefs.fileSizeElementId}
+              onClick={() =>
+                metadataFilePreviewCallBack && metadataFilePreviewCallBack()
+              }
             >
               {file?.name || metaDataFileName}
             </Link>

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -52,17 +52,15 @@ const BaseFileItem = (props: FileItemProps) => {
     fileItemDetails,
   } = props;
 
-  const {
-    fileName: metadataFileName,
-    fileSize: metadataFileSize,
-    fileURL: metadataFileURL,
-  } = fileItemDetails?.metadata || {};
+  const { fileName: metadataFileName, fileSize: metadataFileSize } =
+    fileItemDetails?.metadata || {};
 
   const filePreviewCallBack = fileItemDetails?.filePreviewOnClick;
+  const fileUrl = fileItemDetails?.fileURL;
 
   const getPreviewLinkHref = () => {
     if (filePreviewCallBack) return '';
-    if (metadataFileURL) return metadataFileURL;
+    if (fileUrl) return fileUrl;
     if (file) return URL.createObjectURL(file);
     return '';
   };

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -23,7 +23,7 @@ interface FileItemProps {
   removeFileText: ReactNode;
   removeFile: (file: any) => void;
   smallScreen: boolean;
-  fileItemProps?: ControlledFileItem;
+  fileItemDetails?: ControlledFileItem;
 }
 
 const baseClassName = 'fi-file-input';
@@ -49,7 +49,7 @@ const BaseFileItem = (props: FileItemProps) => {
     removeFileText,
     removeFile,
     smallScreen,
-    fileItemProps,
+    fileItemDetails,
   } = props;
 
   const {
@@ -57,7 +57,7 @@ const BaseFileItem = (props: FileItemProps) => {
     fileSize: metaDataFileSize,
     fileURL: metadataFileURL,
     filePreviewCallBack: metadataFilePreviewCallBack,
-  } = fileItemProps?.metadata || {};
+  } = fileItemDetails?.metadata || {};
 
   const getPreviewLinkHref = () => {
     if (metadataFilePreviewCallBack) return '';
@@ -66,7 +66,7 @@ const BaseFileItem = (props: FileItemProps) => {
     return '';
   };
 
-  console.log('fileItemProps', fileItemProps);
+  console.log('fileItemDetails', fileItemDetails);
   console.log('file: ', file);
 
   const getFileSizeText = () => {
@@ -84,8 +84,8 @@ const BaseFileItem = (props: FileItemProps) => {
   };
 
   const getButtonText = () => {
-    if (fileItemProps?.buttonText) {
-      return fileItemProps.buttonText;
+    if (fileItemDetails?.buttonText) {
+      return fileItemDetails.buttonText;
     }
     return !multiFile || (multiFile && !smallScreen)
       ? removeFileText
@@ -94,14 +94,14 @@ const BaseFileItem = (props: FileItemProps) => {
 
   const getFileAriaLabel = () => {
     if (
-      fileItemProps?.status !== 'loading' &&
-      !fileItemProps?.ariaLoadingText
+      fileItemDetails?.status !== 'loading' &&
+      !fileItemDetails?.ariaLoadingText
     ) {
       return `${addedFileAriaText} ${file?.name || metaDataFileName} ${
-        fileItemProps?.errorText ? fileItemProps.errorText : ''
+        fileItemDetails?.errorText ? fileItemDetails.errorText : ''
       }`;
     }
-    return `${fileItemProps?.ariaLoadingText} ${
+    return `${fileItemDetails?.ariaLoadingText} ${
       file?.name || metaDataFileName
     }`;
   };
@@ -113,16 +113,15 @@ const BaseFileItem = (props: FileItemProps) => {
     >
       <HtmlDiv className={fileItemClassNames.fileItem}>
         <HtmlDiv className={fileItemClassNames.fileInfo}>
-          {fileItemProps?.status === 'error' && (
+          {fileItemDetails?.status === 'error' && (
             <IconErrorFilled className={fileItemClassNames.errorIcon} />
           )}
-          {fileItemProps?.status === 'loading' && (
+          {fileItemDetails?.status === 'loading' && (
             <IconPreloader className={fileItemClassNames.loadingIcon} />
           )}
-          {!fileItemProps?.status && <IconGenericFile />}
+          {!fileItemDetails?.status && <IconGenericFile />}
           {filePreview ? (
             <Link
-              asProp={metadataFilePreviewCallBack ? 'button' : undefined}
               ref={
                 fileItemRefs.fileNameRef as React.RefObject<HTMLAnchorElement>
               }
@@ -131,9 +130,12 @@ const BaseFileItem = (props: FileItemProps) => {
               target="_blank"
               aria-label={getFileAriaLabel()}
               aria-describedby={fileItemRefs.fileSizeElementId}
-              onClick={() =>
-                metadataFilePreviewCallBack && metadataFilePreviewCallBack()
-              }
+              onClick={(e) => {
+                if (metadataFilePreviewCallBack) {
+                  e.preventDefault();
+                  metadataFilePreviewCallBack();
+                }
+              }}
             >
               {file?.name || metaDataFileName}
             </Link>
@@ -161,22 +163,22 @@ const BaseFileItem = (props: FileItemProps) => {
             smallScreen && !multiFile ? 'secondary' : 'secondaryNoBorder'
           }
           icon={
-            fileItemProps && fileItemProps.buttonIcon ? (
-              fileItemProps.buttonIcon
+            fileItemDetails && fileItemDetails.buttonIcon ? (
+              fileItemDetails.buttonIcon
             ) : (
               <IconRemove />
             )
           }
           onClick={() => {
-            if (fileItemProps?.buttonOnClick) {
-              fileItemProps.buttonOnClick(file || fileItemProps?.metadata);
+            if (fileItemDetails?.buttonOnClick) {
+              fileItemDetails.buttonOnClick();
             } else {
-              removeFile(file || fileItemProps?.metadata);
+              removeFile(file || fileItemDetails?.metadata);
             }
           }}
           aria-label={`${
-            fileItemProps?.buttonText
-              ? fileItemProps.buttonText
+            fileItemDetails?.buttonText
+              ? fileItemDetails.buttonText
               : removeFileText
           } ${file?.name || metaDataFileName}`}
           className={fileItemClassNames.removeFileButton}
@@ -185,9 +187,9 @@ const BaseFileItem = (props: FileItemProps) => {
           {getButtonText()}
         </Button>
       </HtmlDiv>
-      {fileItemProps?.errorText && (
+      {fileItemDetails?.errorText && (
         <HtmlDiv className={fileItemClassNames.fileItemErrorText}>
-          {fileItemProps.errorText}
+          {fileItemDetails.errorText}
         </HtmlDiv>
       )}
     </HtmlDiv>

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -56,18 +56,19 @@ const BaseFileItem = (props: FileItemProps) => {
     fileName: metadataFileName,
     fileSize: metadataFileSize,
     fileURL: metadataFileURL,
-    filePreviewCallBack: metadataFilePreviewCallBack,
   } = fileItemDetails?.metadata || {};
 
+  const filePreviewCallBack = fileItemDetails?.filePreviewOnClick;
+
   const getPreviewLinkHref = () => {
-    if (metadataFilePreviewCallBack) return '';
+    if (filePreviewCallBack) return '';
     if (metadataFileURL) return metadataFileURL;
     if (file) return URL.createObjectURL(file);
     return '';
   };
 
   const getFileSizeText = () => {
-    const fileSize = file?.size || metadataFileSize;
+    const fileSize = metadataFileSize || file?.size;
     if (!fileSize) {
       return '';
     }
@@ -128,9 +129,9 @@ const BaseFileItem = (props: FileItemProps) => {
               aria-label={getFileAriaLabel()}
               aria-describedby={fileItemRefs.fileSizeElementId}
               onClick={(e) => {
-                if (metadataFilePreviewCallBack) {
+                if (filePreviewCallBack) {
                   e.preventDefault();
-                  metadataFilePreviewCallBack();
+                  filePreviewCallBack();
                 }
               }}
             >

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -15,15 +15,15 @@ import { baseStyles } from './FileInput.baseStyles';
 import classnames from 'classnames';
 
 interface FileItemProps {
-  file: File;
+  file?: File;
   filePreview: boolean;
   multiFile: boolean;
   fileItemRefs: FileItemRefs;
   addedFileAriaText: string;
   removeFileText: ReactNode;
-  removeFile: (file: File) => void;
+  removeFile: (file: any) => void;
   smallScreen: boolean;
-  metaData?: ControlledFileItem;
+  fileItemProps?: ControlledFileItem;
 }
 
 const baseClassName = 'fi-file-input';
@@ -49,11 +49,22 @@ const BaseFileItem = (props: FileItemProps) => {
     removeFileText,
     removeFile,
     smallScreen,
-    metaData,
+    fileItemProps,
   } = props;
 
+  const {
+    fileSize: metaDataFileName,
+    fileSize: metaDataFileSize,
+    fileURL: metadataFileURL,
+  } = fileItemProps?.metadata || {};
+
+  console.log('fileItemProps', fileItemProps);
+
   const getFileSizeText = () => {
-    const fileSize = file.size;
+    const fileSize = file?.size || metaDataFileSize;
+    if (!fileSize) {
+      return '';
+    }
     if (fileSize < 1024) {
       return `${fileSize} B`;
     }
@@ -64,8 +75,8 @@ const BaseFileItem = (props: FileItemProps) => {
   };
 
   const getButtonText = () => {
-    if (metaData?.buttonText) {
-      return metaData.buttonText;
+    if (fileItemProps?.buttonText) {
+      return fileItemProps.buttonText;
     }
     return !multiFile || (multiFile && !smallScreen)
       ? removeFileText
@@ -73,12 +84,17 @@ const BaseFileItem = (props: FileItemProps) => {
   };
 
   const getFileAriaLabel = () => {
-    if (metaData?.status !== 'loading' && !metaData?.ariaLoadingText) {
-      return `${addedFileAriaText} ${file.name} ${
-        metaData?.errorText ? metaData.errorText : ''
+    if (
+      fileItemProps?.status !== 'loading' &&
+      !fileItemProps?.ariaLoadingText
+    ) {
+      return `${addedFileAriaText} ${file?.name || metaDataFileName} ${
+        fileItemProps?.errorText ? fileItemProps.errorText : ''
       }`;
     }
-    return `${metaData?.ariaLoadingText} ${file.name}`;
+    return `${fileItemProps?.ariaLoadingText} ${
+      file?.name || metaDataFileName
+    }`;
   };
 
   return (
@@ -88,25 +104,25 @@ const BaseFileItem = (props: FileItemProps) => {
     >
       <HtmlDiv className={fileItemClassNames.fileItem}>
         <HtmlDiv className={fileItemClassNames.fileInfo}>
-          {metaData?.status === 'error' && (
+          {fileItemProps?.status === 'error' && (
             <IconErrorFilled className={fileItemClassNames.errorIcon} />
           )}
-          {metaData?.status === 'loading' && (
+          {fileItemProps?.status === 'loading' && (
             <IconPreloader className={fileItemClassNames.loadingIcon} />
           )}
-          {!metaData?.status && <IconGenericFile />}
+          {!fileItemProps?.status && <IconGenericFile />}
           {filePreview ? (
             <Link
               ref={
                 fileItemRefs.fileNameRef as React.RefObject<HTMLAnchorElement>
               }
-              href={URL.createObjectURL(file)}
+              href={file ? URL.createObjectURL(file) : metadataFileURL || ''}
               className={classnames(fileItemClassNames.fileName, 'is-link')}
               target="_blank"
               aria-label={getFileAriaLabel()}
               aria-describedby={fileItemRefs.fileSizeElementId}
             >
-              {file.name}
+              {file?.name || metaDataFileName}
             </Link>
           ) : (
             <HtmlDivWithRef
@@ -117,7 +133,7 @@ const BaseFileItem = (props: FileItemProps) => {
               aria-label={getFileAriaLabel()}
               aria-describedby={fileItemRefs.fileSizeElementId}
             >
-              {file.name}
+              {file?.name || metaDataFileName}
             </HtmlDivWithRef>
           )}
           <HtmlDiv
@@ -132,31 +148,33 @@ const BaseFileItem = (props: FileItemProps) => {
             smallScreen && !multiFile ? 'secondary' : 'secondaryNoBorder'
           }
           icon={
-            metaData && metaData.buttonIcon ? (
-              metaData.buttonIcon
+            fileItemProps && fileItemProps.buttonIcon ? (
+              fileItemProps.buttonIcon
             ) : (
               <IconRemove />
             )
           }
           onClick={() => {
-            if (metaData?.buttonOnClick) {
-              metaData.buttonOnClick(file);
+            if (fileItemProps?.buttonOnClick) {
+              fileItemProps.buttonOnClick(file || fileItemProps?.metadata);
             } else {
-              removeFile(file);
+              removeFile(file || fileItemProps?.metadata);
             }
           }}
           aria-label={`${
-            metaData?.buttonText ? metaData.buttonText : removeFileText
-          } ${file.name}`}
+            fileItemProps?.buttonText
+              ? fileItemProps.buttonText
+              : removeFileText
+          } ${file?.name || metaDataFileName}`}
           className={fileItemClassNames.removeFileButton}
           ref={fileItemRefs.removeButtonRef}
         >
           {getButtonText()}
         </Button>
       </HtmlDiv>
-      {metaData?.errorText && (
+      {fileItemProps?.errorText && (
         <HtmlDiv className={fileItemClassNames.fileItemErrorText}>
-          {metaData.errorText}
+          {fileItemProps.errorText}
         </HtmlDiv>
       )}
     </HtmlDiv>

--- a/src/core/Form/index.ts
+++ b/src/core/Form/index.ts
@@ -54,4 +54,5 @@ export {
   FileInput,
   type FileInputProps,
   type ControlledFileItem,
+  type Metadata,
 } from './FileInput/FileInput';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,6 +85,7 @@ export {
   FileInput,
   type FileInputProps,
   type ControlledFileItem,
+  type Metadata,
 } from './core/Form';
 export { Heading, type HeadingProps } from './core/Heading/Heading';
 export {


### PR DESCRIPTION
## Description
This PR brings a new feature to FileInput, which allows it to be used in controlled state without having to store the actual file data in the component state. This can be accomplished by providing the component with an object with the necessary metadata, and storing the actual file elsewhere.

## Motivation and Context
This was a request from several projects, where there were forms with possibly tens of files added. Storing the actual file data in the component state got really unoptimal in those cases.

## How Has This Been Tested?
Tested locally on styleguidist on chrome as well as in a React+Vite test project. Also tested in one of the projects that requested this feature.

## Release notes
### FileInput
- File is no longer required in `ControlledFileItem`
  - Providing the necessary metadata for the component is now enough, which provides more flexibility in terms of where to store the file itself 
