### PR TITLE
[Feature] Toast close button

### DIFF
--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -113,10 +113,10 @@ export const baseStyles = (
       }
       & .fi-notification_close-button {
         margin: 3px;
-        padding: 3px 5px 3px 4px;
+        padding: 3px;
 
         & .fi-icon {
-          margin-right: ${theme.spacing.xxs};
+          margin: 0 8px;
           font-size: 16px;
         }
       }

--- a/src/core/Notification/Notification.baseStyles.ts
+++ b/src/core/Notification/Notification.baseStyles.ts
@@ -116,7 +116,7 @@ export const baseStyles = (
         padding: 3px;
 
         & .fi-icon {
-          margin: 0 8px;
+          margin: 0 ${theme.spacing.insetM};
           font-size: 16px;
         }
       }

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -848,11 +848,11 @@ exports[`props children should match snapshot 1`] = `
 
 .c1.fi-notification.fi-notification--small-screen .fi-notification_close-button {
   margin: 3px;
-  padding: 3px 5px 3px 4px;
+  padding: 3px;
 }
 
 .c1.fi-notification.fi-notification--small-screen .fi-notification_close-button .fi-icon {
-  margin-right: 5px;
+  margin: 0 8px;
   font-size: 16px;
 }
 

--- a/src/core/Toast/Toast.baseStyles.tsx
+++ b/src/core/Toast/Toast.baseStyles.tsx
@@ -16,7 +16,6 @@ export const baseStyles = (
   width: 100%;
   box-shadow: ${theme.shadows.wideBoxShadow};
   border-radius: 4px;
-  overflow: hidden;
   &.fi-toast {
     background-color: ${theme.colors.whiteBase};
     & .fi-toast-wrapper {

--- a/src/core/Toast/Toast.baseStyles.tsx
+++ b/src/core/Toast/Toast.baseStyles.tsx
@@ -55,6 +55,9 @@ export const baseStyles = (
         & .fi-icon {
           margin: 0 ${theme.spacing.xxs};
           font-size: 16px;
+          & .fi-icon-base-fill {
+            fill: ${theme.colors.highlightBase};
+          }
         }
 
         &:focus-visible {

--- a/src/core/Toast/Toast.baseStyles.tsx
+++ b/src/core/Toast/Toast.baseStyles.tsx
@@ -29,6 +29,7 @@ export const baseStyles = (
       & .fi-toast-content-wrapper {
         vertical-align: middle;
         ${font(theme)('bodyTextSmall')}
+        flex-grow: 1;
       }
       & .fi-toast-heading {
         ${font(theme)('bodySemiBold')}
@@ -41,6 +42,29 @@ export const baseStyles = (
         & .fi-toast_icon {
           height: 24px;
           width: 24px;
+        }
+      }
+      & .fi-toast_close-button {
+        height: 40px;
+        padding: 3px 6px 3px 6px;
+        margin-right: -15px;
+        margin-top: -20px;
+        border: 1px solid transparent;
+        color: ${theme.colors.highlightBase};
+
+        & .fi-icon {
+          margin: 0 ${theme.spacing.xxs};
+          font-size: 16px;
+        }
+
+        &:focus-visible {
+          outline: 0;
+          position: relative;
+
+          &:after {
+            ${theme.focuses.absoluteFocus}
+            ${theme.focuses.highContrastFocus} /* For high contrast mode */
+          }
         }
       }
     }

--- a/src/core/Toast/Toast.md
+++ b/src/core/Toast/Toast.md
@@ -8,6 +8,7 @@ Examples:
 
 - [Basic use](./#/Components/Toast?id=basic-use)
 - [Toast with heading](./#/Components/Toast?id=toast-with-heading)
+- [Toast with close button](./#/Components/Toast?id=toast-with-close-button)
 
 <div style="margin-bottom: 40px">
   [Props & methods](./#/Components/Toast?id=props--methods)
@@ -40,11 +41,23 @@ import { Toast } from 'suomifi-ui-components';
 In some cases you might want to give the user the option to close the toast manually. This can be achieved by giving the toast the `showCloseButton` and `closeText` attributes.
 
 ```js
-import { Toast } from 'suomifi-ui-components';
+import { Toast, Button } from 'suomifi-ui-components';
+import { useState } from 'react';
 
-<Toast showCloseButton closeText="Close">
-  Your information was sent successfully.
-</Toast>;
+const [showToast, setShowToast] = useState(true);
+
+<>
+  {showToast && (
+    <Toast
+      showCloseButton
+      closeText="Close"
+      onCloseButtonClick={() => setShowToast(false)}
+    >
+      Your information was sent successfully.
+    </Toast>
+  )}
+  <Button onClick={() => setShowToast(true)}>Show toast</Button>
+</>;
 ```
 
 ### Props & methods

--- a/src/core/Toast/Toast.md
+++ b/src/core/Toast/Toast.md
@@ -18,9 +18,7 @@ Examples:
 ```js
 import { Toast } from 'suomifi-ui-components';
 
-<Toast showCloseButton closeButtonText="close">
-  Information saved successfully
-</Toast>;
+<Toast>Information saved successfully</Toast>;
 ```
 
 ### Toast with heading
@@ -33,6 +31,18 @@ Even with a heading the content should be kept concise.
 import { Toast } from 'suomifi-ui-components';
 
 <Toast headingVariant="h2" headingText="Success">
+  Your information was sent successfully.
+</Toast>;
+```
+
+### Toast with close button
+
+In some cases you might want to give the user the option to close the toast manually. This can be achieved by giving the toast the `showCloseButton` and `closeText` attributes.
+
+```js
+import { Toast } from 'suomifi-ui-components';
+
+<Toast showCloseButton closeText="Close">
   Your information was sent successfully.
 </Toast>;
 ```

--- a/src/core/Toast/Toast.md
+++ b/src/core/Toast/Toast.md
@@ -18,7 +18,9 @@ Examples:
 ```js
 import { Toast } from 'suomifi-ui-components';
 
-<Toast>Information saved successfully</Toast>;
+<Toast showCloseButton closeButtonText="close">
+  Information saved successfully
+</Toast>;
 ```
 
 ### Toast with heading

--- a/src/core/Toast/Toast.test.tsx
+++ b/src/core/Toast/Toast.test.tsx
@@ -84,6 +84,54 @@ describe('props', () => {
       );
     });
   });
+  describe('close button', () => {
+    const ToastWithCloseButton = (
+      <Toast showCloseButton closeText="Close">
+        Testcontent
+      </Toast>
+    );
+    it('should have close button', () => {
+      const { container } = render(ToastWithCloseButton);
+      expect(
+        container.querySelector('.fi-toast_close-button'),
+      ).toBeInTheDocument();
+    });
+    it('has close text as aria-label', () => {
+      const { container } = render(ToastWithCloseButton);
+      expect(container.querySelector('.fi-toast_close-button')).toHaveAttribute(
+        'aria-label',
+        'Close',
+      );
+    });
+    it('has given onClick callback', () => {
+      const onCloseButtonClick = jest.fn();
+      const { getByLabelText } = render(
+        <Toast
+          showCloseButton
+          closeText="Close"
+          onCloseButtonClick={onCloseButtonClick}
+        >
+          Testcontent
+        </Toast>,
+      );
+      getByLabelText('Close').click();
+      expect(onCloseButtonClick).toHaveBeenCalledTimes(1);
+    });
+    it('has given custom props', () => {
+      const { container } = render(
+        <Toast
+          showCloseButton
+          closeText="Close"
+          closeButtonProps={{ className: 'custom-class' }}
+        >
+          Testcontent
+        </Toast>,
+      );
+      expect(container.querySelector('.fi-toast_close-button')).toHaveClass(
+        'custom-class',
+      );
+    });
+  });
 });
 
 describe('margin', () => {

--- a/src/core/Toast/Toast.tsx
+++ b/src/core/Toast/Toast.tsx
@@ -55,9 +55,7 @@ export type CloseButtonProps =
        */
       showCloseButton: true;
       /**
-       * Text to label the close button.
-       * Is visible and as `aria-label` in regular size and only used as `aria-label` in small screen variant.
-       * Required when clear button is shown.
+       * Text to be used as aria-label for the close button.
        */
       closeText: string;
       /** Callback fired on close button click */

--- a/src/core/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/core/Toast/__snapshots__/Toast.test.tsx.snap
@@ -165,6 +165,10 @@ exports[`props children should match snapshot 1`] = `
   font-size: 16px;
 }
 
+.c1.fi-toast .fi-toast-wrapper .fi-toast_close-button .fi-icon .fi-icon-base-fill {
+  fill: hsl(212, 63%, 45%);
+}
+
 .c1.fi-toast .fi-toast-wrapper .fi-toast_close-button:focus-visible {
   outline: 0;
   position: relative;

--- a/src/core/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/core/Toast/__snapshots__/Toast.test.tsx.snap
@@ -96,7 +96,6 @@ exports[`props children should match snapshot 1`] = `
   width: 100%;
   box-shadow: 0px 4px 8px 0px hsla(0, 0%, 13%, 0.14);
   border-radius: 4px;
-  overflow: hidden;
 }
 
 .c1.fi-toast {

--- a/src/core/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/core/Toast/__snapshots__/Toast.test.tsx.snap
@@ -124,6 +124,7 @@ exports[`props children should match snapshot 1`] = `
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
+  flex-grow: 1;
 }
 
 .c1.fi-toast .fi-toast-wrapper .fi-toast-heading {
@@ -148,6 +149,42 @@ exports[`props children should match snapshot 1`] = `
 .c1.fi-toast .fi-toast-wrapper .fi-toast_icon-wrapper .fi-toast_icon {
   height: 24px;
   width: 24px;
+}
+
+.c1.fi-toast .fi-toast-wrapper .fi-toast_close-button {
+  height: 40px;
+  padding: 3px 6px 3px 6px;
+  margin-right: -15px;
+  margin-top: -20px;
+  border: 1px solid transparent;
+  color: hsl(212, 63%, 45%);
+}
+
+.c1.fi-toast .fi-toast-wrapper .fi-toast_close-button .fi-icon {
+  margin: 0 5px;
+  font-size: 16px;
+}
+
+.c1.fi-toast .fi-toast-wrapper .fi-toast_close-button:focus-visible {
+  outline: 0;
+  position: relative;
+}
+
+.c1.fi-toast .fi-toast-wrapper .fi-toast_close-button:focus-visible:after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0, 0%, 100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196, 77%, 44%);
+  z-index: 9999;
+  outline: 3px solid transparent;
 }
 
 <div>


### PR DESCRIPTION
## Description
This PR adds the option to add a close button to the `Toast` component. The implementation is similar to that in notification and alert.

This PR also fixes the close button size in `Notification` small screen variant.

## Motivation and Context
This was a request from a project, where they had situations with multiple Toasts open at the same time, which blocked a fair chunk of the UI in smaller screens.

## How Has This Been Tested?
Tested by running locally on styleguidist as well as a React+Vite test project.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/5ab8ba7a-edb3-44ba-8ba8-93878e343489)

## Release notes
### Toast
- Add option for close button
