### PR TITLE
[Feature] Pagination accessibility and custom button variant

### DIFF
--- a/src/core/Pagination/Pagination.md
+++ b/src/core/Pagination/Pagination.md
@@ -250,13 +250,17 @@ import {
   Block,
   Heading,
   Link,
+  Text,
   IconArrowRight,
   IconArrowLeft,
   suomifiDesignTokens
 } from 'suomifi-ui-components';
+import { useRef } from 'react';
 
 const [current, setCurrent] = React.useState(2);
 const lastPage = 8;
+const prevPageLinkRef = useRef();
+const nextPageLinkRef = useRef();
 
 const fakePageNode = (
   <Block
@@ -273,6 +277,10 @@ const fakePageNode = (
 const handlePageChange = (newPage) => {
   if (newPage <= 0 || newPage > lastPage) return;
   setCurrent(newPage);
+  if (newPage === 1) {
+    nextPageLinkRef.current.focus();
+  }
+  if (newPage === lastPage) prevPageLinkRef.current.focus();
 };
 
 <Block style={{ width: '600px' }}>
@@ -281,23 +289,40 @@ const handlePageChange = (newPage) => {
     currentPage={current}
     lastPage={lastPage}
     customPreviousButton={
-      <Link
-        href="./#/Components/Pagination?id=page-browsing-using-links"
-        rel="prev"
-        onClick={() => handlePageChange(current - 1)}
-        disabled={current <= 1}
-      >
-        Previous page
-      </Link>
+      current <= 1 ? (
+        <Text
+          style={{ color: suomifiDesignTokens.colors.depthLight3 }}
+        >
+          Previous page
+        </Text>
+      ) : (
+        <Link
+          forwardedRef={prevPageLinkRef}
+          href="./#/Components/Pagination?id=page-browsing-using-links"
+          rel="prev"
+          onClick={() => handlePageChange(current - 1)}
+        >
+          Previous page
+        </Link>
+      )
     }
     customNextButton={
-      <Link
-        href="./#/Components/Pagination?id=page-browsing-using-links"
-        rel="next"
-        onClick={() => handlePageChange(current + 1)}
-      >
-        Next page
-      </Link>
+      current >= lastPage ? (
+        <Text
+          style={{ color: suomifiDesignTokens.colors.depthLight3 }}
+        >
+          Next page
+        </Text>
+      ) : (
+        <Link
+          forwardedRef={nextPageLinkRef}
+          href="./#/Components/Pagination?id=page-browsing-using-links"
+          rel="next"
+          onClick={() => handlePageChange(current + 1)}
+        >
+          Next page
+        </Link>
+      )
     }
     aria-label="Pagination"
     pageInputProps={{

--- a/src/core/Pagination/Pagination.md
+++ b/src/core/Pagination/Pagination.md
@@ -6,6 +6,7 @@ Examples:
 - [Using internal state](./#/Components/Pagination?id=using-internal-state)
 - [Slicing a dataset based on current page](./#/Components/Pagination?id=slicing-a-dataset-based-on-current-page)
 - [Without page input](./#/Components/Pagination?id=without-page-input)
+- [Page browsing using links](./#/Components/Pagination?id=page-browsing-using-links)
 - [Small screen](./#/Components/Pagination?id=small-screen)
 
 <div style="margin-bottom: 40px">
@@ -226,6 +227,85 @@ const fakePageNode = (
     nextButtonAriaLabel="Next page"
     previousButtonAriaLabel="Previous page"
     aria-label="Pagination"
+    onChange={(page) => {
+      setCurrent(page);
+    }}
+    pageIndicatorText={(currentPage, lastPage) =>
+      'Page ' + currentPage + ' / ' + lastPage
+    }
+    ariaPageIndicatorText={(currentPage, lastPage) =>
+      'Showing page ' + currentPage + ' out of ' + lastPage
+    }
+  />
+</Block>;
+```
+
+### Page browsing using links
+
+For search engine optimization or other such reasons, it is possible to give custom components to use instead of the regular arrow buttons for browsing. If you do decide to replace the buttons, make sure that the customized solution is accessible.
+
+```js
+import {
+  Pagination,
+  Block,
+  Heading,
+  Link,
+  IconArrowRight,
+  IconArrowLeft,
+  suomifiDesignTokens
+} from 'suomifi-ui-components';
+
+const [current, setCurrent] = React.useState(2);
+const lastPage = 8;
+
+const fakePageNode = (
+  <Block
+    padding="xl"
+    mb="l"
+    style={{
+      border: `1px solid ${suomifiDesignTokens.colors.depthLight1}`
+    }}
+  >
+    <Heading variant="h3"> Page: {current}</Heading>
+  </Block>
+);
+
+const handlePageChange = (newPage) => {
+  if (newPage <= 0 || newPage > lastPage) return;
+  setCurrent(newPage);
+};
+
+<Block style={{ width: '600px' }}>
+  {fakePageNode}
+  <Pagination
+    currentPage={current}
+    lastPage={lastPage}
+    customPreviousButton={
+      <Link
+        href="./#/Components/Pagination?id=page-browsing-using-links"
+        rel="prev"
+        onClick={() => handlePageChange(current - 1)}
+        disabled={current <= 1}
+      >
+        Previous page
+      </Link>
+    }
+    customNextButton={
+      <Link
+        href="./#/Components/Pagination?id=page-browsing-using-links"
+        rel="next"
+        onClick={() => handlePageChange(current + 1)}
+      >
+        Next page
+      </Link>
+    }
+    aria-label="Pagination"
+    pageInputProps={{
+      invalidValueErrorText: (value) => `"${value}" is not allowed`,
+      inputPlaceholderText: 'Go to',
+      buttonText: 'Jump to page',
+      labelText: 'Page number'
+    }}
     onChange={(page) => {
       setCurrent(page);
     }}

--- a/src/core/Pagination/Pagination.md
+++ b/src/core/Pagination/Pagination.md
@@ -290,9 +290,7 @@ const handlePageChange = (newPage) => {
     lastPage={lastPage}
     customPreviousButton={
       current <= 1 ? (
-        <Text
-          style={{ color: suomifiDesignTokens.colors.depthLight3 }}
-        >
+        <Text style={{ color: suomifiDesignTokens.colors.depthBase }}>
           Previous page
         </Text>
       ) : (
@@ -308,9 +306,7 @@ const handlePageChange = (newPage) => {
     }
     customNextButton={
       current >= lastPage ? (
-        <Text
-          style={{ color: suomifiDesignTokens.colors.depthLight3 }}
-        >
+        <Text style={{ color: suomifiDesignTokens.colors.depthBase }}>
           Next page
         </Text>
       ) : (

--- a/src/core/Pagination/Pagination.md
+++ b/src/core/Pagination/Pagination.md
@@ -23,6 +23,7 @@ Examples:
 - The `onChange()` function runs both on arrow button press and pageInput submit
 - The visible text shown between the arrow buttons is formed using the `pageIndicatorText()` prop
 - Current page is indicated to screen readers using text formed in the `ariaPageIndicatorText()` prop
+- After page change, move focus to a relevant element at the top of the paginated content, e.g. a heading or a focusable list element
 
 ```js
 import {
@@ -31,11 +32,13 @@ import {
   Heading,
   suomifiDesignTokens
 } from 'suomifi-ui-components';
+import { useRef } from 'react';
 
 const [current, setCurrent] = React.useState(2);
 const lastPage = 8;
+const headingRef = useRef();
 
-const fakePageNode = (
+<Block style={{ width: '600px' }}>
   <Block
     padding="xl"
     mb="l"
@@ -43,12 +46,11 @@ const fakePageNode = (
       border: `1px solid ${suomifiDesignTokens.colors.depthLight1}`
     }}
   >
-    <Heading variant="h3"> Page: {current}</Heading>
+    <Heading variant="h3" forwardedRef={headingRef} tabIndex="-1">
+      {' '}
+      Page: {current}
+    </Heading>
   </Block>
-);
-
-<Block style={{ width: '600px' }}>
-  {fakePageNode}
   <Pagination
     currentPage={current}
     lastPage={lastPage}
@@ -64,6 +66,7 @@ const fakePageNode = (
     }}
     onChange={(page) => {
       setCurrent(page);
+      headingRef.current.focus();
     }}
     pageIndicatorText={(currentPage, lastPage) =>
       'Page ' + currentPage + ' / ' + lastPage
@@ -86,9 +89,11 @@ import {
   Heading,
   suomifiDesignTokens
 } from 'suomifi-ui-components';
+import { useRef } from 'react';
 
 const [current, setCurrent] = React.useState(1);
 const lastPage = 8;
+const headingRef = useRef();
 
 const fakePageNode = (
   <Block
@@ -98,7 +103,9 @@ const fakePageNode = (
       border: `1px solid ${suomifiDesignTokens.colors.depthLight1}`
     }}
   >
-    <Heading variant="h3"> Page: {current}</Heading>
+    <Heading variant="h3" forwardedRef={headingRef} tabIndex="-1">
+      Page: {current}
+    </Heading>
   </Block>
 );
 
@@ -118,6 +125,7 @@ const fakePageNode = (
     }}
     onChange={(page) => {
       setCurrent(page);
+      headingRef.current.focus();
     }}
     pageIndicatorText={(currentPage, lastPage) =>
       'Page ' + currentPage + ' / ' + lastPage
@@ -137,8 +145,10 @@ You can determine which chunk of a bigger dataset to render based on the number 
 import {
   Pagination,
   Block,
+  Heading,
   suomifiDesignTokens
 } from 'suomifi-ui-components';
+import { useRef } from 'react';
 
 const arrLength = 100;
 const amountOfConcurrentItems = 5;
@@ -150,6 +160,7 @@ const firstShown = (chunk - 1) * amountOfConcurrentItems;
 const lastShown =
   (chunk - 1) * amountOfConcurrentItems + amountOfConcurrentItems;
 const currentItems = items.slice(firstShown, lastShown);
+const headingRef = useRef();
 
 const fakePageNode = (
   <Block
@@ -159,6 +170,9 @@ const fakePageNode = (
       border: `1px solid ${suomifiDesignTokens.colors.depthLight1}`
     }}
   >
+    <Heading variant="h3" forwardedRef={headingRef} tabIndex="-1">
+      Page: {chunk}
+    </Heading>
     {currentItems.map((item, id) => (
       <div key={id}>Item {item + 1}</div>
     ))}
@@ -181,6 +195,7 @@ const fakePageNode = (
     }}
     onChange={(page) => {
       setChunk(page);
+      headingRef.current.focus();
     }}
     pageIndicatorText={(currentPage, lastPage) =>
       'Page ' + currentPage + ' / ' + lastPage
@@ -203,9 +218,11 @@ import {
   Heading,
   suomifiDesignTokens
 } from 'suomifi-ui-components';
+import { useRef } from 'react';
 
 const [current, setCurrent] = React.useState(2);
 const lastPage = 8;
+const headingRef = useRef();
 
 const fakePageNode = (
   <Block
@@ -215,7 +232,9 @@ const fakePageNode = (
       border: `1px solid ${suomifiDesignTokens.colors.depthLight1}`
     }}
   >
-    <Heading variant="h3"> Page: {current}</Heading>
+    <Heading variant="h3" forwardedRef={headingRef} tabIndex="-1">
+      Page: {current}
+    </Heading>
   </Block>
 );
 
@@ -229,6 +248,7 @@ const fakePageNode = (
     aria-label="Pagination"
     onChange={(page) => {
       setCurrent(page);
+      headingRef.current.focus();
     }}
     pageIndicatorText={(currentPage, lastPage) =>
       'Page ' + currentPage + ' / ' + lastPage
@@ -261,6 +281,7 @@ const [current, setCurrent] = React.useState(2);
 const lastPage = 8;
 const prevPageLinkRef = useRef();
 const nextPageLinkRef = useRef();
+const headingRef = useRef();
 
 const fakePageNode = (
   <Block
@@ -270,17 +291,16 @@ const fakePageNode = (
       border: `1px solid ${suomifiDesignTokens.colors.depthLight1}`
     }}
   >
-    <Heading variant="h3"> Page: {current}</Heading>
+    <Heading variant="h3" forwardedRef={headingRef} tabIndex="-1">
+      Page: {current}
+    </Heading>
   </Block>
 );
 
 const handlePageChange = (newPage) => {
   if (newPage <= 0 || newPage > lastPage) return;
   setCurrent(newPage);
-  if (newPage === 1) {
-    nextPageLinkRef.current.focus();
-  }
-  if (newPage === lastPage) prevPageLinkRef.current.focus();
+  headingRef.current.focus();
 };
 
 <Block style={{ width: '600px' }}>
@@ -329,6 +349,7 @@ const handlePageChange = (newPage) => {
     }}
     onChange={(page) => {
       setCurrent(page);
+      headingRef.current.focus();
     }}
     pageIndicatorText={(currentPage, lastPage) =>
       'Page ' + currentPage + ' / ' + lastPage
@@ -353,9 +374,11 @@ import {
   Heading,
   suomifiDesignTokens
 } from 'suomifi-ui-components';
+import { useRef } from 'react';
 
 const [current, setCurrent] = React.useState(2);
 const lastPage = 8;
+const headingRef = useRef();
 
 const fakePageNode = (
   <Block
@@ -365,7 +388,9 @@ const fakePageNode = (
       border: `1px solid ${suomifiDesignTokens.colors.depthLight1}`
     }}
   >
-    <Heading variant="h3"> Page: {current}</Heading>
+    <Heading variant="h3" forwardedRef={headingRef} tabIndex="-1">
+      Page: {current}
+    </Heading>
   </Block>
 );
 
@@ -386,6 +411,7 @@ const fakePageNode = (
     }}
     onChange={(page) => {
       setCurrent(page);
+      headingRef.current.focus();
     }}
     pageIndicatorText={(currentPage, lastPage) =>
       'Page ' + currentPage + ' / ' + lastPage

--- a/src/core/Pagination/Pagination.md
+++ b/src/core/Pagination/Pagination.md
@@ -341,12 +341,6 @@ const handlePageChange = (newPage) => {
       )
     }
     aria-label="Pagination"
-    pageInputProps={{
-      invalidValueErrorText: (value) => `"${value}" is not allowed`,
-      inputPlaceholderText: 'Go to',
-      buttonText: 'Jump to page',
-      labelText: 'Page number'
-    }}
     onChange={(page) => {
       setCurrent(page);
       headingRef.current.focus();

--- a/src/core/Pagination/Pagination.md
+++ b/src/core/Pagination/Pagination.md
@@ -242,7 +242,7 @@ const fakePageNode = (
 
 ### Page browsing using links
 
-For search engine optimization or other such reasons, it is possible to give custom components to use instead of the regular arrow buttons for browsing. If you do decide to replace the buttons, make sure that the customized solution is accessible.
+For search engine optimization or other such reasons, it is possible to give custom components to use instead of the regular arrow buttons for browsing. If you do decide to replace the buttons, make sure that the customized solution is accessible. When the first or last page is reach via clicking the links or other custom components, move focus to the other browse button.
 
 ```js
 import {

--- a/src/core/Pagination/Pagination.test.tsx
+++ b/src/core/Pagination/Pagination.test.tsx
@@ -187,38 +187,4 @@ describe('props', () => {
       expect(ref.current?.tagName).toBe('NAV');
     });
   });
-  describe('button focus', () => {
-    it('should focus other button when button gets disabled', async () => {
-      const { getAllByRole } = render(
-        <Pagination
-          data-testid="pagination"
-          lastPage={2}
-          pageInputProps={{
-            invalidValueErrorText: (value) => `${value} is not allowed`,
-            inputPlaceholderText: 'placeholder text',
-            buttonText: 'Jump',
-            labelText: 'Page number input',
-          }}
-          nextButtonAriaLabel="Next page"
-          previousButtonAriaLabel="Previous page"
-          onChange={() => null}
-          pageIndicatorText={(current, last) => `Page ${current} / ${last}`}
-          ariaPageIndicatorText={(current, last) =>
-            `Page ${current} of ${last}`
-          }
-          aria-label="my component here"
-        />,
-      );
-      const previousButton = getAllByRole('button')[0];
-      const nextButton = getAllByRole('button')[1];
-      expect(nextButton).not.toBeDisabled();
-      fireEvent.click(nextButton);
-      expect(nextButton).toBeDisabled();
-      expect(previousButton).toHaveFocus();
-
-      fireEvent.click(previousButton);
-      expect(previousButton).toBeDisabled();
-      expect(nextButton).toHaveFocus();
-    });
-  });
 });

--- a/src/core/Pagination/Pagination.test.tsx
+++ b/src/core/Pagination/Pagination.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { axeTest } from '../../utils/test';
 import { Pagination, PaginationProps } from './Pagination';
+import { Link } from '../Link';
 
 const TestPagination = (props: Partial<PaginationProps> = {}) => (
   <Pagination
@@ -122,6 +123,36 @@ describe('props', () => {
     });
   });
 
+  describe('custom previous and next elements', () => {
+    it('should render custom previous and next elements', () => {
+      const { getByText, getAllByRole } = render(
+        <Pagination
+          data-testid="pagination"
+          lastPage={2}
+          pageInputProps={{
+            invalidValueErrorText: (value) => `${value} is not allowed`,
+            inputPlaceholderText: 'placeholder text',
+            buttonText: 'Jump',
+            labelText: 'Page number input',
+          }}
+          onChange={() => null}
+          pageIndicatorText={(current, last) => `Page ${current} / ${last}`}
+          ariaPageIndicatorText={(current, last) =>
+            `Page ${current} of ${last}`
+          }
+          aria-label="my component here"
+          customNextButton={<Link href="https://example.com">Next</Link>}
+          customPreviousButton={
+            <Link href="https://example.com">Previous</Link>
+          }
+        />,
+      );
+      expect(getByText('Next')).toBeInTheDocument();
+      expect(getByText('Previous')).toBeInTheDocument();
+      expect(getAllByRole('link')).toHaveLength(2);
+    });
+  });
+
   describe('ref', () => {
     it('ref is forwarded to input', () => {
       const ref = React.createRef<HTMLElement>();
@@ -154,6 +185,40 @@ describe('props', () => {
       );
 
       expect(ref.current?.tagName).toBe('NAV');
+    });
+  });
+  describe('button focus', () => {
+    it('should focus other button when button gets disabled', async () => {
+      const { getAllByRole } = render(
+        <Pagination
+          data-testid="pagination"
+          lastPage={2}
+          pageInputProps={{
+            invalidValueErrorText: (value) => `${value} is not allowed`,
+            inputPlaceholderText: 'placeholder text',
+            buttonText: 'Jump',
+            labelText: 'Page number input',
+          }}
+          nextButtonAriaLabel="Next page"
+          previousButtonAriaLabel="Previous page"
+          onChange={() => null}
+          pageIndicatorText={(current, last) => `Page ${current} / ${last}`}
+          ariaPageIndicatorText={(current, last) =>
+            `Page ${current} of ${last}`
+          }
+          aria-label="my component here"
+        />,
+      );
+      const previousButton = getAllByRole('button')[0];
+      const nextButton = getAllByRole('button')[1];
+      expect(nextButton).not.toBeDisabled();
+      fireEvent.click(nextButton);
+      expect(nextButton).toBeDisabled();
+      expect(previousButton).toHaveFocus();
+
+      fireEvent.click(previousButton);
+      expect(previousButton).toBeDisabled();
+      expect(nextButton).toHaveFocus();
     });
   });
 });

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -31,7 +31,7 @@ export interface PageInputProps {
   labelText: string;
 }
 
-type nextPreviousButtonProps =
+export type NextPreviousButtonProps =
   | {
       /** Next page button label for screen readers */
       nextButtonAriaLabel: string;
@@ -49,7 +49,7 @@ type nextPreviousButtonProps =
       customNextButton: React.ReactNode;
     };
 
-type ShowInputProps =
+export type ShowInputProps =
   | {
       pageInput: false;
       pageInputProps?: never;
@@ -106,7 +106,7 @@ interface InternalPaginationProps {
 
 export type PaginationProps = ShowInputProps &
   InternalPaginationProps &
-  nextPreviousButtonProps &
+  NextPreviousButtonProps &
   Omit<HtmlNavProps, 'onChange'> &
   MarginProps;
 
@@ -133,26 +133,51 @@ interface PaginationState {
   currentPage: number;
 }
 
+const leftButtonRef = React.createRef<HTMLButtonElement>();
+const rightButtonRef = React.createRef<HTMLButtonElement>();
+
 class BasePagination extends Component<PaginationProps> {
   private onLeftButtonClick = () => {
     if (this.props.currentPage) {
-      this.props.onChange(this.props.currentPage - 1);
+      const newPage = this.props.currentPage - 1;
+      this.props.onChange(newPage);
+      if (newPage <= 1) {
+        rightButtonRef.current?.focus();
+      }
     } else {
-      this.props.onChange(this.state.currentPage - 1);
-      this.setState((prevState: PaginationState) => ({
-        currentPage: prevState.currentPage - 1,
-      }));
+      this.setState(
+        (prevState: PaginationState) => ({
+          currentPage: prevState.currentPage - 1,
+        }),
+        () => {
+          this.props.onChange(this.state.currentPage);
+          if (this.state.currentPage <= 1) {
+            rightButtonRef.current?.focus();
+          }
+        },
+      );
     }
   };
 
   private onRightButtonClick = () => {
     if (this.props.currentPage) {
-      this.props.onChange(this.props.currentPage + 1);
+      const newPage = this.props.currentPage + 1;
+      this.props.onChange(newPage);
+      if (newPage >= this.props.lastPage) {
+        leftButtonRef.current?.focus();
+      }
     } else {
-      this.props.onChange(this.state.currentPage + 1);
-      this.setState((prevState: PaginationState) => ({
-        currentPage: prevState.currentPage + 1,
-      }));
+      this.setState(
+        (prevState: PaginationState) => ({
+          currentPage: prevState.currentPage + 1,
+        }),
+        () => {
+          this.props.onChange(this.state.currentPage);
+          if (this.state.currentPage >= this.props.lastPage) {
+            leftButtonRef.current?.focus();
+          }
+        },
+      );
     }
   };
 
@@ -221,6 +246,7 @@ class BasePagination extends Component<PaginationProps> {
                 icon={<IconArrowLeft />}
                 disabled={this.getCurrentPage() <= 1}
                 aria-label={previousButtonAriaLabel}
+                forwardedRef={leftButtonRef}
               />
             )}
 
@@ -236,6 +262,7 @@ class BasePagination extends Component<PaginationProps> {
                 disabled={this.getCurrentPage() >= lastPage}
                 aria-label={nextButtonAriaLabel}
                 icon={<IconArrowRight />}
+                forwardedRef={rightButtonRef}
               />
             )}
           </HtmlDiv>

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -142,9 +142,6 @@ class BasePagination extends Component<PaginationProps> {
     if (this.props.currentPage) {
       const newPage = this.props.currentPage - 1;
       this.props.onChange(newPage);
-      if (newPage <= 1) {
-        this.rightButtonRef.current?.focus();
-      }
     } else {
       this.setState(
         (prevState: PaginationState) => ({
@@ -152,9 +149,6 @@ class BasePagination extends Component<PaginationProps> {
         }),
         () => {
           this.props.onChange(this.state.currentPage);
-          if (this.state.currentPage <= 1) {
-            this.rightButtonRef.current?.focus();
-          }
         },
       );
     }
@@ -164,9 +158,6 @@ class BasePagination extends Component<PaginationProps> {
     if (this.props.currentPage) {
       const newPage = this.props.currentPage + 1;
       this.props.onChange(newPage);
-      if (newPage >= this.props.lastPage) {
-        this.leftButtonRef.current?.focus();
-      }
     } else {
       this.setState(
         (prevState: PaginationState) => ({
@@ -174,9 +165,6 @@ class BasePagination extends Component<PaginationProps> {
         }),
         () => {
           this.props.onChange(this.state.currentPage);
-          if (this.state.currentPage >= this.props.lastPage) {
-            this.leftButtonRef.current?.focus();
-          }
         },
       );
     }

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -133,16 +133,17 @@ interface PaginationState {
   currentPage: number;
 }
 
-const leftButtonRef = React.createRef<HTMLButtonElement>();
-const rightButtonRef = React.createRef<HTMLButtonElement>();
-
 class BasePagination extends Component<PaginationProps> {
+  private leftButtonRef = React.createRef<HTMLButtonElement>();
+
+  private rightButtonRef = React.createRef<HTMLButtonElement>();
+
   private onLeftButtonClick = () => {
     if (this.props.currentPage) {
       const newPage = this.props.currentPage - 1;
       this.props.onChange(newPage);
       if (newPage <= 1) {
-        rightButtonRef.current?.focus();
+        this.rightButtonRef.current?.focus();
       }
     } else {
       this.setState(
@@ -152,7 +153,7 @@ class BasePagination extends Component<PaginationProps> {
         () => {
           this.props.onChange(this.state.currentPage);
           if (this.state.currentPage <= 1) {
-            rightButtonRef.current?.focus();
+            this.rightButtonRef.current?.focus();
           }
         },
       );
@@ -164,7 +165,7 @@ class BasePagination extends Component<PaginationProps> {
       const newPage = this.props.currentPage + 1;
       this.props.onChange(newPage);
       if (newPage >= this.props.lastPage) {
-        leftButtonRef.current?.focus();
+        this.leftButtonRef.current?.focus();
       }
     } else {
       this.setState(
@@ -174,7 +175,7 @@ class BasePagination extends Component<PaginationProps> {
         () => {
           this.props.onChange(this.state.currentPage);
           if (this.state.currentPage >= this.props.lastPage) {
-            leftButtonRef.current?.focus();
+            this.leftButtonRef.current?.focus();
           }
         },
       );
@@ -246,7 +247,7 @@ class BasePagination extends Component<PaginationProps> {
                 icon={<IconArrowLeft />}
                 disabled={this.getCurrentPage() <= 1}
                 aria-label={previousButtonAriaLabel}
-                forwardedRef={leftButtonRef}
+                forwardedRef={this.leftButtonRef}
               />
             )}
 
@@ -262,7 +263,7 @@ class BasePagination extends Component<PaginationProps> {
                 disabled={this.getCurrentPage() >= lastPage}
                 aria-label={nextButtonAriaLabel}
                 icon={<IconArrowRight />}
-                forwardedRef={rightButtonRef}
+                forwardedRef={this.rightButtonRef}
               />
             )}
           </HtmlDiv>

--- a/src/core/Pagination/Pagination.tsx
+++ b/src/core/Pagination/Pagination.tsx
@@ -31,6 +31,24 @@ export interface PageInputProps {
   labelText: string;
 }
 
+type nextPreviousButtonProps =
+  | {
+      /** Next page button label for screen readers */
+      nextButtonAriaLabel: string;
+      /** Previous page button label for screen readers */
+      previousButtonAriaLabel: string;
+      customPreviousButton?: never;
+      customNextButton?: never;
+    }
+  | {
+      nextButtonAriaLabel?: never;
+      previousButtonAriaLabel?: never;
+      /** Custom previous button component */
+      customPreviousButton: React.ReactNode;
+      /** Custom next button component */
+      customNextButton: React.ReactNode;
+    };
+
 type ShowInputProps =
   | {
       pageInput: false;
@@ -84,14 +102,11 @@ interface InternalPaginationProps {
   onChange: (page: number) => void;
   /** Ref is placed to the outermost div element of the component. Alternative for React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLElement>;
-  /** Next page button label for screen readers  */
-  nextButtonAriaLabel: string;
-  /** Previous page button label for screen readers */
-  previousButtonAriaLabel: string;
 }
 
 export type PaginationProps = ShowInputProps &
   InternalPaginationProps &
+  nextPreviousButtonProps &
   Omit<HtmlNavProps, 'onChange'> &
   MarginProps;
 
@@ -163,8 +178,10 @@ class BasePagination extends Component<PaginationProps> {
       onChange,
       currentPage,
       lastPage,
-      previousButtonAriaLabel,
-      nextButtonAriaLabel,
+      previousButtonAriaLabel = '',
+      nextButtonAriaLabel = '',
+      customNextButton,
+      customPreviousButton,
       pageInput,
       pageInputProps,
       smallScreen,
@@ -195,28 +212,32 @@ class BasePagination extends Component<PaginationProps> {
               {ariaPageIndicatorText(this.getCurrentPage(), lastPage)}
             </VisuallyHidden>
 
-            <Button
-              id={`${id}-previous-button`}
-              className={paginationClassNames.arrowButton}
-              variant="secondary"
-              onClick={this.onLeftButtonClick}
-              icon={<IconArrowLeft />}
-              disabled={this.getCurrentPage() <= 1}
-              aria-label={previousButtonAriaLabel}
-            />
+            {customPreviousButton || (
+              <Button
+                id={`${id}-previous-button`}
+                className={paginationClassNames.arrowButton}
+                variant="secondary"
+                onClick={this.onLeftButtonClick}
+                icon={<IconArrowLeft />}
+                disabled={this.getCurrentPage() <= 1}
+                aria-label={previousButtonAriaLabel}
+              />
+            )}
 
             <HtmlSpan className={paginationClassNames.pageNumbers}>
               {pageIndicatorText(this.getCurrentPage(), lastPage)}
             </HtmlSpan>
-            <Button
-              id={`${id}-next-button`}
-              className={paginationClassNames.arrowButton}
-              variant="secondary"
-              onClick={this.onRightButtonClick}
-              disabled={this.getCurrentPage() >= lastPage}
-              aria-label={nextButtonAriaLabel}
-              icon={<IconArrowRight />}
-            />
+            {customNextButton || (
+              <Button
+                id={`${id}-next-button`}
+                className={paginationClassNames.arrowButton}
+                variant="secondary"
+                onClick={this.onRightButtonClick}
+                disabled={this.getCurrentPage() >= lastPage}
+                aria-label={nextButtonAriaLabel}
+                icon={<IconArrowRight />}
+              />
+            )}
           </HtmlDiv>
 
           {pageInput === true && pageInputProps && (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -153,6 +153,8 @@ export {
   Pagination,
   type PaginationProps,
   type PageInputProps,
+  type NextPreviousButtonProps,
+  type ShowInputProps,
 } from './core/Pagination/Pagination';
 export { Text, type TextProps } from './core/Text/Text';
 export { Textarea, type TextareaProps } from './core/Form/Textarea/Textarea';


### PR DESCRIPTION
## Description
This PR adds the possibility to replace the page change buttons with a custom component in Pagination. It also updates all the examples to show the preferred accessibility behavior upon page change, which is to focus the heading of the content area or a relevant focusable list element.

## Motivation and Context
This was a request from a service using the library. Using buttons for browsing the pages prevents search engines from indexing the paginated content. Thus they wanted the possibility to use links instead.

## How Has This Been Tested?
Tested by running locally on styleguidist

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/67219190-a564-435a-beb6-3274211329a6)

## Release notes
### Pagination
- Allow replacing browse buttons with custom components
