### PR TITLE
[Dependencies] Update suomifi-icons to 7.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "react-modal": "3.16.1",
         "react-popper": "2.3.0",
         "suomifi-design-tokens": "6.0.0",
-        "suomifi-icons": "7.3.0"
+        "suomifi-icons": "7.4.0"
       },
       "devDependencies": {
         "@axe-core/react": "4.7.3",
@@ -20860,9 +20860,10 @@
       "integrity": "sha512-CefkL11cCgovUnTIuJQ5+hmBGRI+hjjy0QWSSNAq4onMKzqYtz0Dx84wBWbK1eltI6Pe2dLLBJ1P9X33izWJKw=="
     },
     "node_modules/suomifi-icons": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-7.3.0.tgz",
-      "integrity": "sha512-hPzPhEC/04uXlccLr85nGs3u/ZO9dytNHB7BSe6cau62NTsYof9sSSkif5d/7Cs7FNv+mu/3GLl74F8cqHWoeQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-7.4.0.tgz",
+      "integrity": "sha512-Rw66eXMCGOcdWsVWpxU/PaqEmYWMqBvxiD1wpzjtmyBRHab3bEsGsC3/fvDyQLMGZxyqoLmc1CLmcV4DKPn+3A==",
+      "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.1"
       },

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "react-modal": "3.16.1",
     "react-popper": "2.3.0",
     "suomifi-design-tokens": "6.0.0",
-    "suomifi-icons": "7.3.0"
+    "suomifi-icons": "7.4.0"
   },
   "peerDependencies": {
     "@types/styled-components": ">=5.1.9",


### PR DESCRIPTION
## Description
This PR updates the `suomifi-icons` library to its latest version, 7.4.0. This brings one additional icon into the mix.
## Motivation and Context
Dependencies should be kept up to date

## How Has This Been Tested?
By running styleguidist and checkin that the new icon is found and works as intended

## Release notes
### Dependencies
- Update `suomifi-icons` to 7.4.0
