### PR TITLE
[Bugfix] Drag and drop file handling in single file variant

### DIFF
--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -334,15 +334,16 @@ const BaseFileInput = (props: InternalFileInputProps) => {
   const dropEventHandler = (e: DragEvent) => {
     generalDragEventHandler(e, 'remove');
     const dt = e.dataTransfer;
-    const filesFromInput = dt?.files;
-    const previousAndNewFiles = Array.from(
-      inputRef.current?.files || [],
-    ).concat(Array.from(filesFromInput || []));
+    const incomingFiles = Array.from(dt?.files || []);
+    const previousFiles = Array.from(inputRef.current?.files || []);
+    const previousAndNewFiles = multiFile
+      ? previousFiles.concat(incomingFiles)
+      : incomingFiles.slice(0, 1);
     const newFileList = new DataTransfer();
     previousAndNewFiles.forEach((file) => {
       newFileList.items.add(file);
     });
-    if (!controlledValue && filesFromInput) {
+    if (!controlledValue && incomingFiles.length > 0) {
       setFilesToStateAndInput(newFileList.files);
     }
     if (propOnChange) {


### PR DESCRIPTION
## Description
This PR fixes the drag and drop logic in `FileInput` to correctly handle cases where files get dropped into a single file FileInput. Previously dropping a file into a single file FileInput with already a file in it resulted in "bricking" the component for the user. The case was the same for dropping multiple file into a single file FileInput.

This PR should fix these issues without any adverse effects.

## Motivation and Context
This was a bug that was noticed while making other changes to the component. Bugs need to be fixed.

## How Has This Been Tested?
Tested locally on styleguidist on chrome. 

## Release notes
### FileInput
* Fix drag and drop file handling in single file variant
