### PR TITLE
[Fix] FileInput long names

### DIFF
--- a/src/core/Form/FileInput/FileInput.baseStyles.tsx
+++ b/src/core/Form/FileInput/FileInput.baseStyles.tsx
@@ -53,9 +53,6 @@ export const baseStyles = (
     }
 
     .fi-file-input_single-file-container {
-      position: absolute;
-      top: 0;
-      left: 0;
       width: 100%;
       max-width: 600px;
       height: 100%;
@@ -80,7 +77,7 @@ export const baseStyles = (
       justify-content: space-between;
       .fi-file-input_file-info {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         gap: ${theme.spacing.insetL};
         flex-shrink: 1;
         ${font(theme)('bodyTextSmall')};
@@ -89,6 +86,7 @@ export const baseStyles = (
           width: 24px;
           height: 24px;
           flex-shrink: 0;
+          margin-top: 6px;
         }
 
         .fi-file-input_file-name {
@@ -97,6 +95,7 @@ export const baseStyles = (
           flex-shrink: 1;
           font-size: 16px;
           word-break: break-word;
+          align-self: center;
 
           &:not(.is-link) {
             &:focus {
@@ -113,11 +112,13 @@ export const baseStyles = (
           color: ${theme.colors.blackLight1};
           min-width: 70px;
           margin-right: ${theme.spacing.insetL};
+          margin-top: 12px;
         }
       }
 
       .fi-file-input_remove-file-button {
         flex-shrink: 0;
+        height: 40px;
       }
     }
 
@@ -135,6 +136,7 @@ export const baseStyles = (
 
         &.fi-file-input_drag-area--has-file {
           border: 1px solid ${theme.colors.depthLight2};
+          padding: 0;
         }
 
         .fi-file-input_input-wrapper {
@@ -146,6 +148,7 @@ export const baseStyles = (
 
           &.fi-file-input_input-wrapper--hidden {
             visibility: hidden;
+            height: 0;
           }
 
           .fi-file-input_drag-text-container {

--- a/src/core/Form/FileInput/FileInput.baseStyles.tsx
+++ b/src/core/Form/FileInput/FileInput.baseStyles.tsx
@@ -137,6 +137,18 @@ export const baseStyles = (
         &.fi-file-input_drag-area--has-file {
           border: 1px solid ${theme.colors.depthLight2};
           padding: 0;
+
+          & .fi-file-input_drag-text-container {
+            height: 0;
+            margin-bottom: 0 !important;
+          }
+
+          & .fi-file-input_input-label.fi-file-input_input-label {
+            height: 0;
+            padding: 0;
+            min-height: 0;
+            border: 0;
+          }
         }
 
         .fi-file-input_input-wrapper {

--- a/src/core/Form/FileInput/FileInput.baseStyles.tsx
+++ b/src/core/Form/FileInput/FileInput.baseStyles.tsx
@@ -96,6 +96,7 @@ export const baseStyles = (
           flex-grow: 1;
           flex-shrink: 1;
           font-size: 16px;
+          word-break: break-word;
 
           &:not(.is-link) {
             &:focus {
@@ -183,6 +184,7 @@ export const baseStyles = (
             background-color: ${theme.colors.whiteBase};
             border: 1px solid ${theme.colors.highlightBase};
             text-shadow: none;
+            word-break: normal;
             cursor: pointer;
 
             &:hover {

--- a/src/core/Form/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/src/core/Form/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -315,9 +315,6 @@ exports[`snapshots match error status with statustext 1`] = `
 }
 
 .c1.fi-file-input .fi-file-input_single-file-container {
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
   max-width: 600px;
   height: 100%;
@@ -344,7 +341,7 @@ exports[`snapshots match error status with statustext 1`] = `
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   flex-shrink: 1;
   letter-spacing: 0;
@@ -362,6 +359,7 @@ exports[`snapshots match error status with statustext 1`] = `
   width: 24px;
   height: 24px;
   flex-shrink: 0;
+  margin-top: 6px;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name {
@@ -370,6 +368,7 @@ exports[`snapshots match error status with statustext 1`] = `
   flex-shrink: 1;
   font-size: 16px;
   word-break: break-word;
+  align-self: center;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name:not(.is-link):focus {
@@ -397,10 +396,12 @@ exports[`snapshots match error status with statustext 1`] = `
   color: hsl(0, 0%, 42%);
   min-width: 70px;
   margin-right: 10px;
+  margin-top: 12px;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_remove-file-button {
   flex-shrink: 0;
+  height: 40px;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area {
@@ -417,6 +418,19 @@ exports[`snapshots match error status with statustext 1`] = `
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file {
   border: 1px solid hsl(202, 7%, 93%);
+  padding: 0;
+}
+
+.c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file .fi-file-input_drag-text-container {
+  height: 0;
+  margin-bottom: 0!important;
+}
+
+.c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file .fi-file-input_input-label.fi-file-input_input-label {
+  height: 0;
+  padding: 0;
+  min-height: 0;
+  border: 0;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper {
@@ -429,6 +443,7 @@ exports[`snapshots match error status with statustext 1`] = `
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper.fi-file-input_input-wrapper--hidden {
   visibility: hidden;
+  height: 0;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper .fi-file-input_drag-text-container {
@@ -947,9 +962,6 @@ exports[`snapshots match hidden label 1`] = `
 }
 
 .c1.fi-file-input .fi-file-input_single-file-container {
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
   max-width: 600px;
   height: 100%;
@@ -976,7 +988,7 @@ exports[`snapshots match hidden label 1`] = `
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   flex-shrink: 1;
   letter-spacing: 0;
@@ -994,6 +1006,7 @@ exports[`snapshots match hidden label 1`] = `
   width: 24px;
   height: 24px;
   flex-shrink: 0;
+  margin-top: 6px;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name {
@@ -1002,6 +1015,7 @@ exports[`snapshots match hidden label 1`] = `
   flex-shrink: 1;
   font-size: 16px;
   word-break: break-word;
+  align-self: center;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name:not(.is-link):focus {
@@ -1029,10 +1043,12 @@ exports[`snapshots match hidden label 1`] = `
   color: hsl(0, 0%, 42%);
   min-width: 70px;
   margin-right: 10px;
+  margin-top: 12px;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_remove-file-button {
   flex-shrink: 0;
+  height: 40px;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area {
@@ -1049,6 +1065,19 @@ exports[`snapshots match hidden label 1`] = `
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file {
   border: 1px solid hsl(202, 7%, 93%);
+  padding: 0;
+}
+
+.c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file .fi-file-input_drag-text-container {
+  height: 0;
+  margin-bottom: 0!important;
+}
+
+.c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file .fi-file-input_input-label.fi-file-input_input-label {
+  height: 0;
+  padding: 0;
+  min-height: 0;
+  border: 0;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper {
@@ -1061,6 +1090,7 @@ exports[`snapshots match hidden label 1`] = `
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper.fi-file-input_input-wrapper--hidden {
   visibility: hidden;
+  height: 0;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper .fi-file-input_drag-text-container {
@@ -1566,9 +1596,6 @@ exports[`snapshots match hint text 1`] = `
 }
 
 .c1.fi-file-input .fi-file-input_single-file-container {
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
   max-width: 600px;
   height: 100%;
@@ -1595,7 +1622,7 @@ exports[`snapshots match hint text 1`] = `
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   flex-shrink: 1;
   letter-spacing: 0;
@@ -1613,6 +1640,7 @@ exports[`snapshots match hint text 1`] = `
   width: 24px;
   height: 24px;
   flex-shrink: 0;
+  margin-top: 6px;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name {
@@ -1621,6 +1649,7 @@ exports[`snapshots match hint text 1`] = `
   flex-shrink: 1;
   font-size: 16px;
   word-break: break-word;
+  align-self: center;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name:not(.is-link):focus {
@@ -1648,10 +1677,12 @@ exports[`snapshots match hint text 1`] = `
   color: hsl(0, 0%, 42%);
   min-width: 70px;
   margin-right: 10px;
+  margin-top: 12px;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_remove-file-button {
   flex-shrink: 0;
+  height: 40px;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area {
@@ -1668,6 +1699,19 @@ exports[`snapshots match hint text 1`] = `
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file {
   border: 1px solid hsl(202, 7%, 93%);
+  padding: 0;
+}
+
+.c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file .fi-file-input_drag-text-container {
+  height: 0;
+  margin-bottom: 0!important;
+}
+
+.c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file .fi-file-input_input-label.fi-file-input_input-label {
+  height: 0;
+  padding: 0;
+  min-height: 0;
+  border: 0;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper {
@@ -1680,6 +1724,7 @@ exports[`snapshots match hint text 1`] = `
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper.fi-file-input_input-wrapper--hidden {
   visibility: hidden;
+  height: 0;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper .fi-file-input_drag-text-container {
@@ -2179,9 +2224,6 @@ exports[`snapshots match minimal implementation 1`] = `
 }
 
 .c1.fi-file-input .fi-file-input_single-file-container {
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
   max-width: 600px;
   height: 100%;
@@ -2208,7 +2250,7 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   flex-shrink: 1;
   letter-spacing: 0;
@@ -2226,6 +2268,7 @@ exports[`snapshots match minimal implementation 1`] = `
   width: 24px;
   height: 24px;
   flex-shrink: 0;
+  margin-top: 6px;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name {
@@ -2234,6 +2277,7 @@ exports[`snapshots match minimal implementation 1`] = `
   flex-shrink: 1;
   font-size: 16px;
   word-break: break-word;
+  align-self: center;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name:not(.is-link):focus {
@@ -2261,10 +2305,12 @@ exports[`snapshots match minimal implementation 1`] = `
   color: hsl(0, 0%, 42%);
   min-width: 70px;
   margin-right: 10px;
+  margin-top: 12px;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_remove-file-button {
   flex-shrink: 0;
+  height: 40px;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area {
@@ -2281,6 +2327,19 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file {
   border: 1px solid hsl(202, 7%, 93%);
+  padding: 0;
+}
+
+.c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file .fi-file-input_drag-text-container {
+  height: 0;
+  margin-bottom: 0!important;
+}
+
+.c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area.fi-file-input_drag-area--has-file .fi-file-input_input-label.fi-file-input_input-label {
+  height: 0;
+  padding: 0;
+  min-height: 0;
+  border: 0;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper {
@@ -2293,6 +2352,7 @@ exports[`snapshots match minimal implementation 1`] = `
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper.fi-file-input_input-wrapper--hidden {
   visibility: hidden;
+  height: 0;
 }
 
 .c1.fi-file-input .fi-file-input_input-outer-wrapper .fi-file-input_drag-area .fi-file-input_input-wrapper .fi-file-input_drag-text-container {

--- a/src/core/Form/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/src/core/Form/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -369,6 +369,7 @@ exports[`snapshots match error status with statustext 1`] = `
   flex-grow: 1;
   flex-shrink: 1;
   font-size: 16px;
+  word-break: break-word;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name:not(.is-link):focus {
@@ -491,6 +492,7 @@ exports[`snapshots match error status with statustext 1`] = `
   background-color: hsl(0, 0%, 100%);
   border: 1px solid hsl(212, 63%, 45%);
   text-shadow: none;
+  word-break: normal;
   cursor: pointer;
 }
 
@@ -999,6 +1001,7 @@ exports[`snapshots match hidden label 1`] = `
   flex-grow: 1;
   flex-shrink: 1;
   font-size: 16px;
+  word-break: break-word;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name:not(.is-link):focus {
@@ -1121,6 +1124,7 @@ exports[`snapshots match hidden label 1`] = `
   background-color: hsl(0, 0%, 100%);
   border: 1px solid hsl(212, 63%, 45%);
   text-shadow: none;
+  word-break: normal;
   cursor: pointer;
 }
 
@@ -1616,6 +1620,7 @@ exports[`snapshots match hint text 1`] = `
   flex-grow: 1;
   flex-shrink: 1;
   font-size: 16px;
+  word-break: break-word;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name:not(.is-link):focus {
@@ -1738,6 +1743,7 @@ exports[`snapshots match hint text 1`] = `
   background-color: hsl(0, 0%, 100%);
   border: 1px solid hsl(212, 63%, 45%);
   text-shadow: none;
+  word-break: normal;
   cursor: pointer;
 }
 
@@ -2227,6 +2233,7 @@ exports[`snapshots match minimal implementation 1`] = `
   flex-grow: 1;
   flex-shrink: 1;
   font-size: 16px;
+  word-break: break-word;
 }
 
 .c1.fi-file-input .fi-file-input_file-item .fi-file-input_file-info .fi-file-input_file-name:not(.is-link):focus {
@@ -2349,6 +2356,7 @@ exports[`snapshots match minimal implementation 1`] = `
   background-color: hsl(0, 0%, 100%);
   border: 1px solid hsl(212, 63%, 45%);
   text-shadow: none;
+  word-break: normal;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Description
FileInput had some issues with long filenames breaking the styles of the file list and/or the input in some cases. This should be remedied by giving it the possibility to break words.

This PR applies this fix. It also changes the FileInput button content word break rule so that it doesn't break words.

## Motivation and Context
This was a reported bug that needed fixing.

## How Has This Been Tested?
Tested by running locally on styleguidist on Chrome and testing with different component combinations.

## Release notes
### FileInput
* **Breaking change**: change word break rules for file list items and input button
