### PR TITLE
[Fix] Dropdown width glitch

### DIFF
--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -260,7 +260,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   list-style-type: none;
-  box-sizing: content-box;
+  box-sizing: border-box;
   max-height: 265px;
   background-color: hsl(0, 0%, 100%);
   border-width: 0 1px 1px 1px;
@@ -271,6 +271,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
+  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -911,7 +912,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   list-style-type: none;
-  box-sizing: content-box;
+  box-sizing: border-box;
   max-height: 265px;
   background-color: hsl(0, 0%, 100%);
   border-width: 0 1px 1px 1px;
@@ -922,6 +923,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
+  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -1603,7 +1605,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   list-style-type: none;
-  box-sizing: content-box;
+  box-sizing: border-box;
   max-height: 265px;
   background-color: hsl(0, 0%, 100%);
   border-width: 0 1px 1px 1px;
@@ -1614,6 +1616,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
+  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }

--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -271,7 +271,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
-  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -923,7 +922,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
-  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -1616,7 +1614,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
-  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
@@ -5,7 +5,7 @@ import { font } from '../../../../theme/reset';
 export const baseStyles = (theme: SuomifiTheme) => css`
   ${font(theme)('bodyText')}
   list-style-type: none;
-  box-sizing: content-box;
+  box-sizing: border-box;
   max-height: 265px;
   background-color: ${theme.colors.whiteBase};
   border-width: 0 1px 1px 1px;
@@ -17,6 +17,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   padding: 4px 0 0 0;
 
   display: block;
+  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
@@ -17,7 +17,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   padding: 4px 0 0 0;
 
   display: block;
-  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -547,7 +547,7 @@ exports[`has matching snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   list-style-type: none;
-  box-sizing: content-box;
+  box-sizing: border-box;
   max-height: 265px;
   background-color: hsl(0, 0%, 100%);
   border-width: 0 1px 1px 1px;
@@ -558,6 +558,7 @@ exports[`has matching snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
+  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -558,7 +558,6 @@ exports[`has matching snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
-  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -604,7 +604,6 @@ exports[`has matching snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
-  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -593,7 +593,7 @@ exports[`has matching snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   list-style-type: none;
-  box-sizing: content-box;
+  box-sizing: border-box;
   max-height: 265px;
   background-color: hsl(0, 0%, 100%);
   border-width: 0 1px 1px 1px;
@@ -604,6 +604,7 @@ exports[`has matching snapshot 1`] = `
   margin: 0;
   padding: 4px 0 0 0;
   display: block;
+  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
## Description

PR fixes a visual issue which appears in version 15.0.1 in the `<Dropdown>` component. Changing box-sizing to border-box in`<SelectItemList>` seems to fix it.

## Motivation and Context

An annoying visual glitch which needs addressing

## How Has This Been Tested?

macOS Chrome + Safari

## Screenshots
Before:
<img width="386" alt="image" src="https://github.com/user-attachments/assets/3972db77-7a24-4acc-b5b1-2c2423ec0b8a" />

After:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/e3c710ff-cebd-476d-ad77-10350f2ab9e6" />

## Release notes

### Dropdown
- Fix dropdown width glitch
