### PR TITLE
[Fix] Table horizontal scroll a11y

### DIFF
--- a/src/core/Table/Table.baseStyles.tsx
+++ b/src/core/Table/Table.baseStyles.tsx
@@ -38,6 +38,15 @@ export const baseStyles = (
 
     background-attachment: local, local, scroll, scroll;
 
+    &:focus {
+      position: relative;
+      ${theme.focuses.highContrastFocus} /* For high contrast mode */
+
+      &::after {
+        ${theme.focuses.absoluteFocus}
+      }
+    }
+
     .fi-table_table {
       ${element(theme)}
       ${buildSpacingCSS(globalMargins)}
@@ -64,7 +73,7 @@ export const baseStyles = (
         line-height: 2;
 
         &.fi-table_td--selection {
-          width: 45px;
+          min-width: 45px;
           padding: 0;
           position: relative;
         }
@@ -183,7 +192,7 @@ export const baseStyles = (
           }
 
           .fi-table_selection-cell-skeleton {
-            width: 45px;
+            min-width: 45px;
             padding: 5px 12px 5px 20px;
           }
         }
@@ -237,7 +246,7 @@ export const baseStyles = (
       }
 
       .fi-table_selection-cell-skeleton {
-        width: 45px;
+        min-width: 45px;
         padding-right: 12px;
       }
     }

--- a/src/core/Table/Table.baseStyles.tsx
+++ b/src/core/Table/Table.baseStyles.tsx
@@ -38,13 +38,13 @@ export const baseStyles = (
 
     background-attachment: local, local, scroll, scroll;
 
-    &:focus {
-      position: relative;
-      ${theme.focuses.highContrastFocus} /* For high contrast mode */
+    /* This exists as a bit of a hack to make the focus ring work in horizontal scrolling tables */
+    border: 2px solid transparent;
 
-      &::after {
-        ${theme.focuses.absoluteFocus}
-      }
+    &:focus {
+      outline: none;
+      border: 2px solid ${theme.colors.accentSecondary};
+      border-radius: ${theme.radiuses.focus};
     }
 
     .fi-table_table {

--- a/src/core/Table/Table.baseStyles.tsx
+++ b/src/core/Table/Table.baseStyles.tsx
@@ -41,7 +41,7 @@ export const baseStyles = (
     /* This exists as a bit of a hack to make the focus ring work in horizontal scrolling tables */
     border: 2px solid transparent;
 
-    &:focus {
+    &:focus-visible {
       outline: none;
       border: 2px solid ${theme.colors.accentSecondary};
       border-radius: ${theme.radiuses.focus};

--- a/src/core/Table/Table.md
+++ b/src/core/Table/Table.md
@@ -551,7 +551,7 @@ const data = [
     lastName: 'Ackermann',
     hours_worked: '',
     title: 'Security consultant',
-    country: <Link href="https://suomi.fi">Germany</Link>
+    country: 'Germany'
   },
   {
     id: '5',

--- a/src/core/Table/Table.md
+++ b/src/core/Table/Table.md
@@ -243,7 +243,7 @@ const customDataSort = (key, dir) => {
   setData(sortedData);
 };
 
-<div style={{ width: '900px' }}>
+<div style={{ width: '920px' }}>
   <Table
     caption="People in the project"
     columns={columns}

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -282,7 +282,7 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
   }
 
   const tableCaptionId = `${id}-caption`;
-  const getTableCaptionId = () => (caption ? `${id}-caption` : ariaLabelledBy);
+  const getTableCaptionId = () => (caption ? tableCaptionId : ariaLabelledBy);
 
   return (
     <HtmlDivWithRef

--- a/src/core/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/core/Table/__snapshots__/Table.test.tsx.snap
@@ -326,27 +326,13 @@ exports[`Table functionalities matches snapshot 1`] = `
   background-color: white;
   background-size: 30px 100%,30px 100%,20px 100%,20px 100%;
   background-attachment: local,local,scroll,scroll;
+  border: 2px solid transparent;
 }
 
 .c1.fi-table:focus {
-  position: relative;
-  outline: 3px solid transparent;
-}
-
-.c1.fi-table:focus::after {
-  content: '';
-  position: absolute;
-  pointer-events: none;
-  top: -2px;
-  right: -2px;
-  bottom: -2px;
-  left: -2px;
+  outline: none;
+  border: 2px solid hsl(196, 77%, 44%);
   border-radius: 2px;
-  background-color: transparent;
-  border: 0px solid hsl(0, 0%, 100%);
-  box-sizing: border-box;
-  box-shadow: 0 0 0 2px hsl(196, 77%, 44%);
-  z-index: 9999;
 }
 
 .c1.fi-table .fi-table_table {

--- a/src/core/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/core/Table/__snapshots__/Table.test.tsx.snap
@@ -328,6 +328,27 @@ exports[`Table functionalities matches snapshot 1`] = `
   background-attachment: local,local,scroll,scroll;
 }
 
+.c1.fi-table:focus {
+  position: relative;
+  outline: 3px solid transparent;
+}
+
+.c1.fi-table:focus::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  left: -2px;
+  border-radius: 2px;
+  background-color: transparent;
+  border: 0px solid hsl(0, 0%, 100%);
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px hsl(196, 77%, 44%);
+  z-index: 9999;
+}
+
 .c1.fi-table .fi-table_table {
   color: hsl(0, 0%, 13%);
   font-size: 16px;
@@ -363,7 +384,7 @@ exports[`Table functionalities matches snapshot 1`] = `
 
 .c1.fi-table .fi-table_table .fi-table_th.fi-table_td--selection,
 .c1.fi-table .fi-table_table .fi-table_td.fi-table_td--selection {
-  width: 45px;
+  min-width: 45px;
   padding: 0;
   position: relative;
 }
@@ -503,7 +524,7 @@ exports[`Table functionalities matches snapshot 1`] = `
 }
 
 .c1.fi-table .fi-table_table.fi-table--condensed .fi-table_skeleton-row .fi-table_selection-cell-skeleton {
-  width: 45px;
+  min-width: 45px;
   padding: 5px 12px 5px 20px;
 }
 
@@ -570,7 +591,7 @@ exports[`Table functionalities matches snapshot 1`] = `
 }
 
 .c1.fi-table .fi-table_skeleton-row .fi-table_selection-cell-skeleton {
-  width: 45px;
+  min-width: 45px;
   padding-right: 12px;
 }
 
@@ -593,6 +614,7 @@ exports[`Table functionalities matches snapshot 1`] = `
     >
       <caption
         class="c5 fi-table_caption"
+        id="1-caption"
       >
         People in the project
       </caption>

--- a/src/core/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/core/Table/__snapshots__/Table.test.tsx.snap
@@ -329,7 +329,7 @@ exports[`Table functionalities matches snapshot 1`] = `
   border: 2px solid transparent;
 }
 
-.c1.fi-table:focus {
+.c1.fi-table:focus-visible {
   outline: none;
   border: 2px solid hsl(196, 77%, 44%);
   border-radius: 2px;


### PR DESCRIPTION
## Description

PR makes the `<Table>` component's wrapping div focusable when it has horizontal scroll. This is due to Safari not being able to handle scrolling with a keyboard otherwise.

## Motivation and Context

This issue was reported by an accessibility expert

## How Has This Been Tested?

macOS Chrome + Safari in styleguidist

## Release notes

### Table
- Make the component's wrapping div focusable when it has horizontal scroll to allow keyboard scrolling on Safari
