### PR TITLE
[Chore] React 19 dependency updates + popoverClassName props

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Suomi.fi-styleguide in React components. [Living styleguide](https://vrk-kpa.git
 - Suomi.fi brand styles
 - Highly customizable (CSS, CSS-in-JS)
 
-Works with [React >= 16.8.0](https://github.com/facebook/react) (React 18 supported) and [Styled Components >= 5.2.1](https://github.com/styled-components/styled-components). Supports [TypeScript](https://github.com/Microsoft/TypeScript). CJS and ESM builds provided via the npm package.
+Works with [React >= 16.8.0](https://github.com/facebook/react) (React 19 supported) and [Styled Components >= 5.2.1](https://github.com/styled-components/styled-components). Supports [TypeScript](https://github.com/Microsoft/TypeScript). CJS and ESM builds provided via the npm package.
 
 ### Supported browser and screenreader combinations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "suomifi-ui-components",
-  "version": "16.0.0-deps",
+  "version": "16.0.1-r19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suomifi-ui-components",
-      "version": "16.0.0-deps",
+      "version": "16.0.1-r19",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.5",
-        "@popperjs/core": "2.11.8",
-        "@types/react-modal": "3.16.0",
+        "@floating-ui/react-dom": "2.1.2",
+        "@types/react-modal": "3.16.3",
         "classnames": "2.3.2",
         "date-fns": "2.30.0",
         "polished": "4.2.2",
-        "react-modal": "3.16.1",
+        "react-modal": "3.16.3",
         "react-popper": "2.3.0",
         "suomifi-design-tokens": "6.0.0",
         "suomifi-icons": "7.5.0"
@@ -2236,6 +2236,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
       "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
@@ -2245,12 +2246,14 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2353,6 +2356,44 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -3377,6 +3418,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4431,9 +4473,10 @@
       }
     },
     "node_modules/@types/react-modal": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
-      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
@@ -4528,6 +4571,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
@@ -6429,6 +6473,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7129,6 +7174,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -7239,6 +7285,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -15273,6 +15320,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16124,22 +16172,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
       "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-      "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
+      "license": "ISC"
     },
     "node_modules/pidtree": {
       "version": "0.6.0",
@@ -16898,7 +16932,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -17261,6 +17296,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -17493,6 +17529,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -17511,7 +17548,8 @@
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
     },
     "node_modules/react-group": {
       "version": "3.0.2",
@@ -17552,27 +17590,26 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-modal": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
-      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
+      "license": "MIT",
       "dependencies": {
         "exenv": "^1.2.0",
         "prop-types": "^15.7.2",
         "react-lifecycles-compat": "^3.0.0",
         "warning": "^4.0.3"
       },
-      "engines": {
-        "node": ">=8"
-      },
       "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
-        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-popper": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
       "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "license": "MIT",
       "dependencies": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -19471,6 +19508,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -19747,7 +19785,8 @@
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -19899,6 +19938,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20385,6 +20425,7 @@
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.13.tgz",
       "integrity": "sha512-M0+N2xSnAtwcVAQeFEsGWFFxXDftHUD7XrKla06QbpUMmbmtFBMMTcKWvFXtWxuD5qQkB8iU5gk6QASlx2ZRMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
@@ -20413,6 +20454,7 @@
       "version": "8.4.38",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
       "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -20441,6 +20483,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/stylehacks": {
@@ -20638,6 +20681,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
       "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/suomifi-design-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suomifi-ui-components",
-  "version": "16.0.1-r19",
+  "version": "16.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suomifi-ui-components",
-      "version": "16.0.1-r19",
+      "version": "16.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.5",
@@ -17,7 +17,7 @@
         "polished": "4.2.2",
         "react-modal": "3.16.3",
         "suomifi-design-tokens": "6.0.0",
-        "suomifi-icons": "7.5.0"
+        "suomifi-icons": "7.6.0"
       },
       "devDependencies": {
         "@axe-core/react": "4.7.3",
@@ -20649,9 +20649,9 @@
       "integrity": "sha512-CefkL11cCgovUnTIuJQ5+hmBGRI+hjjy0QWSSNAq4onMKzqYtz0Dx84wBWbK1eltI6Pe2dLLBJ1P9X33izWJKw=="
     },
     "node_modules/suomifi-icons": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-7.5.0.tgz",
-      "integrity": "sha512-/IDNSpKslWzsb69j1MMfEXY5T4boWYcSzVki++w+TBAXiLbmOf4VABaY9bRer37hPwoRDe8Rc9D/aQcG3qZeRw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-7.6.0.tgz",
+      "integrity": "sha512-MYE1T3EDRRVgNis8tEq1tOuvqCjiD/0Q5KsLsmLVF0dlFtbJc3bRxiRNcfyhl3702Z8mMViFbuhEnWJomIn/EQ==",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "date-fns": "2.30.0",
         "polished": "4.2.2",
         "react-modal": "3.16.3",
-        "react-popper": "2.3.0",
         "suomifi-design-tokens": "6.0.0",
         "suomifi-icons": "7.5.0"
       },
@@ -2236,7 +2235,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
       "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
@@ -2246,14 +2244,12 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4571,7 +4567,6 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
@@ -6473,7 +6468,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7174,7 +7168,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -7285,7 +7278,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "dev": true,
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -15320,7 +15312,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16172,7 +16163,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
       "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/pidtree": {
@@ -16932,8 +16922,7 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -17296,7 +17285,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -17529,7 +17517,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -17544,12 +17531,6 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
-    },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
     },
     "node_modules/react-group": {
       "version": "3.0.2",
@@ -17603,21 +17584,6 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
-      }
-    },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-simple-code-editor": {
@@ -19508,7 +19474,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -19785,8 +19750,7 @@
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -19938,7 +19902,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20425,7 +20388,6 @@
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.13.tgz",
       "integrity": "sha512-M0+N2xSnAtwcVAQeFEsGWFFxXDftHUD7XrKla06QbpUMmbmtFBMMTcKWvFXtWxuD5qQkB8iU5gk6QASlx2ZRMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
@@ -20454,7 +20416,6 @@
       "version": "8.4.38",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
       "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -20483,7 +20444,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/stylehacks": {
@@ -20681,7 +20641,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
       "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/suomifi-design-tokens": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "16.0.1-r19",
+  "version": "16.0.1",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "date-fns": "2.30.0",
     "polished": "4.2.2",
     "react-modal": "3.16.3",
-    "react-popper": "2.3.0",
     "suomifi-design-tokens": "6.0.0",
     "suomifi-icons": "7.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "polished": "4.2.2",
     "react-modal": "3.16.3",
     "suomifi-design-tokens": "6.0.0",
-    "suomifi-icons": "7.5.0"
+    "suomifi-icons": "7.6.0"
   },
   "peerDependencies": {
     "@types/styled-components": ">=5.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-ui-components",
-  "version": "16.0.1",
+  "version": "16.0.1-r19",
   "description": "Suomi.fi UI component library",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -150,12 +150,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.5",
-    "@popperjs/core": "2.11.8",
-    "@types/react-modal": "3.16.0",
+    "@floating-ui/react-dom": "2.1.2",
+    "@types/react-modal": "3.16.3",
     "classnames": "2.3.2",
     "date-fns": "2.30.0",
     "polished": "4.2.2",
-    "react-modal": "3.16.1",
+    "react-modal": "3.16.3",
     "react-popper": "2.3.0",
     "suomifi-design-tokens": "6.0.0",
     "suomifi-icons": "7.5.0"

--- a/src/core/ActionMenu/ActionMenuPopover/ActionMenuPopover.baseStyles.tsx
+++ b/src/core/ActionMenu/ActionMenuPopover/ActionMenuPopover.baseStyles.tsx
@@ -36,8 +36,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   /* Arrow base */
-  & .fi-action-menu-popover_popper-arrow::before,
-  & .fi-action-menu-popover_popper-arrow::after {
+  & .fi-action-menu-popover_floatingui-arrow::before,
+  & .fi-action-menu-popover_floatingui-arrow::after {
     content: '';
     position: absolute;
     left: -9px;
@@ -48,12 +48,13 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   /* Arrow on top side */
-  & .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end'] {
+  &
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
     bottom: 100%;
   }
 
   &
-    .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::before {
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
     border-bottom-color: ${theme.colors.blackLight1};
     border-width: 9px;
     margin-right: -9px;
@@ -61,7 +62,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   &
-    .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::after {
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
     border-bottom-color: ${theme.colors.whiteBase};
     border-width: 8px;
     margin-right: -9px;
@@ -70,19 +71,20 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   /* Arrow on bottom side */
-  & .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end'] {
+  &
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
     top: 100%;
   }
 
   &
-    .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::before {
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
     border-top-color: ${theme.colors.blackLight1};
     border-width: 9px;
     margin-right: -9px;
   }
 
   &
-    .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::after {
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
     border-top-color: ${theme.colors.whiteBase};
     border-width: 8px;
     margin-right: -9px;

--- a/src/core/ActionMenu/ActionMenuPopover/ActionMenuPopover.tsx
+++ b/src/core/ActionMenu/ActionMenuPopover/ActionMenuPopover.tsx
@@ -349,7 +349,6 @@ export const BaseActionMenuPopover = (
         className={actionMenuClassNames.floatinguiArrow}
         data-floatingui-placement={middlewareData?.offset?.placement}
         aria-hidden={true}
-        tabIndex={-1}
         style={{
           position: 'absolute',
           left: middlewareData.arrow?.x,

--- a/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
@@ -178,8 +178,8 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   outline: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow::before,
-.c8 .fi-action-menu-popover_popper-arrow::after {
+.c8 .fi-action-menu-popover_floatingui-arrow::before,
+.c8 .fi-action-menu-popover_floatingui-arrow::after {
   content: '';
   position: absolute;
   left: -9px;
@@ -189,18 +189,18 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -208,17 +208,17 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -726,7 +726,7 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
       <div
         class="c7 c8 fi-action-menu-popover fi-action-menu-popover--hidden"
         role="none"
-        style="position: fixed; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
         tabindex="-1"
       >
         <div
@@ -774,10 +774,8 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
         </div>
         <div
           aria-hidden="true"
-          class="fi-action-menu-popover_popper-arrow"
-          data-popper-arrow="true"
+          class="c7 fi-action-menu-popover_floatingui-arrow"
           style="position: absolute;"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -963,8 +961,8 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   outline: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow::before,
-.c8 .fi-action-menu-popover_popper-arrow::after {
+.c8 .fi-action-menu-popover_floatingui-arrow::before,
+.c8 .fi-action-menu-popover_floatingui-arrow::after {
   content: '';
   position: absolute;
   left: -9px;
@@ -974,18 +972,18 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -993,17 +991,17 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -1511,7 +1509,7 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
       <div
         class="c7 c8 fi-action-menu-popover fi-action-menu-popover--hidden"
         role="none"
-        style="position: fixed; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
         tabindex="-1"
       >
         <div
@@ -1559,10 +1557,8 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
         </div>
         <div
           aria-hidden="true"
-          class="fi-action-menu-popover_popper-arrow"
-          data-popper-arrow="true"
+          class="c7 fi-action-menu-popover_floatingui-arrow"
           style="position: absolute;"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -1748,8 +1744,8 @@ exports[`No borders variant should match snapshot 1`] = `
   outline: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow::before,
-.c8 .fi-action-menu-popover_popper-arrow::after {
+.c8 .fi-action-menu-popover_floatingui-arrow::before,
+.c8 .fi-action-menu-popover_floatingui-arrow::after {
   content: '';
   position: absolute;
   left: -9px;
@@ -1759,18 +1755,18 @@ exports[`No borders variant should match snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -1778,17 +1774,17 @@ exports[`No borders variant should match snapshot 1`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -2296,7 +2292,7 @@ exports[`No borders variant should match snapshot 1`] = `
       <div
         class="c7 c8 fi-action-menu-popover fi-action-menu-popover--hidden"
         role="none"
-        style="position: fixed; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
         tabindex="-1"
       >
         <div
@@ -2344,10 +2340,8 @@ exports[`No borders variant should match snapshot 1`] = `
         </div>
         <div
           aria-hidden="true"
-          class="fi-action-menu-popover_popper-arrow"
-          data-popper-arrow="true"
+          class="c7 fi-action-menu-popover_floatingui-arrow"
           style="position: absolute;"
-          tabindex="-1"
         />
       </div>
     </div>
@@ -2533,8 +2527,8 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   outline: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow::before,
-.c8 .fi-action-menu-popover_popper-arrow::after {
+.c8 .fi-action-menu-popover_floatingui-arrow::before,
+.c8 .fi-action-menu-popover_floatingui-arrow::after {
   content: '';
   position: absolute;
   left: -9px;
@@ -2544,18 +2538,18 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -2563,17 +2557,17 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -3081,7 +3075,7 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
       <div
         class="c7 c8 fi-action-menu-popover"
         role="none"
-        style="position: fixed; left: 0px; top: 0px; right: 0px; transform: translate(0px, 10px);"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 10px);"
         tabindex="-1"
       >
         <div
@@ -3092,10 +3086,10 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
           tabindex="-1"
         >
           <button
-            class="c4 fi-action-menu-item c9 fi-action-menu-item--selected"
+            class="c4 fi-action-menu-item c9"
             id="test-id-menu-list-item-0"
             role="menuitem"
-            tabindex="0"
+            tabindex="-1"
             type="button"
           >
             Item 1
@@ -3129,11 +3123,9 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
         </div>
         <div
           aria-hidden="true"
-          class="fi-action-menu-popover_popper-arrow"
-          data-popper-arrow="true"
-          data-popper-placement="bottom-end"
-          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
-          tabindex="-1"
+          class="c7 fi-action-menu-popover_floatingui-arrow"
+          data-floatingui-placement="bottom-end"
+          style="position: absolute; left: 0px;"
         />
       </div>
     </div>
@@ -3319,8 +3311,8 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   outline: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow::before,
-.c8 .fi-action-menu-popover_popper-arrow::after {
+.c8 .fi-action-menu-popover_floatingui-arrow::before,
+.c8 .fi-action-menu-popover_floatingui-arrow::after {
   content: '';
   position: absolute;
   left: -9px;
@@ -3330,18 +3322,18 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -3349,17 +3341,17 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_popper-arrow[data-popper-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -3867,7 +3859,7 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
       <div
         class="c7 c8 fi-action-menu-popover"
         role="none"
-        style="position: fixed; left: 0px; top: 0px; right: 0px; transform: translate(0px, 10px);"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 10px);"
         tabindex="-1"
       >
         <div
@@ -3915,11 +3907,9 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
         </div>
         <div
           aria-hidden="true"
-          class="fi-action-menu-popover_popper-arrow"
-          data-popper-arrow="true"
-          data-popper-placement="bottom-end"
-          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
-          tabindex="-1"
+          class="c7 fi-action-menu-popover_floatingui-arrow"
+          data-floatingui-placement="bottom-end"
+          style="position: absolute; left: 0px;"
         />
       </div>
     </div>

--- a/src/core/Form/DateInput/DateInput.test.tsx
+++ b/src/core/Form/DateInput/DateInput.test.tsx
@@ -755,19 +755,19 @@ describe('props', () => {
         });
 
         describe('not enabled', () => {
-          it('has position fixed', () => {
+          it('has position absolute', () => {
             const { baseElement } = render(
               <DateInput labelText="Date" datePickerEnabled />,
             );
             const dialog = baseElement.querySelector('[role="dialog"]');
             expect(dialog).toHaveClass('fi-date-picker');
-            expect(dialog).toHaveStyle('position: fixed');
+            expect(dialog).toHaveStyle('position: absolute');
             cleanup();
           });
         });
 
         describe('enabled', () => {
-          it('does not have position fixed', () => {
+          it('does not have position absolute', () => {
             const { baseElement } = render(
               <DateInput labelText="Date" smallScreen datePickerEnabled />,
             );

--- a/src/core/Form/DateInput/DatePicker/DatePicker.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.baseStyles.tsx
@@ -90,34 +90,32 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     touch-action: auto;
   }
 
-  & .fi-date-picker_popper-arrow,
-  & .fi-date-picker_popper-arrow::before {
+  & .fi-date-picker_floatingui-arrow,
+  & .fi-date-picker_floatingui-arrow::before {
     position: absolute;
     width: 11px;
     height: 11px;
   }
 
-  & .fi-date-picker_popper-arrow::before {
+  & .fi-date-picker_floatingui-arrow::before {
     content: '';
     background-color: ${theme.colors.whiteBase};
     transform: rotate(45deg);
   }
 
-  & .fi-date-picker_popper-arrow[data-popper-placement^='bottom-end'] {
-    top: -7px;
+  & .fi-date-picker_floatingui-arrow[data-floatingui-placement^='bottom'] {
+    top: -6px;
+    &::before {
+      border-top: 1px solid ${theme.colors.blackLight1};
+      border-left: 1px solid ${theme.colors.blackLight1};
+    }
   }
 
-  & .fi-date-picker_popper-arrow[data-popper-placement^='bottom-end']::before {
-    border-top: 1px solid ${theme.colors.blackLight1};
-    border-left: 1px solid ${theme.colors.blackLight1};
-  }
-
-  & .fi-date-picker_popper-arrow[data-popper-placement^='top-end'] {
+  & .fi-date-picker_floatingui-arrow[data-floatingui-placement^='top'] {
     bottom: -6px;
-  }
-
-  & .fi-date-picker_popper-arrow[data-popper-placement^='top-end']::before {
-    border-bottom: 1px solid ${theme.colors.blackLight1};
-    border-right: 1px solid ${theme.colors.blackLight1};
+    &::before {
+      border-bottom: 1px solid ${theme.colors.blackLight1};
+      border-right: 1px solid ${theme.colors.blackLight1};
+    }
   }
 `;

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3730,33 +3730,33 @@ exports[`snapshots match date input with datepicker with controlled input value 
   touch-action: auto;
 }
 
-.c10 .fi-date-picker_popper-arrow,
-.c10 .fi-date-picker_popper-arrow::before {
+.c10 .fi-date-picker_floatingui-arrow,
+.c10 .fi-date-picker_floatingui-arrow::before {
   position: absolute;
   width: 11px;
   height: 11px;
 }
 
-.c10 .fi-date-picker_popper-arrow::before {
+.c10 .fi-date-picker_floatingui-arrow::before {
   content: '';
   background-color: hsl(0, 0%, 100%);
   transform: rotate(45deg);
 }
 
-.c10 .fi-date-picker_popper-arrow[data-popper-placement^='bottom-end'] {
-  top: -7px;
+.c10 .fi-date-picker_floatingui-arrow[data-floatingui-placement^='bottom'] {
+  top: -6px;
 }
 
-.c10 .fi-date-picker_popper-arrow[data-popper-placement^='bottom-end']::before {
+.c10 .fi-date-picker_floatingui-arrow[data-floatingui-placement^='bottom']::before {
   border-top: 1px solid hsl(0, 0%, 42%);
   border-left: 1px solid hsl(0, 0%, 42%);
 }
 
-.c10 .fi-date-picker_popper-arrow[data-popper-placement^='top-end'] {
+.c10 .fi-date-picker_floatingui-arrow[data-floatingui-placement^='top'] {
   bottom: -6px;
 }
 
-.c10 .fi-date-picker_popper-arrow[data-popper-placement^='top-end']::before {
+.c10 .fi-date-picker_floatingui-arrow[data-floatingui-placement^='top']::before {
   border-bottom: 1px solid hsl(0, 0%, 42%);
   border-right: 1px solid hsl(0, 0%, 42%);
 }
@@ -4055,7 +4055,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
     aria-hidden="false"
     class="c2 c10 fi-date-picker"
     role="dialog"
-    style="position: fixed; left: 0px; top: 0px;"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
   >
     <div
       class="c0 fi-date-picker_application"
@@ -4815,9 +4815,9 @@ exports[`snapshots match date input with datepicker with controlled input value 
       </div>
     </div>
     <div
-      class="fi-date-picker_popper-arrow"
-      data-popper-arrow="true"
-      style="position: absolute;"
+      aria-hidden="true"
+      class="c2 fi-date-picker_floatingui-arrow"
+      tabindex="-1"
     />
   </div>
 </body>
@@ -5869,33 +5869,33 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   touch-action: auto;
 }
 
-.c10 .fi-date-picker_popper-arrow,
-.c10 .fi-date-picker_popper-arrow::before {
+.c10 .fi-date-picker_floatingui-arrow,
+.c10 .fi-date-picker_floatingui-arrow::before {
   position: absolute;
   width: 11px;
   height: 11px;
 }
 
-.c10 .fi-date-picker_popper-arrow::before {
+.c10 .fi-date-picker_floatingui-arrow::before {
   content: '';
   background-color: hsl(0, 0%, 100%);
   transform: rotate(45deg);
 }
 
-.c10 .fi-date-picker_popper-arrow[data-popper-placement^='bottom-end'] {
-  top: -7px;
+.c10 .fi-date-picker_floatingui-arrow[data-floatingui-placement^='bottom'] {
+  top: -6px;
 }
 
-.c10 .fi-date-picker_popper-arrow[data-popper-placement^='bottom-end']::before {
+.c10 .fi-date-picker_floatingui-arrow[data-floatingui-placement^='bottom']::before {
   border-top: 1px solid hsl(0, 0%, 42%);
   border-left: 1px solid hsl(0, 0%, 42%);
 }
 
-.c10 .fi-date-picker_popper-arrow[data-popper-placement^='top-end'] {
+.c10 .fi-date-picker_floatingui-arrow[data-floatingui-placement^='top'] {
   bottom: -6px;
 }
 
-.c10 .fi-date-picker_popper-arrow[data-popper-placement^='top-end']::before {
+.c10 .fi-date-picker_floatingui-arrow[data-floatingui-placement^='top']::before {
   border-bottom: 1px solid hsl(0, 0%, 42%);
   border-right: 1px solid hsl(0, 0%, 42%);
 }

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
@@ -169,6 +169,8 @@ export interface DropdownProps<T extends string = string>
    * @default true
    */
   portal?: boolean;
+  /** Popover container div CSS class for custom styles. Can be used to modify popover z-index. */
+  popoverClassName?: string;
   /** Set component's width to 100% */
   fullWidth?: boolean;
   /** Ref is forwarded to the button element. Alternative to React `ref` attribute. */
@@ -536,6 +538,7 @@ class BaseDropdown<T extends string = string> extends Component<
       onBlur,
       tooltipComponent,
       portal = true,
+      popoverClassName,
       statusTextAriaLiveMode = 'assertive',
       fullWidth,
       style,
@@ -670,6 +673,7 @@ class BaseDropdown<T extends string = string> extends Component<
               matchWidth={true}
               onKeyDown={this.handleKeyDown}
               portal={portal}
+              className={popoverClassName}
             >
               <DropdownProvider
                 value={{

--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -613,7 +613,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   <div
     class="fi-portal"
     role="presentation"
-    style="position: absolute; left: 0px; top: 0px; width: 0px; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px); width: 0px;"
     tabindex="-1"
   >
     <div
@@ -1290,7 +1290,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   <div
     class="fi-portal"
     role="presentation"
-    style="position: absolute; left: 0px; top: 0px; width: 0px; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px); width: 0px;"
     tabindex="-1"
   >
     <div
@@ -1958,7 +1958,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   <div
     class="fi-portal"
     role="presentation"
-    style="position: absolute; left: 0px; top: 0px; width: 0px; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px); width: 0px;"
     tabindex="-1"
   >
     <div

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -202,6 +202,8 @@ interface InternalMultiSelectProps<T extends MultiSelectData> {
   forwardedRef?: React.RefObject<HTMLInputElement>;
   /** Props passed to unordered list element inside the popover. For example data-attributes */
   listProps?: HTMLAttributesIncludingDataAttributes<HTMLUListElement>;
+  /** Popover container div CSS class for custom styles. Can be used to modify popover z-index. */
+  popoverClassName?: string;
   /** Sets component's width to 100% of its parent */
   fullWidth?: boolean;
 }
@@ -665,6 +667,7 @@ class BaseMultiSelect<T> extends Component<
       items, // Only destructured away so they don't end up in the DOM
       forwardedRef, // Only destructured away so it doesn't end up in the DOM
       listProps,
+      popoverClassName,
       style,
       fullWidth,
       ...rest
@@ -783,6 +786,7 @@ class BaseMultiSelect<T> extends Component<
                     this.setState({ showPopover: false });
                   }
                 }}
+                className={popoverClassName}
               >
                 <PopoverConsumer>
                   {(consumer) => (

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1449,7 +1449,7 @@ exports[`has matching snapshot 1`] = `
   <div
     class="fi-portal"
     role="presentation"
-    style="position: absolute; left: 0px; top: 0px; width: 0px; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px); width: 0px;"
     tabindex="-1"
   >
     <div

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -136,6 +136,8 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
   forwardedRef?: React.RefObject<HTMLInputElement>;
   /** Props passed to the unordered list element inside the popover. For example data-attributes */
   listProps?: HTMLAttributesIncludingDataAttributes<HTMLUListElement>;
+  /** Popover container div CSS class for custom styles. Can be used to modify popover z-index. */
+  popoverClassName?: string;
   /** Sets component's width to 100% of its parent */
   fullWidth?: boolean;
 }
@@ -561,6 +563,7 @@ class BaseSingleSelect<T> extends Component<
       items, // Only destructured away so they don't end up in the DOM
       forwardedRef, // Only destructured away so it doesn't end up in the DOM
       listProps,
+      popoverClassName,
       style,
       fullWidth,
       ...rest
@@ -694,6 +697,7 @@ class BaseSingleSelect<T> extends Component<
                 this.setState({ showPopover: false });
               }
             }}
+            className={popoverClassName}
           >
             <SelectItemList
               id={popoverItemListId}

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -951,7 +951,7 @@ exports[`has matching snapshot 1`] = `
   <div
     class="fi-portal"
     role="presentation"
-    style="position: absolute; left: 0px; top: 0px; width: 0px; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px); width: 0px;"
     tabindex="-1"
   >
     <div

--- a/src/core/LanguageMenu/LanguageMenuPopover/LanguageMenuPopover.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenuPopover/LanguageMenuPopover.baseStyles.tsx
@@ -36,8 +36,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   /* Arrow base */
-  & .fi-language-menu-popover_popper-arrow::before,
-  & .fi-language-menu-popover_popper-arrow::after {
+  & .fi-language-menu-popover_floatingui-arrow::before,
+  & .fi-language-menu-popover_floatingui-arrow::after {
     content: '';
     position: absolute;
     left: -9px;
@@ -49,12 +49,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   /* Arrow on top side */
   &
-    .fi-language-menu-popover_popper-arrow[data-popper-placement^='bottom-end'] {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
     bottom: 100%;
   }
 
   &
-    .fi-language-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::before {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
     border-bottom-color: ${theme.colors.blackLight1};
     border-width: 9px;
     margin-right: -9px;
@@ -62,7 +62,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   &
-    .fi-language-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::after {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
     border-bottom-color: ${theme.colors.whiteBase};
     border-width: 8px;
     margin-right: -9px;
@@ -71,19 +71,20 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   /* Arrow on bottom side */
-  & .fi-language-menu-popover_popper-arrow[data-popper-placement^='top-end'] {
+  &
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
     top: 100%;
   }
 
   &
-    .fi-language-menu-popover_popper-arrow[data-popper-placement^='top-end']::before {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
     border-top-color: ${theme.colors.blackLight1};
     border-width: 9px;
     margin-right: -9px;
   }
 
   &
-    .fi-language-menu-popover_popper-arrow[data-popper-placement^='top-end']::after {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
     border-top-color: ${theme.colors.whiteBase};
     border-width: 8px;
     margin-right: -9px;

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -150,8 +150,8 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
   outline: none;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow::before,
-.c5 .fi-language-menu-popover_popper-arrow::after {
+.c5 .fi-language-menu-popover_floatingui-arrow::before,
+.c5 .fi-language-menu-popover_floatingui-arrow::after {
   content: '';
   position: absolute;
   left: -9px;
@@ -161,18 +161,18 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
   pointer-events: none;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='bottom-end'] {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::before {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::after {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -180,17 +180,17 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='top-end'] {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
   top: 100%;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='top-end']::before {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='top-end']::after {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -370,7 +370,7 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
       </button>
       <div
         class="c4 c5 fi-language-menu-popover fi-language-menu-popover--hidden"
-        style="position: fixed; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
       >
         <div
           class="c4 fi-language-menu-popover_list"
@@ -411,8 +411,8 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
           </button>
         </div>
         <div
-          class="c0 fi-language-menu-popover_popper-arrow"
-          data-popper-arrow="true"
+          aria-hidden="true"
+          class="c4 fi-language-menu-popover_floatingui-arrow"
           style="position: absolute;"
         />
       </div>
@@ -571,8 +571,8 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
   outline: none;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow::before,
-.c5 .fi-language-menu-popover_popper-arrow::after {
+.c5 .fi-language-menu-popover_floatingui-arrow::before,
+.c5 .fi-language-menu-popover_floatingui-arrow::after {
   content: '';
   position: absolute;
   left: -9px;
@@ -582,18 +582,18 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
   pointer-events: none;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='bottom-end'] {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::before {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='bottom-end']::after {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -601,17 +601,17 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='top-end'] {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
   top: 100%;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='top-end']::before {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c5 .fi-language-menu-popover_popper-arrow[data-popper-placement^='top-end']::after {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -791,7 +791,7 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
       </button>
       <div
         class="c4 c5 fi-language-menu-popover"
-        style="position: fixed; left: 0px; top: 0px; right: 0px; transform: translate(0px, 15px);"
+        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 10px);"
       >
         <div
           class="c4 fi-language-menu-popover_list"
@@ -832,10 +832,10 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
           </button>
         </div>
         <div
-          class="c0 fi-language-menu-popover_popper-arrow"
-          data-popper-arrow="true"
-          data-popper-placement="bottom-end"
-          style="position: absolute; left: 0px; transform: translate(0px, 0px);"
+          aria-hidden="true"
+          class="c4 fi-language-menu-popover_floatingui-arrow"
+          data-floatingui-placement="bottom-end"
+          style="position: absolute; left: 0px;"
         />
       </div>
     </div>

--- a/src/core/Popover/Popover.tsx
+++ b/src/core/Popover/Popover.tsx
@@ -2,21 +2,14 @@ import React, { useState, ReactNode, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { useEnhancedEffect } from '../../utils/common';
 import { HtmlDivProps, HtmlDivWithRef } from '../../reset/HtmlDiv/HtmlDiv';
-import {
-  useFloating,
-  flip,
-  shift,
-  autoUpdate,
-  size,
-} from '@floating-ui/react-dom';
+import { useFloating, shift, autoUpdate, size } from '@floating-ui/react-dom';
+import classNames from 'classnames';
 
 export interface PopoverProps extends HtmlDivProps {
   /** Source ref for positioning the Popover */
   sourceRef: React.RefObject<any>;
   /** Content for the Popover */
   children: ReactNode;
-  /** Style props for portal element */
-  portalStyleProps?: React.CSSProperties;
   /**
    * Menu placement, top or bottom
    * @default bottom
@@ -33,6 +26,8 @@ export interface PopoverProps extends HtmlDivProps {
    * @default true
    */
   portal?: boolean;
+  /** CSS class for custom styles */
+  className?: string;
 }
 
 export interface PopoverProviderState {
@@ -50,7 +45,6 @@ export { PopoverConsumer };
 
 export const Popover = (props: PopoverProps) => {
   const {
-    portalStyleProps = {},
     placement = 'bottom',
     allowFlip = false,
     matchWidth = true,
@@ -58,6 +52,7 @@ export const Popover = (props: PopoverProps) => {
     sourceRef,
     onClickOutside,
     portal = true,
+    className,
     ...passProps
   } = props;
 
@@ -77,7 +72,6 @@ export const Popover = (props: PopoverProps) => {
   } = useFloating({
     open: true,
     middleware: [
-      flip(),
       shift(),
       ...(matchWidth
         ? [
@@ -145,9 +139,9 @@ export const Popover = (props: PopoverProps) => {
       <>
         {ReactDOM.createPortal(
           <div
-            className={'fi-portal'}
+            className={classNames('fi-portal', className)}
             ref={setFloatingElement}
-            style={{ ...floatingStyles, ...portalStyleProps }}
+            style={floatingStyles}
             tabIndex={-1}
             role="presentation"
           >
@@ -168,8 +162,9 @@ export const Popover = (props: PopoverProps) => {
   }
   return (
     <div
+      className={className}
       ref={setFloatingElement}
-      style={{ ...floatingStyles, ...portalStyleProps }}
+      style={floatingStyles}
       tabIndex={-1}
       role="presentation"
     >


### PR DESCRIPTION
## Description

PR updates two dependencies to officially support React 19: 
`react-modal` 3.16.1 --> 3.16.3
`popperjs` --> `floating-ui`

Migrating to floating-ui required quite a few code changes (since the APIs are quite different) but the end-user result and our component APIs remain unchanged

Also added `popoverClassName` prop to Dropdown, SingleSelect and MultiSelect

## Motivation and Context

We want to officially support React 19. While the old deps seemed to work with with R19, their peer deps only officially supported R18.

## How Has This Been Tested?

By running the components in Styleguidist macOS Chrome + Safari and checking that no React version warnings come up when installing the library into a React 19 project.

## Release notes

### Dependecy updates to support React 19
- `react-modal` 3.16.1 --> 3.16.3
- Migrate from `popperjs` to `floating-ui`
    - Affects the under-the-hood implementations of the following components: `<ActionMenu>`, `<DateInput>`, `<Dropdown>`, `<LanguageMenu>`, `<SingleSelect>`, `<MultiSelect>`

### General
- Update `suomifi-icons` to 7.6.0

### Dropdown
- Add `popoverClassName` prop. Allows e.g. modification of popover z-index

### SingleSelect
- Add `popoverClassName` prop. Allows e.g. modification of popover z-index

### MultiSelect
- Add `popoverClassName` prop. Allows e.g. modification of popover z-index
