### PR TITLE
Feature/search auto suggest

### DIFF
--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -219,28 +219,5 @@ export const baseStyles = (
         }
       }
     }
-    &.fi-search-input_suggestions {
-      ${font(theme)('bodyText')}
-      list-style-type: none;
-      box-sizing: border-box;
-      max-height: 265px;
-      background-color: ${theme.colors.whiteBase};
-      border-width: 0 1px 1px 1px;
-      border-style: solid;
-      border-color: ${theme.colors.depthDark3};
-      border-bottom-left-radius: ${theme.radiuses.basic};
-      border-bottom-right-radius: ${theme.radiuses.basic};
-      margin: 0;
-      padding: 4px 0 0 0;
-
-      display: block;
-      width: 100%;
-      overflow-y: auto;
-      overflow-x: hidden;
-
-      &:focus {
-        outline: none;
-      }
-    }
   }
 `;

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -219,5 +219,28 @@ export const baseStyles = (
         }
       }
     }
+    &.fi-search-input_suggestions {
+      ${font(theme)('bodyText')}
+      list-style-type: none;
+      box-sizing: border-box;
+      max-height: 265px;
+      background-color: ${theme.colors.whiteBase};
+      border-width: 0 1px 1px 1px;
+      border-style: solid;
+      border-color: ${theme.colors.depthDark3};
+      border-bottom-left-radius: ${theme.radiuses.basic};
+      border-bottom-right-radius: ${theme.radiuses.basic};
+      margin: 0;
+      padding: 4px 0 0 0;
+
+      display: block;
+      width: 100%;
+      overflow-y: auto;
+      overflow-x: hidden;
+
+      &:focus {
+        outline: none;
+      }
+    }
   }
 `;

--- a/src/core/Form/SearchInput/SearchInput.md
+++ b/src/core/Form/SearchInput/SearchInput.md
@@ -82,6 +82,13 @@ import { SearchInput } from 'suomifi-ui-components';
 import { useState } from 'react';
 
 const [controlledValue, setControlledValue] = useState('');
+const suggestedResults = [
+  { id: 1, label: 'Jalkapallo' },
+  { id: 2, label: 'Sulkapallo' },
+  { id: 3, label: 'Jääpallo' },
+  { id: 4, label: 'Koripallo' },
+  { id: 5, label: 'Pallo' }
+];
 
 <SearchInput
   labelText="Search the site"
@@ -90,7 +97,13 @@ const [controlledValue, setControlledValue] = useState('');
   visualPlaceholder="Write search terms..."
   onSearch={(value) => console.log(`Searching for ${value}...`)}
   value={controlledValue}
-  onChange={(newValue) => setControlledValue(newValue)}
+  onChange={(newValue) => {
+    console.log(newValue);
+    console.log(controlledValue.length >= 3);
+    setControlledValue(newValue);
+  }}
+  autosuggest={controlledValue.length >= 3}
+  suggestions={suggestedResults}
 />;
 ```
 

--- a/src/core/Form/SearchInput/SearchInput.md
+++ b/src/core/Form/SearchInput/SearchInput.md
@@ -10,6 +10,7 @@ Examples:
 - [Debounce](./#/Components/SearchInput?id=debounce)
 - [Full width](./#/Components/SearchInput?id=full-width)
 - [Hidden label](./#/Components/SearchInput?id=hidden-label)
+- [Search suggestions](./#/Components/SearchInput?id=search-suggestions)
 
 <div style="margin-bottom: 40px">
   [Props & methods](./#/Components/SearchInput?id=props--methods)
@@ -175,11 +176,11 @@ import { SearchInput } from 'suomifi-ui-components';
 
 ### Search suggestions
 
-You can provide search suggestions for the user using the `autosuggest` and `suggestions` props. The suggestions are shown in a popover list under the input field.
+You can provide search suggestions for the user using the `autosuggest` and `suggestions` props. The suggestions are shown in a popover list under the input field. Provide a descriptive `suggestionHintText` to let screen reader users know there will be a suggestion list under the component, as the usual accessible pattern is not available for search input component. Also provide `ariaOptionsAvailableText` to inform screen reader users about the updating amount of suggestions.
 
 When the user selects a suggestion from the list, the `onSuggestionSelected` callback gets called with the `uniqueId` of the element.
 
-It's recommended to use debounce on fetching the suggestions to avoid fetchin on every keypress.
+It's recommended to use debounce on fetching the suggestions to avoid unnecessary fetches. Do not use debounce prop of the component for this purpose.
 
 ```jsx
 import { SearchInput } from 'suomifi-ui-components';

--- a/src/core/Form/SearchInput/SearchInput.md
+++ b/src/core/Form/SearchInput/SearchInput.md
@@ -82,13 +82,6 @@ import { SearchInput } from 'suomifi-ui-components';
 import { useState } from 'react';
 
 const [controlledValue, setControlledValue] = useState('');
-const suggestedResults = [
-  { id: 1, label: 'Jalkapallo' },
-  { id: 2, label: 'Sulkapallo' },
-  { id: 3, label: 'Jääpallo' },
-  { id: 4, label: 'Koripallo' },
-  { id: 5, label: 'Pallo' }
-];
 
 <SearchInput
   labelText="Search the site"
@@ -98,12 +91,8 @@ const suggestedResults = [
   onSearch={(value) => console.log(`Searching for ${value}...`)}
   value={controlledValue}
   onChange={(newValue) => {
-    console.log(newValue);
-    console.log(controlledValue.length >= 3);
     setControlledValue(newValue);
   }}
-  autosuggest={controlledValue.length >= 3}
-  suggestions={suggestedResults}
 />;
 ```
 
@@ -181,6 +170,62 @@ import { SearchInput } from 'suomifi-ui-components';
   visualPlaceholder="Write search terms..."
   onSearch={(value) => console.log(`Searching for ${value}...`)}
   labelMode="hidden"
+/>;
+```
+
+### Search suggestions
+
+You can provide search suggestions for the user using the `autosuggest` and `suggestions` props. The suggestions are shown in a popover list under the input field.
+
+When the user selects a suggestion from the list, the `onSuggestionSelected` callback gets called with the `uniqueId` of the element.
+
+It's recommended to use debounce on fetching the suggestions to avoid fetchin on every keypress.
+
+```jsx
+import { SearchInput } from 'suomifi-ui-components';
+import { useState } from 'react';
+
+const [controlledValue, setControlledValue] = useState('');
+const [suggestions, setSuggestions] = useState([]);
+
+const potentialSearches = [
+  { uniqueId: 1, label: 'Jalkapallo' },
+  { uniqueId: 2, label: 'Sulkapallo' },
+  { uniqueId: 3, label: 'Jääpallo' },
+  { uniqueId: 4, label: 'Koripallo' },
+  { uniqueId: 5, label: 'Sulkapallo' },
+  { uniqueId: 6, label: 'Pallo' },
+  { uniqueId: 7, label: 'Jäätanssi' },
+  { uniqueId: 8, label: 'Jääkiekko' }
+];
+
+const filterSuggestions = (input, items) => {
+  return items.filter((item) =>
+    item.label.toLowerCase().includes(input.toLowerCase())
+  );
+};
+
+const handleSuggestionSelection = (id) => {
+  console.log(
+    'Searching for',
+    suggestions.find((element) => element.uniqueId === id).label
+  );
+};
+
+<SearchInput
+  labelText="Search the site"
+  searchButtonLabel="Search"
+  clearButtonLabel="Clear"
+  visualPlaceholder="Write search terms..."
+  onSearch={(value) => console.log(`Searching for ${value}...`)}
+  value={controlledValue}
+  onChange={(newValue) => {
+    setControlledValue(newValue);
+    setSuggestions(filterSuggestions(newValue, potentialSearches));
+  }}
+  autosuggest={controlledValue.length >= 3}
+  suggestions={suggestions}
+  onSuggestionSelected={(id) => handleSuggestionSelection(id)}
 />;
 ```
 

--- a/src/core/Form/SearchInput/SearchInput.md
+++ b/src/core/Form/SearchInput/SearchInput.md
@@ -189,14 +189,14 @@ const [controlledValue, setControlledValue] = useState('');
 const [suggestions, setSuggestions] = useState([]);
 
 const potentialSearches = [
-  { uniqueId: 1, label: 'Jalkapallo' },
-  { uniqueId: 2, label: 'Sulkapallo' },
-  { uniqueId: 3, label: 'Jääpallo' },
-  { uniqueId: 4, label: 'Koripallo' },
-  { uniqueId: 5, label: 'Sulkapallo' },
-  { uniqueId: 6, label: 'Pallo' },
-  { uniqueId: 7, label: 'Jäätanssi' },
-  { uniqueId: 8, label: 'Jääkiekko' }
+  { uniqueId: 1, label: 'Football' },
+  { uniqueId: 2, label: 'Badminton' },
+  { uniqueId: 3, label: 'Tennis' },
+  { uniqueId: 4, label: 'Basketball' },
+  { uniqueId: 5, label: 'Ice hockey' },
+  { uniqueId: 6, label: 'Ball' },
+  { uniqueId: 7, label: 'Ice skating' },
+  { uniqueId: 8, label: 'Figure skating' }
 ];
 
 const filterSuggestions = (input, items) => {
@@ -226,6 +226,8 @@ const handleSuggestionSelection = (id) => {
   autosuggest={controlledValue.length >= 3}
   suggestions={suggestions}
   onSuggestionSelected={(id) => handleSuggestionSelection(id)}
+  suggestionHintText="Search suggestions open under the input"
+  ariaOptionsAvailableText={`${suggestions.length} suggestions available`}
 />;
 ```
 

--- a/src/core/Form/SearchInput/SearchInput.test.tsx
+++ b/src/core/Form/SearchInput/SearchInput.test.tsx
@@ -366,6 +366,23 @@ describe('autosuggest', () => {
     expect(queryAllByRole('option')).toHaveLength(0);
   });
 
+  it('should retain focus on input after Escape key press', async () => {
+    const { getByRole } = render(
+      TestSearchInput({
+        autosuggest: true,
+        suggestions,
+      }),
+    );
+
+    const inputElement = getByRole('searchbox') as HTMLInputElement;
+
+    fireEvent.keyDown(inputElement, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(inputElement).toHaveFocus();
+    });
+  });
+
   it('should update suggestions dynamically', async () => {
     const updatedSuggestions = [
       { uniqueId: '3', label: 'cherry' },

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -205,7 +205,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
   private inputRef = this.props.forwardedRef || createRef<HTMLInputElement>();
 
   componentDidMount() {
-    if (!!this.props.autosuggest) {
+    if (!!this.props.autosuggest && this.props.suggestions.length > 0) {
       this.setState({ showPopover: true });
     }
   }
@@ -404,8 +404,8 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
                     {...passProps}
                     {...getConditionalAriaProp('aria-describedby', [
                       !!statusText ? statusTextId : undefined,
+                      !!autosuggest ? suggestionHintId : undefined,
                       ariaDescribedBy,
-                      suggestionHintId,
                     ])}
                     forwardedRef={this.inputRef}
                     aria-invalid={status === 'error'}

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -54,8 +54,11 @@ interface AutoSuggestProps {
   onSuggestionsFetchRequested?: (value: string) => void;
   /** Callback to clear suggestions on */
   onSuggestionsClearRequested?: () => void;
+  /** Callback when a suggestion is selected */
+  onSuggestionSelected?: (suggestionId: string) => void;
   /** List of suggestions to show */
   suggestions?: any[];
+  /** Text to show during loading state */
   suggestionsLoadingText?: string;
 }
 
@@ -203,6 +206,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
       statusTextAriaLiveMode = 'assertive',
       autosuggest = 'false',
       suggestions,
+      onSuggestionSelected,
       ...rest
     } = this.props;
     const [_marginProps, passProps] = separateMarginProps(rest);
@@ -270,8 +274,8 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
           );
           if (selectedItem) {
             this.setState({ showPopover: false });
-            if (this.props.onSearch) {
-              this.props.onSearch(selectedItem.label);
+            if (this.props.onSuggestionSelected) {
+              this.props.onSuggestionSelected(selectedItem.uniqueId);
             }
           }
         }
@@ -409,13 +413,13 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
               this.setState({ showPopover: false });
             }}
           >
-            <SuggestionList
-              className={searchInputClassNames.suggestions}
-              focusedDescendantId={this.state.focusedDescendantId || ''}
-              id={`${id}-itemlist`}
-            >
-              {suggestions && suggestions.length > 0 ? (
-                suggestions.map((item) => (
+            {suggestions && suggestions.length > 0 && (
+              <SuggestionList
+                className={searchInputClassNames.suggestions}
+                focusedDescendantId={this.state.focusedDescendantId || ''}
+                id={`${id}-itemlist`}
+              >
+                {suggestions.map((item) => (
                   <SelectItem
                     key={item.uniqueId}
                     id={item.uniqueId}
@@ -428,28 +432,16 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
                     checked={false}
                     onClick={() => {
                       this.setState({ showPopover: false });
-                      if (this.props.onChange) {
-                        this.props.onChange(item.label);
+                      if (onSuggestionSelected) {
+                        onSuggestionSelected(item.uniqueId);
                       }
                     }}
                   >
                     {item.label}
                   </SelectItem>
-                ))
-              ) : (
-                <SelectItem
-                  id="default-item"
-                  hasKeyboardFocus={false}
-                  hightlightQuery=""
-                  checked={false}
-                  onClick={() => {
-                    this.setState({ showPopover: false });
-                  }}
-                >
-                  No suggestions available
-                </SelectItem>
-              )}
-            </SuggestionList>
+                ))}
+              </SuggestionList>
+            )}
           </Popover>
         )}
       </HtmlDiv>

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -41,20 +41,15 @@ import { Popover } from '../../Popover/Popover';
 import { SelectItem } from '../Select/BaseSelect/SelectItem/SelectItem';
 import { SuggestionList } from './SuggestionList/SuggestionList';
 
-type SearchInputValue = string | number | undefined;
-
-type SearchInputStatus = Exclude<InputStatus, 'success'>;
+export type SearchInputStatus = Exclude<InputStatus, 'success'>;
 
 export type SearchSuggestionItem = {
   uniqueId: string;
   label: string;
+  [key: string]: string;
 };
 
 export type AutosSuggestElementProps = {
-  /** Callback to fetch suggestions based on input value */
-  onSuggestionsFetchRequested?: (value: string) => void;
-  /** Callback to clear suggestions on */
-  onSuggestionsClearRequested?: () => void;
   /** Callback when a suggestion is selected */
   onSuggestionSelected: (suggestionId: string) => void;
   /** List of suggestions to show */
@@ -73,10 +68,6 @@ type AutoSuggestProps =
        * @default false
        */
       autosuggest?: false | never;
-      /** Callback to fetch suggestions based on input value */
-      onSuggestionsFetchRequested?: (value: string) => void;
-      /** Callback to clear suggestions on */
-      onSuggestionsClearRequested?: () => void;
       /** Callback when a suggestion is selected */
       onSuggestionSelected?: (suggestionId: string) => void;
       /** List of suggestions to show */
@@ -93,16 +84,10 @@ type AutoSuggestProps =
        * @default false
        */
       autosuggest: true;
-      /** Callback to fetch suggestions based on input value */
-      onSuggestionsFetchRequested?: (value: string) => void;
-      /** Callback to clear suggestions on */
-      onSuggestionsClearRequested?: () => void;
       /** Callback when a suggestion is selected */
       onSuggestionSelected: (suggestionId: string) => void;
       /** List of suggestions to show */
       suggestions: SearchSuggestionItem[];
-      /** Text to show during loading state */
-      suggestionsLoadingText?: string;
       /** Hint text to let the users know that the suggestions will appear below the input */
       suggestionHintText: string;
       /** Text to let the user know how many suggestions are available */
@@ -155,15 +140,15 @@ export type SearchInputProps = StatusTextCommonProps &
     /** Sets components width to 100% */
     fullWidth?: boolean;
     /** Controlled value */
-    value?: SearchInputValue;
+    value?: string;
     /** Default value */
-    defaultValue?: SearchInputValue;
+    defaultValue?: string;
     /** Callback fired when input text changes */
-    onChange?: (value: SearchInputValue) => void;
+    onChange?: (value: string) => void;
     /** Callback fired on input blur */
     onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
     /** Callback fired on search button click */
-    onSearch?: (value: SearchInputValue) => void;
+    onSearch?: (value: string) => void;
     /** Debounce time in milliseconds for `onChange()` function. No debounce is applied if no value is given. */
     debounce?: number;
     /** Ref is forwarded to the underlying input element. Alternative for React `ref` attribute. */
@@ -190,7 +175,7 @@ const searchInputClassNames = {
 };
 
 interface SearchInputState {
-  value: SearchInputValue;
+  value: string;
   showPopover: boolean;
   focusedDescendantId: string | null;
 }
@@ -263,13 +248,13 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
     const statusTextId = `${id}-statusText`;
     const suggestionHintId = `${id}-suggestionHintText`;
 
-    const conditionalSetState = (newValue: SearchInputValue) => {
+    const conditionalSetState = (newValue: string) => {
       if (!('value' in this.props)) {
         this.setState({ value: newValue });
       }
     };
 
-    const onSearch = (searchValue: SearchInputValue) => {
+    const onSearch = (searchValue: string) => {
       if (!!propOnSearch) {
         propOnSearch(searchValue);
       }
@@ -394,6 +379,11 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
           >
             {labelText}
           </Label>
+          {autosuggest && (
+            <VisuallyHidden id={suggestionHintId}>
+              {suggestionHintText}
+            </VisuallyHidden>
+          )}
           <Debounce waitFor={debounce}>
             {(debouncer: Function, cancelDebounce: Function) => (
               <HtmlDiv className={searchInputClassNames.functionalityContainer}>
@@ -458,14 +448,9 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
             {statusText}
           </StatusText>
           {autosuggest && (
-            <>
-              <VisuallyHidden aria-live="polite" aria-atomic="true">
-                {this.state.showPopover ? ariaOptionsAvailableText : ''}
-              </VisuallyHidden>
-              <VisuallyHidden id={suggestionHintId}>
-                {suggestionHintText}
-              </VisuallyHidden>
-            </>
+            <VisuallyHidden aria-live="polite" aria-atomic="true">
+              {this.state.showPopover ? ariaOptionsAvailableText : ''}
+            </VisuallyHidden>
           )}
         </HtmlSpan>
         {this.state.showPopover && (

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -50,21 +50,21 @@ export type SearchSuggestionItem = {
   label: string;
 };
 
-type AutosSuggestElementProps = {
+export type AutosSuggestElementProps = {
   /** Callback to fetch suggestions based on input value */
   onSuggestionsFetchRequested?: (value: string) => void;
   /** Callback to clear suggestions on */
   onSuggestionsClearRequested?: () => void;
   /** Callback when a suggestion is selected */
-  onSuggestionSelected?: (suggestionId: string) => void;
+  onSuggestionSelected: (suggestionId: string) => void;
   /** List of suggestions to show */
   suggestions: SearchSuggestionItem[];
   /** Text to show during loading state */
-  suggestionsLoadingText?: string;
+  suggestionsLoadingText: string;
   /** Hint text to let the users know that the suggestions will appear below the input */
-  suggestionHintText?: string;
+  suggestionHintText: string;
   /** Text to let the user know how many suggestions are available */
-  ariaOptionsAvailableText?: string;
+  ariaOptionsAvailableText: string;
 };
 
 type AutoSuggestProps =
@@ -72,15 +72,41 @@ type AutoSuggestProps =
       /** Enable search suggestions
        * @default false
        */
-      autosuggest?: false;
-      autoSuggestProps?: never;
+      autosuggest?: false | never;
+      /** Callback to fetch suggestions based on input value */
+      onSuggestionsFetchRequested?: (value: string) => void;
+      /** Callback to clear suggestions on */
+      onSuggestionsClearRequested?: () => void;
+      /** Callback when a suggestion is selected */
+      onSuggestionSelected?: (suggestionId: string) => void;
+      /** List of suggestions to show */
+      suggestions?: SearchSuggestionItem[];
+      /** Text to show during loading state */
+      suggestionsLoadingText?: string;
+      /** Hint text to let the users know that the suggestions will appear below the input */
+      suggestionHintText?: string;
+      /** Text to let the user know how many suggestions are available */
+      ariaOptionsAvailableText?: string;
     }
   | {
       /** Enable search suggestions
        * @default false
        */
-      autosuggest?: true;
-      autoSuggestProps?: AutosSuggestElementProps;
+      autosuggest: true;
+      /** Callback to fetch suggestions based on input value */
+      onSuggestionsFetchRequested?: (value: string) => void;
+      /** Callback to clear suggestions on */
+      onSuggestionsClearRequested?: () => void;
+      /** Callback when a suggestion is selected */
+      onSuggestionSelected: (suggestionId: string) => void;
+      /** List of suggestions to show */
+      suggestions: SearchSuggestionItem[];
+      /** Text to show during loading state */
+      suggestionsLoadingText?: string;
+      /** Hint text to let the users know that the suggestions will appear below the input */
+      suggestionHintText: string;
+      /** Text to let the user know how many suggestions are available */
+      ariaOptionsAvailableText: string;
     };
 
 export type SearchInputProps = StatusTextCommonProps &
@@ -179,14 +205,14 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
   private inputRef = this.props.forwardedRef || createRef<HTMLInputElement>();
 
   componentDidMount() {
-    if (this.props.autosuggest) {
-      this.setState({ showPopover: true }); // Update showPopover based on autosuggest
+    if (!!this.props.autosuggest) {
+      this.setState({ showPopover: true });
     }
   }
 
   componentDidUpdate(prevProps: SearchInputProps) {
     if (prevProps.autosuggest !== this.props.autosuggest) {
-      this.setState({ showPopover: !!this.props.autosuggest }); // Update showPopover when autosuggest changes
+      this.setState({ showPopover: !!this.props.autosuggest });
     }
   }
 
@@ -226,20 +252,16 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
       'aria-describedby': ariaDescribedBy,
       statusTextAriaLiveMode = 'assertive',
       autosuggest = false, // Default autosuggest to false
-      autoSuggestProps,
+      suggestions,
+      suggestionHintText,
+      ariaOptionsAvailableText,
+      onSuggestionSelected,
       ...rest
     } = this.props;
     const [_marginProps, passProps] = separateMarginProps(rest);
 
     const statusTextId = `${id}-statusText`;
     const suggestionHintId = `${id}-suggestionHintText`;
-
-    const {
-      suggestions,
-      suggestionHintText,
-      ariaOptionsAvailableText,
-      onSuggestionSelected,
-    } = autoSuggestProps || {};
 
     const conditionalSetState = (newValue: SearchInputValue) => {
       if (!('value' in this.props)) {
@@ -277,7 +299,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
       const { focusedDescendantId } = this.state;
-      const popoverItems = autoSuggestProps?.suggestions || [];
+      const popoverItems = suggestions || [];
 
       const index = focusedDescendantId
         ? popoverItems.findIndex(
@@ -302,8 +324,8 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
           );
           if (selectedItem) {
             this.setState({ showPopover: false });
-            if (autoSuggestProps?.onSuggestionSelected) {
-              autoSuggestProps.onSuggestionSelected(selectedItem.uniqueId);
+            if (onSuggestionSelected) {
+              onSuggestionSelected(selectedItem.uniqueId);
             }
           }
         }

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -299,6 +299,11 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
       if (event.key === 'Escape') {
         event.preventDefault();
         this.setState({ showPopover: false, focusedDescendantId: null });
+        setTimeout(() => {
+          if (this.inputRef.current) {
+            this.inputRef.current.focus();
+          }
+        }, 100);
       }
 
       if (event.key === 'Enter') {
@@ -402,8 +407,6 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
                     id={id}
                     className={searchInputClassNames.inputElement}
                     type="search"
-                    role="searchbox"
-                    aria-controls={`${id}-itemlist`}
                     aria-activedescendant={this.state.focusedDescendantId}
                     autoComplete="off"
                     value={this.state.value}

--- a/src/core/Form/SearchInput/SuggestionList/SuggestionList.baseStyles.ts
+++ b/src/core/Form/SearchInput/SuggestionList/SuggestionList.baseStyles.ts
@@ -1,0 +1,27 @@
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+import { font } from '../../../theme/reset';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  ${font(theme)('bodyText')}
+  list-style-type: none;
+  box-sizing: border-box;
+  max-height: 265px;
+  background-color: ${theme.colors.whiteBase};
+  border-width: 0 1px 1px 1px;
+  border-style: solid;
+  border-color: ${theme.colors.depthDark3};
+  border-bottom-left-radius: ${theme.radiuses.basic};
+  border-bottom-right-radius: ${theme.radiuses.basic};
+  margin: 0;
+  padding: 4px 0 0 0;
+
+  display: block;
+  width: calc(100% + 26px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  margin-left: -1px;
+  &:focus {
+    outline: none;
+  }
+`;

--- a/src/core/Form/SearchInput/SuggestionList/SuggestionList.tsx
+++ b/src/core/Form/SearchInput/SuggestionList/SuggestionList.tsx
@@ -1,0 +1,139 @@
+import React, {
+  Component,
+  RefObject,
+  forwardRef,
+  ReactElement,
+  createRef,
+  FocusEvent,
+} from 'react';
+import styled from 'styled-components'; // Fixed import for styled-components
+import classnames from 'classnames';
+import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../theme';
+import { HtmlUlWithRef } from '../../../../reset';
+import { forkRefs } from '../../../../utils/common/common';
+import { baseStyles } from './SuggestionList.baseStyles';
+
+const baseClassName = 'fi-suggstion-list';
+
+export interface SuggestionListProps {
+  /** SuggestionList container div class name for custom styling. */
+  className?: string;
+  /** List items */
+  children: ReactElement | Array<ReactElement | Array<ReactElement>>;
+  /** Id for the currently focused list item for styles and scrolling */
+  focusedDescendantId: string;
+  /** onBlur event handler */
+  onBlur?: (event: FocusEvent<Element>) => void;
+  /** onKeyDown event handler */
+  onKeyDown?: (event: React.KeyboardEvent<HTMLUListElement>) => void;
+  /** Id needed for aria-owns and aria-controls */
+  id: string;
+  /** Prevents scrollItemList() function from running */
+  preventScrolling?: boolean;
+}
+
+interface InnerRef {
+  forwardedRef: React.Ref<HTMLUListElement>;
+}
+class BaseSuggestionList extends Component<
+  SuggestionListProps & InnerRef & SuomifiThemeProp
+> {
+  private wrapperRef: RefObject<HTMLUListElement>;
+
+  constructor(props: SuggestionListProps & InnerRef & SuomifiThemeProp) {
+    super(props);
+    this.wrapperRef = createRef();
+  }
+
+  componentDidUpdate(
+    prevProps: SuggestionListProps & InnerRef & SuomifiThemeProp,
+  ) {
+    if (
+      this.props.focusedDescendantId !== prevProps.focusedDescendantId &&
+      !!this.props.focusedDescendantId &&
+      !this.props.preventScrolling
+    ) {
+      this.scrollItemList(this.props.focusedDescendantId);
+    }
+  }
+
+  componentDidMount() {
+    if (!!this.props.focusedDescendantId && !this.props.preventScrolling) {
+      this.scrollItemList(this.props.focusedDescendantId);
+    }
+  }
+
+  private scrollItemList = (elementId: string) => {
+    // 4px reduction to scroll position is required due to container padding.
+    const wrapperOffsetPx = 4;
+    if (this.wrapperRef !== null && this.wrapperRef.current !== null) {
+      const elementOffsetTop =
+        document.getElementById(elementId)?.offsetTop || 0;
+      const elementOffsetHeight =
+        document.getElementById(elementId)?.offsetHeight || 0;
+      if (elementOffsetTop < this.wrapperRef.current.scrollTop) {
+        this.wrapperRef.current.scrollTop = elementOffsetTop - wrapperOffsetPx;
+      } else {
+        const offsetBottom = elementOffsetTop + elementOffsetHeight;
+        const scrollBottom =
+          this.wrapperRef.current.scrollTop +
+          this.wrapperRef.current.offsetHeight;
+        if (offsetBottom > scrollBottom) {
+          this.wrapperRef.current.scrollTop =
+            offsetBottom -
+            this.wrapperRef.current.offsetHeight -
+            wrapperOffsetPx;
+        }
+      }
+    }
+  };
+
+  render() {
+    const {
+      className,
+      theme,
+      forwardedRef,
+      children,
+      onBlur,
+      onKeyDown,
+      id,
+      focusedDescendantId,
+      preventScrolling,
+      ...passProps
+    } = this.props;
+
+    return (
+      <HtmlUlWithRef
+        id={id}
+        tabIndex={0}
+        forwardRef={forkRefs(this.wrapperRef, forwardedRef)}
+        className={classnames(baseClassName, className, {})}
+        {...passProps}
+        role="listbox"
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+        aria-activedescendant={focusedDescendantId}
+      >
+        {children}
+      </HtmlUlWithRef>
+    );
+  }
+}
+
+const StyledSuggestionList = styled(BaseSuggestionList)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+export const SuggestionList = forwardRef(
+  (props: SuggestionListProps, ref: RefObject<HTMLUListElement>) => (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <StyledSuggestionList
+          theme={suomifiTheme}
+          forwardedRef={ref}
+          {...props}
+        />
+      )}
+    </SuomifiThemeConsumer>
+  ),
+);

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -646,10 +646,10 @@ exports[`snapshot should have matching default structure 1`] = `
       >
         <input
           aria-invalid="false"
+          autocomplete="off"
           class="c5 fi-search-input_input"
           data-testid="searchinput"
           id="1"
-          role="searchbox"
           type="search"
           value=""
         />

--- a/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.tsx
@@ -45,7 +45,7 @@ class BaseSelectItem extends Component<SelectItemProps & SuomifiThemeProp> {
       );
       return substrings.map((substring, i) => {
         const isMatch = substring.toLowerCase() === query.toLowerCase();
-        if (isMatch) {
+        if (!isMatch && substring.length > 0) {
           return (
             // eslint-disable-next-line react/no-array-index-key
             <HtmlMark className={selectItemClassNames.queryHighlight} key={i}>

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
@@ -17,10 +17,9 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   padding: 4px 0 0 0;
 
   display: block;
-  width: calc(100% + 26px);
+  width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
-  margin-left: -1px;
   &:focus {
     outline: none;
   }

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
@@ -17,10 +17,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   padding: 4px 0 0 0;
 
   display: block;
-  width: 100%;
+  width: calc(100% + 26px);
   overflow-y: auto;
   overflow-x: hidden;
-
+  margin-left: -1px;
   &:focus {
     outline: none;
   }

--- a/src/core/Form/index.ts
+++ b/src/core/Form/index.ts
@@ -10,7 +10,12 @@ export {
   type TextInputValue,
 } from './TextInput/TextInput';
 export { TimeInput, type TimeInputProps } from './TimeInput/TimeInput';
-export { SearchInput, type SearchInputProps } from './SearchInput/SearchInput';
+export {
+  SearchInput,
+  type SearchInputProps,
+  type SearchSuggestionItem,
+  type SearchInputStatus,
+} from './SearchInput/SearchInput';
 export { Checkbox, type CheckboxProps } from './Checkbox/Checkbox';
 export {
   CheckboxGroup,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,8 @@ export {
   type ToggleButtonProps,
   SearchInput,
   type SearchInputProps,
+  type SearchSuggestionItem,
+  type SearchInputStatus,
   RadioButton,
   type RadioButtonProps,
   RadioButtonGroup,


### PR DESCRIPTION
## Description
This PR adds an autosuggest feature to SearchInput. It also changes the mark logic in popover lists to work so that instead of the user entry being bolded, the rest of the matching label is. SearchInputValue type is changed to just string too.

## Motivation and Context
This feature has been requested for a long time, and it allows changing third party solutions to our component in Suomi.fi services in cases where the suggestions are needed.

## How Has This Been Tested?
Tested by running locally on styleguidist as well as in a React + vite project.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c39ebc6e-d15d-4968-b9c3-a9e5050d3c83)

## Release notes
### SearchInput
* **Breaking change:** remove SearchInputValue type and replace it with `string`
* Add search suggestion popover feature
### SingleSelect, MultiSelect
* **Breaking change:** flip bolding logic for matching text in popover menu items 
