### PR TITLE
[Fix] FileInput file preview improvements

### DIFF
--- a/src/core/Form/FileInput/FileInput.tsx
+++ b/src/core/Form/FileInput/FileInput.tsx
@@ -203,10 +203,6 @@ export interface Metadata {
    */
   fileType: string;
   /**
-   * URL to the file
-   */
-  fileURL?: string;
-  /**
    * id of the file
    */
   id?: string;

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -116,7 +116,9 @@ const BaseFileItem = (props: FileItemProps) => {
             <IconPreloader className={fileItemClassNames.loadingIcon} />
           )}
           {!fileItemDetails?.status && <IconGenericFile />}
-          {filePreview ? (
+          {filePreview &&
+          fileItemDetails?.status !== 'error' &&
+          fileItemDetails?.status !== 'loading' ? (
             <Link
               ref={
                 fileItemRefs.fileNameRef as React.RefObject<HTMLAnchorElement>

--- a/src/core/Form/FileInput/FileItem.tsx
+++ b/src/core/Form/FileInput/FileItem.tsx
@@ -67,10 +67,8 @@ const BaseFileItem = (props: FileItemProps) => {
 
   const getFileSizeText = () => {
     const fileSize = metadataFileSize || file?.size;
-    if (!fileSize) {
-      return '';
-    }
-    if (fileSize < 1024) {
+
+    if (!fileSize || fileSize < 1024) {
       return `${fileSize} B`;
     }
     if (fileSize < 1024 * 1024) {
@@ -153,7 +151,7 @@ const BaseFileItem = (props: FileItemProps) => {
             className={fileItemClassNames.fileSize}
             id={filePreview ? fileItemRefs.fileSizeElementId : undefined}
           >
-            {`(${getFileSizeText()})`}
+            {getFileSizeText()}
           </HtmlDiv>
         </HtmlDiv>
         <Button


### PR DESCRIPTION
## Description
This PR addresses several issues in the FileInput component:
* File preview link is now only shown for items that don't have a status of `error` or 'loading'
* Removed a redundant key from the metadata interface
* To avoid empty file size in UI, show file size of `0 B` when the size is either zero or undefined/null

## Motivation and Context
These were minor issues that were reported by developers using the component and needed to be addressed.

## How Has This Been Tested?
Tested by running locally in styleguidist on chrome, since the changes were straightforward

## Release notes
### FileInput
* **Breaking change:** Prevent showing preview link for files that have a status of `error` or  `loading`
* **Breaking change:** Show file size of `0 B` for empty files and when file size is undefined
* Removed a redundant key from file metadata interface
