### PR TITLE
[Fix]: Dropdown and SingleSelect undefined value

### DIFF
--- a/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
@@ -306,6 +306,16 @@ class BaseDropdown<T extends string = string> extends Component<
     this.componentIsMounted = false;
   }
 
+  componentDidUpdate(prevProps: Readonly<DropdownProps<T>>): void {
+    // Case nullifying value by setting it from a defined value to undefined
+    if (this.props.value === undefined && prevProps.value !== undefined) {
+      this.setState({
+        selectedValue: undefined,
+        selectedValueNode: undefined,
+      });
+    }
+  }
+
   private isOutsideClick(event: MouseEvent) {
     return (
       !!this.buttonRef &&

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
@@ -105,7 +105,7 @@ interface DropdownState<T> {
 export interface DropdownProps<T extends string = string>
   extends StatusTextCommonProps,
     MarginProps,
-    Omit<HtmlButtonProps, 'onChange'> {
+    Omit<HtmlButtonProps, 'onChange' | 'value'> {
   /**
    * HTML id attribute
    * If no id is specified, one will be generated automatically
@@ -116,7 +116,7 @@ export interface DropdownProps<T extends string = string>
   /** Sets a default, initially selected value for non controlled Dropdown */
   defaultValue?: T;
   /** Controlled selected value, overrides `defaultValue` if provided. */
-  value?: T;
+  value?: T | null;
   /** Label for the Dropdown component. */
   labelText: ReactNode;
   /** Hint text to be shown below the label */
@@ -257,7 +257,7 @@ class BaseDropdown<T extends string = string> extends Component<
   }
 
   static getSelectedValueNode<U extends string>(
-    selectedValue: string | undefined,
+    selectedValue: string | undefined | null,
     children:
       | Array<
           | ReactElement<DropdownItemProps<U>>

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -289,6 +289,16 @@ class BaseSingleSelect<T> extends Component<
         computedItems: this.props.items,
       });
     }
+    // Case nullifying selectedItem by setting it from a defined value to undefined
+    if (
+      this.props.selectedItem === undefined &&
+      prevProps.selectedItem !== undefined
+    ) {
+      this.setState({
+        selectedItem: null,
+        filterInputValue: '',
+      });
+    }
   }
 
   private filter = (data: SingleSelectData, query: string) =>


### PR DESCRIPTION
## Description

PR fixes an issue in the `<Dropdown>` and `<SingleSelect>` components where setting the controlled value from a defined value to undefined did not clear the input as intuitively expected.

## Motivation and Context

This was reported by a user

## How Has This Been Tested?

Styleguidist

## Release notes

### Dropdown
- Fix issue of input not clearing when setting `value` from a defined value to undefined

### SingleSelect
- Fix issue of input not clearing when setting `selectedItem` from a defined value to undefined
