### PR TITLE
[Feature] Change ActionMenu button content type

### DIFF
--- a/src/core/ActionMenu/ActionMenu.tsx
+++ b/src/core/ActionMenu/ActionMenu.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useRef,
   ReactElement,
+  ReactNode,
 } from 'react';
 import { styled } from 'styled-components';
 import classnames from 'classnames';
@@ -52,7 +53,7 @@ export type MenuContent =
 export type ActionMenuProps = MarginProps &
   Omit<ButtonProps, keyof ForcedAccessibleNameProps | keyof LoadingProps> & {
     /** Text content for the menu button */
-    buttonText?: string;
+    buttonText?: ReactNode;
     /**
      * `'default'` | `'inverted'` | `'secondary'` | `'secondaryLight'`| `'secondaryNoBorder'`
      *


### PR DESCRIPTION
## Description
This PR changes the button content type for ActionMenu from string to ReactNode to allow for more versatile content when needed. This is the type in other similar components already.

## Motivation and Context
This was requested by a developer using the component.

## How Has This Been Tested?
Tested by automated unit tests and by running locally on styleguidist.

## Release notes
### ActionMenu
* **Breaking change:** Change `buttonText` prop type from `string` to `ReactNode`