### PR TITLE
[Fix] Trigger search on enter keypress in SearchInput

### DIFF
--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -413,6 +413,8 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
               onSuggestionSelected(selectedItem.uniqueId);
             }
           }
+        } else if (!!this.state.value) {
+          onSearch(this.state.displayValue);
         }
       }
 


### PR DESCRIPTION
## Description
This PR fixes the behavior of enter keypress in SearchInput. With the addition of the search suggestions the original function of "search on enter keypress" was lost. This PR adds it back.

## Motivation and Context
This was reported by a developer and was an oversight that is also easily fixed.

## How Has This Been Tested?
Tested by running locally on styleguidist and checking that no functionality is broken with this change.

## Release notes
- Included in the search suggest feature
