### PR TITLE
[Fix] Dropdown typing issue with React 19

### DIFF
--- a/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
@@ -174,7 +174,7 @@ export interface DropdownProps<T extends string = string>
   /** Set component's width to 100% */
   fullWidth?: boolean;
   /** Ref is forwarded to the button element. Alternative to React `ref` attribute. */
-  forwardedRef?: React.RefObject<HTMLButtonElement>;
+  forwardedRef?: React.Ref<HTMLButtonElement>;
 }
 
 class BaseDropdown<T extends string = string> extends Component<
@@ -773,12 +773,12 @@ const DropdownInner = <T extends string = string>(
 };
 
 // Not directly exporting the DropdownInner as styleguidist was not showing props then.
-export const Dropdown = React.forwardRef(DropdownInner) as <
-  T extends string = string,
->(
-  props: DropdownProps<T>,
-  ref: React.RefObject<HTMLButtonElement>,
-) => ReturnType<typeof DropdownInner>;
+export const Dropdown = React.forwardRef<
+  HTMLButtonElement,
+  DropdownProps<string>
+>(DropdownInner) as <T extends string = string>(
+  props: DropdownProps<T> & { ref?: React.Ref<HTMLButtonElement> },
+) => React.ReactElement | null;
 
 DropdownInner.displayName = 'Dropdown';
 export { DropdownProvider, DropdownConsumer };


### PR DESCRIPTION
## Description
Dropdown component had a prop pattern for providing ref, that is no longer supported in React 19. Even in older versions it is not the recommended pattern. This PR changes the typing to support React 19 in addition to older versions.

## Motivation and Context
This bug was reported by a developer. It only appeared after installing @types/react at version 19. That's why it didn't show up in tests earlier.

## How Has This Been Tested?
Tested in a React + Vite project with React 18 and 19. The bug was confirmed in React 19, and the fix was tested in both React 18 and React 19 environments.

## Release notes
**Breaking change:** Change Dropdown ref prop and return type to fix an issue with React 19  
