### PR TITLE
[Fix] Apply flip() to Popover and adjust floating-ui tests

### DIFF
--- a/src/core/ActionMenu/ActionMenu.test.tsx
+++ b/src/core/ActionMenu/ActionMenu.test.tsx
@@ -5,6 +5,9 @@ import { ActionMenuItem } from '../ActionMenu/ActionMenuItem';
 import { ActionMenuDivider } from '../ActionMenu/ActionMenuDivider/ActionMenuDivider';
 import { axeTest } from '../../utils/test';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const waitForPosition = () => act(async () => {});
+
 const actionMenuProps: ActionMenuProps = {
   buttonText: 'Actions',
   name: 'am-test-name',
@@ -44,6 +47,7 @@ describe('Basic ActionMenu', () => {
 
   it('should match snapshot', async () => {
     const { baseElement } = render(BasicActionMenu);
+
     await waitFor(() => {
       expect(baseElement).toMatchSnapshot();
     });
@@ -60,6 +64,7 @@ describe('Disabled ActionMenu', () => {
 
   it('should have disabled attributes when disabled', async () => {
     const { findByRole } = render(BasicActionMenu);
+
     const button = await findByRole('button');
     await waitFor(() => {
       expect(button).toHaveClass('fi-button--disabled');
@@ -70,6 +75,7 @@ describe('Disabled ActionMenu', () => {
 
   it('should match snapshot', async () => {
     const { baseElement } = render(BasicActionMenu);
+
     await waitFor(() => {
       expect(baseElement).toMatchSnapshot();
     });
@@ -127,11 +133,9 @@ describe('movement in ActionMenu', () => {
 
     await act(async () => {
       fireEvent.click(menuButton);
-
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10);
-      });
     });
+
+    await waitForPosition();
 
     await waitFor(() => {
       expect(baseElement).toMatchSnapshot();
@@ -140,10 +144,6 @@ describe('movement in ActionMenu', () => {
     await act(async () => {
       fireEvent.keyPress(baseElement, {
         key: 'ArrowDown',
-      });
-
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10);
       });
     });
 

--- a/src/core/ActionMenu/ActionMenuPopover/ActionMenuPopover.baseStyles.tsx
+++ b/src/core/ActionMenu/ActionMenuPopover/ActionMenuPopover.baseStyles.tsx
@@ -49,12 +49,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   /* Arrow on top side */
   &
-    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom'] {
     bottom: 100%;
   }
 
   &
-    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
     border-bottom-color: ${theme.colors.blackLight1};
     border-width: 9px;
     margin-right: -9px;
@@ -62,7 +62,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   &
-    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::after {
     border-bottom-color: ${theme.colors.whiteBase};
     border-width: 8px;
     margin-right: -9px;
@@ -71,20 +71,19 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   /* Arrow on bottom side */
-  &
-    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
+  & .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top'] {
     top: 100%;
   }
 
   &
-    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
     border-top-color: ${theme.colors.blackLight1};
     border-width: 9px;
     margin-right: -9px;
   }
 
   &
-    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
+    .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::after {
     border-top-color: ${theme.colors.whiteBase};
     border-width: 8px;
     margin-right: -9px;

--- a/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
@@ -189,18 +189,18 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -208,17 +208,17 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -972,18 +972,18 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -991,17 +991,17 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -1755,18 +1755,18 @@ exports[`No borders variant should match snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -1774,17 +1774,17 @@ exports[`No borders variant should match snapshot 1`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -2538,18 +2538,18 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -2557,17 +2557,17 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -3086,10 +3086,10 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
           tabindex="-1"
         >
           <button
-            class="c4 fi-action-menu-item c9"
+            class="c4 fi-action-menu-item c9 fi-action-menu-item--selected"
             id="test-id-menu-list-item-0"
             role="menuitem"
-            tabindex="-1"
+            tabindex="0"
             type="button"
           >
             Item 1
@@ -3322,18 +3322,18 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   pointer-events: none;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom'] {
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -3341,17 +3341,17 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
   bottom: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top'] {
   top: 100%;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
+.c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;

--- a/src/core/Form/DateInput/DateInput.test.tsx
+++ b/src/core/Form/DateInput/DateInput.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { act } from 'react';
 import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { DateInput } from './DateInput';
 
@@ -355,7 +355,9 @@ describe('props', () => {
         );
         const dropdownButton = dropdown?.querySelector('.fi-dropdown_button');
         if (dropdownButton) {
-          fireEvent.click(dropdownButton);
+          await act(async () => {
+            fireEvent.click(dropdownButton);
+          });
           const lis = dropdown?.querySelectorAll('li');
           await waitFor(() => {
             expect(lis?.[0]).toHaveTextContent('Tammikuu');

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3541,9 +3541,24 @@ exports[`snapshots match date input with datepicker with controlled input value 
   padding-bottom: 8px;
 }
 
+.c12.fi-dropdown--open .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 1px solid hsl(201, 7%, 58%);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  border-top: 0;
+  padding-top: 8px;
+  box-shadow: none;
+}
+
 .c12.fi-dropdown--error .fi-dropdown_button {
   border-color: hsl(3, 59%, 43%);
   border-width: 2px;
+}
+
+.c12.fi-dropdown--error .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 2px solid hsl(3, 59%, 43%);
 }
 
 .c12.fi-dropdown--italicize .fi-dropdown_button {
@@ -4087,6 +4102,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               aria-haspopup="listbox"
               aria-labelledby="16-displayValue 16-label"
               class="c6 fi-dropdown_button"
+              data-floating-ui-placement="bottom"
               id="16_button"
               tabindex="0"
               type="button"
@@ -4135,6 +4151,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
               aria-haspopup="listbox"
               aria-labelledby="17-displayValue 17-label"
               class="c6 fi-dropdown_button"
+              data-floating-ui-placement="bottom"
               id="17_button"
               tabindex="0"
               type="button"
@@ -5680,9 +5697,24 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   padding-bottom: 8px;
 }
 
+.c12.fi-dropdown--open .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 1px solid hsl(201, 7%, 58%);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  border-top: 0;
+  padding-top: 8px;
+  box-shadow: none;
+}
+
 .c12.fi-dropdown--error .fi-dropdown_button {
   border-color: hsl(3, 59%, 43%);
   border-width: 2px;
+}
+
+.c12.fi-dropdown--error .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 2px solid hsl(3, 59%, 43%);
 }
 
 .c12.fi-dropdown--italicize .fi-dropdown_button {
@@ -6235,6 +6267,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 aria-haspopup="listbox"
                 aria-labelledby="9-displayValue 9-label"
                 class="c6 fi-dropdown_button"
+                data-floating-ui-placement="bottom"
                 id="9_button"
                 tabindex="0"
                 type="button"
@@ -6283,6 +6316,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
                 aria-haspopup="listbox"
                 aria-labelledby="10-displayValue 10-label"
                 class="c6 fi-dropdown_button"
+                data-floating-ui-placement="bottom"
                 id="10_button"
                 tabindex="0"
                 type="button"

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -115,6 +115,17 @@ export const baseStyles = (
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
         padding-bottom: 8px;
+
+        &[data-floating-ui-placement^='top'] {
+          border-bottom: 1px solid ${theme.colors.depthDark3};
+          border-top-left-radius: 0;
+          border-top-right-radius: 0;
+          border-bottom-left-radius: ${theme.radiuses.basic};
+          border-bottom-right-radius: ${theme.radiuses.basic};
+          border-top: 0;
+          padding-top: 8px;
+          box-shadow: none;
+        }
       }
     }
 
@@ -122,6 +133,10 @@ export const baseStyles = (
       .fi-dropdown_button {
         border-color: ${theme.colors.alertBase};
         border-width: 2px;
+
+        &[data-floating-ui-placement^='top'] {
+          border-bottom: 2px solid ${theme.colors.alertBase};
+        }
       }
     }
 

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.test.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.test.tsx
@@ -5,6 +5,9 @@ import { Dropdown, DropdownProps } from './Dropdown';
 import { DropdownItem } from '../DropdownItem/DropdownItem';
 import { axeTest } from '../../../../utils/test';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const waitForPosition = () => act(async () => {});
+
 const dropdownProps = {
   labelText: 'Dropdown test',
   name: 'dropdown-test',
@@ -77,6 +80,7 @@ describe('Basic dropdown', () => {
 
   it('should match snapshot', async () => {
     const { baseElement, getByRole } = render(BasicDropdown);
+    await waitForPosition();
     const menuButton = getByRole('button') as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(menuButton);
@@ -147,6 +151,7 @@ describe('Controlled Dropdown', () => {
 
   it('should match snapshot', async () => {
     const { baseElement, getByRole } = render(ControlledDropdown);
+    await waitForPosition();
     const button = getByRole('button') as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(button);
@@ -172,6 +177,7 @@ describe('Dropdown with additional aria-label', () => {
 
   it('should match snapshot', async () => {
     const { baseElement, getByRole } = render(DropdownWithExtraLabel);
+    await waitForPosition();
     const menuButton = getByRole('button') as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(menuButton);
@@ -186,6 +192,7 @@ describe('Children', () => {
       labelText: 'Dropdown',
     });
     const { getByRole, getAllByRole } = render(NestedDropdown);
+    await waitForPosition();
     const menuButton = getByRole('button') as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(menuButton);
@@ -203,6 +210,7 @@ describe('Children', () => {
       visualPlaceholder: 'Select',
     });
     const { getByRole, getAllByRole } = render(NestedDropdown);
+    await waitForPosition();
     const menuButton = getByRole('button') as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(menuButton);
@@ -217,6 +225,7 @@ describe('Children', () => {
   it('should select item when item is clicked', async () => {
     const NestedDropdown = TestNestedDropdown({ labelText: 'Dropdown' });
     const { getByRole, getAllByRole } = render(NestedDropdown);
+    await waitForPosition();
     const menuButton = getByRole('button') as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(menuButton);
@@ -233,6 +242,7 @@ describe('DropdownItem', () => {
   it('should be selected when item is clicked', async () => {
     const BasicDropdown = TestDropdown({ labelText: 'Dropdown' });
     const { getByRole, getAllByRole } = render(BasicDropdown);
+    await waitForPosition();
     const menuButton = getByRole('button') as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(menuButton);
@@ -254,6 +264,7 @@ describe('DropdownItem', () => {
       </Dropdown>
     );
     const { getByRole, getAllByRole } = render(BasicDropdown);
+    await waitForPosition();
     const menuButton = getByRole('button') as HTMLButtonElement;
     await act(async () => {
       fireEvent.click(menuButton);
@@ -267,7 +278,7 @@ describe('DropdownItem', () => {
 });
 
 describe('statusText', () => {
-  it('has status text defined by prop', () => {
+  it('has status text defined by prop', async () => {
     const statusTextProps: DropdownProps = {
       ...dropdownProps,
       statusText: 'Test status',
@@ -279,7 +290,7 @@ describe('statusText', () => {
 });
 
 describe('statusTextAriaLiveMode', () => {
-  it('has assertive aria-live by default', () => {
+  it('has assertive aria-live by default', async () => {
     const statusTextProps: DropdownProps = {
       ...dropdownProps,
       statusText: 'Test status',
@@ -288,7 +299,7 @@ describe('statusTextAriaLiveMode', () => {
     const { getByText } = render(DropdownWithStatusText);
     expect(getByText('Test status')).toHaveAttribute('aria-live', 'assertive');
   });
-  it('has aria-live defined by prop', () => {
+  it('has aria-live defined by prop', async () => {
     const statusTextProps: DropdownProps = {
       ...dropdownProps,
       statusText: 'Test status',
@@ -302,7 +313,7 @@ describe('statusTextAriaLiveMode', () => {
 });
 
 describe('hintText', () => {
-  it('has hint text', () => {
+  it('has hint text', async () => {
     const hintTextProps: DropdownProps = {
       ...dropdownProps,
       hintText: 'Test hint text',
@@ -315,7 +326,7 @@ describe('hintText', () => {
 });
 
 describe('margin', () => {
-  it('should have margin style from margin prop', () => {
+  it('should have margin style from margin prop', async () => {
     const props: DropdownProps = {
       ...dropdownProps,
       margin: 'xs',
@@ -325,7 +336,7 @@ describe('margin', () => {
     expect(div).toHaveStyle('margin: 10px');
   });
 
-  it('should have margin style overwritten by style prop', () => {
+  it('should have margin style overwritten by style prop', async () => {
     const props: DropdownProps = {
       ...dropdownProps,
       margin: 'xs',

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
@@ -29,7 +29,7 @@ import {
   forkRefs,
   getOwnerDocument,
 } from '../../../../utils/common/common';
-import { Popover } from '../../../../core/Popover/Popover';
+import { Popover, PopoverConsumer } from '../../../../core/Popover/Popover';
 import { SelectItemList } from '../../../Form/Select/BaseSelect/SelectItemList/SelectItemList';
 import { HintText } from '../../../Form/HintText/HintText';
 import { StatusText } from '../../../Form/StatusText/StatusText';
@@ -100,6 +100,7 @@ interface DropdownState<T> {
    * This prevents scrolling bugs
    */
   preventListScrolling: boolean;
+  popoverPlacement: string | undefined;
 }
 
 export interface DropdownProps<T extends string = string>
@@ -204,6 +205,7 @@ class BaseDropdown<T extends string = string> extends Component<
         ? this.props.defaultValue
         : this.getFirstItemValue(),
     preventListScrolling: false,
+    popoverPlacement: 'bottom',
   };
 
   buttonRef: React.RefObject<HTMLButtonElement>;
@@ -527,6 +529,17 @@ class BaseDropdown<T extends string = string> extends Component<
     }, 200);
   }
 
+  private updatePopoverPlacement = (placement: string | undefined) => {
+    if (!placement) return;
+    if (placement !== this.state.popoverPlacement) {
+      requestAnimationFrame(() => {
+        if (this.componentIsMounted) {
+          this.setState({ popoverPlacement: placement });
+        }
+      });
+    }
+  };
+
   render() {
     const {
       id,
@@ -643,6 +656,7 @@ class BaseDropdown<T extends string = string> extends Component<
             }}
             onKeyDown={this.handleKeyDown}
             onBlur={this.handleOnBlur}
+            data-floating-ui-placement={this.state.popoverPlacement}
             {...passProps}
           >
             <HtmlSpan
@@ -685,38 +699,47 @@ class BaseDropdown<T extends string = string> extends Component<
               portal={portal}
               className={popoverClassName}
             >
-              <DropdownProvider
-                value={{
-                  onItemClick: (itemValue: T) =>
-                    this.handleItemSelection(itemValue),
-                  selectedDropdownValue: selectedValue,
-                  id,
-                  focusedItemValue: focusedDescendantId,
-                  noSelectedStyles: alwaysShowVisualPlaceholder,
-                  onItemTabPress: () => this.focusToButtonAndClosePopover(),
-                  onItemMouseOver: (itemValue) =>
-                    this.setState({
-                      preventListScrolling: true,
-                      focusedDescendantId: itemValue,
-                    }),
+              <PopoverConsumer>
+                {(consumer) => {
+                  this.updatePopoverPlacement(consumer?.popoverPlacement);
+                  return (
+                    <DropdownProvider
+                      value={{
+                        onItemClick: (itemValue: T) =>
+                          this.handleItemSelection(itemValue),
+                        selectedDropdownValue: selectedValue,
+                        id,
+                        focusedItemValue: focusedDescendantId,
+                        noSelectedStyles: alwaysShowVisualPlaceholder,
+                        onItemTabPress: () =>
+                          this.focusToButtonAndClosePopover(),
+                        onItemMouseOver: (itemValue) =>
+                          this.setState({
+                            preventListScrolling: true,
+                            focusedDescendantId: itemValue,
+                          }),
+                      }}
+                    >
+                      <SelectItemList
+                        id={popoverItemListId}
+                        ref={this.popoverRef}
+                        focusedDescendantId={ariaActiveDescendant}
+                        className={dropdownClassNames.itemList}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Tab') {
+                            event.preventDefault();
+                            this.focusToButtonAndClosePopover();
+                          }
+                        }}
+                        preventScrolling={preventListScrolling}
+                        popoverPlacement={consumer?.popoverPlacement}
+                      >
+                        {children || []}
+                      </SelectItemList>
+                    </DropdownProvider>
+                  );
                 }}
-              >
-                <SelectItemList
-                  id={popoverItemListId}
-                  ref={this.popoverRef}
-                  focusedDescendantId={ariaActiveDescendant}
-                  className={dropdownClassNames.itemList}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Tab') {
-                      event.preventDefault();
-                      this.focusToButtonAndClosePopover();
-                    }
-                  }}
-                  preventScrolling={preventListScrolling}
-                >
-                  {children || []}
-                </SelectItemList>
-              </DropdownProvider>
+              </PopoverConsumer>
             </Popover>
           )}
         </HtmlDiv>

--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -280,6 +280,15 @@ exports[`Basic dropdown should match snapshot 1`] = `
   outline: none;
 }
 
+.c9[data-floating-ui-placement^='top'] {
+  border-width: 1px 1px 0 1px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  padding: 0;
+}
+
 .c7 {
   letter-spacing: 0;
   text-decoration: none;
@@ -446,9 +455,24 @@ exports[`Basic dropdown should match snapshot 1`] = `
   padding-bottom: 8px;
 }
 
+.c1.fi-dropdown--open .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 1px solid hsl(201, 7%, 58%);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  border-top: 0;
+  padding-top: 8px;
+  box-shadow: none;
+}
+
 .c1.fi-dropdown--error .fi-dropdown_button {
   border-color: hsl(3, 59%, 43%);
   border-width: 2px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 2px solid hsl(3, 59%, 43%);
 }
 
 .c1.fi-dropdown--italicize .fi-dropdown_button {
@@ -584,6 +608,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
           aria-haspopup="listbox"
           aria-labelledby="test-id-displayValue test-id-label"
           class="c5 fi-dropdown_button"
+          data-floating-ui-placement="bottom"
           id="test-id_button"
           tabindex="0"
           type="button"
@@ -622,6 +647,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
       <ul
         aria-activedescendant="test-id-item-1"
         class="c8 fi-select-item-list c9 fi-dropdown_item-list"
+        data-floating-ui-placement="bottom"
         id="test-id-popover"
         role="listbox"
         tabindex="0"
@@ -932,6 +958,15 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   outline: none;
 }
 
+.c9[data-floating-ui-placement^='top'] {
+  border-width: 1px 1px 0 1px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  padding: 0;
+}
+
 .c12 {
   vertical-align: baseline;
 }
@@ -1122,9 +1157,24 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   padding-bottom: 8px;
 }
 
+.c1.fi-dropdown--open .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 1px solid hsl(201, 7%, 58%);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  border-top: 0;
+  padding-top: 8px;
+  box-shadow: none;
+}
+
 .c1.fi-dropdown--error .fi-dropdown_button {
   border-color: hsl(3, 59%, 43%);
   border-width: 2px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 2px solid hsl(3, 59%, 43%);
 }
 
 .c1.fi-dropdown--italicize .fi-dropdown_button {
@@ -1260,6 +1310,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
           aria-haspopup="listbox"
           aria-labelledby="test-id-displayValue test-id-label"
           class="c5 fi-dropdown_button"
+          data-floating-ui-placement="bottom"
           id="test-id_button"
           tabindex="0"
           type="button"
@@ -1299,6 +1350,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
       <ul
         aria-activedescendant="test-id-item-2"
         class="c8 fi-select-item-list c9 fi-dropdown_item-list"
+        data-floating-ui-placement="bottom"
         id="test-id-popover"
         role="listbox"
         tabindex="0"
@@ -1625,6 +1677,15 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   outline: none;
 }
 
+.c9[data-floating-ui-placement^='top'] {
+  border-width: 1px 1px 0 1px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  padding: 0;
+}
+
 .c7 {
   letter-spacing: 0;
   text-decoration: none;
@@ -1791,9 +1852,24 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   padding-bottom: 8px;
 }
 
+.c1.fi-dropdown--open .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 1px solid hsl(201, 7%, 58%);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  border-top: 0;
+  padding-top: 8px;
+  box-shadow: none;
+}
+
 .c1.fi-dropdown--error .fi-dropdown_button {
   border-color: hsl(3, 59%, 43%);
   border-width: 2px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 2px solid hsl(3, 59%, 43%);
 }
 
 .c1.fi-dropdown--italicize .fi-dropdown_button {
@@ -1929,6 +2005,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
           aria-haspopup="listbox"
           aria-labelledby="test-id-displayValue additional-label-id test-id-label"
           class="c5 fi-dropdown_button"
+          data-floating-ui-placement="bottom"
           id="test-id_button"
           tabindex="0"
           type="button"
@@ -1967,6 +2044,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
       <ul
         aria-activedescendant="test-id-item-1"
         class="c8 fi-select-item-list c9 fi-dropdown_item-list"
+        data-floating-ui-placement="bottom"
         id="test-id-popover"
         role="listbox"
         tabindex="0"
@@ -2369,9 +2447,24 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   padding-bottom: 8px;
 }
 
+.c1.fi-dropdown--open .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 1px solid hsl(201, 7%, 58%);
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  border-top: 0;
+  padding-top: 8px;
+  box-shadow: none;
+}
+
 .c1.fi-dropdown--error .fi-dropdown_button {
   border-color: hsl(3, 59%, 43%);
   border-width: 2px;
+}
+
+.c1.fi-dropdown--error .fi-dropdown_button[data-floating-ui-placement^='top'] {
+  border-bottom: 2px solid hsl(3, 59%, 43%);
 }
 
 .c1.fi-dropdown--italicize .fi-dropdown_button {
@@ -2441,6 +2534,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
           aria-haspopup="listbox"
           aria-labelledby="test-id-displayValue test-id-label"
           class="c6 fi-dropdown_button"
+          data-floating-ui-placement="bottom"
           id="test-id_button"
           tabindex="0"
           type="button"

--- a/src/core/Form/SearchInput/SearchInput.test.tsx
+++ b/src/core/Form/SearchInput/SearchInput.test.tsx
@@ -104,28 +104,32 @@ describe('props', () => {
   });
 
   describe('onBlur', () => {
-    test('should notice when leaving area', () => {
+    test('should notice when leaving area', async () => {
       const mockOnBlur = jest.fn();
       const { getByRole } = render(TestSearchInput({ onBlur: mockOnBlur }));
       const inputElement = getByRole('searchbox');
-      fireEvent.blur(inputElement);
+      await act(async () => {
+        fireEvent.blur(inputElement);
+      });
       expect(mockOnBlur).toBeCalledTimes(1);
     });
   });
 
   describe('onChange', () => {
-    it('should notice change and have the given text', () => {
+    it('should notice change and have the given text', async () => {
       const mockOnChange = jest.fn();
       const { getByRole } = render(TestSearchInput({ onChange: mockOnChange }));
       const inputElement = getByRole('searchbox') as HTMLTextAreaElement;
-      fireEvent.change(inputElement, { target: { value: 'abc' } });
+      await act(async () => {
+        fireEvent.change(inputElement, { target: { value: 'abc' } });
+      });
       expect(mockOnChange).toBeCalledTimes(1);
       expect(inputElement.value).toBe('abc');
     });
   });
 
   describe('onSearch', () => {
-    it('should trigger onSearch callback', () => {
+    it('should trigger onSearch callback', async () => {
       const mockOnSearch = jest.fn();
       const { getAllByRole } = render(
         TestSearchInput({
@@ -134,13 +138,15 @@ describe('props', () => {
         }),
       );
       const searchButton = getAllByRole('button')[1];
-      fireEvent.click(searchButton);
+      await act(async () => {
+        fireEvent.click(searchButton);
+      });
       expect(mockOnSearch).toBeCalledTimes(1);
     });
   });
 
   describe('onClear', () => {
-    it('should trigger onChange and clear input value', () => {
+    it('should trigger onChange and clear input value', async () => {
       const mockOnChange = jest.fn();
       const { getAllByRole } = render(
         TestSearchInput({
@@ -149,7 +155,9 @@ describe('props', () => {
         }),
       );
       const clearButton = getAllByRole('button')[0];
-      fireEvent.click(clearButton);
+      await act(async () => {
+        fireEvent.click(clearButton);
+      });
       expect(mockOnChange).toBeCalledTimes(1);
       const inputElement = getAllByRole('searchbox')[0] as HTMLInputElement;
       expect(inputElement.value).toBe('');
@@ -234,7 +242,7 @@ describe('props', () => {
   });
 
   describe('debounce', () => {
-    it('delays the running of onChange by the given time', () => {
+    it('delays the running of onChange by the given time', async () => {
       jest.useFakeTimers();
       const mockOnChange = jest.fn();
       const searchInput = (
@@ -249,11 +257,21 @@ describe('props', () => {
       const { getByRole } = render(searchInput);
 
       const inputElement = getByRole('searchbox') as HTMLInputElement;
-      fireEvent.change(inputElement, { target: { value: 'new value' } });
+      await act(async () => {
+        fireEvent.change(inputElement, { target: { value: 'new value' } });
+      });
+
       expect(mockOnChange).not.toBeCalled();
-      jest.advanceTimersByTime(1000);
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
       expect(mockOnChange).toBeCalledTimes(1);
       expect(inputElement.value).toBe('new value');
+
+      jest.runAllTimers();
+      jest.useRealTimers();
     });
   });
 
@@ -291,17 +309,19 @@ describe('autosuggest', () => {
     );
 
     const inputElement = getByRole('searchbox') as HTMLInputElement;
-    fireEvent.change(inputElement, { target: { value: 'app' } });
+
+    await act(async () => {
+      fireEvent.change(inputElement, { target: { value: 'app' } });
+    });
 
     const items = await waitFor(() => getAllByRole('option'));
     expect(items).toHaveLength(3);
-
     expect(getByText('app')).toBeInTheDocument();
     expect(getByText('banana')).toBeInTheDocument();
     expect(getByText('cherry')).toBeInTheDocument();
   });
 
-  it('should not display suggestions when autosuggest is false', () => {
+  it('should not display suggestions when autosuggest is false', async () => {
     const { getByRole, queryAllByRole } = render(
       TestSearchInput({
         autosuggest: false,
@@ -310,12 +330,14 @@ describe('autosuggest', () => {
     );
 
     const inputElement = getByRole('searchbox') as HTMLInputElement;
-    fireEvent.change(inputElement, { target: { value: 'app' } });
+    await act(async () => {
+      fireEvent.change(inputElement, { target: { value: 'app' } });
+    });
 
     expect(queryAllByRole('option')).toHaveLength(0);
   });
 
-  it('should have ariaOptionsAvailableText and suggestionHintText when autosuggest is true', () => {
+  it('should have ariaOptionsAvailableText and suggestionHintText when autosuggest is true', async () => {
     const { getByText } = render(
       TestSearchInput({
         autosuggest: true,
@@ -326,10 +348,13 @@ describe('autosuggest', () => {
     );
 
     const hintText = getByText('Search suggestion open under the input');
+
     expect(hintText).toBeInTheDocument();
 
     const optionsAvailableText = getByText('Options are available');
-    expect(optionsAvailableText).toBeInTheDocument();
+    await waitFor(() => {
+      expect(optionsAvailableText).toBeInTheDocument();
+    });
   });
 
   it('should call onSuggestionSelect when a suggestion is clicked', async () => {
@@ -352,7 +377,9 @@ describe('autosuggest', () => {
     });
 
     const suggestion = getByText('app');
-    fireEvent.click(suggestion);
+    await act(async () => {
+      fireEvent.click(suggestion);
+    });
 
     expect(mockOnSuggestionSelect).toBeCalledWith('1');
   });
@@ -366,17 +393,25 @@ describe('autosuggest', () => {
     );
 
     const inputElement = getByRole('searchbox') as HTMLInputElement;
-    fireEvent.change(inputElement, { target: { value: 'a' } });
+    await act(async () => {
+      fireEvent.change(inputElement, { target: { value: 'a' } });
+    });
 
     const items = await waitFor(() => getAllByRole('option'));
-    fireEvent.keyDown(inputElement, { key: 'ArrowDown' });
+    await act(async () => {
+      fireEvent.keyDown(inputElement, { key: 'ArrowDown' });
+    });
     expect(items[0]).toHaveClass('fi-select-item--hasKeyboardFocus');
 
-    fireEvent.keyDown(inputElement, { key: 'ArrowDown' });
+    await act(async () => {
+      fireEvent.keyDown(inputElement, { key: 'ArrowDown' });
+    });
     expect(items[1]).toHaveClass('fi-select-item--hasKeyboardFocus');
     expect(items[0]).not.toHaveClass('fi-select-item--hasKeyboardFocus');
 
-    fireEvent.keyDown(inputElement, { key: 'ArrowUp' });
+    await act(async () => {
+      fireEvent.keyDown(inputElement, { key: 'ArrowUp' });
+    });
     expect(items[0]).toHaveClass('fi-select-item--hasKeyboardFocus');
   });
 
@@ -393,7 +428,9 @@ describe('autosuggest', () => {
     const items = await waitFor(() => queryAllByRole('option'));
     expect(items).toHaveLength(3);
 
-    fireEvent.keyDown(inputElement, { key: 'Escape' });
+    await act(async () => {
+      fireEvent.keyDown(inputElement, { key: 'Escape' });
+    });
     expect(queryAllByRole('option')).toHaveLength(0);
   });
 
@@ -407,7 +444,9 @@ describe('autosuggest', () => {
 
     const inputElement = getByRole('searchbox') as HTMLInputElement;
 
-    fireEvent.keyDown(inputElement, { key: 'Escape' });
+    await act(async () => {
+      fireEvent.keyDown(inputElement, { key: 'Escape' });
+    });
 
     await waitFor(() => {
       expect(inputElement).toHaveFocus();
@@ -431,7 +470,10 @@ describe('autosuggest', () => {
     );
 
     const inputElement = getByRole('searchbox') as HTMLInputElement;
-    fireEvent.change(inputElement, { target: { value: 'a' } });
+
+    await act(async () => {
+      fireEvent.change(inputElement, { target: { value: 'a' } });
+    });
 
     const items = await waitFor(() => getAllByRole('option'));
     expect(items).toHaveLength(3);
@@ -449,11 +491,12 @@ describe('autosuggest', () => {
 
     expect(inputElement.value).toBe('abc');
 
-    fireEvent.keyDown(inputElement, { key: 'ArrowDown' });
+    await act(async () => {
+      fireEvent.keyDown(inputElement, { key: 'ArrowDown' });
+    });
 
     const newItems = await waitFor(() => getAllByRole('option'));
     expect(newItems).toHaveLength(2);
-
     expect(newItems[0]).toHaveClass('fi-select-item--hasKeyboardFocus');
     expect(newItems[0]).toHaveTextContent('kiwi');
     expect(newItems[1]).toHaveTextContent('date');
@@ -468,7 +511,7 @@ describe('states', () => {
       expect(buttons).toHaveLength(0);
     });
 
-    it('should not react to enter before adding text to input', () => {
+    it('should not react to enter before adding text to input', async () => {
       const mockOnSearch = jest.fn();
       const { getByRole, getAllByRole } = render(
         TestSearchInput({
@@ -477,21 +520,27 @@ describe('states', () => {
         }),
       );
       const inputElement = getByRole('searchbox') as HTMLTextAreaElement;
-      fireEvent.keyPress(inputElement, {
-        key: 'Enter',
-        code: 13,
-        charCode: 13,
+      await act(async () => {
+        fireEvent.keyPress(inputElement, {
+          key: 'Enter',
+          code: 13,
+          charCode: 13,
+        });
       });
       expect(mockOnSearch).toBeCalledTimes(0);
-      fireEvent.change(inputElement, { target: { value: 'abc' } });
-      fireEvent.keyPress(inputElement, {
-        key: 'Enter',
-        code: 13,
-        charCode: 13,
+      await act(async () => {
+        fireEvent.change(inputElement, { target: { value: 'abc' } });
+        fireEvent.keyPress(inputElement, {
+          key: 'Enter',
+          code: 13,
+          charCode: 13,
+        });
       });
       expect(mockOnSearch).toBeCalledTimes(1);
       const searchButton = getAllByRole('button')[1];
-      fireEvent.click(searchButton);
+      await act(async () => {
+        fireEvent.click(searchButton);
+      });
       expect(mockOnSearch).toBeCalledTimes(2);
     });
   });

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
@@ -23,4 +23,13 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &:focus {
     outline: none;
   }
+
+  &[data-floating-ui-placement^='top'] {
+    border-width: 1px 1px 0 1px;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-top-left-radius: ${theme.radiuses.basic};
+    border-top-right-radius: ${theme.radiuses.basic};
+    padding: 0;
+  }
 `;

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
@@ -30,6 +30,8 @@ export interface SelectItemListProps {
   id: string;
   /** Prevents scrollItemList() function from running */
   preventScrolling?: boolean;
+  /** Floating-ui popover placement */
+  popoverPlacement?: string;
 }
 
 interface InnerRef {
@@ -99,6 +101,7 @@ class BaseSelectItemList extends Component<
       id,
       focusedDescendantId,
       preventScrolling,
+      popoverPlacement,
       ...passProps
     } = this.props;
 
@@ -113,6 +116,7 @@ class BaseSelectItemList extends Component<
         onBlur={onBlur}
         onKeyDown={onKeyDown}
         aria-activedescendant={focusedDescendantId}
+        data-floating-ui-placement={popoverPlacement}
       >
         {children}
       </HtmlUlWithRef>

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
@@ -37,6 +37,23 @@ export const baseStyles = (
       border-bottom: 0;
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
+
+      &[data-floating-ui-placement^='top'] {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        border-bottom-left-radius: ${theme.radiuses.basic};
+        border-bottom-right-radius: ${theme.radiuses.basic};
+        border-top: 0;
+        border-bottom: 1px solid ${theme.colors.depthDark3};
+      }
+    }
+
+    .fi-filter-input--error {
+      .fi-filter-input_input {
+        &[data-floating-ui-placement^='top'] {
+          border-bottom: 2px solid ${theme.colors.alertBase};
+        }
+      }
     }
   }
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -3,6 +3,9 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
 import { axeTest } from '../../../../../utils/test';
 import { MultiSelect, MultiSelectData } from './MultiSelect';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const waitForPosition = () => act(async () => {});
+
 const tools = [
   {
     name: 'Jackhammer',
@@ -118,6 +121,7 @@ it('should not have basic accessibility issues', async () => {
 
 it('has matching snapshot', async () => {
   const { baseElement, getByRole } = render(BasicMultiSelect);
+  await waitForPosition();
   const textfield = getByRole('textbox') as HTMLInputElement;
   await act(async () => {
     fireEvent.focus(textfield);
@@ -249,6 +253,7 @@ describe('Non-controlled', () => {
         ariaOptionChipRemovedText="removed"
       />,
     );
+    await waitForPosition();
     const textfield = getByRole('textbox') as HTMLInputElement;
     await act(async () => {
       fireEvent.change(textfield, { target: { value: 'hammer' } });
@@ -285,6 +290,7 @@ describe('Non-controlled', () => {
         ariaOptionChipRemovedText="removed"
       />,
     );
+    await waitForPosition();
     let chips = container.querySelectorAll('.fi-chip');
     expect(chips).toHaveLength(0);
 
@@ -306,6 +312,7 @@ describe('Non-controlled', () => {
         ariaOptionChipRemovedText="removed"
       />,
     );
+    await waitForPosition();
     const hammerItem = getByText('Hammer');
 
     await act(async () => {
@@ -356,6 +363,7 @@ describe('Controlled', () => {
     );
 
     const { container } = render(multiselect);
+    await waitForPosition();
     await waitFor(() => {
       expect(container.querySelectorAll('.fi-chip')).toHaveLength(2);
 
@@ -409,7 +417,7 @@ describe('Controlled', () => {
         ariaOptionChipRemovedText="removed"
       />
     );
-
+    await waitForPosition();
     const { getByText, getAllByText } = render(multiselect);
     const turtleChip = getByText('Turtle');
     await act(async () => {
@@ -480,6 +488,7 @@ describe('Controlled', () => {
     );
 
     const { getByRole, rerender, findAllByRole } = render(multiMutti);
+    await waitForPosition();
     const textfield = getByRole('textbox') as HTMLInputElement;
     await act(async () => {
       fireEvent.change(textfield, { target: { value: 'sn' } });
@@ -509,6 +518,7 @@ describe('Controlled', () => {
           id="mutti"
         />,
       );
+      await waitForPosition();
       const allOptions = await findAllByRole('option');
       expect(allOptions).toHaveLength(1);
     });
@@ -701,6 +711,7 @@ describe('custom item addition mode', () => {
         ariaOptionChipRemovedText="removed"
       />,
     );
+    await waitForPosition();
     const input = getByRole('textbox');
     await act(async () => {
       fireEvent.change(input, { target: { value: 'hamm' } });
@@ -794,6 +805,7 @@ describe('listProps', () => {
         }}
       />,
     );
+    await waitForPosition();
     const input = getByRole('textbox');
     await act(async () => {
       fireEvent.focus(input);
@@ -821,6 +833,7 @@ describe('listItemProps', () => {
         ariaOptionChipRemovedText=""
       />,
     );
+    await waitForPosition();
     const input = getByRole('textbox');
     await act(async () => {
       fireEvent.focus(input);

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -247,6 +247,7 @@ interface MultiSelectState<T extends MultiSelectData> {
   focusedDescendantId: string | null;
   selectedItems: Array<T & MultiSelectData>;
   chipRemovalAnnounceText: string;
+  popoverPlacement?: string;
 }
 
 class BaseMultiSelect<T> extends Component<
@@ -283,6 +284,7 @@ class BaseMultiSelect<T> extends Component<
       : this.props.defaultSelectedItems || [],
     chipRemovalAnnounceText: '',
     computedItems: this.props.items,
+    popoverPlacement: 'bottom',
   };
 
   static getDerivedStateFromProps<U>(
@@ -619,6 +621,15 @@ class BaseMultiSelect<T> extends Component<
           this.state.filterInputValue.toLowerCase(),
     );
 
+  private updatePopoverPlacement = (placement: string | undefined) => {
+    if (!placement) return;
+    if (placement !== this.state.popoverPlacement) {
+      requestAnimationFrame(() => {
+        this.setState({ popoverPlacement: placement });
+      });
+    }
+  };
+
   render() {
     const {
       filteredItems,
@@ -764,6 +775,7 @@ class BaseMultiSelect<T> extends Component<
                   aria-controls={popoverItemListId}
                   disabled={disabled}
                   tooltipComponent={tooltipComponent}
+                  data-floating-ui-placement={this.state.popoverPlacement}
                 >
                   <InputToggleButton
                     open={showPopover}
@@ -789,87 +801,92 @@ class BaseMultiSelect<T> extends Component<
                 className={popoverClassName}
               >
                 <PopoverConsumer>
-                  {(consumer) => (
-                    <SelectItemList
-                      id={popoverItemListId}
-                      ref={this.popoverListRef}
-                      focusedDescendantId={ariaActiveDescendant}
-                      aria-multiselectable="true"
-                      {...listProps}
-                    >
-                      <>
-                        {!loading &&
-                          filteredItemsWithChecked.length > 0 &&
-                          filteredItemsWithChecked.map((item) => {
-                            const isCurrentlySelected =
-                              item.uniqueItemId === focusedDescendantId;
-                            return (
-                              <SelectItem
-                                hasKeyboardFocus={isCurrentlySelected}
-                                key={`${item.uniqueItemId}_${item.checked}`}
-                                id={`${id}-${item.uniqueItemId}`}
-                                checked={item.checked}
-                                disabled={item.disabled}
-                                onClick={() => {
-                                  this.handleItemSelection(item);
-                                  consumer.updatePopover();
-                                }}
-                                hightlightQuery={
-                                  this.filterInputRef.current?.value
+                  {(consumer) => {
+                    this.updatePopoverPlacement(consumer.popoverPlacement);
+                    return (
+                      <SelectItemList
+                        id={popoverItemListId}
+                        ref={this.popoverListRef}
+                        focusedDescendantId={ariaActiveDescendant}
+                        aria-multiselectable="true"
+                        popoverPlacement={consumer.popoverPlacement}
+                        {...listProps}
+                      >
+                        <>
+                          {!loading &&
+                            filteredItemsWithChecked.length > 0 &&
+                            filteredItemsWithChecked.map((item) => {
+                              const isCurrentlySelected =
+                                item.uniqueItemId === focusedDescendantId;
+                              return (
+                                <SelectItem
+                                  hasKeyboardFocus={isCurrentlySelected}
+                                  key={`${item.uniqueItemId}_${item.checked}`}
+                                  id={`${id}-${item.uniqueItemId}`}
+                                  checked={item.checked}
+                                  disabled={item.disabled}
+                                  onClick={() => {
+                                    this.handleItemSelection(item);
+                                    consumer.updatePopover();
+                                  }}
+                                  hightlightQuery={
+                                    this.filterInputRef.current?.value
+                                  }
+                                  {...item.listItemProps}
+                                >
+                                  {item.labelText}
+                                </SelectItem>
+                              );
+                            })}
+
+                          {!loading &&
+                            filteredItemsWithChecked.length === 0 &&
+                            !allowItemAddition && (
+                              <SelectEmptyItem>{noItemsText}</SelectEmptyItem>
+                            )}
+
+                          {!loading &&
+                            filterInputValue !== '' &&
+                            !this.inputValueInItems() &&
+                            allowItemAddition && (
+                              <SelectItemAddition
+                                hintText={itemAdditionHelpText}
+                                hasKeyboardFocus={
+                                  filterInputValue === focusedDescendantId
                                 }
-                                {...item.listItemProps}
+                                id={`${id}-${filterInputValue.toLowerCase()}`}
+                                onClick={() => {
+                                  // @ts-expect-error: Cannot create an object which implements unknown generic type T
+                                  const item: T & MultiSelectData = {
+                                    labelText: filterInputValue,
+                                    uniqueItemId:
+                                      filterInputValue.toLowerCase(),
+                                  };
+                                  this.handleItemSelection(item);
+                                  this.setState({
+                                    focusedDescendantId:
+                                      filterInputValue.toLowerCase(),
+                                  });
+                                }}
                               >
-                                {item.labelText}
-                              </SelectItem>
-                            );
-                          })}
+                                {filterInputValue}
+                              </SelectItemAddition>
+                            )}
 
-                        {!loading &&
-                          filteredItemsWithChecked.length === 0 &&
-                          !allowItemAddition && (
-                            <SelectEmptyItem>{noItemsText}</SelectEmptyItem>
+                          {loading && (
+                            <SelectEmptyItem className="loading">
+                              <LoadingSpinner
+                                status="loading"
+                                variant="small"
+                                textAlign="right"
+                                text={loadingText}
+                              />
+                            </SelectEmptyItem>
                           )}
-
-                        {!loading &&
-                          filterInputValue !== '' &&
-                          !this.inputValueInItems() &&
-                          allowItemAddition && (
-                            <SelectItemAddition
-                              hintText={itemAdditionHelpText}
-                              hasKeyboardFocus={
-                                filterInputValue === focusedDescendantId
-                              }
-                              id={`${id}-${filterInputValue.toLowerCase()}`}
-                              onClick={() => {
-                                // @ts-expect-error: Cannot create an object which implements unknown generic type T
-                                const item: T & MultiSelectData = {
-                                  labelText: filterInputValue,
-                                  uniqueItemId: filterInputValue.toLowerCase(),
-                                };
-                                this.handleItemSelection(item);
-                                this.setState({
-                                  focusedDescendantId:
-                                    filterInputValue.toLowerCase(),
-                                });
-                              }}
-                            >
-                              {filterInputValue}
-                            </SelectItemAddition>
-                          )}
-
-                        {loading && (
-                          <SelectEmptyItem className="loading">
-                            <LoadingSpinner
-                              status="loading"
-                              variant="small"
-                              textAlign="right"
-                              text={loadingText}
-                            />
-                          </SelectEmptyItem>
-                        )}
-                      </>
-                    </SelectItemList>
-                  )}
+                        </>
+                      </SelectItemList>
+                    );
+                  }}
                 </PopoverConsumer>
               </Popover>
             )}

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -567,6 +567,15 @@ exports[`has matching snapshot 1`] = `
   outline: none;
 }
 
+.c18[data-floating-ui-placement^='top'] {
+  border-width: 1px 1px 0 1px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  padding: 0;
+}
+
 .c20 {
   position: relative;
   padding: 8px 32px 8px 10px;
@@ -1132,6 +1141,19 @@ exports[`has matching snapshot 1`] = `
   border-bottom-right-radius: 0;
 }
 
+.c1.fi-multiselect--open .fi-filter-input_input[data-floating-ui-placement^='top'] {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  border-top: 0;
+  border-bottom: 1px solid hsl(201, 7%, 58%);
+}
+
+.c1.fi-multiselect--open .fi-filter-input--error .fi-filter-input_input[data-floating-ui-placement^='top'] {
+  border-bottom: 2px solid hsl(3, 59%, 43%);
+}
+
 .c1 .fi-multiselect_removeAllButton {
   margin: 10px 0 0 0;
 }
@@ -1235,6 +1257,7 @@ exports[`has matching snapshot 1`] = `
                   autocapitalize="none"
                   autocomplete="off"
                   class="c6 fi-filter-input_input"
+                  data-floating-ui-placement="bottom"
                   id="1"
                   placeholder="Choose your tool(s)"
                   spellcheck="false"
@@ -1459,6 +1482,7 @@ exports[`has matching snapshot 1`] = `
         aria-activedescendant=""
         aria-multiselectable="true"
         class="c17 fi-select-item-list c18"
+        data-floating-ui-placement="bottom"
         id="3-popover"
         role="listbox"
         tabindex="0"

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -35,6 +35,23 @@ export const baseStyles = (
       border-bottom: 0;
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
+
+      &[data-floating-ui-placement^='top'] {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+        border-bottom-left-radius: ${theme.radiuses.basic};
+        border-bottom-right-radius: ${theme.radiuses.basic};
+        border-top: 0;
+        border-bottom: 1px solid ${theme.colors.depthDark3};
+      }
+    }
+
+    .fi-filter-input--error {
+      .fi-filter-input_input {
+        &[data-floating-ui-placement^='top'] {
+          border-bottom: 2px solid ${theme.colors.alertBase};
+        }
+      }
     }
   }
 `;

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -4,6 +4,9 @@ import '@testing-library/jest-dom';
 import { axeTest } from '../../../../utils/test/axe';
 import { SingleSelect, SingleSelectData } from './SingleSelect';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const waitForPosition = () => act(async () => {});
+
 const tools = [
   {
     name: 'Jackhammer',
@@ -101,6 +104,7 @@ it('should not have basic accessibility issues', async () => {
 
 it('has matching snapshot', async () => {
   const { baseElement, getByRole } = render(BasicSingleSelect);
+  await waitForPosition();
   const textfield = getByRole('textbox') as HTMLInputElement;
   await act(async () => {
     fireEvent.focus(textfield);
@@ -136,6 +140,7 @@ describe('Controlled', () => {
     );
 
     const { getByRole, getByText, rerender } = render(singleSelect);
+    await waitForPosition();
     expect(getByRole('textbox')).toHaveValue('Powersaw');
     const input = getByRole('textbox');
     fireEvent.click(input);
@@ -155,6 +160,7 @@ describe('Controlled', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
+    await waitForPosition();
     const rerenderedInput = getByRole('textbox');
     expect(rerenderedInput).toHaveValue('');
   });
@@ -196,6 +202,7 @@ describe('Controlled', () => {
     );
 
     const { getByText, getByRole } = render(singleSelect);
+    await waitForPosition();
     const clearButton = getByText('Clear selection');
     await act(async () => {
       fireEvent.click(clearButton, {});
@@ -226,6 +233,7 @@ test('className: has given custom classname', async () => {
 describe('filter', () => {
   it('should be available with default selection', async () => {
     const { getByRole, getAllByRole } = render(BasicSingleSelect);
+    await waitForPosition();
     const input = getByRole('textbox');
     expect(input).toHaveValue('Hammer');
     fireEvent.change(input, { target: { value: 'h' } });
@@ -245,6 +253,7 @@ describe('filter', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
+    await waitForPosition();
     const input = getByRole('textbox');
     fireEvent.change(input, { target: { value: 'h' } });
     expect(input).toHaveValue('h');
@@ -254,6 +263,7 @@ describe('filter', () => {
 
   it('should be removed onBlur', async () => {
     const { getByRole, getAllByRole } = render(BasicSingleSelect);
+    await waitForPosition();
     const input = getByRole('textbox');
     expect(input).toHaveValue('Hammer');
     fireEvent.change(input, { target: { value: 'h' } });
@@ -272,6 +282,7 @@ describe('filter', () => {
 
 test('option: should be selected when clicked', async () => {
   const { getByText, getByRole } = render(BasicSingleSelect);
+  await waitForPosition();
   const input = getByRole('textbox');
   fireEvent.click(input);
 
@@ -295,7 +306,7 @@ test('labelText: has the given text as label', async () => {
   expect(queryByText('SingleSelect')).not.toBeNull();
 });
 
-test('visualPlaceholder: has the given text as placeholder attribute', () => {
+test('visualPlaceholder: has the given text as placeholder attribute', async () => {
   const { getByRole } = render(
     <SingleSelect
       labelText="SingleSelect"
@@ -310,7 +321,7 @@ test('visualPlaceholder: has the given text as placeholder attribute', () => {
   expect(inputfield).toHaveAttribute('placeholder', 'Select item');
 });
 
-test('id: has the given id', () => {
+test('id: has the given id', async () => {
   const { getByRole } = render(
     <SingleSelect
       id="cb-123"
@@ -325,7 +336,7 @@ test('id: has the given id', () => {
 });
 
 describe('statusText', () => {
-  it('should have element and correct classname for it', () => {
+  it('should have element and correct classname for it', async () => {
     const { getByText } = render(
       <SingleSelect
         id="123"
@@ -342,7 +353,7 @@ describe('statusText', () => {
     expect(statusText).toHaveClass('fi-status-text');
   });
 
-  it('will be added to input aria-describedby', () => {
+  it('will be added to input aria-describedby', async () => {
     const { getByRole } = render(
       <SingleSelect
         id="123"
@@ -363,7 +374,7 @@ describe('statusText', () => {
 });
 
 describe('status', () => {
-  it('should have error classname', () => {
+  it('should have error classname', async () => {
     const { container } = render(
       <SingleSelect
         id="123"
@@ -381,7 +392,7 @@ describe('status', () => {
 });
 
 describe('fullWidth', () => {
-  it('should have full width classname', () => {
+  it('should have full width classname', async () => {
     const { container } = render(
       <SingleSelect
         labelText="SingleSelect"
@@ -430,6 +441,7 @@ describe('custom item addition mode', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
+    await waitForPosition();
     const input = getByRole('textbox');
     await act(async () => {
       fireEvent.change(input, { target: { value: 'hamm' } });
@@ -491,6 +503,7 @@ describe('ariaOptionsAvailable', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
+    await waitForPosition();
     const input = getByRole('textbox');
     await act(async () => {
       fireEvent.change(input, { target: { value: 'M' } });
@@ -514,6 +527,7 @@ describe('ariaOptionsAvailable', () => {
         }
       />,
     );
+    await waitForPosition();
     const input = getByRole('textbox');
     await act(async () => {
       fireEvent.change(input, { target: { value: 'V' } });
@@ -528,7 +542,7 @@ describe('ariaOptionsAvailable', () => {
 });
 
 describe('forward ref', () => {
-  it('ref is forwarded to input', () => {
+  it('ref is forwarded to input', async () => {
     const ref = React.createRef<HTMLInputElement>();
 
     render(
@@ -563,6 +577,7 @@ describe('listProps', () => {
         }}
       />,
     );
+    await waitForPosition();
     const input = getByRole('textbox');
     fireEvent.focus(input);
     const menu = getByRole('listbox');
@@ -591,6 +606,7 @@ describe('listItemProps', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
+    await waitForPosition();
     const input = getByRole('textbox');
     await act(async () => {
       fireEvent.focus(input);
@@ -637,6 +653,7 @@ describe('External update to item array', () => {
 
   it('updated item array should be visible in input', async () => {
     const { getByRole, getByTestId } = render(<ModalWithSiblings />);
+    await waitForPosition();
     const input = getByRole('textbox');
     expect(input).toHaveDisplayValue('Mercury');
 
@@ -649,7 +666,7 @@ describe('External update to item array', () => {
 });
 
 describe('margin', () => {
-  it('should have margin style from margin prop', () => {
+  it('should have margin style from margin prop', async () => {
     const { container } = render(
       <SingleSelect
         labelText=""

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../../utils/common/common';
 import { AutoId } from '../../../utils/AutoId/AutoId';
 import { Debounce } from '../../../utils/Debounce/Debounce';
-import { Popover } from '../../../Popover/Popover';
+import { Popover, PopoverConsumer } from '../../../Popover/Popover';
 import {
   SpacingConsumer,
   SuomifiThemeConsumer,
@@ -193,6 +193,7 @@ interface SingleSelectState<T extends SingleSelectData> {
   focusedDescendantId: string | null;
   selectedItem: (T & SingleSelectData) | null;
   initialItems: T[];
+  popoverPlacement?: string;
 }
 
 class BaseSingleSelect<T> extends Component<
@@ -236,6 +237,7 @@ class BaseSingleSelect<T> extends Component<
       : this.props.defaultSelectedItem || null,
     initialItems: this.props.items,
     computedItems: this.props.items,
+    popoverPlacement: 'bottom',
   };
 
   static getDerivedStateFromProps<U>(
@@ -531,6 +533,15 @@ class BaseSingleSelect<T> extends Component<
           this.state.filterInputValue.toLowerCase(),
     );
 
+  private updatePopoverPlacement = (placement: string | undefined) => {
+    if (!placement) return;
+    if (placement !== this.state.popoverPlacement) {
+      requestAnimationFrame(() => {
+        this.setState({ popoverPlacement: placement });
+      });
+    }
+  };
+
   render() {
     const {
       filteredItems,
@@ -665,6 +676,7 @@ class BaseSingleSelect<T> extends Component<
               statusText={statusText}
               disabled={disabled}
               tooltipComponent={tooltipComponent}
+              data-floating-ui-placement={this.state.popoverPlacement}
             >
               {!!selectedItem && (
                 <HtmlDiv className={singleSelectClassNames.clearButtonWrapper}>
@@ -709,81 +721,93 @@ class BaseSingleSelect<T> extends Component<
             }}
             className={popoverClassName}
           >
-            <SelectItemList
-              id={popoverItemListId}
-              ref={this.popoverListRef}
-              focusedDescendantId={ariaActiveDescendant}
-              {...listProps}
-            >
-              <>
-                {popoverItems.length > 0 &&
-                  !loading &&
-                  popoverItems.map((item) => {
-                    const isCurrentlySelected =
-                      item.uniqueItemId === focusedDescendantId;
-                    return (
-                      <SelectItem
-                        hasKeyboardFocus={isCurrentlySelected}
-                        key={`${item.uniqueItemId}_${
-                          item.uniqueItemId === selectedItem?.uniqueItemId
-                        }`}
-                        id={`${id}-${item.uniqueItemId}`}
-                        checked={
-                          item.uniqueItemId === selectedItem?.uniqueItemId
-                        }
-                        disabled={item.disabled}
-                        onClick={() => {
-                          this.handleItemSelection(item);
-                        }}
-                        hightlightQuery={
-                          filterMode ? this.filterInputRef.current?.value : ''
-                        }
-                        {...item.listItemProps}
-                      >
-                        {item.labelText}
-                      </SelectItem>
-                    );
-                  })}
+            <PopoverConsumer>
+              {(consumer) => {
+                this.updatePopoverPlacement(consumer?.popoverPlacement);
+                return (
+                  <SelectItemList
+                    id={popoverItemListId}
+                    ref={this.popoverListRef}
+                    focusedDescendantId={ariaActiveDescendant}
+                    popoverPlacement={consumer?.popoverPlacement}
+                    {...listProps}
+                  >
+                    <>
+                      {popoverItems.length > 0 &&
+                        !loading &&
+                        popoverItems.map((item) => {
+                          const isCurrentlySelected =
+                            item.uniqueItemId === focusedDescendantId;
+                          return (
+                            <SelectItem
+                              hasKeyboardFocus={isCurrentlySelected}
+                              key={`${item.uniqueItemId}_${
+                                item.uniqueItemId === selectedItem?.uniqueItemId
+                              }`}
+                              id={`${id}-${item.uniqueItemId}`}
+                              checked={
+                                item.uniqueItemId === selectedItem?.uniqueItemId
+                              }
+                              disabled={item.disabled}
+                              onClick={() => {
+                                this.handleItemSelection(item);
+                              }}
+                              hightlightQuery={
+                                filterMode
+                                  ? this.filterInputRef.current?.value
+                                  : ''
+                              }
+                              {...item.listItemProps}
+                            >
+                              {item.labelText}
+                            </SelectItem>
+                          );
+                        })}
 
-                {popoverItems.length === 0 &&
-                  !allowItemAddition &&
-                  !loading && <SelectEmptyItem>{noItemsText}</SelectEmptyItem>}
+                      {popoverItems.length === 0 &&
+                        !allowItemAddition &&
+                        !loading && (
+                          <SelectEmptyItem>{noItemsText}</SelectEmptyItem>
+                        )}
 
-                {loading && (
-                  <SelectEmptyItem className="loading">
-                    <LoadingSpinner
-                      status="loading"
-                      variant="small"
-                      textAlign="right"
-                      text={loadingText}
-                    />
-                  </SelectEmptyItem>
-                )}
+                      {loading && (
+                        <SelectEmptyItem className="loading">
+                          <LoadingSpinner
+                            status="loading"
+                            variant="small"
+                            textAlign="right"
+                            text={loadingText}
+                          />
+                        </SelectEmptyItem>
+                      )}
 
-                {filterInputValue !== '' &&
-                  !this.inputValueInItems() &&
-                  allowItemAddition &&
-                  !loading && (
-                    <SelectItemAddition
-                      hintText={itemAdditionHelpText}
-                      hasKeyboardFocus={
-                        filterInputValue === focusedDescendantId
-                      }
-                      id={`${id}-${filterInputValue.toLowerCase()}`}
-                      onClick={() => {
-                        // @ts-expect-error: Cannot create an object which implements unknown generic type T
-                        const item: T & MultiSelectData = {
-                          labelText: filterInputValue,
-                          uniqueItemId: filterInputValue.toLowerCase(),
-                        };
-                        this.handleItemSelection(item);
-                      }}
-                    >
-                      {filterInputValue}
-                    </SelectItemAddition>
-                  )}
-              </>
-            </SelectItemList>
+                      {filterInputValue !== '' &&
+                        !this.inputValueInItems() &&
+                        allowItemAddition &&
+                        !loading && (
+                          <SelectItemAddition
+                            hintText={itemAdditionHelpText}
+                            hasKeyboardFocus={
+                              filterInputValue === focusedDescendantId
+                            }
+                            id={`${id}-${filterInputValue.toLowerCase()}`}
+                            onClick={() => {
+                              // @ts-expect-error: Cannot create an object which implements unknown generic type T
+                              const item: T & MultiSelectData = {
+                                labelText: filterInputValue,
+                                uniqueItemId: filterInputValue.toLowerCase(),
+                              };
+                              this.handleItemSelection(item);
+                            }}
+                          >
+                            {filterInputValue}
+                          </SelectItemAddition>
+                        )}
+                    </>
+                  </SelectItemList>
+                );
+              }}
+            </PopoverConsumer>
           </Popover>
         )}
 

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -613,6 +613,15 @@ exports[`has matching snapshot 1`] = `
   outline: none;
 }
 
+.c16[data-floating-ui-placement^='top'] {
+  border-width: 1px 1px 0 1px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  padding: 0;
+}
+
 .c18 {
   position: relative;
   padding: 8px 32px 8px 10px;
@@ -769,6 +778,19 @@ exports[`has matching snapshot 1`] = `
   border-bottom-right-radius: 0;
 }
 
+.c1.fi-single-select--open .fi-filter-input_input[data-floating-ui-placement^='top'] {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  border-top: 0;
+  border-bottom: 1px solid hsl(201, 7%, 58%);
+}
+
+.c1.fi-single-select--open .fi-filter-input--error .fi-filter-input_input[data-floating-ui-placement^='top'] {
+  border-bottom: 2px solid hsl(3, 59%, 43%);
+}
+
 @media (forced-colors: active) {
   .c18.fi-select-item .fi-select-item--query_highlight {
     background-color: Highlight;
@@ -860,6 +882,7 @@ exports[`has matching snapshot 1`] = `
                 autocapitalize="none"
                 autocomplete="off"
                 class="c7 fi-filter-input_input"
+                data-floating-ui-placement="bottom"
                 id="1"
                 placeholder=""
                 spellcheck="false"
@@ -960,6 +983,7 @@ exports[`has matching snapshot 1`] = `
       <ul
         aria-activedescendant=""
         class="c15 fi-select-item-list c16"
+        data-floating-ui-placement="bottom"
         id="2-popover"
         role="listbox"
         tabindex="0"

--- a/src/core/LanguageMenu/LanguageMenu.test.tsx
+++ b/src/core/LanguageMenu/LanguageMenu.test.tsx
@@ -5,6 +5,9 @@ import { LanguageMenu, LanguageMenuProps } from './LanguageMenu';
 import { LanguageMenuItem } from './LanguageMenuItem/LanguageMenuItem';
 import { HTMLAttributesIncludingDataAttributes } from 'utils/common/common';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const waitForPosition = () => act(async () => {});
+
 type MenuProps = LanguageMenuProps &
   HTMLAttributesIncludingDataAttributes<HTMLButtonElement>;
 
@@ -44,10 +47,8 @@ describe('Basic LanguageMenu', () => {
     const menuButton = getByRole('button');
     await act(async () => {
       fireEvent.click(menuButton);
-      await new Promise((resolve) => {
-        setTimeout(resolve, 100);
-      });
     });
+    await waitForPosition();
     expect(baseElement).toMatchSnapshot();
   });
 });
@@ -59,6 +60,7 @@ describe('LanguageMenuItem', () => {
         TestLanguageMenu(languageMenuProps),
       );
       fireEvent.click(getByRole('button'));
+      await waitForPosition();
       const item = getAllByRole('menuitem')[0];
       fireEvent.click(item);
       await waitFor(() => {
@@ -173,6 +175,7 @@ describe('callbacks', () => {
         TestLanguageMenu({ ...languageMenuProps, onOpen: mockOnOpen }),
       );
       fireEvent.click(getByRole('button'));
+      await waitForPosition();
       await waitFor(() => {
         expect(mockOnOpen).toBeCalledTimes(1);
       });
@@ -184,6 +187,7 @@ describe('callbacks', () => {
         TestLanguageMenu({ ...languageMenuProps, onOpen: mockOnOpen }),
       );
       fireEvent.keyDown(getByRole('button'), { key: 'Enter' });
+      await waitForPosition();
       await waitFor(() => expect(mockOnOpen).toBeCalledTimes(1));
     });
 
@@ -193,6 +197,7 @@ describe('callbacks', () => {
         TestLanguageMenu({ ...languageMenuProps, onOpen: mockOnOpen }),
       );
       fireEvent.keyDown(getByRole('button'), { key: ' ' });
+      await waitForPosition();
       await waitFor(() => expect(mockOnOpen).toBeCalledTimes(1));
     });
 
@@ -202,6 +207,7 @@ describe('callbacks', () => {
         TestLanguageMenu({ ...languageMenuProps, onOpen: mockOnOpen }),
       );
       fireEvent.keyDown(getByRole('button'), { key: 'ArrowUp' });
+      await waitForPosition();
       await waitFor(() => expect(mockOnOpen).toBeCalledTimes(1));
     });
 
@@ -211,6 +217,7 @@ describe('callbacks', () => {
         TestLanguageMenu({ ...languageMenuProps, onOpen: mockOnOpen }),
       );
       fireEvent.keyDown(getByRole('button'), { key: 'ArrowDown' });
+      await waitForPosition();
       await waitFor(() => expect(mockOnOpen).toBeCalledTimes(1));
     });
   });
@@ -222,6 +229,7 @@ describe('callbacks', () => {
         TestLanguageMenu({ ...languageMenuProps, onClose: mockOnClose }),
       );
       fireEvent.click(getByRole('button'));
+      await waitForPosition();
       const item = getAllByRole('menuitem')[0];
       fireEvent.click(item);
       fireEvent.keyDown(item, { key: 'Escape' });
@@ -234,6 +242,7 @@ describe('callbacks', () => {
         TestLanguageMenu({ ...languageMenuProps, onClose: mockOnClose }),
       );
       fireEvent.click(getByRole('button'));
+      await waitForPosition();
       await waitFor(() => expect(getByRole('menu')).toBeVisible());
       fireEvent.click(getByRole('button'));
       await waitFor(() => expect(mockOnClose).toBeCalledTimes(1));

--- a/src/core/LanguageMenu/LanguageMenuPopover/LanguageMenuPopover.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenuPopover/LanguageMenuPopover.baseStyles.tsx
@@ -49,12 +49,12 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   /* Arrow on top side */
   &
-    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom'] {
     bottom: 100%;
   }
 
   &
-    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
     border-bottom-color: ${theme.colors.blackLight1};
     border-width: 9px;
     margin-right: -9px;
@@ -62,7 +62,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   &
-    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::after {
     border-bottom-color: ${theme.colors.whiteBase};
     border-width: 8px;
     margin-right: -9px;
@@ -72,19 +72,19 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   /* Arrow on bottom side */
   &
-    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top'] {
     top: 100%;
   }
 
   &
-    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
     border-top-color: ${theme.colors.blackLight1};
     border-width: 9px;
     margin-right: -9px;
   }
 
   &
-    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
+    .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::after {
     border-top-color: ${theme.colors.whiteBase};
     border-width: 8px;
     margin-right: -9px;

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -161,18 +161,18 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
   pointer-events: none;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom'] {
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -180,17 +180,17 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top'] {
   top: 100%;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -582,18 +582,18 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
   pointer-events: none;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end'] {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom'] {
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::before {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
   border-bottom-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom-end']::after {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::after {
   border-bottom-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;
@@ -601,17 +601,17 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
   bottom: 100%;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end'] {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top'] {
   top: 100%;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::before {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
   border-top-color: hsl(0, 0%, 42%);
   border-width: 9px;
   margin-right: -9px;
 }
 
-.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top-end']::after {
+.c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::after {
   border-top-color: hsl(0, 0%, 100%);
   border-width: 8px;
   margin-right: -9px;

--- a/src/core/Popover/Popover.tsx
+++ b/src/core/Popover/Popover.tsx
@@ -1,8 +1,14 @@
-import React, { useState, ReactNode, useEffect, useRef } from 'react';
+import React, { useState, ReactNode, useEffect, useRef, useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import { useEnhancedEffect } from '../../utils/common';
 import { HtmlDivProps, HtmlDivWithRef } from '../../reset/HtmlDiv/HtmlDiv';
-import { useFloating, shift, autoUpdate, size } from '@floating-ui/react-dom';
+import {
+  useFloating,
+  shift,
+  autoUpdate,
+  size,
+  flip,
+} from '@floating-ui/react-dom';
 import classNames from 'classnames';
 
 export interface PopoverProps extends HtmlDivProps {
@@ -32,10 +38,12 @@ export interface PopoverProps extends HtmlDivProps {
 
 export interface PopoverProviderState {
   updatePopover: () => void;
+  popoverPlacement: string;
 }
 
 const defaultProviderValue: PopoverProviderState = {
   updatePopover: () => null,
+  popoverPlacement: 'bottom',
 };
 
 const { Provider: PopoverProvider, Consumer: PopoverConsumer } =
@@ -46,7 +54,7 @@ export { PopoverConsumer };
 export const Popover = (props: PopoverProps) => {
   const {
     placement = 'bottom',
-    allowFlip = false,
+    allowFlip = true,
     matchWidth = true,
     children,
     sourceRef,
@@ -67,11 +75,12 @@ export const Popover = (props: PopoverProps) => {
   const {
     refs: floatingUiRefs,
     floatingStyles,
-
+    placement: resolvedPlacement,
     update,
   } = useFloating({
     open: true,
     middleware: [
+      ...(allowFlip ? [flip()] : []),
       shift(),
       ...(matchWidth
         ? [
@@ -91,7 +100,7 @@ export const Popover = (props: PopoverProps) => {
         : []),
     ],
     whileElementsMounted: autoUpdate,
-    placement: 'bottom',
+    placement,
   });
 
   useEffect(() => {
@@ -105,6 +114,24 @@ export const Popover = (props: PopoverProps) => {
       floatingUiRefs.setFloating(floatingElement);
     }
   }, [floatingUiRefs, floatingElement]);
+
+  const [consumerPlacement, setConsumerPlacement] = useState<
+    string | undefined
+  >(undefined);
+  useEffect(() => {
+    const id = requestAnimationFrame(() =>
+      setConsumerPlacement(resolvedPlacement),
+    );
+    return () => cancelAnimationFrame(id);
+  }, [resolvedPlacement]);
+
+  const providerValue = useMemo(
+    () => ({
+      updatePopover: () => update?.(),
+      popoverPlacement: consumerPlacement || placement,
+    }),
+    [update, consumerPlacement, placement],
+  );
 
   useEffect(() => {
     const globalClickHandler = (nativeEvent: MouseEvent) => {
@@ -146,11 +173,7 @@ export const Popover = (props: PopoverProps) => {
             role="presentation"
           >
             <HtmlDivWithRef forwardedRef={portalRef} {...passProps}>
-              <PopoverProvider
-                value={{
-                  updatePopover: () => update?.(),
-                }}
-              >
+              <PopoverProvider value={providerValue}>
                 {children}
               </PopoverProvider>
             </HtmlDivWithRef>
@@ -169,13 +192,7 @@ export const Popover = (props: PopoverProps) => {
       role="presentation"
     >
       <HtmlDivWithRef forwardedRef={portalRef} {...passProps}>
-        <PopoverProvider
-          value={{
-            updatePopover: () => update?.(),
-          }}
-        >
-          {children}
-        </PopoverProvider>
+        <PopoverProvider value={providerValue}>{children}</PopoverProvider>
       </HtmlDivWithRef>
     </div>
   );


### PR DESCRIPTION
## Description

This PR is basically the same as #921 but without the inline styles converted to styled-components based solution

- Apply flip() to Popover
- Adjust tests to run better with floating-ui

## Release notes
### Dropdown, SingleSelect, MultiSelect
- Add "flip" functionality to the popover: it will now be placed above the input if there is not enough space underneath
