### PR TITLE
[Fix] Popover flicker near bottom of the page

### DIFF
--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -286,7 +286,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   border-bottom-right-radius: 0;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  padding: 0;
+  padding: 0 0 4px 0;
 }
 
 .c7 {
@@ -964,7 +964,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   border-bottom-right-radius: 0;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  padding: 0;
+  padding: 0 0 4px 0;
 }
 
 .c12 {
@@ -1683,7 +1683,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   border-bottom-right-radius: 0;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  padding: 0;
+  padding: 0 0 4px 0;
 }
 
 .c7 {

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.baseStyles.tsx
@@ -30,6 +30,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     border-bottom-right-radius: 0;
     border-top-left-radius: ${theme.radiuses.basic};
     border-top-right-radius: ${theme.radiuses.basic};
-    padding: 0;
+    padding: 0 0 4px 0;
   }
 `;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -573,7 +573,7 @@ exports[`has matching snapshot 1`] = `
   border-bottom-right-radius: 0;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  padding: 0;
+  padding: 0 0 4px 0;
 }
 
 .c20 {

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -619,7 +619,7 @@ exports[`has matching snapshot 1`] = `
   border-bottom-right-radius: 0;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  padding: 0;
+  padding: 0 0 4px 0;
 }
 
 .c18 {


### PR DESCRIPTION
## Description
This PR will fix the flicker of components that use popover, when the popover is near the bottom of the page. The issue was due to mismatch in popover size depending on its position, and fix is simple.

## Motivation and Context
This is a clear and rather visible bug and needs to be fixed.

## How Has This Been Tested?
Tested by running locally on styleguidist on chrome
