### PR TITLE
[Fix] Modal footer display

### DIFF
--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -477,6 +477,7 @@ exports[`Basic modal should match snapshot 1`] = `
   padding-right: 15px;
   padding-bottom: 20px;
   padding-left: 30px;
+  display: flex;
 }
 
 .c7.fi-modal_footer .fi-modal_footer_content>* {
@@ -502,6 +503,7 @@ exports[`Basic modal should match snapshot 1`] = `
   padding-right: 0;
   padding-bottom: 15px;
   padding-left: 15px;
+  flex-direction: column;
 }
 
 .c7.fi-modal_footer--small-screen .fi-modal_footer_content>* {

--- a/src/core/Modal/ModalFooter/ModalFooter.baseStyles.tsx
+++ b/src/core/Modal/ModalFooter/ModalFooter.baseStyles.tsx
@@ -10,6 +10,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       padding-right: ${theme.spacing.s};
       padding-bottom: ${theme.spacing.m};
       padding-left: ${theme.spacing.xl};
+      display: flex;
       & > * {
         margin-top: ${theme.spacing.m};
         margin-right: ${theme.spacing.s};
@@ -38,6 +39,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         padding-right: 0;
         padding-bottom: ${theme.spacing.s};
         padding-left: ${theme.spacing.s};
+        flex-direction: column;
         & > * {
           display: block;
           width: calc(100% - ${theme.spacing.s});

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -182,6 +182,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   padding-right: 15px;
   padding-bottom: 20px;
   padding-left: 30px;
+  display: flex;
 }
 
 .c2.fi-modal_footer .fi-modal_footer_content>* {
@@ -207,6 +208,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   padding-right: 0;
   padding-bottom: 15px;
   padding-left: 15px;
+  flex-direction: column;
 }
 
 .c2.fi-modal_footer--small-screen .fi-modal_footer_content>* {


### PR DESCRIPTION
## Description

PR adds `display: flex` to Modal footer content. This ensures elements inside it are displayed side by side. In full screen mode, also add `flex-direction: column` to make the content stack vertically

## Motivation and Context

There was an issue where buttons did not appear inline inside the footer when one button had the `loading` state. Loading state applies `display: flex` to the button which breaks the layout. Making this change to the Modal footer styles mitigates the issue.

## How Has This Been Tested?

macOS Chrome, Styleguidist

## Release notes

### Modal
- **Breaking change**: Add `display: flex` to Modal footer
