### PR TITLE
[Feature] Update suomifi-icons to 7.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "polished": "4.2.2",
         "react-modal": "3.16.3",
         "suomifi-design-tokens": "6.1.0",
-        "suomifi-icons": "7.6.0"
+        "suomifi-icons": "7.7.0"
       },
       "devDependencies": {
         "@axe-core/react": "4.7.3",
@@ -20715,9 +20715,9 @@
       "license": "MIT"
     },
     "node_modules/suomifi-icons": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-7.6.0.tgz",
-      "integrity": "sha512-MYE1T3EDRRVgNis8tEq1tOuvqCjiD/0Q5KsLsmLVF0dlFtbJc3bRxiRNcfyhl3702Z8mMViFbuhEnWJomIn/EQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-7.7.0.tgz",
+      "integrity": "sha512-Yq4UtHAWtWn8KHOrT9yP78gKTtVsJkvQ5TJHRc9dgaqbQvQegbV5ejilJKCezErYoq7g7Yc3cqXBtAw5an62ww==",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "polished": "4.2.2",
     "react-modal": "3.16.3",
     "suomifi-design-tokens": "6.1.0",
-    "suomifi-icons": "7.6.0"
+    "suomifi-icons": "7.7.0"
   },
   "peerDependencies": {
     "@types/styled-components": ">=5.1.9",


### PR DESCRIPTION
## Description
This PR updates the `suomifi-icons` library version to 7.7.0, adding a new icon, `MessageUnread` in the process.

## How Has This Been Tested?
Tested by checking in styleguidist that the new icon appears correctly and that nothing is broken.

## Release notes
### Dependencies
- Update `suomifi-icons` to 7.7.0
