### PR TITLE
[Fix] Wrong border color in some components

### DIFF
--- a/src/core/ActionMenu/ActionMenuPopover/ActionMenuPopover.baseStyles.tsx
+++ b/src/core/ActionMenu/ActionMenuPopover/ActionMenuPopover.baseStyles.tsx
@@ -8,7 +8,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-action-menu-popover {
     background-color: ${theme.colors.whiteBase};
     box-shadow: ${theme.shadows.wideBoxShadow};
-    border: 1px solid ${theme.colors.blackLight1};
+    border: 1px solid ${theme.colors.depthDark3};
     border-radius: ${theme.radiuses.basic};
     padding-top: 8px;
     padding-bottom: 8px;
@@ -55,7 +55,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   &
     .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
-    border-bottom-color: ${theme.colors.blackLight1};
+    border-bottom-color: ${theme.colors.depthDark3};
     border-width: 9px;
     margin-right: -9px;
     bottom: 100%;
@@ -77,7 +77,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   &
     .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
-    border-top-color: ${theme.colors.blackLight1};
+    border-top-color: ${theme.colors.depthDark3};
     border-width: 9px;
     margin-right: -9px;
   }

--- a/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
 .c8.fi-action-menu-popover {
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0px 4px 8px 0px hsla(0, 0%, 13%, 0.14);
-  border: 1px solid hsl(0, 0%, 42%);
+  border: 1px solid hsl(201, 7%, 58%);
   border-radius: 2px;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -194,7 +194,7 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
-  border-bottom-color: hsl(0, 0%, 42%);
+  border-bottom-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
@@ -213,7 +213,7 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
-  border-top-color: hsl(0, 0%, 42%);
+  border-top-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
 }
@@ -935,7 +935,7 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
 .c8.fi-action-menu-popover {
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0px 4px 8px 0px hsla(0, 0%, 13%, 0.14);
-  border: 1px solid hsl(0, 0%, 42%);
+  border: 1px solid hsl(201, 7%, 58%);
   border-radius: 2px;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -977,7 +977,7 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
-  border-bottom-color: hsl(0, 0%, 42%);
+  border-bottom-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
@@ -996,7 +996,7 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
-  border-top-color: hsl(0, 0%, 42%);
+  border-top-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
 }
@@ -1718,7 +1718,7 @@ exports[`No borders variant should match snapshot 1`] = `
 .c8.fi-action-menu-popover {
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0px 4px 8px 0px hsla(0, 0%, 13%, 0.14);
-  border: 1px solid hsl(0, 0%, 42%);
+  border: 1px solid hsl(201, 7%, 58%);
   border-radius: 2px;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -1760,7 +1760,7 @@ exports[`No borders variant should match snapshot 1`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
-  border-bottom-color: hsl(0, 0%, 42%);
+  border-bottom-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
@@ -1779,7 +1779,7 @@ exports[`No borders variant should match snapshot 1`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
-  border-top-color: hsl(0, 0%, 42%);
+  border-top-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
 }
@@ -2501,7 +2501,7 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
 .c8.fi-action-menu-popover {
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0px 4px 8px 0px hsla(0, 0%, 13%, 0.14);
-  border: 1px solid hsl(0, 0%, 42%);
+  border: 1px solid hsl(201, 7%, 58%);
   border-radius: 2px;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -2543,7 +2543,7 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
-  border-bottom-color: hsl(0, 0%, 42%);
+  border-bottom-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
@@ -2562,7 +2562,7 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
-  border-top-color: hsl(0, 0%, 42%);
+  border-top-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
 }
@@ -3285,7 +3285,7 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
 .c8.fi-action-menu-popover {
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0px 4px 8px 0px hsla(0, 0%, 13%, 0.14);
-  border: 1px solid hsl(0, 0%, 42%);
+  border: 1px solid hsl(201, 7%, 58%);
   border-radius: 2px;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -3327,7 +3327,7 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
-  border-bottom-color: hsl(0, 0%, 42%);
+  border-bottom-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
@@ -3346,7 +3346,7 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
 }
 
 .c8 .fi-action-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
-  border-top-color: hsl(0, 0%, 42%);
+  border-top-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
 }

--- a/src/core/LanguageMenu/LanguageMenuPopover/LanguageMenuPopover.baseStyles.tsx
+++ b/src/core/LanguageMenu/LanguageMenuPopover/LanguageMenuPopover.baseStyles.tsx
@@ -8,7 +8,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   &.fi-language-menu-popover {
     background-color: ${theme.colors.whiteBase};
     box-shadow: ${theme.shadows.wideBoxShadow};
-    border: 1px solid ${theme.colors.blackLight1};
+    border: 1px solid ${theme.colors.depthDark3};
     border-radius: ${theme.radiuses.basic};
     z-index: ${theme.zindexes.menu};
   }
@@ -55,7 +55,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   &
     .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
-    border-bottom-color: ${theme.colors.blackLight1};
+    border-bottom-color: ${theme.colors.depthDark3};
     border-width: 9px;
     margin-right: -9px;
     bottom: 100%;
@@ -78,7 +78,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
   &
     .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
-    border-top-color: ${theme.colors.blackLight1};
+    border-top-color: ${theme.colors.depthDark3};
     border-width: 9px;
     margin-right: -9px;
   }

--- a/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/core/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -124,7 +124,7 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
 .c5.fi-language-menu-popover {
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0px 4px 8px 0px hsla(0, 0%, 13%, 0.14);
-  border: 1px solid hsl(0, 0%, 42%);
+  border: 1px solid hsl(201, 7%, 58%);
   border-radius: 2px;
   z-index: 888;
 }
@@ -166,7 +166,7 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
 }
 
 .c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
-  border-bottom-color: hsl(0, 0%, 42%);
+  border-bottom-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
@@ -185,7 +185,7 @@ exports[`Basic LanguageMenu should match snapshot when closed 1`] = `
 }
 
 .c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
-  border-top-color: hsl(0, 0%, 42%);
+  border-top-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
 }
@@ -545,7 +545,7 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
 .c5.fi-language-menu-popover {
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0px 4px 8px 0px hsla(0, 0%, 13%, 0.14);
-  border: 1px solid hsl(0, 0%, 42%);
+  border: 1px solid hsl(201, 7%, 58%);
   border-radius: 2px;
   z-index: 888;
 }
@@ -587,7 +587,7 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
 }
 
 .c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='bottom']::before {
-  border-bottom-color: hsl(0, 0%, 42%);
+  border-bottom-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
   bottom: 100%;
@@ -606,7 +606,7 @@ exports[`Basic LanguageMenu should match snapshot when opened 1`] = `
 }
 
 .c5 .fi-language-menu-popover_floatingui-arrow[data-floatingui-placement^='top']::before {
-  border-top-color: hsl(0, 0%, 42%);
+  border-top-color: hsl(201, 7%, 58%);
   border-width: 9px;
   margin-right: -9px;
 }

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -348,7 +348,7 @@ exports[`calling render with the same component on the same container does not r
   justify-content: center;
   align-items: center;
   border-radius: 50%;
-  border: 1px solid hsl(0, 0%, 42%);
+  border: 1px solid hsl(201, 7%, 58%);
   width: 26px;
   height: 26px;
   line-height: 26px;
@@ -399,7 +399,7 @@ exports[`calling render with the same component on the same container does not r
   justify-content: center;
   align-items: center;
   border-radius: 50%;
-  border: 1px solid hsl(0, 0%, 42%);
+  border: 1px solid hsl(201, 7%, 58%);
   width: 26px;
   height: 26px;
   line-height: 26px;

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -71,7 +71,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
           justify-content: center;
           align-items: center;
           border-radius: 50%;
-          border: 1px solid ${theme.colors.blackLight1};
+          border: 1px solid ${theme.colors.depthDark3};
           width: 26px;
           height: 26px;
           line-height: 26px;
@@ -112,7 +112,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
           justify-content: center;
           align-items: center;
           border-radius: 50%;
-          border: 1px solid ${theme.colors.blackLight1};
+          border: 1px solid ${theme.colors.depthDark3};
           width: 26px;
           height: 26px;
           line-height: 26px;


### PR DESCRIPTION
## Description
Some components erroneously use `blackLight1` as the border color token. This PR changes those to use the right one, `depthDark3`.

## How Has This Been Tested?
Tested by automated tests and by checking the visual side manually on styleguidist on Chrome.

## Release notes
### ActionMenu, LanguageMenu, WizardNavigationItem
* **Breaking change:** switch border color token to the correct one

