### PR TITLE
[Fix] Adjust Esc-key behavior in SingleSelect

### DIFF
--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -699,3 +699,60 @@ describe('margin', () => {
     expect(container.firstChild).toHaveAttribute('style', 'margin: 2px;');
   });
 });
+
+describe('keyboard interactions', () => {
+  it('should reset input value to selected item when pressing Escape after typing', async () => {
+    const { getByRole, getByText } = render(BasicSingleSelect);
+    await waitForPosition();
+
+    const input = getByRole('textbox');
+
+    // First, select an item
+    fireEvent.click(input);
+    const option = await waitFor(() => getByText('Rake'));
+    fireEvent.click(option);
+    expect(input).toHaveValue('Rake');
+
+    // Then type something different in the input
+    await act(async () => {
+      fireEvent.click(input);
+      fireEvent.change(input, { target: { value: 'something else' } });
+    });
+    expect(input).toHaveValue('something else');
+
+    // Press Escape - should reset to selected item
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+    });
+    expect(input).toHaveValue('Rake');
+  });
+
+  it('should clear input when pressing Escape with no selected item', async () => {
+    const { getByRole } = render(
+      <SingleSelect
+        labelText="SingleSelect"
+        clearButtonLabel="Clear selection"
+        items={tools}
+        visualPlaceholder="Choose your tool"
+        noItemsText="No items"
+        ariaOptionsAvailableText="Options available"
+      />,
+    );
+    await waitForPosition();
+
+    const input = getByRole('textbox');
+
+    // Type something in the input without selecting
+    await act(async () => {
+      fireEvent.click(input);
+      fireEvent.change(input, { target: { value: 'something' } });
+    });
+    expect(input).toHaveValue('something');
+
+    // Press Escape - should clear input since no item is selected
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+    });
+    expect(input).toHaveValue('');
+  });
+});

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -366,11 +366,13 @@ class BaseSingleSelect<T> extends Component<
 
   private focusToInputAndCloseMenu = () => {
     this.focusToInputAndSelectText();
-    this.setState({
+    this.setState((prevState: SingleSelectState<T & SingleSelectData>) => ({
       showPopover: false,
       filterMode: false,
       focusedDescendantId: null,
-    });
+      filterInputValue:
+        prevState.selectedItem?.labelText || prevState.filterInputValue,
+    }));
   };
 
   private handleItemSelection = (item: (T & SingleSelectData) | null) => {
@@ -505,9 +507,9 @@ class BaseSingleSelect<T> extends Component<
         if (this.state.showPopover) {
           event.stopPropagation();
         }
-        if (!this.state.selectedItem) {
-          this.setState({ filterInputValue: '' });
-        }
+        this.setState((prevState: SingleSelectState<T & SingleSelectData>) => ({
+          filterInputValue: prevState.selectedItem?.labelText || '',
+        }));
         this.focusToInputAndCloseMenu();
         break;
       }

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -370,8 +370,7 @@ class BaseSingleSelect<T> extends Component<
       showPopover: false,
       filterMode: false,
       focusedDescendantId: null,
-      filterInputValue:
-        prevState.selectedItem?.labelText || prevState.filterInputValue,
+      filterInputValue: prevState.selectedItem?.labelText || '',
     }));
   };
 
@@ -507,9 +506,6 @@ class BaseSingleSelect<T> extends Component<
         if (this.state.showPopover) {
           event.stopPropagation();
         }
-        this.setState((prevState: SingleSelectState<T & SingleSelectData>) => ({
-          filterInputValue: prevState.selectedItem?.labelText || '',
-        }));
         this.focusToInputAndCloseMenu();
         break;
       }


### PR DESCRIPTION
## Description

PR adjusts the behavior of pressing the Esc-key when browsing the popover list in SingleSelect. Before this fix, it was possible to have a mismatch between the input text value and the selected item when exiting from the component by pressing Esc. With this fix, the component always returns the selectedItem label to the text input if there is a selected value.

## Motivation and Context

This inconsistency was reported by a library user

## How Has This Been Tested?

macOS Chrome Styleguidist

## Release notes

### SingleSelect
- Fix an inconsistent behavior regarding the Esc-key
