### PR TITLE
[Feature] Table: Add disabled row selection functionality

### DIFF
--- a/src/core/Table/Table.md
+++ b/src/core/Table/Table.md
@@ -38,6 +38,37 @@ interface TableColumn {
 
 - Define table data (rows) by providing an array of objects where each column key is present. Each row must also have a unique id. In case of empty cell, provide an empty string `''` for that column key
 
+#### TypeScript type safety
+
+If you're using TypeScript, you can get compile-time validation to ensure all column keys are present in your data rows:
+
+```tsx static
+import { Table, TableRow } from 'suomifi-ui-components';
+
+// 1. Define columns with 'as const' to preserve literal types
+const columns = [
+  { key: 'firstName', labelText: 'First name' },
+  { key: 'lastName', labelText: 'Last name' },
+  { key: 'title', labelText: 'Title' }
+] as const;
+
+// 2. Explicitly type your data array with TableRow<typeof columns>
+const data: TableRow<typeof columns>[] = [
+  {
+    id: '1',
+    firstName: 'John',
+    lastName: 'Doe',
+    title: 'Developer'
+    // TypeScript will show an error if you forget any column key
+  }
+];
+
+// 3. Use in component
+<Table columns={columns} data={data} caption="Team" />;
+```
+
+This ensures TypeScript will show an error if you forget to include any column key in your data objects.
+
 ```jsx
 import { Table, Link } from 'suomifi-ui-components';
 import React from 'react';
@@ -296,6 +327,8 @@ Also provide a `rowSelectionCheckboxLabel` to each row object to give an accessi
 
 You can pass additional props to the row selection Checkbox or RadioButton elements using the `rowSelectionLabelProps` property on each row. This is useful for adding test identifiers like `data-testid`.
 
+Individual rows can be disabled from selection by adding `rowSelectionDisabled: true` to the row data object.
+
 You can control the selected rows programmatically by using the `controlledSelectedRowIds` prop as shown in the third example below.
 
 ```jsx
@@ -349,7 +382,8 @@ const data = [
     rowSelectionCheckboxLabel: 'Select row Jane Doe',
     rowSelectionLabelProps: {
       'data-testid': 'jane-doe-selection'
-    }
+    },
+    rowSelectionDisabled: true
   },
   {
     id: '3',
@@ -361,7 +395,8 @@ const data = [
     rowSelectionCheckboxLabel: 'Select row Bruce Willis',
     rowSelectionLabelProps: {
       'data-testid': 'bruce-willis-selection'
-    }
+    },
+    rowSelectionDisabled: true
   },
   {
     id: '4',

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Table, TableColumn, TableProps } from './Table';
+import { Table, TableProps, TableRow } from './Table';
 import { axeTest } from '../../utils/test';
 
-const columns: TableColumn[] = [
+const columns = [
   { key: 'name', labelText: 'Name', sortable: true },
   {
     key: 'age',
@@ -13,9 +13,9 @@ const columns: TableColumn[] = [
     textAlign: 'right',
     sortIcon: 'generic',
   },
-];
+] as const;
 
-const data = [
+const data: TableRow<typeof columns>[] = [
   {
     id: '1',
     name: 'John Doe',
@@ -296,5 +296,61 @@ describe('Table functionalities', () => {
       expect(rows[1]).toHaveTextContent('John Doe');
       expect(rows[2]).toHaveTextContent('Jane Smith');
     });
+  });
+
+  it('removes checkbox when rowSelectionDisabled is true', () => {
+    const dataWithDisabled: TableRow<typeof columns>[] = [
+      {
+        id: '1',
+        name: 'John Doe',
+        age: 28,
+        rowSelectionCheckboxLabel: 'Select row John Doe',
+        rowSelectionDisabled: true,
+      },
+      {
+        id: '2',
+        name: 'Jane Smith',
+        age: 34,
+        rowSelectionCheckboxLabel: 'Select row Jane Doe',
+      },
+    ];
+    render(
+      <Table
+        caption="People in the project"
+        columns={columns}
+        data={dataWithDisabled}
+        enableRowSelection
+      />,
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(1);
+  });
+
+  it('removes radio button when rowSelectionDisabled is true', () => {
+    const dataWithDisabled: TableRow<typeof columns>[] = [
+      {
+        id: '1',
+        name: 'John Doe',
+        age: 28,
+        rowSelectionCheckboxLabel: 'Select row John Doe',
+        rowSelectionDisabled: true,
+      },
+      {
+        id: '2',
+        name: 'Jane Smith',
+        age: 34,
+        rowSelectionCheckboxLabel: 'Select row Jane Doe',
+      },
+    ];
+    render(
+      <Table
+        caption="People in the project"
+        columns={columns}
+        data={dataWithDisabled}
+        enableSingleRowSelection
+      />,
+    );
+    const radioButtons = screen.getAllByRole('radio');
+    expect(radioButtons).toHaveLength(1);
   });
 });

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -80,22 +80,37 @@ export interface TableColumn {
   className?: string;
 }
 
-/** Valid types for table cell values */
-export type TableCellValue =
-  | string
-  | number
-  | React.ReactElement<any, string | React.JSXElementConstructor<any>>;
-
-// Infer the literal types from columns
+/**
+ * TableRow type that enforces all column keys must be present as properties.
+ * Each column key property accepts ReactNode as its value type.
+ *
+ * @example
+ * // For type safety, define columns with 'as const' and explicitly type your data array
+ * const columns = [
+ *   { key: 'name', labelText: 'Name' },
+ *   { key: 'age', labelText: 'Age' }
+ * ] as const;
+ *
+ * // Explicitly type the data array to enforce all column keys are present
+ * const data: TableRow<typeof columns>[] = [
+ *   { id: '1', name: 'John', age: 30 },
+ *   { id: '2', name: 'Jane', age: 25 },
+ * ];
+ * // TypeScript will show an error if you forget a column key (e.g., missing 'age')
+ *
+ * // Then use in the component
+ * <Table columns={columns} data={data} caption="Users" />
+ */
 export type TableRow<TColumns extends readonly TableColumn[]> = {
   [K in TColumns[number]['key']]:
-    | TableCellValue
+    | React.ReactNode
     | HTMLAttributesIncludingDataAttributes<HTMLLabelElement>;
 } & {
   id: string;
   rowSelectionCheckboxLabel?: string;
   /** Props to pass to the row selection Checkbox or RadioButton label */
   rowSelectionLabelProps?: HTMLAttributesIncludingDataAttributes<HTMLLabelElement>;
+  rowSelectionDisabled?: boolean;
 };
 
 export interface BaseTableProps<TColumns extends readonly TableColumn[]>
@@ -106,13 +121,29 @@ export interface BaseTableProps<TColumns extends readonly TableColumn[]>
    * If no id is specified, one will be generated automatically
    */
   id?: string;
-  /** Table columns and their configurations */
-  columns: TColumns; // Use the generic type parameter for columns
+  /**
+   * Table columns and their configurations.
+   *
+   * @example
+   * // Use 'as const' for type safety
+   * const columns = [
+   *   { key: 'name', labelText: 'Name', sortable: true },
+   *   { key: 'age', labelText: 'Age', sortable: true, textAlign: 'right' }
+   * ] as const;
+   */
+  columns: TColumns;
   /**
    * Rows for the table. Each object must have an `id` property that is unique for the table
-   * plus the key-value pairs that match the `key` properties of the columns.
+   * plus all the key properties defined in columns.
+   *
+   * @example
+   * // Type the data array explicitly to get TypeScript validation
+   * const data: TableRow<typeof columns>[] = [
+   *   { id: '1', name: 'John Doe', age: 28 },
+   *   { id: '2', name: 'Jane Smith', age: 34 }
+   * ];
    */
-  data: TableRow<TColumns>[]; // Use the inferred type for data
+  data: TableRow<TColumns>[];
   /** Condenses the padding of table cells */
   condensed?: boolean;
   /** Enables selection of rows via checkboxes
@@ -238,8 +269,8 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
         : 'desc');
 
     const sortedData = [...data].sort((a, b) => {
-      const aValue = a[key as keyof TableRow<TColumns>] as TableCellValue;
-      const bValue = b[key as keyof TableRow<TColumns>] as TableCellValue;
+      const aValue = a[key as keyof TableRow<TColumns>] as React.ReactNode;
+      const bValue = b[key as keyof TableRow<TColumns>] as React.ReactNode;
 
       const getTextContent = (element: React.ReactNode): string => {
         if (typeof element === 'string' || typeof element === 'number') {
@@ -437,7 +468,16 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
                     highlighted: selectedRowIds.includes(row.id),
                   })}
                 >
-                  {enableRowSelection && (
+                  {(enableRowSelection || enableSingleRowSelection) &&
+                    row.rowSelectionDisabled === true && (
+                      <HtmlTableCell
+                        className={classnames(
+                          tableClassNames.td,
+                          tableClassNames.selectionTd,
+                        )}
+                      />
+                    )}
+                  {enableRowSelection && row.rowSelectionDisabled !== true && (
                     <HtmlTableCell
                       className={classnames(
                         tableClassNames.td,
@@ -460,30 +500,31 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
                       </Checkbox>
                     </HtmlTableCell>
                   )}
-                  {enableSingleRowSelection && (
-                    <HtmlTableCell
-                      className={classnames(
-                        tableClassNames.td,
-                        tableClassNames.selectionTd,
-                      )}
-                    >
-                      <RadioButton
-                        value={`radiobutton-${row.id}`}
-                        checked={selectedRowIds.includes(row.id)}
-                        onChange={(newValue) =>
-                          handleRowSelection(
-                            row.id,
-                            newValue ? 'add' : 'remove',
-                          )
-                        }
-                        labelProps={row.rowSelectionLabelProps}
+                  {enableSingleRowSelection &&
+                    row.rowSelectionDisabled !== true && (
+                      <HtmlTableCell
+                        className={classnames(
+                          tableClassNames.td,
+                          tableClassNames.selectionTd,
+                        )}
                       >
-                        <VisuallyHidden>
-                          {row.rowSelectionCheckboxLabel}
-                        </VisuallyHidden>
-                      </RadioButton>
-                    </HtmlTableCell>
-                  )}
+                        <RadioButton
+                          value={`radiobutton-${row.id}`}
+                          checked={selectedRowIds.includes(row.id)}
+                          onChange={(newValue) =>
+                            handleRowSelection(
+                              row.id,
+                              newValue ? 'add' : 'remove',
+                            )
+                          }
+                          labelProps={row.rowSelectionLabelProps}
+                        >
+                          <VisuallyHidden>
+                            {row.rowSelectionCheckboxLabel}
+                          </VisuallyHidden>
+                        </RadioButton>
+                      </HtmlTableCell>
+                    )}
                   {columns.map((col) => (
                     <HtmlTableCell
                       key={`${row.id}-${col.key}`}
@@ -497,7 +538,7 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
                       {
                         row[
                           col.key as keyof TableRow<TColumns>
-                        ] as TableCellValue
+                        ] as React.ReactNode
                       }
                     </HtmlTableCell>
                   ))}


### PR DESCRIPTION
## Description

PR adds `rowSelectionDisabled` as a possible property for the TableRow objects. Also adjusts Table TS stuff to allow for better type safety. 

## Motivation and Context

Users requested a feature to disable selecting a row. Disabling row input (Checkbox or Radiobutton) is not visually very distinctive, so when a row is disabled, the input is removed from the row.

## Screenshots


<img width="1013" height="359" alt="image" src="https://github.com/user-attachments/assets/87fc6323-1f31-49d7-ac42-1034f3364b97" />

<img width="1010" height="356" alt="image" src="https://github.com/user-attachments/assets/f9e6e7dc-1563-427f-94ef-e57f3d9f0281" />

## How Has This Been Tested?
Tested with Styleguidist and Create React App project. Accessibility testing was done to see how removal of input affects screen reader users.

## Release notes

### Table
- Add `rowSelectionDisabled` as a possible property for the TableRow objects


