### PR TITLE
[Feature] Table: Add default sort functionality

### DIFF
--- a/src/core/Table/Table.md
+++ b/src/core/Table/Table.md
@@ -123,6 +123,11 @@ const data = [
 
 You can set `sortable: true` to any column you wish be able to sort the table with. You can either let the component handle the data sorting, or provide a `tableSortCallback()` prop to handle data sorting with a custom logic. The function receives the key of the sorted column and a string of `'asc' | 'desc'` as parameters.
 
+You can also apply a default sort order when the table first renders by using the `defaultSort` prop. The prop accepts an object with two properties:
+
+- `columnKey`: The key of the column to sort by (must match a column with `sortable: true`)
+- `direction`: Either `'asc'` for ascending or `'desc'` for descending order
+
 Always use the `tableSortedAriaLiveText()` function as demonstrated below to give screen readers information about table sorting.
 
 ```jsx
@@ -266,6 +271,17 @@ const customDataSort = (key, dir) => {
     }
     mb="xxl"
     tableSortCallback={customDataSort}
+  />
+  <Table
+    caption="People in the project"
+    columns={columns}
+    data={data}
+    defaultSort={{ columnKey: 'hours_worked', direction: 'desc' }}
+    tableSortedAriaLiveText={(sortedColumn, direction) =>
+      `Table is sorted by ${sortedColumn} ${
+        direction === 'asc' ? 'ascending' : 'descending'
+      }`
+    }
   />
 </div>;
 ```

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -142,4 +142,101 @@ describe('Table functionalities', () => {
       expect(row).toHaveClass('fi-table_skeleton-row');
     });
   });
+
+  describe('Default sorting', () => {
+    it('applies default sort on mount with ascending order', () => {
+      renderTable({
+        caption: 'People in the project',
+        defaultSort: { columnKey: 'name', direction: 'asc' },
+      });
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('Jane Smith');
+      expect(rows[2]).toHaveTextContent('John Doe');
+    });
+
+    it('applies default sort on mount with descending order', () => {
+      renderTable({
+        caption: 'People in the project',
+        defaultSort: { columnKey: 'name', direction: 'desc' },
+      });
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('John Doe');
+      expect(rows[2]).toHaveTextContent('Jane Smith');
+    });
+
+    it('applies default sort on numeric column', () => {
+      renderTable({
+        caption: 'People in the project',
+        defaultSort: { columnKey: 'age', direction: 'asc' },
+      });
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('28');
+      expect(rows[2]).toHaveTextContent('34');
+    });
+
+    it('sets aria-sort attribute correctly for default sorted column', () => {
+      renderTable({
+        caption: 'People in the project',
+        defaultSort: { columnKey: 'name', direction: 'asc' },
+      });
+      const nameHeader = screen.getByRole('columnheader', { name: /Name/i });
+      expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('displays correct sort icon for default ascending sort', () => {
+      renderTable({
+        caption: 'People in the project',
+        defaultSort: { columnKey: 'name', direction: 'asc' },
+      });
+      const nameButton = screen.getByRole('button', { name: /Name/i });
+      expect(nameButton).toBeInTheDocument();
+    });
+
+    it('allows manual re-sorting after default sort is applied', async () => {
+      renderTable({
+        caption: 'People in the project',
+        defaultSort: { columnKey: 'name', direction: 'asc' },
+      });
+      // Initially sorted ascending by name
+      let rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('Jane Smith');
+
+      // Click to reverse sort
+      const nameHeader = screen.getByText('Name');
+      await userEvent.click(nameHeader);
+      rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('John Doe');
+      expect(rows[2]).toHaveTextContent('Jane Smith');
+    });
+
+    it('does not sort if column is not sortable', () => {
+      const nonSortableColumns = [
+        { key: 'name', labelText: 'Name', sortable: false },
+        { key: 'age', labelText: 'Age', sortable: true },
+      ];
+      render(
+        <Table
+          caption="People in the project"
+          columns={nonSortableColumns}
+          data={data}
+          defaultSort={{ columnKey: 'name', direction: 'asc' }}
+        />,
+      );
+      // Data should remain in original order
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('John Doe');
+      expect(rows[2]).toHaveTextContent('Jane Smith');
+    });
+
+    it('ignores invalid column key in defaultSort', () => {
+      renderTable({
+        caption: 'People in the project',
+        defaultSort: { columnKey: 'nonexistent', direction: 'asc' },
+      });
+      // Data should remain in original order
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('John Doe');
+      expect(rows[2]).toHaveTextContent('Jane Smith');
+    });
+  });
 });

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -119,6 +119,11 @@ export interface BaseTableProps<TColumns extends readonly TableColumn[]>
   ) => string;
   /** Optional custom callback which is fired when table is sorted */
   tableSortCallback?: (columnLabel: string, direction: 'asc' | 'desc') => void;
+  /** Default sort configuration to be applied when table is first rendered */
+  defaultSort?: {
+    columnKey: string;
+    direction: 'asc' | 'desc';
+  };
   /** Displays skeleton rows (default of 5) to indicate the table is waiting to receive data */
   loading?: boolean;
   /** Optional override of the default amount (5) of skeleton rows when `loading` is true */
@@ -156,6 +161,7 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
     onSelectedRowsChange,
     tableSortedAriaLiveText,
     tableSortCallback,
+    defaultSort,
     loading,
     loadingRowAmount = 5,
     controlledSelectedRowIds,
@@ -185,6 +191,17 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
     setData(propData);
   }, [propData]);
 
+  // Apply default sort on mount or when defaultSort changes
+  useEffect(() => {
+    if (defaultSort && defaultSort.columnKey) {
+      // Verify that the column exists and is sortable
+      const column = columns.find((col) => col.key === defaultSort.columnKey);
+      if (column && column.sortable) {
+        sortData(defaultSort.columnKey, defaultSort.direction);
+      }
+    }
+  }, [defaultSort?.columnKey, defaultSort?.direction]);
+
   useEffect(() => {
     const targetDiv = wrapperRef.current;
     if (!targetDiv) return;
@@ -199,7 +216,14 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
     return () => observer.disconnect();
   }, []);
 
-  const sortData = (key: string) => {
+  const sortData = (key: string, forceDirection?: 'asc' | 'desc') => {
+    // Determine the direction to sort
+    const newDirection =
+      forceDirection ||
+      (!sortColumn.includes(key) || sortColumn === `${key}-desc`
+        ? 'asc'
+        : 'desc');
+
     const sortedData = [...data].sort((a, b) => {
       const aValue = a[key as keyof TableRow<TColumns>];
       const bValue = b[key as keyof TableRow<TColumns>];
@@ -225,30 +249,22 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
         !Number.isNaN(Number(aValueText)) && !Number.isNaN(Number(bValueText));
 
       if (isNumeric) {
-        return !sortColumn.includes(key) || sortColumn === `${key}-desc`
+        return newDirection === 'asc'
           ? Number(aValueText) - Number(bValueText)
           : Number(bValueText) - Number(aValueText);
       }
 
-      return !sortColumn.includes(key) || sortColumn === `${key}-desc`
+      return newDirection === 'asc'
         ? aValueText.localeCompare(bValueText)
         : bValueText.localeCompare(aValueText);
     });
+
     if (!!tableSortCallback) {
-      tableSortCallback(
-        key,
-        !sortColumn.includes(key) || sortColumn === `${key}-desc`
-          ? 'asc'
-          : 'desc',
-      );
+      tableSortCallback(key, newDirection);
     } else {
       setData(sortedData);
     }
-    if (!sortColumn.includes(key) || sortColumn === `${key}-desc`) {
-      setSortColumn(`${key}-asc`);
-    } else {
-      setSortColumn(`${key}-desc`);
-    }
+    setSortColumn(`${key}-${newDirection}`);
   };
 
   const handleRowSelection = (rowId: string, operation: 'add' | 'remove') => {


### PR DESCRIPTION
## Description

PR adds default sorting possibility to the `<Table>` component

## Motivation and Context

This functionality was requested by a user

## How Has This Been Tested?

macOS Chrome Styleguidist

## Release notes

### Table
- Add `defaultSort` prop
