### PR TITLE
[Feature] Table selection element props

### DIFF
--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -138,6 +138,7 @@ export const baseStyles = (
     padding-left: ${theme.spacing.l};
     cursor: pointer;
     line-height: 27px;
+    min-height: 18px; /* Enable clicking when label text is empty */
 
     &::before {
       content: '';

--- a/src/core/Form/Checkbox/Checkbox.test.tsx
+++ b/src/core/Form/Checkbox/Checkbox.test.tsx
@@ -192,4 +192,16 @@ describe('props', () => {
     );
     expect(container.firstChild).toHaveAttribute('style', 'margin: 2px;');
   });
+
+  describe('labelProps', () => {
+    it('should pass labelProps to the label element', () => {
+      const { getByText } = render(
+        <Checkbox id="test" labelProps={{ 'data-testid': 'label-test' }}>
+          Text
+        </Checkbox>,
+      );
+      const label = getByText('Text');
+      expect(label).toHaveAttribute('data-testid', 'label-test');
+    });
+  });
 });

--- a/src/core/Form/Checkbox/Checkbox.tsx
+++ b/src/core/Form/Checkbox/Checkbox.tsx
@@ -21,7 +21,10 @@ import { HintText } from '../HintText/HintText';
 import { CheckboxGroupConsumer } from './CheckboxGroup';
 import { baseStyles } from './Checkbox.baseStyles';
 import { IconCheck } from 'suomifi-icons';
-import { filterDuplicateKeys } from '../../../utils/common/common';
+import {
+  filterDuplicateKeys,
+  HTMLAttributesIncludingDataAttributes,
+} from '../../../utils/common/common';
 
 const baseClassName = 'fi-checkbox';
 
@@ -102,6 +105,11 @@ export interface CheckboxProps
   value?: string;
   /** Ref is passed to the underlying input element. Alternative to React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLInputElement>;
+  /** Props to be passed to the label element, for example data attributes */
+  labelProps?: Omit<
+    HTMLAttributesIncludingDataAttributes<HTMLLabelElement>,
+    'htmlFor' | 'id'
+  >;
 }
 
 class BaseCheckbox extends Component<CheckboxProps> {
@@ -153,6 +161,7 @@ class BaseCheckbox extends Component<CheckboxProps> {
       onClick,
       variant,
       style,
+      labelProps,
       ...rest
     } = this.props;
     const [_marginProps, passProps] = separateMarginProps(rest);
@@ -216,6 +225,7 @@ class BaseCheckbox extends Component<CheckboxProps> {
           htmlFor={id}
           className={checkboxClassNames.label}
           id={`${id}-label`}
+          {...labelProps}
         >
           {!!checkedState && <IconCheck className={checkboxClassNames.icon} />}
           {children}

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -171,6 +171,7 @@ exports[`props children has matching snapshot 1`] = `
   padding-left: 25px;
   cursor: pointer;
   line-height: 27px;
+  min-height: 18px;
 }
 
 .c1 .fi-checkbox_label::before {

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -302,6 +302,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   padding-left: 25px;
   cursor: pointer;
   line-height: 27px;
+  min-height: 18px;
 }
 
 .c7 .fi-checkbox_label::before {

--- a/src/core/Form/RadioButton/RadioButton.test.tsx
+++ b/src/core/Form/RadioButton/RadioButton.test.tsx
@@ -160,4 +160,16 @@ describe('margin', () => {
     );
     expect(container.firstChild).toHaveAttribute('style', 'margin: 2px;');
   });
+
+  describe('labelProps', () => {
+    it('should pass labelProps to the label element', () => {
+      const { container } = render(
+        <RadioButton value="value" labelProps={{ 'data-testid': 'label-test' }}>
+          Text
+        </RadioButton>,
+      );
+      const label = container.querySelector('label');
+      expect(label).toHaveAttribute('data-testid', 'label-test');
+    });
+  });
 });

--- a/src/core/Form/RadioButton/RadioButton.tsx
+++ b/src/core/Form/RadioButton/RadioButton.tsx
@@ -28,7 +28,10 @@ import {
 } from './RadioButtonGroup';
 import { baseStyles } from './RadioButton.baseStyles';
 import { IconRadioButton, IconRadioButtonLarge } from 'suomifi-icons';
-import { filterDuplicateKeys } from '../../../utils/common/common';
+import {
+  filterDuplicateKeys,
+  HTMLAttributesIncludingDataAttributes,
+} from '../../../utils/common/common';
 
 const baseClassName = 'fi-radio-button';
 const radioButtonClassNames = {
@@ -88,9 +91,13 @@ export interface RadioButtonProps
    * Screen readers will ignore children as label if this is provided.
    */
   'aria-labelledby'?: string;
-
   /** Ref object is forwarded to the underlying input element. Alternative to React `ref` attribute. */
   forwardedRef?: React.RefObject<HTMLInputElement>;
+  /** Props to be passed to the label element, for example data attributes */
+  labelProps?: Omit<
+    HTMLAttributesIncludingDataAttributes<HTMLLabelElement>,
+    'htmlFor'
+  >;
 }
 
 interface RadioButtonState {
@@ -129,6 +136,7 @@ class BaseRadioButton extends Component<RadioButtonProps> {
       onChange,
       disabled = false,
       style,
+      labelProps,
       ...rest
     } = this.props;
     const [_marginProps, passProps] = separateMarginProps(rest);
@@ -186,7 +194,11 @@ class BaseRadioButton extends Component<RadioButtonProps> {
             />
           )}
         </HtmlSpan>
-        <HtmlLabel htmlFor={id} className={radioButtonClassNames.label}>
+        <HtmlLabel
+          htmlFor={id}
+          className={radioButtonClassNames.label}
+          {...labelProps}
+        >
           {children}
         </HtmlLabel>
         <HintText className={radioButtonClassNames.hintText} id={hintTextId}>

--- a/src/core/Table/Table.md
+++ b/src/core/Table/Table.md
@@ -294,7 +294,7 @@ Alternatively, you can use the `enableSingleRowSelection` prop to allow single r
 
 Also provide a `rowSelectionCheckboxLabel` to each row object to give an accessible label to the selection Checkbox/RadioButton.
 
-You can pass additional props to the row selection Checkbox or RadioButton elements using the `rowSelectionElementProps` property on each row. This is useful for adding test identifiers like `data-testid`.
+You can pass additional props to the row selection Checkbox or RadioButton elements using the `rowSelectionLabelProps` property on each row. This is useful for adding test identifiers like `data-testid`.
 
 You can control the selected rows programmatically by using the `controlledSelectedRowIds` prop as shown in the third example below.
 
@@ -335,7 +335,7 @@ const data = [
     title: 'Developer',
     country: 'United Kingdom',
     rowSelectionCheckboxLabel: 'Select row John Doe',
-    rowSelectionElementProps: {
+    rowSelectionLabelProps: {
       'data-testid': 'john-doe-selection'
     }
   },
@@ -347,7 +347,7 @@ const data = [
     title: 'Architect',
     country: 'Norway',
     rowSelectionCheckboxLabel: 'Select row Jane Doe',
-    rowSelectionElementProps: {
+    rowSelectionLabelProps: {
       'data-testid': 'jane-doe-selection'
     }
   },
@@ -359,7 +359,7 @@ const data = [
     title: 'Project manager',
     country: 'United States of America',
     rowSelectionCheckboxLabel: 'Select row Bruce Willis',
-    rowSelectionElementProps: {
+    rowSelectionLabelProps: {
       'data-testid': 'bruce-willis-selection'
     }
   },
@@ -371,7 +371,7 @@ const data = [
     title: 'Security consultant',
     country: <Link href="https://suomi.fi">Germany</Link>,
     rowSelectionCheckboxLabel: 'Select row Harriet Ackermann',
-    rowSelectionElementProps: {
+    rowSelectionLabelProps: {
       'data-testid': 'harriet-ackermann-selection'
     }
   },
@@ -383,7 +383,7 @@ const data = [
     title: 'President',
     country: 'Finland',
     rowSelectionCheckboxLabel: 'Select row Alexander Stubb',
-    rowSelectionElementProps: {
+    rowSelectionLabelProps: {
       'data-testid': 'alexander-stubb-selection'
     }
   }

--- a/src/core/Table/Table.md
+++ b/src/core/Table/Table.md
@@ -294,6 +294,8 @@ Alternatively, you can use the `enableSingleRowSelection` prop to allow single r
 
 Also provide a `rowSelectionCheckboxLabel` to each row object to give an accessible label to the selection Checkbox/RadioButton.
 
+You can pass additional props to the row selection Checkbox or RadioButton elements using the `rowSelectionElementProps` property on each row. This is useful for adding test identifiers like `data-testid`.
+
 You can control the selected rows programmatically by using the `controlledSelectedRowIds` prop as shown in the third example below.
 
 ```jsx
@@ -332,7 +334,10 @@ const data = [
     hours_worked: 125,
     title: 'Developer',
     country: 'United Kingdom',
-    rowSelectionCheckboxLabel: 'Select row John Doe'
+    rowSelectionCheckboxLabel: 'Select row John Doe',
+    rowSelectionElementProps: {
+      'data-testid': 'john-doe-selection'
+    }
   },
   {
     id: '2',
@@ -341,7 +346,10 @@ const data = [
     hours_worked: 150,
     title: 'Architect',
     country: 'Norway',
-    rowSelectionCheckboxLabel: 'Select row Jane Doe'
+    rowSelectionCheckboxLabel: 'Select row Jane Doe',
+    rowSelectionElementProps: {
+      'data-testid': 'jane-doe-selection'
+    }
   },
   {
     id: '3',
@@ -350,7 +358,10 @@ const data = [
     hours_worked: 10,
     title: 'Project manager',
     country: 'United States of America',
-    rowSelectionCheckboxLabel: 'Select row Bruce Willis'
+    rowSelectionCheckboxLabel: 'Select row Bruce Willis',
+    rowSelectionElementProps: {
+      'data-testid': 'bruce-willis-selection'
+    }
   },
   {
     id: '4',
@@ -359,7 +370,10 @@ const data = [
     hours_worked: '',
     title: 'Security consultant',
     country: <Link href="https://suomi.fi">Germany</Link>,
-    rowSelectionCheckboxLabel: 'Select row Harriet Ackermann'
+    rowSelectionCheckboxLabel: 'Select row Harriet Ackermann',
+    rowSelectionElementProps: {
+      'data-testid': 'harriet-ackermann-selection'
+    }
   },
   {
     id: '5',
@@ -368,7 +382,10 @@ const data = [
     hours_worked: 2543,
     title: 'President',
     country: 'Finland',
-    rowSelectionCheckboxLabel: 'Select row Alexander Stubb'
+    rowSelectionCheckboxLabel: 'Select row Alexander Stubb',
+    rowSelectionElementProps: {
+      'data-testid': 'alexander-stubb-selection'
+    }
   }
 ];
 

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Table, TableColumn, TableProps, TableRow } from './Table';
+import { Table, TableColumn, TableProps } from './Table';
 import { axeTest } from '../../utils/test';
 
 const columns: TableColumn[] = [
@@ -159,7 +159,7 @@ describe('Table functionalities', () => {
         rowSelectionCheckboxLabel: 'Select row Jane Doe',
         rowSelectionElementProps: { 'data-testid': 'checkbox-jane' },
       },
-    ] as any as TableRow<typeof columns>[];
+    ];
     render(
       <Table
         caption="People in the project"
@@ -188,7 +188,7 @@ describe('Table functionalities', () => {
         rowSelectionCheckboxLabel: 'Select row Jane Doe',
         rowSelectionElementProps: { 'data-testid': 'radio-jane' },
       },
-    ] as any as TableRow<typeof columns>[];
+    ];
     render(
       <Table
         caption="People in the project"

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Table, TableColumn, TableProps } from './Table';
+import { Table, TableColumn, TableProps, TableRow } from './Table';
 import { axeTest } from '../../utils/test';
 
 const columns: TableColumn[] = [
@@ -141,6 +141,64 @@ describe('Table functionalities', () => {
     skeletonRows.forEach((row) => {
       expect(row).toHaveClass('fi-table_skeleton-row');
     });
+  });
+
+  it('passes rowSelectionElementProps to checkboxes including data-testid', () => {
+    const dataWithTestIds = [
+      {
+        id: '1',
+        name: 'John Doe',
+        age: 28,
+        rowSelectionCheckboxLabel: 'Select row John Doe',
+        rowSelectionElementProps: { 'data-testid': 'checkbox-john' },
+      },
+      {
+        id: '2',
+        name: 'Jane Smith',
+        age: 34,
+        rowSelectionCheckboxLabel: 'Select row Jane Doe',
+        rowSelectionElementProps: { 'data-testid': 'checkbox-jane' },
+      },
+    ] as any as TableRow<typeof columns>[];
+    render(
+      <Table
+        caption="People in the project"
+        columns={columns}
+        data={dataWithTestIds}
+        enableRowSelection
+      />,
+    );
+    expect(screen.getByTestId('checkbox-john')).toBeInTheDocument();
+    expect(screen.getByTestId('checkbox-jane')).toBeInTheDocument();
+  });
+
+  it('passes rowSelectionElementProps to radiobuttons including data-testid', () => {
+    const dataWithTestIds = [
+      {
+        id: '1',
+        name: 'John Doe',
+        age: 28,
+        rowSelectionCheckboxLabel: 'Select row John Doe',
+        rowSelectionElementProps: { 'data-testid': 'radio-john' },
+      },
+      {
+        id: '2',
+        name: 'Jane Smith',
+        age: 34,
+        rowSelectionCheckboxLabel: 'Select row Jane Doe',
+        rowSelectionElementProps: { 'data-testid': 'radio-jane' },
+      },
+    ] as any as TableRow<typeof columns>[];
+    render(
+      <Table
+        caption="People in the project"
+        columns={columns}
+        data={dataWithTestIds}
+        enableSingleRowSelection
+      />,
+    );
+    expect(screen.getByTestId('radio-john')).toBeInTheDocument();
+    expect(screen.getByTestId('radio-jane')).toBeInTheDocument();
   });
 
   describe('Default sorting', () => {

--- a/src/core/Table/Table.test.tsx
+++ b/src/core/Table/Table.test.tsx
@@ -143,21 +143,21 @@ describe('Table functionalities', () => {
     });
   });
 
-  it('passes rowSelectionElementProps to checkboxes including data-testid', () => {
+  it('passes rowSelectionLabelProps to checkboxes including data-testid', () => {
     const dataWithTestIds = [
       {
         id: '1',
         name: 'John Doe',
         age: 28,
         rowSelectionCheckboxLabel: 'Select row John Doe',
-        rowSelectionElementProps: { 'data-testid': 'checkbox-john' },
+        rowSelectionLabelProps: { 'data-testid': 'checkbox-john' },
       },
       {
         id: '2',
         name: 'Jane Smith',
         age: 34,
         rowSelectionCheckboxLabel: 'Select row Jane Doe',
-        rowSelectionElementProps: { 'data-testid': 'checkbox-jane' },
+        rowSelectionLabelProps: { 'data-testid': 'checkbox-jane' },
       },
     ];
     render(
@@ -172,21 +172,21 @@ describe('Table functionalities', () => {
     expect(screen.getByTestId('checkbox-jane')).toBeInTheDocument();
   });
 
-  it('passes rowSelectionElementProps to radiobuttons including data-testid', () => {
+  it('passes rowSelectionLabelProps to radiobuttons including data-testid', () => {
     const dataWithTestIds = [
       {
         id: '1',
         name: 'John Doe',
         age: 28,
         rowSelectionCheckboxLabel: 'Select row John Doe',
-        rowSelectionElementProps: { 'data-testid': 'radio-john' },
+        rowSelectionLabelProps: { 'data-testid': 'radio-john' },
       },
       {
         id: '2',
         name: 'Jane Smith',
         age: 34,
         rowSelectionCheckboxLabel: 'Select row Jane Doe',
-        rowSelectionElementProps: { 'data-testid': 'radio-jane' },
+        rowSelectionLabelProps: { 'data-testid': 'radio-jane' },
       },
     ];
     render(

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -86,12 +86,17 @@ interface TableRowSelectionElementProps
     'onClick' | 'onChange' | 'checked' | 'value'
   > {}
 
+/** Valid types for table cell values */
+export type TableCellValue =
+  | string
+  | number
+  | React.ReactElement<any, string | React.JSXElementConstructor<any>>;
+
 // Infer the literal types from columns
 export type TableRow<TColumns extends readonly TableColumn[]> = {
   [K in TColumns[number]['key']]:
-    | string
-    | number
-    | React.ReactElement<any, string | React.JSXElementConstructor<any>>;
+    | TableCellValue
+    | TableRowSelectionElementProps;
 } & {
   id: string;
   rowSelectionCheckboxLabel?: string;
@@ -239,8 +244,8 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
         : 'desc');
 
     const sortedData = [...data].sort((a, b) => {
-      const aValue = a[key as keyof TableRow<TColumns>];
-      const bValue = b[key as keyof TableRow<TColumns>];
+      const aValue = a[key as keyof TableRow<TColumns>] as TableCellValue;
+      const bValue = b[key as keyof TableRow<TColumns>] as TableCellValue;
 
       const getTextContent = (element: React.ReactNode): string => {
         if (typeof element === 'string' || typeof element === 'number') {
@@ -495,7 +500,11 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
                           col.textAlign === 'center',
                       })}
                     >
-                      {row[col.key as keyof TableRow<TColumns>]}
+                      {
+                        row[
+                          col.key as keyof TableRow<TColumns>
+                        ] as TableCellValue
+                      }
                     </HtmlTableCell>
                   ))}
                 </HtmlTableRow>

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -80,12 +80,6 @@ export interface TableColumn {
   className?: string;
 }
 
-interface TableRowSelectionElementProps
-  extends Omit<
-    HTMLAttributesIncludingDataAttributes<HTMLInputElement>,
-    'onClick' | 'onChange' | 'checked' | 'value'
-  > {}
-
 /** Valid types for table cell values */
 export type TableCellValue =
   | string
@@ -96,12 +90,12 @@ export type TableCellValue =
 export type TableRow<TColumns extends readonly TableColumn[]> = {
   [K in TColumns[number]['key']]:
     | TableCellValue
-    | TableRowSelectionElementProps;
+    | HTMLAttributesIncludingDataAttributes<HTMLLabelElement>;
 } & {
   id: string;
   rowSelectionCheckboxLabel?: string;
-  /** Props to pass to the row selection Checkbox or RadioButton element */
-  rowSelectionElementProps?: TableRowSelectionElementProps;
+  /** Props to pass to the row selection Checkbox or RadioButton label */
+  rowSelectionLabelProps?: HTMLAttributesIncludingDataAttributes<HTMLLabelElement>;
 };
 
 export interface BaseTableProps<TColumns extends readonly TableColumn[]>
@@ -458,7 +452,7 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
                             checkedVal.checkboxState ? 'add' : 'remove',
                           )
                         }
-                        {...row.rowSelectionElementProps}
+                        labelProps={row.rowSelectionLabelProps}
                       >
                         <VisuallyHidden>
                           {row.rowSelectionCheckboxLabel}
@@ -482,7 +476,7 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
                             newValue ? 'add' : 'remove',
                           )
                         }
-                        {...row.rowSelectionElementProps}
+                        labelProps={row.rowSelectionLabelProps}
                       >
                         <VisuallyHidden>
                           {row.rowSelectionCheckboxLabel}

--- a/src/core/Table/Table.tsx
+++ b/src/core/Table/Table.tsx
@@ -13,7 +13,10 @@ import {
   GlobalMargins,
 } from '../theme/utils/spacing';
 import { baseStyles } from './Table.baseStyles';
-import { filterDuplicateKeys } from '../../utils/common/common';
+import {
+  filterDuplicateKeys,
+  HTMLAttributesIncludingDataAttributes,
+} from '../../utils/common/common';
 import { AutoId } from '../utils/AutoId/AutoId';
 import {
   HtmlButton,
@@ -77,13 +80,24 @@ export interface TableColumn {
   className?: string;
 }
 
+interface TableRowSelectionElementProps
+  extends Omit<
+    HTMLAttributesIncludingDataAttributes<HTMLInputElement>,
+    'onClick' | 'onChange' | 'checked' | 'value'
+  > {}
+
 // Infer the literal types from columns
 export type TableRow<TColumns extends readonly TableColumn[]> = {
   [K in TColumns[number]['key']]:
     | string
     | number
     | React.ReactElement<any, string | React.JSXElementConstructor<any>>;
-} & { id: string; rowSelectionCheckboxLabel?: string };
+} & {
+  id: string;
+  rowSelectionCheckboxLabel?: string;
+  /** Props to pass to the row selection Checkbox or RadioButton element */
+  rowSelectionElementProps?: TableRowSelectionElementProps;
+};
 
 export interface BaseTableProps<TColumns extends readonly TableColumn[]>
   extends MarginProps,
@@ -439,6 +453,7 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
                             checkedVal.checkboxState ? 'add' : 'remove',
                           )
                         }
+                        {...row.rowSelectionElementProps}
                       >
                         <VisuallyHidden>
                           {row.rowSelectionCheckboxLabel}
@@ -462,6 +477,7 @@ const BaseTable = <TColumns extends readonly TableColumn[]>(
                             newValue ? 'add' : 'remove',
                           )
                         }
+                        {...row.rowSelectionElementProps}
                       >
                         <VisuallyHidden>
                           {row.rowSelectionCheckboxLabel}


### PR DESCRIPTION
## Description

PR adds `rowSelectionLabelProps` to the TableRow specification. The primary use case for this is the ability to pass data-testid to the checkbox/radiobutton element.

## Motivation and Context

Users have reported problems testing the Table component because it has not been possible to pass data-testids to the row selection elements.

Props are passed to the label element, since it is clickable with robot tests. (Input elements are hidden for style overrides, so they cannot be clicked with for example Selenium.)

## How Has This Been Tested?

Through Styleguidist and unit tests and Selenium tests

## Release notes

### Checkbox
- Add `labelProps`. Allows the passing of e.g. `data-testid` to label element

### RadioButton
- Add `labelProps`. Allows the passing of e.g. `data-testid` to label element

### Table
- Add `rowSelectionLabelProps` to table rows. Allows the passing of e.g. `data-testid` to the Checkbox/RadioButton


