### PR TITLE
[Feature] DropdownItemGroup

### DIFF
--- a/.styleguidist/styleguidist.sections.js
+++ b/.styleguidist/styleguidist.sections.js
@@ -29,7 +29,6 @@ const singularComponents = [
   ['Form/Select', 'SingleSelect'],
   ['Form', 'ErrorSummary'],
   ['Form', 'FileInput'],
-  ['Form/Dropdown', 'Dropdown'],
 ];
 
 const getComponent = ({ name, underName }) =>
@@ -278,6 +277,14 @@ module.exports = {
             'ActionMenu/ActionMenu',
             'ActionMenuItem/ActionMenuItem',
             'ActionMenuDivider/ActionMenuDivider',
+          ]),
+        },
+        {
+          name: 'Dropdown',
+          components: getComponentWithVariants('Form/Dropdown')([
+            'Dropdown/Dropdown',
+            'DropdownItem/DropdownItem',
+            'DropdownItemGroup/DropdownItemGroup',
           ]),
         },
       ],

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.md
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.md
@@ -7,6 +7,7 @@ If there are only 2-3 options, consider using the <a href="./#/Components/RadioB
 Examples:
 
 - [Basic use](./#/Components/Dropdown?id=basic-use)
+- [Grouped items](./#/Components/Dropdown?id=grouped-items)
 - [Default value](./#/Components/Dropdown?id=default-value)
 - [Controlled value](./#/Components/Dropdown?id=controlled-value)
 - [Accessing the component with ref](./#/Components/Dropdown?id=accessing-the-component-with-ref)
@@ -18,8 +19,11 @@ Examples:
 <div style="margin-bottom: 5px">
   [Props & methods (Dropdown)](./#/Components/Dropdown?id=props--methods)
 </div>
-<div style="margin-bottom: 40px">
+<div style="margin-bottom: 5px">
   [Props & methods (DropdownItem)](./#/Components/Dropdown?id=dropdownitem)
+</div>
+<div style="margin-bottom: 40px">
+  [Props & methods (DropdownItemGroup)](./#/Components/Dropdown?id=dropdownitemgroup)
 </div>
 
 ### Basic use
@@ -66,6 +70,35 @@ const countries = [
       {country.name}
     </DropdownItem>
   ))}
+</Dropdown>;
+```
+
+### Grouped items
+
+You can use `<DropdownItemGroup>` components to organize items into groups with headings, similar to native HTML `<optgroup>` elements.
+
+The component uses proper ARIA attributes (`role="group"` and `aria-labelledby`) to ensure screen readers can navigate the grouped structure correctly. Group headings are not interactive and cannot be selected.
+
+```js
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownItemGroup
+} from 'suomifi-ui-components';
+
+<Dropdown labelText="Food" visualPlaceholder="Choose a food">
+  <DropdownItemGroup label="Fruits">
+    <DropdownItem value="apple">Apple</DropdownItem>
+    <DropdownItem value="banana">Banana</DropdownItem>
+    <DropdownItem value="orange">Orange</DropdownItem>
+    <DropdownItem value="strawberry">Strawberry</DropdownItem>
+  </DropdownItemGroup>
+  <DropdownItemGroup label="Vegetables">
+    <DropdownItem value="carrot">Carrot</DropdownItem>
+    <DropdownItem value="broccoli">Broccoli</DropdownItem>
+    <DropdownItem value="tomato">Tomato</DropdownItem>
+    <DropdownItem value="cucumber">Cucumber</DropdownItem>
+  </DropdownItemGroup>
 </Dropdown>;
 ```
 

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../../reset';
 import { Label, LabelMode } from '../../Label/Label';
 import { DropdownItemProps } from '../DropdownItem/DropdownItem';
+import { DropdownItemGroupProps } from '../DropdownItemGroup/DropdownItemGroup';
 import { baseStyles } from './Dropdown.baseStyles';
 import {
   SuomifiThemeProp,
@@ -152,13 +153,15 @@ export interface DropdownProps<T extends string = string>
   className?: string;
   /** Disables the component */
   disabled?: boolean;
-  /** Use `<DropdownItem>` components as children */
+  /** Use `<DropdownItem>` or `<DropdownItemGroup>` components as children */
   children?:
     | Array<
         | ReactElement<DropdownItemProps<T>>
+        | ReactElement<DropdownItemGroupProps<T>>
         | Array<ReactElement<DropdownItemProps<T>>>
       >
-    | ReactElement<DropdownItemProps<T>>;
+    | ReactElement<DropdownItemProps<T>>
+    | ReactElement<DropdownItemGroupProps<T>>;
   /** Callback that fires when the Dropdown value changes. */
   onChange?(value: T): void;
   /** Callback that fires on blur */
@@ -258,30 +261,71 @@ class BaseDropdown<T extends string = string> extends Component<
     return null;
   }
 
+  /**
+   * Flattens children to get all DropdownItem elements, extracting items from groups
+   */
+  static getFlattenedItems<U extends string>(
+    children:
+      | Array<
+          | ReactElement<DropdownItemProps<U>>
+          | ReactElement<DropdownItemGroupProps<U>>
+          | Array<ReactElement<DropdownItemProps<U>>>
+        >
+      | ReactElement<DropdownItemProps<U>>
+      | ReactElement<DropdownItemGroupProps<U>>
+      | undefined,
+  ): Array<ReactElement<DropdownItemProps<U>>> {
+    if (!children) return [];
+
+    const items: Array<ReactElement<DropdownItemProps<U>>> = [];
+    const childArray = Array.isArray(children) ? children.flat() : [children];
+
+    childArray.forEach((child) => {
+      if (
+        child.type &&
+        (child.type as any).displayName === 'DropdownItemGroup'
+      ) {
+        // Extract items from group
+        const groupChildren = (child as ReactElement<DropdownItemGroupProps<U>>)
+          .props.children;
+        if (Array.isArray(groupChildren)) {
+          items.push(...groupChildren);
+        } else if (groupChildren) {
+          items.push(groupChildren);
+        }
+      } else if (
+        (child as ReactElement<DropdownItemProps<U>>).props?.value !== undefined
+      ) {
+        // Regular DropdownItem
+        items.push(child as ReactElement<DropdownItemProps<U>>);
+      }
+    });
+
+    return items;
+  }
+
   static getSelectedValueNode<U extends string>(
     selectedValue: string | undefined | null,
     children:
       | Array<
           | ReactElement<DropdownItemProps<U>>
+          | ReactElement<DropdownItemGroupProps<U>>
           | Array<ReactElement<DropdownItemProps<U>>>
         >
       | ReactElement<DropdownItemProps<U>>
+      | ReactElement<DropdownItemGroupProps<U>>
       | undefined,
   ): ReactNode | undefined {
     if (selectedValue === undefined || children === undefined) return undefined;
 
-    if (Array.isArray(children)) {
-      const flatChildren = children.flat();
-      for (let index = 0; index < flatChildren.length; index += 1) {
-        const element = flatChildren[index];
-
-        if (element.props.value === selectedValue) {
-          return element.props.children;
-        }
+    const flatItems = BaseDropdown.getFlattenedItems(children);
+    for (let index = 0; index < flatItems.length; index += 1) {
+      const element = flatItems[index];
+      if (element.props.value === selectedValue) {
+        return element.props.children;
       }
-    } else {
-      return children.props.children;
     }
+    return undefined;
   }
 
   static valueExistsInChildren<U extends string>(
@@ -289,15 +333,14 @@ class BaseDropdown<T extends string = string> extends Component<
     children:
       | Array<
           | ReactElement<DropdownItemProps<U>>
+          | ReactElement<DropdownItemGroupProps<U>>
           | Array<ReactElement<DropdownItemProps<U>>>
         >
-      | ReactElement<DropdownItemProps<U>>,
+      | ReactElement<DropdownItemProps<U>>
+      | ReactElement<DropdownItemGroupProps<U>>,
   ) {
-    if (Array.isArray(children)) {
-      const flatChildren = children.flat();
-      return flatChildren.some((child) => child.props.value === value);
-    }
-    return children.props.value === value;
+    const flatItems = BaseDropdown.getFlattenedItems(children);
+    return flatItems.some((child) => child.props.value === value);
   }
 
   componentDidMount(): void {
@@ -350,8 +393,8 @@ class BaseDropdown<T extends string = string> extends Component<
   }
 
   private handleSpaceAndEnter = (
-    popoverItems: Array<ReactElement<DropdownItemProps<T>>>,
-    getNextItem: () => ReactElement<DropdownItemProps<T>>,
+    popoverItems: Array<ReactElement<DropdownItemProps<any>>>,
+    getNextItem: () => ReactElement<DropdownItemProps<any>>,
   ) => {
     const { focusedDescendantId, showPopover } = this.state;
     if (!showPopover) {
@@ -377,14 +420,8 @@ class BaseDropdown<T extends string = string> extends Component<
     this.setState({ preventListScrolling: false });
 
     const { focusedDescendantId, ariaExpanded, showPopover } = this.state;
-    const items = Array.isArray(this.props.children)
-      ? this.props.children
-      : this.props.children !== undefined
-      ? [this.props.children]
-      : undefined;
-    if (!items) return;
-    const popoverItems: Array<ReactElement<DropdownItemProps<T>>> =
-      items.flat();
+    const popoverItems = BaseDropdown.getFlattenedItems<T>(this.props.children);
+    if (popoverItems.length === 0) return;
     const index = !!focusedDescendantId
       ? popoverItems.findIndex(
           (item) => item?.props.value === focusedDescendantId,
@@ -490,19 +527,8 @@ class BaseDropdown<T extends string = string> extends Component<
   };
 
   private getFirstItemValue() {
-    if (Array.isArray(this.props.children)) {
-      const element = this.props.children[0];
-
-      if (Array.isArray(element)) {
-        return element[0].props.value;
-      }
-
-      return element.props.value;
-    }
-    if (!!this.props.children) {
-      return this.props.children.props.value;
-    }
-    return null;
+    const flatItems = BaseDropdown.getFlattenedItems(this.props.children);
+    return flatItems.length > 0 ? flatItems[0].props.value : null;
   }
 
   private getDisplayValue() {

--- a/src/core/Form/Dropdown/DropdownItemGroup/DropdownItemGroup.baseStyles.tsx
+++ b/src/core/Form/Dropdown/DropdownItemGroup/DropdownItemGroup.baseStyles.tsx
@@ -1,0 +1,19 @@
+import { css } from 'styled-components';
+import { SuomifiTheme } from '../../../theme';
+
+export const baseStyles = (theme: SuomifiTheme) => css`
+  &.fi-dropdown_item-group {
+    .fi-dropdown_item-group_label {
+      ${theme.typography.bodySemiBoldSmall}
+      padding: ${theme.spacing.insetM};
+      color: ${theme.colors.blackBase};
+      cursor: default;
+      user-select: none;
+      background-color: ${theme.colors.whiteBase};
+    }
+
+    .fi-dropdown_item {
+      padding-left: ${theme.spacing.xl};
+    }
+  }
+`;

--- a/src/core/Form/Dropdown/DropdownItemGroup/DropdownItemGroup.test.tsx
+++ b/src/core/Form/Dropdown/DropdownItemGroup/DropdownItemGroup.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Dropdown } from '../Dropdown/Dropdown';
+import { DropdownItem } from '../DropdownItem/DropdownItem';
+import { DropdownItemGroup } from './DropdownItemGroup';
+
+describe('DropdownItemGroup', () => {
+  it('should render grouped items', () => {
+    const { container } = render(
+      <Dropdown labelText="Vakinainen asuminen" visualPlaceholder="Valitse">
+        <DropdownItemGroup label="Vakinainen asuminen">
+          <DropdownItem value="parents">Vanhempien luona</DropdownItem>
+          <DropdownItem value="mothers">Äidin luona</DropdownItem>
+        </DropdownItemGroup>
+        <DropdownItemGroup label="Vuoroasuminen">
+          <DropdownItem value="rotating-parents">Vanhempien luona</DropdownItem>
+          <DropdownItem value="rotating-mother-guardian">
+            Äidin / oheishuoltajan luona
+          </DropdownItem>
+        </DropdownItemGroup>
+      </Dropdown>,
+    );
+
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it('should have proper ARIA attributes', () => {
+    render(
+      <Dropdown labelText="Test" visualPlaceholder="Choose">
+        <DropdownItemGroup label="Group 1">
+          <DropdownItem value="item1">Item 1</DropdownItem>
+        </DropdownItemGroup>
+      </Dropdown>,
+    );
+
+    // The component should be accessible
+    const dropdown = screen.getByText('Test');
+    expect(dropdown).toBeInTheDocument();
+  });
+});

--- a/src/core/Form/Dropdown/DropdownItemGroup/DropdownItemGroup.tsx
+++ b/src/core/Form/Dropdown/DropdownItemGroup/DropdownItemGroup.tsx
@@ -1,0 +1,84 @@
+import React, { ReactElement } from 'react';
+import { styled } from 'styled-components';
+import { baseStyles } from './DropdownItemGroup.basestyles';
+import { dropdownClassNames } from '../Dropdown/Dropdown';
+import classnames from 'classnames';
+import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../theme';
+import { HtmlDiv, HtmlDivProps } from '../../../../reset';
+import { DropdownItemProps } from '../DropdownItem/DropdownItem';
+import { AutoId } from '../../../utils/AutoId/AutoId';
+
+export interface DropdownItemGroupProps<T extends string = string>
+  extends Omit<HtmlDivProps, 'children'> {
+  /** Group label text */
+  label: string;
+  /** DropdownItem children */
+  children:
+    | Array<ReactElement<DropdownItemProps<T>>>
+    | ReactElement<DropdownItemProps<T>>;
+  /** CSS class for custom styles */
+  className?: string;
+}
+
+interface BaseDropdownItemGroupProps<T extends string = string>
+  extends DropdownItemGroupProps<T> {
+  labelId: string;
+}
+
+const dropdownItemGroupClassNames = {
+  label: `${dropdownClassNames.item}-group_label`,
+  group: `${dropdownClassNames.item}-group`,
+};
+
+const BaseDropdownItemGroup = <T extends string>(
+  props: BaseDropdownItemGroupProps<T> & SuomifiThemeProp,
+) => {
+  const { children, className, theme, label, labelId, ...passProps } = props;
+
+  return (
+    <HtmlDiv
+      className={classnames(className, dropdownItemGroupClassNames.group)}
+      role="group"
+      aria-labelledby={labelId}
+      {...passProps}
+    >
+      <HtmlDiv
+        className={dropdownItemGroupClassNames.label}
+        id={labelId}
+        aria-hidden="true"
+      >
+        {label}
+      </HtmlDiv>
+      {children}
+    </HtmlDiv>
+  );
+};
+
+const StyledDropdownItemGroup = styled(BaseDropdownItemGroup)`
+  ${({ theme }) => baseStyles(theme)}
+`;
+
+const DropdownItemGroup = <T extends string = string>(
+  props: DropdownItemGroupProps<T>,
+) => {
+  const { label, ...passProps } = props;
+  return (
+    <SuomifiThemeConsumer>
+      {({ suomifiTheme }) => (
+        <AutoId>
+          {(id) => (
+            <StyledDropdownItemGroup
+              theme={suomifiTheme}
+              label={label}
+              labelId={id}
+              {...passProps}
+            />
+          )}
+        </AutoId>
+      )}
+    </SuomifiThemeConsumer>
+  );
+};
+
+DropdownItemGroup.displayName = 'DropdownItemGroup';
+export { DropdownItemGroup };

--- a/src/core/Form/Dropdown/index.ts
+++ b/src/core/Form/Dropdown/index.ts
@@ -1,2 +1,6 @@
 export { Dropdown, DropdownProps } from './Dropdown/Dropdown';
 export { DropdownItem, DropdownItemProps } from './DropdownItem/DropdownItem';
+export {
+  DropdownItemGroup,
+  DropdownItemGroupProps,
+} from './DropdownItemGroup/DropdownItemGroup';

--- a/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemList/SelectItemList.tsx
@@ -69,14 +69,26 @@ class BaseSelectItemList extends Component<
     // 4px reduction to scroll position is required due to container padding.
     const wrapperOffsetPx = 4;
     if (this.wrapperRef !== null && this.wrapperRef.current !== null) {
-      const elementOffsetTop =
-        document.getElementById(elementId)?.offsetTop || 0;
-      const elementOffsetHeight =
-        document.getElementById(elementId)?.offsetHeight || 0;
+      const element = document.getElementById(elementId);
+      if (!element) return;
+
+      let elementOffsetTop = element.offsetTop || 0;
+      const elementOffsetHeight = element.offsetHeight || 0;
+
+      // Check if the element is inside a group and adjust offsetTop accordingly
+      const groupParent = element.closest('[role="group"]');
+      if (
+        groupParent &&
+        groupParent.parentElement === this.wrapperRef.current
+      ) {
+        const groupOffsetTop = (groupParent as HTMLElement).offsetTop || 0;
+        elementOffsetTop = Math.min(elementOffsetTop, groupOffsetTop);
+      }
+
       if (elementOffsetTop < this.wrapperRef.current.scrollTop) {
         this.wrapperRef.current.scrollTop = elementOffsetTop - wrapperOffsetPx;
       } else {
-        const offsetBottom = elementOffsetTop + elementOffsetHeight;
+        const offsetBottom = element.offsetTop + elementOffsetHeight;
         const scrollBottom =
           this.wrapperRef.current.scrollTop +
           this.wrapperRef.current.offsetHeight;

--- a/src/core/Form/index.ts
+++ b/src/core/Form/index.ts
@@ -50,11 +50,9 @@ export {
   type ErrorSummaryProps,
   type ErrorSummaryItemProps,
 } from './ErrorSummary/ErrorSummary';
-export { Dropdown, type DropdownProps } from './Dropdown/Dropdown/Dropdown';
-export {
-  DropdownItem,
-  type DropdownItemProps,
-} from './Dropdown/DropdownItem/DropdownItem';
+export { Dropdown, type DropdownProps } from './Dropdown';
+export { DropdownItem, type DropdownItemProps } from './Dropdown';
+export { DropdownItemGroup, type DropdownItemGroupProps } from './Dropdown';
 export {
   FileInput,
   type FileInputProps,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,6 +84,8 @@ export {
   type DropdownProps,
   DropdownItem,
   type DropdownItemProps,
+  DropdownItemGroup,
+  type DropdownItemGroupProps,
   FileInput,
   type FileInputProps,
   type ControlledFileItem,


### PR DESCRIPTION
This draft PR presents an idea to add grouping to the `<Dropdown>` component via `<DropdownItemGroup>` elements. The visual style is just something I put together without too much thought to get this idea working, but I don't think it looks too bad like this tbh.

When it comes to accessibility, I think it needs to be looked into more. The main idea in this version is to use `role=group` and `aria-labelledby` with the groups. This seems to work "okayish" on macOS VoiceOver. But maybe a more verbose approach is needed? Maybe adding something like `aria-label="Fruits, Apple"` to each item?

<img width="592" height="668" alt="image" src="https://github.com/user-attachments/assets/68b152ba-b241-4dff-b303-355229dfb664" />
