### PR TITLE
[Feature] SingleSelect & MultiSelect: Change popover focus logic (a11y improvement)

### DIFF
--- a/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.tsx
@@ -1,8 +1,11 @@
-import React, { Component, ReactNode } from 'react';
+import React, { Component, ReactNode, useLayoutEffect, useRef } from 'react';
 import { styled } from 'styled-components';
 import classnames from 'classnames';
 import { IconCheck } from 'suomifi-icons';
-import { escapeStringRegexp } from '../../../../../utils/common';
+import {
+  escapeStringRegexp,
+  getOwnerDocument,
+} from '../../../../../utils/common';
 import { HtmlLi } from '../../../../../reset';
 import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../../../theme';
 import { baseStyles } from './SelectItem.baseStyles';
@@ -29,6 +32,8 @@ export interface SelectItemProps {
   checked: boolean;
   /** onClick event handler */
   onClick: (event: React.MouseEvent<HTMLLIElement>) => void;
+  /** Callback fired when Tab key is pressed on the item */
+  onTabPress?: () => void;
   /** Item children, dislayed as item content */
   children: ReactNode;
   /** SelectItem container div class name for custom styling. */
@@ -37,8 +42,31 @@ export interface SelectItemProps {
   disabled?: boolean;
 }
 
-class BaseSelectItem extends Component<SelectItemProps & SuomifiThemeProp> {
-  private highlightQuery = (text: string, query: string = '') => {
+const BaseSelectItem = (props: SelectItemProps & SuomifiThemeProp) => {
+  const {
+    className,
+    theme,
+    children,
+    checked,
+    hasKeyboardFocus,
+    hightlightQuery,
+    disabled,
+    id,
+    onClick,
+    onTabPress,
+    ...passProps
+  } = props;
+
+  const listElementRef = useRef<HTMLLIElement>(null);
+
+  useLayoutEffect(() => {
+    const ownerDocument = getOwnerDocument(listElementRef);
+    if (ownerDocument.activeElement?.id !== id && hasKeyboardFocus) {
+      listElementRef.current?.focus({ preventScroll: true });
+    }
+  }, [hasKeyboardFocus, id]);
+
+  const highlightQuery = (text: string, query: string = '') => {
     if (query.length > 0) {
       const substrings = text.split(
         new RegExp(`(${escapeStringRegexp(query)})`, 'gi'),
@@ -60,57 +88,49 @@ class BaseSelectItem extends Component<SelectItemProps & SuomifiThemeProp> {
     return text;
   };
 
-  render() {
-    const {
-      className,
-      theme,
-      children,
-      checked,
-      hasKeyboardFocus,
-      hightlightQuery,
-      disabled,
-      id,
-      onClick,
-      ...passProps
-    } = this.props;
-
-    return (
-      <HtmlLi
-        className={classnames(baseClassName, className, {
-          [selectItemClassNames.hasKeyboardFocus]: hasKeyboardFocus,
-          [selectItemClassNames.selected]: checked,
-          [selectItemClassNames.disabled]: disabled,
-        })}
-        tabIndex={-1}
-        role="option"
-        aria-selected={checked}
-        aria-disabled={disabled || false}
-        id={id}
-        onClick={(event) => {
-          if (!!onClick) {
-            onClick(event);
-          }
-        }}
-        onMouseDown={(event) => {
-          // prevent focusing the li element
+  return (
+    <HtmlLi
+      className={classnames(baseClassName, className, {
+        [selectItemClassNames.hasKeyboardFocus]: hasKeyboardFocus,
+        [selectItemClassNames.selected]: checked,
+        [selectItemClassNames.disabled]: disabled,
+      })}
+      tabIndex={hasKeyboardFocus ? 0 : -1}
+      role="option"
+      aria-selected={checked}
+      aria-disabled={disabled || false}
+      id={id}
+      onClick={(event) => {
+        if (!!onClick) {
+          onClick(event);
+        }
+      }}
+      onKeyDown={(event: React.KeyboardEvent) => {
+        if (event.key === 'Tab' && onTabPress) {
           event.preventDefault();
-        }}
-        {...passProps}
-      >
-        {React.Children.map(children, (child) => {
-          if (typeof child === 'string') {
-            return this.highlightQuery(child, hightlightQuery);
-          }
-          return child;
-        })}
+          onTabPress();
+        }
+      }}
+      onMouseDown={(event) => {
+        // prevent focusing the li element
+        event.preventDefault();
+      }}
+      forwardedRef={listElementRef}
+      {...passProps}
+    >
+      {React.Children.map(children, (child) => {
+        if (typeof child === 'string') {
+          return highlightQuery(child, hightlightQuery);
+        }
+        return child;
+      })}
 
-        {checked && (
-          <IconCheck className={selectItemClassNames.icon} aria-hidden={true} />
-        )}
-      </HtmlLi>
-    );
-  }
-}
+      {checked && (
+        <IconCheck className={selectItemClassNames.icon} aria-hidden={true} />
+      )}
+    </HtmlLi>
+  );
+};
 
 const StyledSelectItem = styled(BaseSelectItem)`
   ${({ theme }) => baseStyles(theme)}

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -127,7 +127,7 @@ it('has matching snapshot', async () => {
   await waitForPosition();
   const textfield = getByRole('textbox') as HTMLInputElement;
   await act(async () => {
-    fireEvent.focus(textfield);
+    fireEvent.click(textfield);
   });
 
   await waitForPosition();
@@ -303,7 +303,7 @@ describe('Non-controlled', () => {
 
     const textfield = getByRole('textbox') as HTMLInputElement;
     await act(async () => {
-      fireEvent.focus(textfield);
+      fireEvent.click(textfield);
     });
     rerender(
       <MultiSelect
@@ -433,8 +433,8 @@ describe('Controlled', () => {
     await waitFor(() => {
       expect(mockItemSelectionsChange).toBeCalledTimes(1);
       expect(mockItemSelectionsChange).toBeCalledWith('turtle-987');
-      // Popover is open, so therefore two
-      expect(getAllByText('Turtle')).toHaveLength(2);
+      // Chip is visible, popover is not open
+      expect(getAllByText('Turtle')).toHaveLength(1);
     });
   });
 
@@ -765,6 +765,11 @@ describe('custom item addition mode', () => {
           fireEvent.click(removeAllButton);
         });
 
+        // Click the input to reopen the popover
+        await act(async () => {
+          fireEvent.click(input);
+        });
+
         const resetItems = await waitFor(() => getAllByRole('option'));
         expect(resetItems).toHaveLength(9);
       } else {
@@ -816,7 +821,7 @@ describe('listProps', () => {
     await waitForPosition();
     const input = await waitFor(async () => getByRole('textbox'));
     await act(async () => {
-      fireEvent.focus(input);
+      fireEvent.click(input);
     });
     const menu = await waitFor(() => getByRole('listbox'));
     expect(menu).toHaveAttribute('data-test-id', 'custom-attr');
@@ -844,7 +849,7 @@ describe('listItemProps', () => {
     await waitForPosition();
     const input = await waitFor(() => getByRole('textbox'));
     await act(async () => {
-      fireEvent.focus(input);
+      fireEvent.click(input);
     });
     const option = await waitFor(() => getByRole('option'));
     expect(option).toHaveAttribute('data-test-id', 'apple');

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -206,6 +206,11 @@ interface InternalMultiSelectProps<T extends MultiSelectData> {
   popoverClassName?: string;
   /** Sets component's width to 100% of its parent */
   fullWidth?: boolean;
+  /**
+   * Whether the component's popover is rendered in a portal
+   * @default true
+   */
+  portal?: boolean;
 }
 
 type AllowItemAdditionProps =
@@ -437,20 +442,25 @@ class BaseMultiSelect<T> extends Component<
       : false;
 
   private handleBlur = () => {
-    if (!!this.props.onBlur) {
-      this.props.onBlur();
-    }
-    const ownerDocument = getOwnerDocument(this.popoverListRef);
+    const ownerDocument = getOwnerDocument(this.filterInputRef);
     if (!ownerDocument) {
       return;
     }
     requestAnimationFrame(() => {
       const focusInPopover = this.focusInPopover(ownerDocument);
+      // If focus was moved to an element inside the popover, it's not really a blur event
+      if (focusInPopover) {
+        return;
+      }
+
+      if (!!this.props.onBlur) {
+        this.props.onBlur();
+      }
+
       const focusInInput = this.focusInInput(ownerDocument);
       const focusInToggleButton = this.focusInToggleButton(ownerDocument);
 
-      const focusInMultiSelect =
-        focusInPopover || focusInInput || focusInToggleButton;
+      const focusInMultiSelect = focusInInput || focusInToggleButton;
 
       const userAddedSelectedItems: Array<T & MultiSelectData> =
         this.state.selectedItems.filter((si) =>
@@ -506,7 +516,9 @@ class BaseMultiSelect<T> extends Component<
     switch (event.key) {
       case 'ArrowDown': {
         event.preventDefault();
-        this.setState({ showPopover: true });
+        if (!this.state.showPopover) {
+          this.openPopover();
+        }
         const nextItem =
           this.props.allowItemAddition &&
           (index === items.length - 1 || items.length === 0) &&
@@ -525,7 +537,9 @@ class BaseMultiSelect<T> extends Component<
 
       case 'ArrowUp': {
         event.preventDefault();
-        this.setState({ showPopover: true });
+        if (!this.state.showPopover) {
+          this.openPopover();
+        }
         const previousItem =
           this.props.allowItemAddition &&
           (index === null || index === 0) &&
@@ -566,17 +580,17 @@ class BaseMultiSelect<T> extends Component<
       case 'Escape': {
         if (this.state.showPopover) {
           event.stopPropagation();
+          this.setState(
+            (
+              _prevState: MultiSelectState<T & MultiSelectData>,
+              prevProps: MultiSelectProps<T & MultiSelectData>,
+            ) => ({
+              filterInputValue: '',
+              filteredItems: prevProps.items,
+            }),
+          );
+          this.focusToInputAndClosePopover();
         }
-        this.setState(
-          (
-            _prevState: MultiSelectState<T & MultiSelectData>,
-            prevProps: MultiSelectProps<T & MultiSelectData>,
-          ) => ({
-            filterInputValue: '',
-            filteredItems: prevProps.items,
-          }),
-        );
-        this.setState({ showPopover: false, focusedDescendantId: null });
         break;
       }
 
@@ -595,15 +609,14 @@ class BaseMultiSelect<T> extends Component<
 
   private handleToggleButtonClick(event: React.MouseEvent<HTMLElement>) {
     event.preventDefault();
-    if (!!this.filterInputRef && this.filterInputRef.current) {
-      if (document.activeElement !== this.filterInputRef.current) {
-        this.filterInputRef.current.focus();
-      } else {
-        this.setState((prevState: MultiSelectState<T & MultiSelectData>) => ({
-          showPopover: !prevState.showPopover,
-          showOptionsAvailableText: !prevState.showOptionsAvailableText,
-        }));
-      }
+    if (!this.state.showPopover) {
+      this.openPopoverAndFocusFirstItem();
+    } else {
+      this.setState({
+        showPopover: false,
+        showOptionsAvailableText: false,
+        focusedDescendantId: null,
+      });
     }
   }
 
@@ -629,6 +642,49 @@ class BaseMultiSelect<T> extends Component<
       });
     }
   };
+
+  private openPopover() {
+    this.setState({ showPopover: true, showOptionsAvailableText: true });
+    /**
+     * Timeout is used here to ensure the popover
+     * exists when setting focus
+     */
+    setTimeout(() => {
+      this.popoverListRef.current?.focus();
+    }, 200);
+  }
+
+  private openPopoverAndFocusFirstItem() {
+    const firstItemValue = this.getFirstItemValue();
+    this.setState({
+      showPopover: true,
+      showOptionsAvailableText: true,
+      focusedDescendantId: firstItemValue,
+    });
+    /**
+     * Timeout is used here to ensure the popover
+     * exists when setting focus
+     */
+    setTimeout(() => {
+      this.popoverListRef.current?.focus();
+    }, 200);
+  }
+
+  private focusToInputAndClosePopover = () => {
+    this.setState({
+      showPopover: false,
+      focusedDescendantId: null,
+      showOptionsAvailableText: false,
+    });
+    this.filterInputRef.current?.focus();
+  };
+
+  private getFirstItemValue() {
+    if (this.props.items && this.props.items.length > 0) {
+      return this.props.items[0].uniqueItemId;
+    }
+    return null;
+  }
 
   render() {
     const {
@@ -681,6 +737,7 @@ class BaseMultiSelect<T> extends Component<
       popoverClassName,
       style,
       fullWidth,
+      portal = true,
       ...rest
     } = this.props;
     const [_marginProps, passProps] = separateMarginProps(rest);
@@ -748,12 +805,7 @@ class BaseMultiSelect<T> extends Component<
                   }}
                   filterFunc={this.filter}
                   forwardedRef={this.filterInputRef}
-                  onFocus={() =>
-                    this.setState({
-                      showPopover: true,
-                      showOptionsAvailableText: true,
-                    })
-                  }
+                  onClick={() => this.openPopoverAndFocusFirstItem()}
                   onKeyDown={this.handleKeyDown}
                   onBlur={this.handleBlur}
                   value={filterInputValue}
@@ -799,6 +851,7 @@ class BaseMultiSelect<T> extends Component<
                   }
                 }}
                 className={popoverClassName}
+                portal={portal}
               >
                 <PopoverConsumer>
                   {(consumer) => {
@@ -829,6 +882,7 @@ class BaseMultiSelect<T> extends Component<
                                     this.handleItemSelection(item);
                                     consumer.updatePopover();
                                   }}
+                                  onTabPress={this.focusToInputAndClosePopover}
                                   hightlightQuery={
                                     this.filterInputRef.current?.value
                                   }

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1248,7 +1248,7 @@ exports[`has matching snapshot 1`] = `
                 role="combobox"
               >
                 <input
-                  aria-activedescendant=""
+                  aria-activedescendant="3-jh2435626"
                   aria-autocomplete="list"
                   aria-controls="3-popover"
                   aria-invalid="false"
@@ -1479,7 +1479,7 @@ exports[`has matching snapshot 1`] = `
       class="c3"
     >
       <ul
-        aria-activedescendant=""
+        aria-activedescendant="3-jh2435626"
         aria-multiselectable="true"
         class="c17 fi-select-item-list c18"
         data-floating-ui-placement="bottom"
@@ -1490,10 +1490,10 @@ exports[`has matching snapshot 1`] = `
         <li
           aria-disabled="false"
           aria-selected="false"
-          class="c19 fi-select-item c20"
+          class="c19 fi-select-item c20 fi-select-item--hasKeyboardFocus"
           id="3-jh2435626"
           role="option"
-          tabindex="-1"
+          tabindex="0"
         >
           Jackhammer
         </li>

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -106,11 +106,13 @@ it('should not have basic accessibility issues', async () => {
 });
 
 it('has matching snapshot', async () => {
-  const { baseElement, getByRole } = render(BasicSingleSelect);
+  const { baseElement, container } = render(BasicSingleSelect);
   await waitForPosition();
-  const textfield = getByRole('textbox') as HTMLInputElement;
+  const toggleButton = container.querySelector(
+    '.fi-input-toggle-button',
+  ) as HTMLButtonElement;
   await act(async () => {
-    fireEvent.focus(textfield);
+    fireEvent.click(toggleButton);
   });
   await waitForPosition();
   expect(baseElement).toMatchSnapshot();
@@ -143,11 +145,13 @@ describe('Controlled', () => {
       />
     );
 
-    const { getByRole, getByText, rerender } = render(singleSelect);
+    const { getByRole, getByText, container, rerender } = render(singleSelect);
     await waitForPosition();
     expect(getByRole('textbox')).toHaveValue('Powersaw');
-    const input = getByRole('textbox');
-    fireEvent.click(input);
+    const toggleButton = container.querySelector(
+      '.fi-input-toggle-button',
+    ) as HTMLButtonElement;
+    fireEvent.click(toggleButton);
     const item = await waitFor(() => getByText('Powersaw'));
     expect(item).toHaveAttribute('aria-disabled');
     expect(item).toHaveClass('fi-select-item--disabled');
@@ -266,7 +270,7 @@ describe('filter', () => {
   });
 
   it('should be removed onBlur', async () => {
-    const { getByRole, getAllByRole } = render(BasicSingleSelect);
+    const { getByRole, getAllByRole, container } = render(BasicSingleSelect);
     await waitForPosition();
     const input = getByRole('textbox');
     expect(input).toHaveValue('Hammer');
@@ -278,17 +282,23 @@ describe('filter', () => {
     await waitFor(() => {
       expect(input).toHaveValue('Hammer');
     });
-    fireEvent.focus(input);
+    const toggleButton = container.querySelector(
+      '.fi-input-toggle-button',
+    ) as HTMLButtonElement;
+    fireEvent.click(toggleButton);
     const options = await waitFor(() => getAllByRole('option'));
     expect(options).toHaveLength(9);
   });
 });
 
 test('option: should be selected when clicked', async () => {
-  const { getByText, getByRole } = render(BasicSingleSelect);
+  const { getByText, getByRole, container } = render(BasicSingleSelect);
   await waitForPosition();
   const input = getByRole('textbox');
-  fireEvent.click(input);
+  const toggleButton = container.querySelector(
+    '.fi-input-toggle-button',
+  ) as HTMLButtonElement;
+  fireEvent.click(toggleButton);
 
   const option = await waitFor(() => getByText('Rake'));
 
@@ -435,7 +445,7 @@ describe('disabled', () => {
 
 describe('custom item addition mode', () => {
   it('should allow user to add & remove their own option as the selected value', async () => {
-    const { getByRole, getAllByRole, getByText } = render(
+    const { getByRole, getAllByRole, getByText, container } = render(
       <SingleSelect
         allowItemAddition={true}
         itemAdditionHelpText="Add custom item"
@@ -463,7 +473,10 @@ describe('custom item addition mode', () => {
         fireEvent.blur(input);
       });
       await act(async () => {
-        fireEvent.focus(input);
+        const toggleButton = container.querySelector(
+          '.fi-input-toggle-button',
+        ) as HTMLButtonElement;
+        fireEvent.click(toggleButton);
       });
       const appendedItems = await waitFor(() => getAllByRole('option'));
       expect(appendedItems).toHaveLength(10);
@@ -478,7 +491,10 @@ describe('custom item addition mode', () => {
       expect(input).toHaveValue('');
 
       await act(async () => {
-        fireEvent.click(input);
+        const toggleButton = container.querySelector(
+          '.fi-input-toggle-button',
+        ) as HTMLButtonElement;
+        fireEvent.click(toggleButton);
       });
       const resetItems = await waitFor(() => getAllByRole('option'));
       expect(resetItems).toHaveLength(9);
@@ -569,7 +585,7 @@ describe('forward ref', () => {
 
 describe('listProps', () => {
   it('adds data-test-id to unordered list element', async () => {
-    const { getByRole } = render(
+    const { container } = render(
       <SingleSelect
         labelText="Test"
         clearButtonLabel="Clear selection"
@@ -582,18 +598,20 @@ describe('listProps', () => {
       />,
     );
     await waitForPosition();
-    const input = await waitFor(() => getByRole('textbox'));
-    await act(() => fireEvent.focus(input));
-    const menu = await waitFor(() => getByRole('listbox'));
-    await waitFor(() =>
-      expect(menu).toHaveAttribute('data-test-id', 'custom-data-attr'),
-    );
+    const toggleButton = container.querySelector(
+      '.fi-input-toggle-button',
+    ) as HTMLButtonElement;
+    fireEvent.click(toggleButton);
+    await waitForPosition();
+    const menu = document.querySelector('[data-test-id="custom-data-attr"]');
+    expect(menu).toBeInTheDocument();
+    expect(menu).toHaveAttribute('role', 'listbox');
   });
 });
 
 describe('listItemProps', () => {
   it('adds data-test-id to list item element', async () => {
-    const { getByRole } = render(
+    const { getByRole, container } = render(
       <SingleSelect
         labelText="Test"
         clearButtonLabel="Clear selection"
@@ -611,9 +629,11 @@ describe('listItemProps', () => {
       />,
     );
     await waitForPosition();
-    const input = await waitFor(() => getByRole('textbox'));
+    const toggleButton = container.querySelector(
+      '.fi-input-toggle-button',
+    ) as HTMLButtonElement;
     await act(async () => {
-      fireEvent.focus(input);
+      fireEvent.click(toggleButton);
     });
     const option = await waitFor(() => getByRole('option'));
 
@@ -702,18 +722,15 @@ describe('margin', () => {
 
 describe('keyboard interactions', () => {
   it('should reset input value to selected item when pressing Escape after typing', async () => {
-    const { getByRole, getByText } = render(BasicSingleSelect);
+    const { getByRole } = render(BasicSingleSelect);
     await waitForPosition();
 
     const input = getByRole('textbox');
 
-    // First, select an item
-    fireEvent.click(input);
-    const option = await waitFor(() => getByText('Rake'));
-    fireEvent.click(option);
-    expect(input).toHaveValue('Rake');
+    // BasicSingleSelect already has 'Hammer' selected by default
+    expect(input).toHaveValue('Hammer');
 
-    // Then type something different in the input
+    // Type something different in the input
     await act(async () => {
       fireEvent.click(input);
       fireEvent.change(input, { target: { value: 'something else' } });
@@ -724,7 +741,7 @@ describe('keyboard interactions', () => {
     await act(async () => {
       fireEvent.keyDown(input, { key: 'Escape' });
     });
-    expect(input).toHaveValue('Rake');
+    expect(input).toHaveValue('Hammer');
   });
 
   it('should clear input when pressing Escape with no selected item', async () => {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -140,6 +140,11 @@ export interface InternalSingleSelectProps<T extends SingleSelectData> {
   popoverClassName?: string;
   /** Sets component's width to 100% of its parent */
   fullWidth?: boolean;
+  /**
+   * Whether the component's popover is rendered in a portal
+   * @default true
+   */
+  portal?: boolean;
 }
 
 type LoadingProps =
@@ -207,7 +212,7 @@ class BaseSingleSelect<T> extends Component<
 
   private clearButtonRef: React.RefObject<HTMLButtonElement>;
 
-  private preventShowPopoverOnInputFocus = false;
+  // private preventShowPopoverOnInputFocus = false;
 
   constructor(
     props: SingleSelectProps<T & SingleSelectData> & SuomifiThemeProp,
@@ -307,10 +312,7 @@ class BaseSingleSelect<T> extends Component<
     data.labelText.toLowerCase().includes(query.toLowerCase());
 
   private handleBlur = () => {
-    if (!!this.props.onBlur) {
-      this.props.onBlur();
-    }
-    const ownerDocument = getOwnerDocument(this.popoverListRef);
+    const ownerDocument = getOwnerDocument(this.filterInputRef);
     if (!ownerDocument) {
       return;
     }
@@ -318,18 +320,26 @@ class BaseSingleSelect<T> extends Component<
       const focusInPopover = this.popoverListRef.current?.contains(
         ownerDocument.activeElement,
       );
+      // If focus was moved to an element inside the popover, it's not really a blur event
+      if (focusInPopover) {
+        return;
+      }
+
+      if (!!this.props.onBlur) {
+        this.props.onBlur();
+      }
+
       const focusInToggleButton = this.toggleButtonRef.current?.contains(
         ownerDocument.activeElement,
       );
       const focusInInput =
         ownerDocument.activeElement === this.filterInputRef.current;
-      const focusInSingleSelect =
-        focusInPopover || focusInInput || focusInToggleButton;
+      const focusInSingleSelect = focusInInput || focusInToggleButton;
       if (!focusInSingleSelect) {
         this.setState((prevState: SingleSelectState<T & SingleSelectData>) => ({
           filterInputValue: prevState.selectedItem?.labelText || '',
           filterMode: false,
-          showPopover: focusInSingleSelect,
+          showPopover: false,
           focusedDescendantId: null,
         }));
       }
@@ -443,7 +453,7 @@ class BaseSingleSelect<T> extends Component<
       case 'ArrowDown': {
         event.preventDefault();
         if (!this.state.showPopover) {
-          this.setState({ showPopover: true });
+          this.openPopover();
         }
         const nextItem =
           this.props.allowItemAddition &&
@@ -464,7 +474,7 @@ class BaseSingleSelect<T> extends Component<
       case 'ArrowUp': {
         event.preventDefault();
         if (!this.state.showPopover) {
-          this.setState({ showPopover: true });
+          this.openPopover();
         }
         const previousItem =
           this.props.allowItemAddition &&
@@ -531,6 +541,37 @@ class BaseSingleSelect<T> extends Component<
           this.state.filterInputValue.toLowerCase(),
     );
 
+  private openPopover() {
+    this.setState({ showPopover: true });
+    /**
+     * Timeout is used here to ensure the popover
+     * exists when setting focus
+     */
+    setTimeout(() => {
+      this.popoverListRef.current?.focus();
+    }, 200);
+  }
+
+  private openPopoverAndFocusFirstItem() {
+    const firstItemValue = this.getFirstItemValue();
+    this.setState({
+      showPopover: true,
+      focusedDescendantId: firstItemValue,
+    });
+    /**
+     * Timeout is used here to ensure the popover
+     * exists when setting focus
+     */
+    setTimeout(() => {
+      this.popoverListRef.current?.focus();
+    }, 200);
+  }
+
+  private focusToInputAndClosePopover = () => {
+    this.setState({ showPopover: false, focusedDescendantId: null });
+    this.filterInputRef.current?.focus();
+  };
+
   private updatePopoverPlacement = (placement: string | undefined) => {
     if (!placement) return;
     if (placement !== this.state.popoverPlacement) {
@@ -539,6 +580,13 @@ class BaseSingleSelect<T> extends Component<
       });
     }
   };
+
+  private getFirstItemValue() {
+    if (this.props.items && this.props.items.length > 0) {
+      return this.props.items[0].uniqueItemId;
+    }
+    return null;
+  }
 
   render() {
     const {
@@ -585,6 +633,7 @@ class BaseSingleSelect<T> extends Component<
       popoverClassName,
       style,
       fullWidth,
+      portal = true,
       ...rest
     } = this.props;
     const [_marginProps, passProps] = separateMarginProps(rest);
@@ -645,17 +694,9 @@ class BaseSingleSelect<T> extends Component<
               }}
               filterFunc={this.filter}
               forwardedRef={this.filterInputRef}
-              onFocus={() => {
-                if (!this.preventShowPopoverOnInputFocus) {
-                  this.setState({ showPopover: true });
-                }
-                this.preventShowPopoverOnInputFocus = false;
-              }}
               onClick={() => {
                 this.focusToInputAndSelectText();
-                this.setState({
-                  showPopover: true,
-                });
+                this.openPopoverAndFocusFirstItem();
               }}
               onKeyDown={this.handleKeyDown}
               onBlur={this.handleBlur}
@@ -692,13 +733,12 @@ class BaseSingleSelect<T> extends Component<
                 ref={this.toggleButtonRef}
                 onClick={(event) => {
                   event.preventDefault();
-                  this.setState(
-                    (prevState: SingleSelectState<T & SingleSelectData>) => ({
-                      showPopover: !prevState.showPopover,
-                    }),
-                  );
-                  this.preventShowPopoverOnInputFocus = true;
-                  this.focusToInputAndSelectText();
+                  if (!showPopover) {
+                    this.openPopoverAndFocusFirstItem();
+                  } else {
+                    this.setState({ showPopover: false });
+                    this.focusToInputAndSelectText();
+                  }
                 }}
                 aria-hidden={true}
                 tabIndex={-1}
@@ -718,6 +758,7 @@ class BaseSingleSelect<T> extends Component<
               }
             }}
             className={popoverClassName}
+            portal={portal}
           >
             <PopoverConsumer>
               {(consumer) => {
@@ -750,6 +791,7 @@ class BaseSingleSelect<T> extends Component<
                               onClick={() => {
                                 this.handleItemSelection(item);
                               }}
+                              onTabPress={this.focusToInputAndClosePopover}
                               hightlightQuery={
                                 filterMode
                                   ? this.filterInputRef.current?.value

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -872,7 +872,7 @@ exports[`has matching snapshot 1`] = `
               role="combobox"
             >
               <input
-                aria-activedescendant=""
+                aria-activedescendant="2-jh2435626"
                 aria-autocomplete="list"
                 aria-controls="2-popover"
                 aria-describedby="1-hintText"
@@ -981,7 +981,7 @@ exports[`has matching snapshot 1`] = `
       class="c3"
     >
       <ul
-        aria-activedescendant=""
+        aria-activedescendant="2-jh2435626"
         class="c15 fi-select-item-list c16"
         data-floating-ui-placement="bottom"
         id="2-popover"
@@ -991,10 +991,10 @@ exports[`has matching snapshot 1`] = `
         <li
           aria-disabled="false"
           aria-selected="false"
-          class="c17 fi-select-item c18"
+          class="c17 fi-select-item c18 fi-select-item--hasKeyboardFocus"
           id="2-jh2435626"
           role="option"
-          tabindex="-1"
+          tabindex="0"
         >
           Jackhammer
         </li>


### PR DESCRIPTION
This draft PR converts SingleSelect and MultiSelect to work similarly to the Dropdown component in terms of the popover. When browsing the popover list the browser's focus now actually goes to the `<li>` elements in the list. This fixes screen reader problems on macOS VoiceOver. Needs further testing though.

Making this change would also change the behavior of the components a little bit: So far, when browsing the popover list via keyboard, the browser's focus has remained in the input field and it has thus been possible to filter the list while browsing. With this change, that would not be possible anymore.

<img width="1046" height="1526" alt="image" src="https://github.com/user-attachments/assets/29f63416-95c0-4dc2-a79f-5977842afb6b" />
