### PR TITLE
[Fix] Add flex wrap to ModalFooter

### DIFF
--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -478,6 +478,7 @@ exports[`Basic modal should match snapshot 1`] = `
   padding-bottom: 20px;
   padding-left: 30px;
   display: flex;
+  flex-wrap: wrap;
 }
 
 .c7.fi-modal_footer .fi-modal_footer_content>* {

--- a/src/core/Modal/ModalFooter/ModalFooter.baseStyles.tsx
+++ b/src/core/Modal/ModalFooter/ModalFooter.baseStyles.tsx
@@ -11,6 +11,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       padding-bottom: ${theme.spacing.m};
       padding-left: ${theme.spacing.xl};
       display: flex;
+      flex-wrap: wrap;
       & > * {
         margin-top: ${theme.spacing.m};
         margin-right: ${theme.spacing.s};

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -183,6 +183,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   padding-bottom: 20px;
   padding-left: 30px;
   display: flex;
+  flex-wrap: wrap;
 }
 
 .c2.fi-modal_footer .fi-modal_footer_content>* {


### PR DESCRIPTION
## Description
After recent changes, ModalFooter behaved in an unwanted manner when it had a lot of content:
<img width="2262" height="266" alt="image" src="https://github.com/user-attachments/assets/894c76d3-39e1-4712-90bc-6d124df31735" />

This PR adds `flex-wrap: wrap` css rule, which allows the content to wrap to a new line in similar instances:
<img width="974" height="148" alt="image" src="https://github.com/user-attachments/assets/ee9fcfbc-b725-40f1-b838-28ec5d2bb24a" />

## How Has This Been Tested?

Tested by running locally on styleguidist on Chrome and by unit tests.

## Release notes
### ModalFooter
**Breaking change:** add `flex-wrap: wrap` to modal footer content wrapper
