### PR TITLE
[Feature] Styled-components peer dependency update

### DIFF
--- a/.styleguidist/introduction.md
+++ b/.styleguidist/introduction.md
@@ -2,12 +2,12 @@
 
 ## ✨ Features
 
-- Accessibility WCAG 2.1 level AA. <a href="./#/Accessibility">Read more on accessibility support</a>.
+- Accessibility WCAG 2.2 level AA. <a href="./#/Accessibility">Read more on accessibility support</a>.
 - React-components with TypeScript support
 - Suomi.fi brand styles
 - Highly customizable (CSS, CSS-in-JS)
 
-Works with [React >= 16.8.0](https://github.com/facebook/react) (React 18 supported) and [Styled Components >= 5.2.1](https://github.com/styled-components/styled-components). Supports [TypeScript](https://github.com/Microsoft/TypeScript). CJS and ESM builds provided via the npm package.
+Works with [React >= 16.8.0](https://github.com/facebook/react) (React 19 supported) and [Styled Components >= 6.0.0](https://github.com/styled-components/styled-components). Supports [TypeScript](https://github.com/Microsoft/TypeScript). CJS and ESM builds provided via the npm package.
 
 ### Supported browser and screenreader combinations
 
@@ -41,7 +41,7 @@ This provides Latin, Latin Extended, Cyrillic, Cyrillic Extended, Greek, Greek E
 You should also install the following peer dependencies.
 
 - [React](https://www.npmjs.com/package/react) version >=16.8.0 and related dependencies and typings.
-- [styled-components](https://www.npmjs.com/package/styled-components) version >=5.2.1 and related dependencies and typings.
+- [styled-components](https://www.npmjs.com/package/styled-components) version >=6.0.0.
 
 - The aim is to keep dependencies up to date and use the latest available versions. We encourage you to use the latest available versions of peer dependencies.
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Suomi.fi-styleguide in React components. [Living styleguide](https://vrk-kpa.git
 
 ## ✨ Features
 
-- Accessibility WCAG 2.1 level AA
+- Accessibility WCAG 2.2 level AA
 - React-components with TypeScript support
 - Suomi.fi brand styles
 - Highly customizable (CSS, CSS-in-JS)
 
-Works with [React >= 16.8.0](https://github.com/facebook/react) (React 19 supported) and [Styled Components >= 5.2.1](https://github.com/styled-components/styled-components). Supports [TypeScript](https://github.com/Microsoft/TypeScript). CJS and ESM builds provided via the npm package.
+Works with [React >= 16.8.0](https://github.com/facebook/react) (React 19 supported) and [Styled Components >= 6.0.0](https://github.com/styled-components/styled-components). Supports [TypeScript](https://github.com/Microsoft/TypeScript). CJS and ESM builds provided via the npm package.
 
 ### Supported browser and screenreader combinations
 
@@ -45,7 +45,7 @@ This loads the font with access to all needed charsets (Latin, Latin Extended, C
 You should also install the following peer dependencies.
 
 - [React](https://www.npmjs.com/package/react) version >=16.8.0 and related dependencies and typings.
-- [styled-components](https://www.npmjs.com/package/styled-components) version >=5.2.1 and related dependencies and typings.
+- [styled-components](https://www.npmjs.com/package/styled-components) version >=6.0.0.
 
 - The aim is to keep dependencies up to date and use the latest available versions. We encourage you to use the latest available versions of peer dependencies.
 

--- a/package.json
+++ b/package.json
@@ -160,10 +160,9 @@
     "suomifi-icons": "7.9.0"
   },
   "peerDependencies": {
-    "@types/styled-components": ">=5.1.9",
     "@types/warning": ">=3.0.0",
     "react": ">=16.8.0",
-    "styled-components": ">=5.2.1"
+    "styled-components": ">=6.0.0"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": "prettier --check",


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Styled-components peer dependency should be raised to 6.0.0 since suomifi-ui-components version 16.0.0. 

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Suomifi-ui-components uses named export for styled-components since version 16.0.0. Styled-components provides named export only since version 6.0.0

## How Has This Been Tested?

Create React App and Vite projects.

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### General 

- Peer dependency to styled-components is updated to 6.0.0.