### PR TITLE
Update suomifi-icons from 7.8.0 to 7.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "polished": "4.2.2",
         "react-modal": "3.16.3",
         "suomifi-design-tokens": "7.0.0",
-        "suomifi-icons": "7.8.0"
+        "suomifi-icons": "7.9.0"
       },
       "devDependencies": {
         "@axe-core/react": "4.7.3",
@@ -21315,9 +21315,9 @@
       "license": "MIT"
     },
     "node_modules/suomifi-icons": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-7.8.0.tgz",
-      "integrity": "sha512-rKxGintGEW1yrI+hB91GT/0O0NsoZX04n7j/RQ+V2+vErmXdqSIDNCr4qHi+FqFJZwwST4IgEx5KSD54lxPnEQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/suomifi-icons/-/suomifi-icons-7.9.0.tgz",
+      "integrity": "sha512-Mi78cFFUBfedeVOOw3LgD2CruxQyxsJC66MuBcdad1g+zmf+VofB9tGg3XTRnXxxffiK2+k5WMBr7TmXPr/FZQ==",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "polished": "4.2.2",
     "react-modal": "3.16.3",
     "suomifi-design-tokens": "7.0.0",
-    "suomifi-icons": "7.8.0"
+    "suomifi-icons": "7.9.0"
   },
   "peerDependencies": {
     "@types/styled-components": ">=5.1.9",


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Updates suomifi-icons from 7.8.0 to 7.9.0 for new icons

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Update to get new icons AuthoriseEstate and BehalfOfAnEstate

## How Has This Been Tested?

Tested with Styleguidist that new icons are available

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

- Update suomifi-icons version from 7.8.0 to 7.9.0