### PR TITLE
[Feature] SingleSelect and MultiSelect updates to remove portal and enhance accessibility

### DIFF
--- a/.styleguidist/accessibility.md
+++ b/.styleguidist/accessibility.md
@@ -2,28 +2,27 @@ Our goal is to be WCAG 2.2 compliant at an AA level for all components. Addition
 
 Using the Suomi.fi component library does not automatically make your project accessible, but it will hopefully significantly reduce the amount of work you need to do to provice an accessible user experience. It is important to read the documentation for each component carefully.
 
-* [Known issues](./#/Accessibility?id=known-issues)
-* [Our acccessibility checklist](./#/Accessibility?id=our-accessibility-checklist)
-    * [On the tests](./#/Accessibility?id=on-the-tests)
-    * [Automated](./#/Accessibility?id=automated)
-    * [Visual inspection](./#/Accessibility?id=visual-inspection)
-    * [Keyboard](./#/Accessibility?id=keyboard)
-    * [Pointer devices](./#/Accessibility?id=pointer-devices)
-    * [Adaptability](./#/Accessibility?id=adaptability)
-    * [Code inspection](./#/Accessibility?id=code-inspection)
-    * [Windows High Contrast Mode](./#/Accessibility?id=windows-high-contrast-mode)
-    * [Motion](./#/Accessibility?id=motion)
-    * [Screen reader tests and support](./#/Accessibility?id=screen-reader-tests-and-support)
-    * [Other assistive technology](./#/Accessibility?id=other-assistive-technology)
+- [Known issues](./#/Accessibility?id=known-issues)
+- [Our acccessibility checklist](./#/Accessibility?id=our-accessibility-checklist)
+  - [On the tests](./#/Accessibility?id=on-the-tests)
+  - [Automated](./#/Accessibility?id=automated)
+  - [Visual inspection](./#/Accessibility?id=visual-inspection)
+  - [Keyboard](./#/Accessibility?id=keyboard)
+  - [Pointer devices](./#/Accessibility?id=pointer-devices)
+  - [Adaptability](./#/Accessibility?id=adaptability)
+  - [Code inspection](./#/Accessibility?id=code-inspection)
+  - [Windows High Contrast Mode](./#/Accessibility?id=windows-high-contrast-mode)
+  - [Motion](./#/Accessibility?id=motion)
+  - [Screen reader tests and support](./#/Accessibility?id=screen-reader-tests-and-support)
+  - [Other assistive technology](./#/Accessibility?id=other-assistive-technology)
 
 ## Known issues
 
-Updated 3rd October 2025.
+Updated 24th April 2026.
 
-* **MultiSelect** and **SingleSelect**: On iOS using VoiceOver, and macOS versions 14 and older using Safari and VoiceOver, accessing and reading out the options in the opened listbox element is either hard or not possible.
-* **SingleSelect**: The selected state of an option is not read out by JAWS.
-* **Breadcrumb**: Height does not adjust when only text is resized 200%.
-* **Dropdown**: Line-height does not adjust when only text is resized 200%.
+- **SingleSelect**: The selected state of an option is not read out by JAWS.
+- **Breadcrumb**: Height does not adjust when only text is resized 200%.
+- **Dropdown**: Line-height does not adjust when only text is resized 200%.
 
 ## Our accessibility checklist
 
@@ -33,51 +32,51 @@ This checklist reflects the current features of the component library and covers
 
 ### Automated
 
-* No errors reported by axe Devtools.
+- No errors reported by axe Devtools.
 
 ### Visual inspection
 
-* Text contrast is at least 4.5:1 in each component state
-* The contrast of essential non-text information is at least 3:1 with its surrroundings.
-* Colour is not used as the only way to convey information.
-* Target size for interactive elements is at least 24 x 24 pixels or there are no adjacent interactive elements within a 24px circle.
+- Text contrast is at least 4.5:1 in each component state
+- The contrast of essential non-text information is at least 3:1 with its surrroundings.
+- Colour is not used as the only way to convey information.
+- Target size for interactive elements is at least 24 x 24 pixels or there are no adjacent interactive elements within a 24px circle.
 
 ### Keyboard and pointer device
 
-* All functionality can be accessed with keyboard
-* Keyboard focus is clearly visible
-* The keyboard focus order within a component is logical
-* Focusing a component or its sub-component does not cause a change of context.
-* Component has no single-character shortcuts.
-* Focused elements are not obscured.
+- All functionality can be accessed with keyboard
+- Keyboard focus is clearly visible
+- The keyboard focus order within a component is logical
+- Focusing a component or its sub-component does not cause a change of context.
+- Component has no single-character shortcuts.
+- Focused elements are not obscured.
 
 ### Pointer devices
 
-* Focusing or hovering a component or its sub-component does not cause a change of context.
-* No actions are performed using the pointer down-event, unless it is native functionality defined by the user-agent.
-* No actions require dragging movements.
+- Focusing or hovering a component or its sub-component does not cause a change of context.
+- No actions are performed using the pointer down-event, unless it is native functionality defined by the user-agent.
+- No actions require dragging movements.
 
 ### Adaptability
 
-* Text resizing to 200% does not cause loss of information or overlapping content. **Must** support full-page zoom. **Should** support text-only zoom. 
-* Changing text settings according to WCAG 1.4.12 does not cause loss of information or overlap.
-* Zooming to 400% in a 1280px wide window does not cause horizontal scrolling, loss or overlap of information.
-* Content is not limited to a specific device orientation.
+- Text resizing to 200% does not cause loss of information or overlapping content. **Must** support full-page zoom. **Should** support text-only zoom.
+- Changing text settings according to WCAG 1.4.12 does not cause loss of information or overlap.
+- Zooming to 400% in a 1280px wide window does not cause horizontal scrolling, loss or overlap of information.
+- Content is not limited to a specific device orientation.
 
 ### Code inspection
 
-* Lists are marked using the correct HTML elements.
-* Correct semantic elements are used where appropriate (headings, lists)
-* For components with text in a different language than the surrounding text, check that the language can be programmatically evaluated.
+- Lists are marked using the correct HTML elements.
+- Correct semantic elements are used where appropriate (headings, lists)
+- For components with text in a different language than the surrounding text, check that the language can be programmatically evaluated.
 
 ### Windows High Contrast mode
 
-* Components and their different states are distinguishable when running in Windows High Contrast Mode.
-* Keyboard focus is visible when running in Windows High Contrast Mode.
+- Components and their different states are distinguishable when running in Windows High Contrast Mode.
+- Keyboard focus is visible when running in Windows High Contrast Mode.
 
 ### Motion
 
-* If the component has animations, check that they respect the Reduced Motion platform setting.
+- If the component has animations, check that they respect the Reduced Motion platform setting.
 
 ### Screen reader tests and support
 
@@ -90,7 +89,7 @@ Officially supported browser / screen reader combinations:
 | iOS              | Safari                | VoiceOver     |
 | Android          | Chrome                | TalkBack      |
 
-Additionally, components are regularly tested using Narrator and Edge in Windows, the latest JAWS version and Chrome on Windows, and Orca and Firefox on Linux. 
+Additionally, components are regularly tested using Narrator and Edge in Windows, the latest JAWS version and Chrome on Windows, and Orca and Firefox on Linux.
 
 All content should be available in reading mode, and all interactive functionality available in focus mode. Commands vary in different screen readers, and support for different HTML and ARIA features also varies and can depend both on what the accessibility tree of the browser exposes, as well as the screen reader itself.
 

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
@@ -698,6 +698,7 @@ class BaseDropdown<T extends string = string> extends Component<
               onKeyDown={this.handleKeyDown}
               portal={portal}
               className={popoverClassName}
+              tabIndex={-1}
             >
               <PopoverConsumer>
                 {(consumer) => {

--- a/src/core/Form/SearchInput/SearchInput.tsx
+++ b/src/core/Form/SearchInput/SearchInput.tsx
@@ -616,6 +616,7 @@ class BaseSearchInput extends Component<SearchInputProps & SuomifiThemeProp> {
               this.setState({ showPopover: false, focusedDescendantId: null });
             }}
             className={popoverClassName}
+            tabIndex={-1}
           >
             <PopoverConsumer>
               {(consumer) => {

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -1159,6 +1159,7 @@ exports[`snapshot should have matching structure with suggestions open 1`] = `
 }
 
 .c15 {
+  display: block;
   position: relative;
   padding: 8px 32px 8px 10px;
   letter-spacing: 0;

--- a/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
@@ -3,6 +3,8 @@ import { SuomifiTheme } from '../../../../theme';
 import { font } from '../../../../theme/reset';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
+  /* Display block instead of list-item to prevent iOS VoiceOver double announcement */
+  display: block;
   position: relative;
   padding: 8px 32px 8px 10px;
   ${font(theme)('actionElementInnerText')}

--- a/src/core/Form/Select/BaseSelect/SelectItemAddition/SelectItemAddition.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemAddition/SelectItemAddition.baseStyles.tsx
@@ -11,6 +11,8 @@ export const selectItemAdditionStyles = (theme: SuomifiTheme) => css`
   }
 
   & .fi-select-item-addition_item {
+    /* Display block instead of list-item to prevent iOS VoiceOver double announcement */
+    display: block;
     padding: 8px 32px 8px 10px;
     cursor: pointer;
     ${font(theme)('actionElementInnerText')}

--- a/src/core/Form/Select/BaseSelect/SelectItemAddition/SelectItemAddition.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItemAddition/SelectItemAddition.tsx
@@ -42,7 +42,9 @@ class BaseSelectItemAddition extends Component<
 
     return (
       <HtmlDiv {...passProps}>
-        <HtmlDiv className={classNames.hint_text}>{hintText}</HtmlDiv>
+        <HtmlDiv className={classNames.hint_text} aria-hidden>
+          {hintText}
+        </HtmlDiv>
         <HtmlLi
           className={classnames(classNames.item, {
             [classNames.hasKeyboardFocus]: hasKeyboardFocus,

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.baseStyles.tsx
@@ -27,6 +27,12 @@ export const baseStyles = (
     }
   }
 
+  /* :where() pseudo-class lowers specificity allowing ".<styled-components-hash> :where(.fi-multiselect_popover)"
+     to be overridden with popoverClassName prop, unlike ".<styled-components-hash> .fi-multiselect_popover" */
+  & :where(.fi-multiselect_popover) {
+    z-index: ${theme.zindexes.menu};
+  }
+
   & .fi-multiselect_content_wrapper {
     display: inline-block;
     width: 100%;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -120,7 +120,7 @@ it('should not have basic accessibility issues', async () => {
 it('has matching snapshot', async () => {
   const user = userEvent.setup();
   const { baseElement, getByRole } = render(BasicMultiSelect);
-  const textfield = getByRole('textbox') as HTMLInputElement;
+  const textfield = getByRole('combobox') as HTMLInputElement;
   await user.click(textfield);
   await waitForPosition();
   expect(baseElement).toMatchSnapshot();
@@ -241,7 +241,7 @@ describe('Non-controlled', () => {
         ariaOptionChipRemovedText="removed"
       />,
     );
-    const textfield = getByRole('textbox') as HTMLInputElement;
+    const textfield = getByRole('combobox') as HTMLInputElement;
     await user.type(textfield, 'hammer');
     await waitForPosition();
 
@@ -277,7 +277,7 @@ describe('Non-controlled', () => {
     let chips = container.querySelectorAll('.fi-chip');
     expect(chips).toHaveLength(0);
 
-    const textfield = getByRole('textbox') as HTMLInputElement;
+    const textfield = getByRole('combobox') as HTMLInputElement;
     await user.click(textfield);
     await waitForPosition();
     rerender(
@@ -461,7 +461,7 @@ describe('Controlled', () => {
     );
 
     const { getByRole, rerender, findAllByRole } = render(multiMutti);
-    const textfield = getByRole('textbox') as HTMLInputElement;
+    const textfield = getByRole('combobox') as HTMLInputElement;
     await user.type(textfield, 'sn');
     await waitForPosition();
 
@@ -541,7 +541,7 @@ test('visualPlaceholder: has the given text as placeholder attribute', () => {
       ariaOptionChipRemovedText=""
     />,
   );
-  const inputfield = getByRole('textbox') as HTMLInputElement;
+  const inputfield = getByRole('combobox') as HTMLInputElement;
   expect(inputfield).toHaveAttribute('placeholder', 'Select item(s)');
 });
 
@@ -573,7 +573,7 @@ test('id: has the given id', () => {
       ariaOptionChipRemovedText=""
     />,
   );
-  expect(getByRole('textbox')).toHaveAttribute('id', 'cb-123');
+  expect(getByRole('combobox')).toHaveAttribute('id', 'cb-123');
 });
 
 describe('statusText', () => {
@@ -609,7 +609,7 @@ describe('statusText', () => {
         ariaOptionChipRemovedText=""
       />,
     );
-    expect(getByRole('textbox')).toHaveAttribute(
+    expect(getByRole('combobox')).toHaveAttribute(
       'aria-describedby',
       '123-statusText',
     );
@@ -675,7 +675,7 @@ describe('custom item addition mode', () => {
         ariaOptionChipRemovedText="removed"
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.type(input, 'hamm');
     await waitForPosition();
 
@@ -764,7 +764,7 @@ describe('listProps', () => {
         }}
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.click(input);
     await waitForPosition();
     const menu = getByRole('listbox');
@@ -791,7 +791,7 @@ describe('listItemProps', () => {
         ariaOptionChipRemovedText=""
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.click(input);
     await waitForPosition();
     const option = getByRole('option');

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -680,49 +680,43 @@ describe('custom item addition mode', () => {
 
     const items = await getAllByRole('option');
     expect(items).toHaveLength(4);
-    const hammItem = items.find((item) => item.textContent === 'hamm');
+    const hammItem = items[3];
+    expect(hammItem).toHaveTextContent('hamm');
+    await user.click(hammItem);
+    await waitForPosition();
 
-    if (hammItem) {
-      await user.click(hammItem);
-      await waitForPosition();
+    await user.clear(input);
+    await user.type(input, 'ha');
+    await waitForPosition();
+    const modifiedItems = getAllByRole('option');
+    expect(modifiedItems).toHaveLength(5);
 
-      await user.clear(input);
-      await user.type(input, 'ha');
-      await waitForPosition();
-      const modifiedItems = getAllByRole('option');
-      expect(modifiedItems).toHaveLength(5);
-      const haItem = modifiedItems.find((item) => item.textContent === 'ha');
+    const haItem = modifiedItems[4];
+    expect(haItem).toHaveTextContent('ha');
 
-      if (haItem) {
-        await user.click(haItem);
-        await waitForPosition();
-        await user.clear(input);
-        await waitForPosition();
+    await user.click(haItem);
+    await waitForPosition();
+    await user.clear(input);
+    await waitForPosition();
 
-        const appendedItems = getAllByRole('option');
-        expect(appendedItems).toHaveLength(11);
-        const secondToLastItem = appendedItems[9];
-        const lastItem = appendedItems[10];
-        expect(secondToLastItem).toHaveTextContent('hamm');
-        expect(secondToLastItem).toHaveClass('fi-select-item--selected');
-        expect(lastItem).toHaveTextContent('ha');
-        expect(lastItem).toHaveClass('fi-select-item--selected');
+    const appendedItems = getAllByRole('option');
+    expect(appendedItems).toHaveLength(11);
+    const secondToLastItem = appendedItems[9];
+    const lastItem = appendedItems[10];
+    expect(secondToLastItem).toHaveTextContent('hamm');
+    expect(secondToLastItem).toHaveClass('fi-select-item--selected');
+    expect(lastItem).toHaveTextContent('ha');
+    expect(lastItem).toHaveClass('fi-select-item--selected');
 
-        const removeAllButton = container.querySelectorAll(
-          '.fi-multiselect_removeAllButton',
-        )[0];
-        await user.click(removeAllButton);
-        await user.click(input);
-        await waitForPosition();
+    const removeAllButton = container.querySelectorAll(
+      '.fi-multiselect_removeAllButton',
+    )[0];
+    await user.click(removeAllButton);
+    await user.click(input);
+    await waitForPosition();
 
-        const resetItems = getAllByRole('option');
-        expect(resetItems).toHaveLength(9);
-      } else {
-        throw new Error('No custom item "ha" found');
-      }
-    } else {
-      throw new Error('No custom item "hamm" found');
-    }
+    const resetItems = getAllByRole('option');
+    expect(resetItems).toHaveLength(9);
   });
 });
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.test.tsx
@@ -399,8 +399,7 @@ describe('Controlled', () => {
     await waitForPosition();
     expect(mockItemSelectionsChange).toBeCalledTimes(1);
     expect(mockItemSelectionsChange).toBeCalledWith('turtle-987');
-    // Popover is open, so therefore two
-    expect(getAllByText('Turtle')).toHaveLength(2);
+    expect(getAllByText('Turtle')).toHaveLength(1);
   });
 
   it('shows correct amount of items after filtering and selecting', async () => {
@@ -713,6 +712,7 @@ describe('custom item addition mode', () => {
           '.fi-multiselect_removeAllButton',
         )[0];
         await user.click(removeAllButton);
+        await user.click(input);
         await waitForPosition();
 
         const resetItems = getAllByRole('option');

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -628,10 +628,14 @@ class BaseMultiSelect<T> extends Component<
       if (document.activeElement !== this.filterInputRef.current) {
         this.filterInputRef.current.focus();
       }
-      this.setState((prevState: MultiSelectState<T & MultiSelectData>) => ({
-        showPopover: !prevState.showPopover,
-        showOptionsAvailableText: !prevState.showOptionsAvailableText,
-      }));
+      if (this.state.showPopover) {
+        this.closeMenu();
+      } else {
+        this.setState(() => ({
+          showPopover: true,
+          showOptionsAvailableText: true,
+        }));
+      }
     }
   }
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -479,6 +479,24 @@ class BaseMultiSelect<T> extends Component<
     });
   };
 
+  private setFocusedDescendantAfterPopoverIsVisible = (
+    item: MultiSelectData,
+  ) => {
+    /** Popover becomes visible after two requestAnimationFrames,
+     * defer setting focused descendant so that screen readers
+     * will read the list item when opening popover with keyboard
+     */
+    this.setState({ showPopover: true }, () => {
+      if (item) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            this.setState({ focusedDescendantId: item.uniqueItemId });
+          });
+        });
+      }
+    });
+  };
+
   private handleKeyDown = (event: React.KeyboardEvent) => {
     const {
       filteredItems: items,
@@ -510,7 +528,6 @@ class BaseMultiSelect<T> extends Component<
     switch (event.key) {
       case 'ArrowDown': {
         event.preventDefault();
-        this.setState({ showPopover: true });
         const nextItem =
           this.props.allowItemAddition &&
           (index === items.length - 1 || items.length === 0) &&
@@ -521,7 +538,9 @@ class BaseMultiSelect<T> extends Component<
                 labelText: filterInputValue,
               }
             : getNextItem();
-        if (nextItem) {
+        if (!this.state.showPopover) {
+          this.setFocusedDescendantAfterPopoverIsVisible(nextItem);
+        } else if (nextItem) {
           this.setState({ focusedDescendantId: nextItem.uniqueItemId });
         }
         break;
@@ -529,7 +548,6 @@ class BaseMultiSelect<T> extends Component<
 
       case 'ArrowUp': {
         event.preventDefault();
-        this.setState({ showPopover: true });
         const previousItem =
           this.props.allowItemAddition &&
           (index === null || index === 0) &&
@@ -540,7 +558,9 @@ class BaseMultiSelect<T> extends Component<
                 labelText: filterInputValue,
               }
             : getPreviousItem();
-        if (previousItem) {
+        if (!this.state.showPopover) {
+          this.setFocusedDescendantAfterPopoverIsVisible(previousItem);
+        } else if (previousItem) {
           this.setState({ focusedDescendantId: previousItem.uniqueItemId });
         }
         break;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -799,6 +799,7 @@ class BaseMultiSelect<T> extends Component<
                   }
                 }}
                 className={popoverClassName}
+                tabIndex={-1}
               >
                 <PopoverConsumer>
                   {(consumer) => {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -437,6 +437,26 @@ class BaseMultiSelect<T> extends Component<
       ? this.toggleButtonRef.current?.contains(ownerDocument.activeElement)
       : false;
 
+  private closeMenu = () => {
+    const userAddedSelectedItems: Array<T & MultiSelectData> =
+      this.state.selectedItems.filter((si) =>
+        this.props.items.every((pi) => pi.uniqueItemId !== si.uniqueItemId),
+      );
+    this.setState(
+      (
+        _prevState: MultiSelectState<T & MultiSelectData>,
+        prevProps: MultiSelectProps<T & MultiSelectData>,
+      ) => ({
+        filterInputValue: '',
+        filteredItems: prevProps.items,
+        showPopover: false,
+        showOptionsAvailableText: false,
+        focusedDescendantId: null,
+        computedItems: prevProps.items.concat(userAddedSelectedItems),
+      }),
+    );
+  };
+
   private handleBlur = () => {
     if (!!this.props.onBlur) {
       this.props.onBlur();
@@ -453,25 +473,8 @@ class BaseMultiSelect<T> extends Component<
       const focusInMultiSelect =
         focusInPopover || focusInInput || focusInToggleButton;
 
-      const userAddedSelectedItems: Array<T & MultiSelectData> =
-        this.state.selectedItems.filter((si) =>
-          this.props.items.every((pi) => pi.uniqueItemId !== si.uniqueItemId),
-        );
-
       if (!focusInMultiSelect) {
-        this.setState(
-          (
-            _prevState: MultiSelectState<T & MultiSelectData>,
-            prevProps: MultiSelectProps<T & MultiSelectData>,
-          ) => ({
-            filterInputValue: '',
-            filteredItems: prevProps.items,
-            showPopover: false,
-            showOptionsAvailableText: false,
-            focusedDescendantId: null,
-            computedItems: prevProps.items.concat(userAddedSelectedItems),
-          }),
-        );
+        this.closeMenu();
       }
     });
   };
@@ -581,6 +584,11 @@ class BaseMultiSelect<T> extends Component<
         break;
       }
 
+      case 'Tab': {
+        this.closeMenu();
+        break;
+      }
+
       default: {
         break;
       }
@@ -599,12 +607,11 @@ class BaseMultiSelect<T> extends Component<
     if (!!this.filterInputRef && this.filterInputRef.current) {
       if (document.activeElement !== this.filterInputRef.current) {
         this.filterInputRef.current.focus();
-      } else {
-        this.setState((prevState: MultiSelectState<T & MultiSelectData>) => ({
-          showPopover: !prevState.showPopover,
-          showOptionsAvailableText: !prevState.showOptionsAvailableText,
-        }));
       }
+      this.setState((prevState: MultiSelectState<T & MultiSelectData>) => ({
+        showPopover: !prevState.showPopover,
+        showOptionsAvailableText: !prevState.showOptionsAvailableText,
+      }));
     }
   }
 
@@ -725,6 +732,12 @@ class BaseMultiSelect<T> extends Component<
                   optionalText={optionalText}
                   hintText={hintText}
                   items={computedItems}
+                  onClick={() => {
+                    this.setState({
+                      showPopover: true,
+                      showOptionsAvailableText: true,
+                    });
+                  }}
                   onFilter={(filtered) => {
                     this.setState(
                       (prevState: MultiSelectState<T & MultiSelectData>) => {
@@ -746,12 +759,6 @@ class BaseMultiSelect<T> extends Component<
                   }}
                   filterFunc={this.filter}
                   forwardedRef={this.filterInputRef}
-                  onFocus={() =>
-                    this.setState({
-                      showPopover: true,
-                      showOptionsAvailableText: true,
-                    })
-                  }
                   onKeyDown={this.handleKeyDown}
                   onBlur={this.handleBlur}
                   value={filterInputValue}

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -42,6 +42,7 @@ const multiSelectClassNames = {
   fullWidth: `${baseClassName}--full-width`,
   content_wrapper: `${baseClassName}_content_wrapper`,
   removeAllButton: `${baseClassName}_removeAllButton`,
+  popover: `${baseClassName}_popover`,
 };
 
 export interface MultiSelectData {
@@ -715,12 +716,9 @@ class BaseMultiSelect<T> extends Component<
             <Debounce waitFor={debounce}>
               {(debouncer: Function) => (
                 <FilterInput
-                  inputElementContainerProps={{
-                    role: 'combobox',
-                    'aria-haspopup': 'listbox',
-                    'aria-owns': popoverItemListId,
-                    'aria-expanded': showPopover,
-                  }}
+                  role="combobox"
+                  aria-haspopup="listbox"
+                  aria-expanded={showPopover}
                   aria-activedescendant={ariaActiveDescendant}
                   id={id}
                   labelText={labelText}
@@ -780,8 +778,8 @@ class BaseMultiSelect<T> extends Component<
                   <InputToggleButton
                     open={showPopover}
                     ref={this.toggleButtonRef}
+                    aria-expanded={showPopover}
                     onClick={(event) => this.handleToggleButtonClick(event)}
-                    aria-hidden={true}
                     tabIndex={-1}
                     disabled={disabled}
                   />
@@ -798,8 +796,11 @@ class BaseMultiSelect<T> extends Component<
                     this.setState({ showPopover: false });
                   }
                 }}
-                className={popoverClassName}
-                tabIndex={-1}
+                className={classnames(
+                  multiSelectClassNames.popover,
+                  popoverClassName,
+                )}
+                portal={false}
               >
                 <PopoverConsumer>
                   {(consumer) => {
@@ -811,6 +812,7 @@ class BaseMultiSelect<T> extends Component<
                         focusedDescendantId={ariaActiveDescendant}
                         aria-multiselectable="true"
                         popoverPlacement={consumer.popoverPlacement}
+                        aria-labelledby={`${id}-label`}
                         {...listProps}
                       >
                         <>

--- a/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/MultiSelect.tsx
@@ -809,7 +809,9 @@ class BaseMultiSelect<T> extends Component<
                   <InputToggleButton
                     open={showPopover}
                     ref={this.toggleButtonRef}
+                    aria-labelledby={`${id}-label`}
                     aria-expanded={showPopover}
+                    aria-controls={popoverItemListId}
                     onClick={(event) => this.handleToggleButtonClick(event)}
                     tabIndex={-1}
                     disabled={disabled}

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1273,7 +1273,9 @@ exports[`has matching snapshot 1`] = `
                 class="c0 fi-filter-input_action-elements-container"
               >
                 <button
+                  aria-controls="3-popover"
                   aria-expanded="true"
+                  aria-labelledby="3-label"
                   class="c7 fi-input-toggle-button c8"
                   tabindex="-1"
                   type="button"

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`has matching snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c19 {
+.c14 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -160,8 +160,8 @@ exports[`has matching snapshot 1`] = `
   display: list-item;
 }
 
-.c19 ::before,
-.c19 ::after {
+.c14 ::before,
+.c14 ::after {
   box-sizing: border-box;
 }
 
@@ -193,7 +193,7 @@ exports[`has matching snapshot 1`] = `
   box-sizing: border-box;
 }
 
-.c17 {
+.c12 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -218,8 +218,8 @@ exports[`has matching snapshot 1`] = `
   padding-left: 40px;
 }
 
-.c17 ::before,
-.c17 ::after {
+.c12 ::before,
+.c12 ::after {
   box-sizing: border-box;
 }
 
@@ -284,54 +284,6 @@ exports[`has matching snapshot 1`] = `
   cursor: inherit;
 }
 
-.c21 {
-  vertical-align: baseline;
-}
-
-.c21.fi-icon {
-  display: inline-block;
-}
-
-.c21 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c21 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c21.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c21.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
-.c14 {
-  vertical-align: baseline;
-}
-
-.c14.fi-icon {
-  display: inline-block;
-}
-
-.c14 .fi-icon-base-fill {
-  fill: currentColor;
-}
-
-.c14 .fi-icon-base-stroke {
-  stroke: currentColor;
-}
-
-.c14.fi-icon--cursor-pointer {
-  cursor: pointer;
-}
-
-.c14.fi-icon--cursor-pointer * {
-  cursor: inherit;
-}
-
 .c16 {
   vertical-align: baseline;
 }
@@ -353,6 +305,54 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c16.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c19 {
+  vertical-align: baseline;
+}
+
+.c19.fi-icon {
+  display: inline-block;
+}
+
+.c19 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c19 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c19.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c19.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
+.c21 {
+  vertical-align: baseline;
+}
+
+.c21.fi-icon {
+  display: inline-block;
+}
+
+.c21 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c21 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c21.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c21.fi-icon--cursor-pointer * {
   cursor: inherit;
 }
 
@@ -536,7 +536,7 @@ exports[`has matching snapshot 1`] = `
   margin-bottom: 0;
 }
 
-.c18 {
+.c13 {
   letter-spacing: 0;
   text-decoration: none;
   word-break: break-word;
@@ -563,11 +563,11 @@ exports[`has matching snapshot 1`] = `
   overflow-x: hidden;
 }
 
-.c18:focus {
+.c13:focus {
   outline: none;
 }
 
-.c18[data-floating-ui-placement^='top'] {
+.c13[data-floating-ui-placement^='top'] {
   border-width: 1px 1px 0 1px;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
@@ -576,7 +576,7 @@ exports[`has matching snapshot 1`] = `
   padding: 0 0 4px 0;
 }
 
-.c20 {
+.c15 {
   display: block;
   position: relative;
   padding: 8px 32px 8px 10px;
@@ -591,20 +591,20 @@ exports[`has matching snapshot 1`] = `
   font-weight: 400;
 }
 
-.c20:focus {
+.c15:focus {
   outline: none;
 }
 
-.c20.fi-select-item {
+.c15.fi-select-item {
   cursor: pointer;
 }
 
-.c20.fi-select-item .fi-select-item--query_highlight {
+.c15.fi-select-item .fi-select-item--query_highlight {
   background-color: transparent;
   font-weight: bold;
 }
 
-.c20.fi-select-item .fi-select-item_icon {
+.c15.fi-select-item .fi-select-item_icon {
   position: absolute;
   top: 14px;
   right: 10px;
@@ -612,57 +612,57 @@ exports[`has matching snapshot 1`] = `
   width: 12px;
 }
 
-.c20.fi-select-item--selected {
+.c15.fi-select-item--selected {
   background-color: hsl(215, 100%, 95%);
   color: hsl(0, 0%, 13%);
 }
 
-.c20.fi-select-item--selected .fi-select-item--query_highlight {
+.c15.fi-select-item--selected .fi-select-item--query_highlight {
   color: hsl(0, 0%, 13%);
 }
 
-.c20.fi-select-item--hasKeyboardFocus {
+.c15.fi-select-item--hasKeyboardFocus {
   background-color: hsl(212, 63%, 45%);
   color: hsl(0, 0%, 100%);
 }
 
-.c20.fi-select-item--hasKeyboardFocus .fi-select-item--query_highlight {
+.c15.fi-select-item--hasKeyboardFocus .fi-select-item--query_highlight {
   color: hsl(0, 0%, 100%);
   background-color: hsl(212, 63%, 45%);
 }
 
-.c20.fi-select-item--disabled {
+.c15.fi-select-item--disabled {
   color: hsl(202, 7%, 67%);
   cursor: not-allowed;
 }
 
-.c20.fi-select-item--disabled .fi-select-item--query_highlight {
+.c15.fi-select-item--disabled .fi-select-item--query_highlight {
   color: hsl(202, 7%, 67%);
 }
 
-.c20.fi-select-item--disabled.fi-select-item:hover {
+.c15.fi-select-item--disabled.fi-select-item:hover {
   color: hsl(202, 7%, 67%);
 }
 
-.c20.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
+.c15.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
   color: hsl(202, 7%, 67%);
 }
 
-.c20.fi-select-item:hover {
+.c15.fi-select-item:hover {
   background-color: hsl(212, 63%, 45%);
   color: hsl(0, 0%, 100%);
 }
 
-.c20.fi-select-item:hover .fi-select-item--query_highlight {
+.c15.fi-select-item:hover .fi-select-item--query_highlight {
   color: hsl(0, 0%, 100%);
 }
 
-.c20 .fi-select-item_wrapper {
+.c15 .fi-select-item_wrapper {
   display: inline-block;
   width: 100%;
 }
 
-.c13 {
+.c18 {
   color: hsl(0, 0%, 13%);
   letter-spacing: 0;
   text-decoration: none;
@@ -675,7 +675,7 @@ exports[`has matching snapshot 1`] = `
   font-weight: 600;
 }
 
-.c13.fi-chip {
+.c18.fi-chip {
   border-radius: 14px;
   padding: 2px 10px;
   color: hsl(0, 0%, 100%);
@@ -684,12 +684,12 @@ exports[`has matching snapshot 1`] = `
   display: inline-block;
 }
 
-.c13.fi-chip:focus {
+.c18.fi-chip:focus {
   outline: 0;
   position: relative;
 }
 
-.c13.fi-chip:focus::after {
+.c18.fi-chip:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -706,40 +706,40 @@ exports[`has matching snapshot 1`] = `
   border-radius: 16px;
 }
 
-.c13.fi-chip .fi-chip--content {
+.c18.fi-chip .fi-chip--content {
   display: block;
   word-break: break-word;
   overflow: hidden;
   line-height: 1.5em;
 }
 
-.c13.fi-chip--disabled.fi-chip {
+.c18.fi-chip--disabled.fi-chip {
   cursor: not-allowed;
   background: hsl(202, 7%, 67%);
 }
 
-.c13.fi-chip--disabled.fi-chip:hover,
-.c13.fi-chip--disabled.fi-chip:active {
+.c18.fi-chip--disabled.fi-chip:hover,
+.c18.fi-chip--disabled.fi-chip:active {
   background: hsl(202, 7%, 67%);
 }
 
-.c13.fi-chip--button {
+.c18.fi-chip--button {
   cursor: pointer;
 }
 
-.c13.fi-chip--button:hover {
+.c18.fi-chip--button:hover {
   background: hsl(212, 63%, 49%);
 }
 
-.c13.fi-chip--button:active {
+.c18.fi-chip--button:active {
   background: hsl(212, 63%, 37%);
 }
 
-.c13.fi-chip--button:focus {
+.c18.fi-chip--button:focus {
   outline: 3px solid transparent;
 }
 
-.c13.fi-chip--removable {
+.c18.fi-chip--removable {
   padding-top: 2px;
   padding-right: 22px;
   padding-bottom: 2px;
@@ -747,7 +747,7 @@ exports[`has matching snapshot 1`] = `
   position: relative;
 }
 
-.c13.fi-chip--removable .fi-chip--icon {
+.c18.fi-chip--removable .fi-chip--icon {
   position: absolute;
   top: 8px;
   right: 10px;
@@ -755,15 +755,15 @@ exports[`has matching snapshot 1`] = `
   width: 12px;
 }
 
-.c13.fi-chip--removable .fi-chip--content {
+.c18.fi-chip--removable .fi-chip--content {
   margin-right: 10px;
 }
 
-.c13.fi-chip--removable.fi-chip--disabled .fi-chip--icon {
+.c18.fi-chip--removable.fi-chip--disabled .fi-chip--icon {
   cursor: not-allowed;
 }
 
-.c12 {
+.c17 {
   letter-spacing: 0;
   text-decoration: none;
   word-break: break-word;
@@ -776,18 +776,18 @@ exports[`has matching snapshot 1`] = `
   padding-top: 5px;
 }
 
-.c12 .fi-chip-list_content_wrapper>* {
+.c17 .fi-chip-list_content_wrapper>* {
   margin: 10px 10px 0 0;
   padding-right: -10px;
 }
 
-.c12 .fi-chip-list_content_wrapper {
+.c17 .fi-chip-list_content_wrapper {
   display: inline-flex;
   flex-wrap: wrap;
   width: 100%;
 }
 
-.c15 {
+.c20 {
   color: hsl(0, 0%, 13%);
   letter-spacing: 0;
   text-decoration: none;
@@ -811,12 +811,12 @@ exports[`has matching snapshot 1`] = `
   border: 1px solid transparent;
 }
 
-.c15:focus {
+.c20:focus {
   position: relative;
   outline: 3px solid transparent;
 }
 
-.c15:focus::after {
+.c20:focus::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -832,59 +832,59 @@ exports[`has matching snapshot 1`] = `
   z-index: 9999;
 }
 
-.c15:hover {
+.c20:hover {
   background: linear-gradient(0deg, hsl(212, 63%, 45%) 0%, hsl(212, 63%, 49%) 100%);
   outline: 2px solid transparent;
 }
 
-.c15:active {
+.c20:active {
   background: hsl(212, 63%, 37%);
 }
 
-.c15.fi-button--disabled,
-.c15[disabled],
-.c15:disabled {
+.c20.fi-button--disabled,
+.c20[disabled],
+.c20:disabled {
   text-shadow: 0 1px 1px rgba(33,33,33,0.5);
   background: linear-gradient(0deg, hsl(202, 7%, 67%) 0%, hsl(202, 7%, 80%) 100%);
   user-select: none;
   cursor: not-allowed;
 }
 
-.c15.fi-button--disabled:not([aria-disabled='true'])::after {
+.c20.fi-button--disabled:not([aria-disabled='true'])::after {
   border: none;
   box-shadow: none;
 }
 
-.c15.fi-button--fullwidth {
+.c20.fi-button--fullwidth {
   display: block;
   width: 100%;
 }
 
-.c15.fi-button--inverted {
+.c20.fi-button--inverted {
   background: none;
   background-color: hsl(212, 63%, 45%);
   border: 1px solid hsl(0, 0%, 100%);
   text-shadow: none;
 }
 
-.c15.fi-button--inverted:hover {
+.c20.fi-button--inverted:hover {
   background: linear-gradient(-180deg, hsla(0, 0%, 100%, 0.1) 0%, hsla(0, 0%, 100%, 0) 100%);
 }
 
-.c15.fi-button--inverted:active {
+.c20.fi-button--inverted:active {
   background: none;
   background-color: hsl(212, 63%, 45%);
 }
 
-.c15.fi-button--inverted.fi-button--disabled,
-.c15.fi-button--inverted[disabled],
-.c15.fi-button--inverted:disabled {
+.c20.fi-button--inverted.fi-button--disabled,
+.c20.fi-button--inverted[disabled],
+.c20.fi-button--inverted:disabled {
   opacity: 0.41;
   background: none;
   background-color: none;
 }
 
-.c15.fi-button--secondary {
+.c20.fi-button--secondary {
   color: hsl(212, 63%, 45%);
   background: none;
   background-color: hsl(0, 0%, 100%);
@@ -892,18 +892,18 @@ exports[`has matching snapshot 1`] = `
   text-shadow: none;
 }
 
-.c15.fi-button--secondary:hover {
+.c20.fi-button--secondary:hover {
   background: linear-gradient(-180deg, hsl(202, 7%, 93%) 0%, hsla(0, 0%, 100%, 0) 100%);
 }
 
-.c15.fi-button--secondary:active {
+.c20.fi-button--secondary:active {
   background: none;
   background-color: hsl(202, 7%, 93%);
 }
 
-.c15.fi-button--secondary.fi-button--disabled,
-.c15.fi-button--secondary[disabled],
-.c15.fi-button--secondary:disabled {
+.c20.fi-button--secondary.fi-button--disabled,
+.c20.fi-button--secondary[disabled],
+.c20.fi-button--secondary:disabled {
   color: hsl(202, 7%, 67%);
   text-shadow: none;
   background: none;
@@ -911,11 +911,11 @@ exports[`has matching snapshot 1`] = `
   border-color: hsl(202, 7%, 67%);
 }
 
-.c15.fi-button--secondary .fi-button_loading-icon .fi-icon-component-brand-fill {
+.c20.fi-button--secondary .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(202, 7%, 67%);
 }
 
-.c15.fi-button--secondary-noborder {
+.c20.fi-button--secondary-noborder {
   color: hsl(212, 63%, 45%);
   background: none;
   background-color: hsl(0, 0%, 100%);
@@ -926,18 +926,18 @@ exports[`has matching snapshot 1`] = `
   background-color: transparent;
 }
 
-.c15.fi-button--secondary-noborder:hover {
+.c20.fi-button--secondary-noborder:hover {
   background: linear-gradient(-180deg, hsl(202, 7%, 93%) 0%, hsla(0, 0%, 100%, 0) 100%);
 }
 
-.c15.fi-button--secondary-noborder:active {
+.c20.fi-button--secondary-noborder:active {
   background: none;
   background-color: hsl(202, 7%, 93%);
 }
 
-.c15.fi-button--secondary-noborder.fi-button--disabled,
-.c15.fi-button--secondary-noborder[disabled],
-.c15.fi-button--secondary-noborder:disabled {
+.c20.fi-button--secondary-noborder.fi-button--disabled,
+.c20.fi-button--secondary-noborder[disabled],
+.c20.fi-button--secondary-noborder:disabled {
   color: hsl(202, 7%, 67%);
   text-shadow: none;
   background: none;
@@ -945,19 +945,19 @@ exports[`has matching snapshot 1`] = `
   border-color: hsl(202, 7%, 67%);
 }
 
-.c15.fi-button--secondary-noborder .fi-button_loading-icon .fi-icon-component-brand-fill {
+.c20.fi-button--secondary-noborder .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(202, 7%, 67%);
 }
 
-.c15.fi-button--secondary-noborder.fi-button--icon-only {
+.c20.fi-button--secondary-noborder.fi-button--icon-only {
   padding: 6px 12px;
 }
 
-.c15.fi-button--secondary-noborder .fi-button_loading-icon .fi-icon-component-brand-fill {
+.c20.fi-button--secondary-noborder .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(202, 7%, 67%);
 }
 
-.c15.fi-button--secondary-light {
+.c20.fi-button--secondary-light {
   color: hsl(212, 63%, 45%);
   color: hsl(212, 63%, 45%);
   background: none;
@@ -969,18 +969,18 @@ exports[`has matching snapshot 1`] = `
   border: none;
 }
 
-.c15.fi-button--secondary-light:hover {
+.c20.fi-button--secondary-light:hover {
   background: linear-gradient(-180deg, hsl(202, 7%, 93%) 0%, hsla(0, 0%, 100%, 0) 100%);
 }
 
-.c15.fi-button--secondary-light:active {
+.c20.fi-button--secondary-light:active {
   background: none;
   background-color: hsl(202, 7%, 93%);
 }
 
-.c15.fi-button--secondary-light.fi-button--disabled,
-.c15.fi-button--secondary-light[disabled],
-.c15.fi-button--secondary-light:disabled {
+.c20.fi-button--secondary-light.fi-button--disabled,
+.c20.fi-button--secondary-light[disabled],
+.c20.fi-button--secondary-light:disabled {
   color: hsl(202, 7%, 67%);
   text-shadow: none;
   background: none;
@@ -988,35 +988,35 @@ exports[`has matching snapshot 1`] = `
   border-color: hsl(202, 7%, 67%);
 }
 
-.c15.fi-button--secondary-light .fi-button_loading-icon .fi-icon-component-brand-fill {
+.c20.fi-button--secondary-light .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(202, 7%, 67%);
 }
 
-.c15.fi-button--secondary-light.fi-button--icon-only {
+.c20.fi-button--secondary-light.fi-button--icon-only {
   padding: 6px 12px;
 }
 
-.c15.fi-button--secondary-light:hover {
+.c20.fi-button--secondary-light:hover {
   background: linear-gradient(0deg, hsl(215, 100%, 97%), hsl(212, 63%, 98%));
 }
 
-.c15.fi-button--secondary-light:active {
+.c20.fi-button--secondary-light:active {
   background: linear-gradient(0deg, hsl(202, 7%, 93%), hsl(202, 7%, 97%));
 }
 
-.c15.fi-button--secondary-light.fi-button--disabled,
-.c15.fi-button--secondary-light[disabled],
-.c15.fi-button--secondary-light:disabled {
+.c20.fi-button--secondary-light.fi-button--disabled,
+.c20.fi-button--secondary-light[disabled],
+.c20.fi-button--secondary-light:disabled {
   color: hsl(202, 7%, 67%);
   background: none;
   background-color: hsl(202, 7%, 97%);
 }
 
-.c15.fi-button--secondary-light .fi-button_loading-icon .fi-icon-component-brand-fill {
+.c20.fi-button--secondary-light .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(202, 7%, 67%);
 }
 
-.c15>.fi-button_icon>.fi-icon {
+.c20>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;
   margin-right: 8px;
@@ -1024,28 +1024,28 @@ exports[`has matching snapshot 1`] = `
   transform: translateY(-0.1em);
 }
 
-.c15>.fi-button_icon--right>.fi-icon {
+.c20>.fi-button_icon--right>.fi-icon {
   margin-right: 0;
   margin-left: 8px;
 }
 
-.c15.fi-button--icon-only {
+.c20.fi-button--icon-only {
   padding: 6px 11px;
 }
 
-.c15.fi-button--icon-only>.fi-button_icon>.fi-icon {
+.c20.fi-button--icon-only>.fi-button_icon>.fi-icon {
   margin-right: 0;
 }
 
-.c15.fi-button--icon-only>.fi-button_icon--right>.fi-icon {
+.c20.fi-button--icon-only>.fi-button_icon--right>.fi-icon {
   margin-left: 0;
 }
 
-.c15.fi-button--disabled>.fi-button_icon {
+.c20.fi-button--disabled>.fi-button_icon {
   cursor: not-allowed;
 }
 
-.c15 .fi-button_loading-icon {
+.c20 .fi-button_loading-icon {
   display: inline-block;
   width: 20px;
   height: 20px;
@@ -1053,16 +1053,16 @@ exports[`has matching snapshot 1`] = `
   animation: rotation 1.5s infinite linear;
 }
 
-.c15 .fi-button_loading-icon .fi-icon-component-brand-fill {
+.c20 .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(0, 0%, 100%);
 }
 
-.c15.fi-button--loading {
+.c20.fi-button--loading {
   display: flex;
   align-items: center;
 }
 
-.c15.fi-button--loading-icon-only .fi-button_loading-icon {
+.c20.fi-button--loading-icon-only .fi-button_loading-icon {
   margin-right: 0;
 }
 
@@ -1131,6 +1131,10 @@ exports[`has matching snapshot 1`] = `
   width: 100%;
 }
 
+.c1 :where(.fi-multiselect_popover) {
+  z-index: 888;
+}
+
 .c1 .fi-multiselect_content_wrapper {
   display: inline-block;
   width: 100%;
@@ -1160,55 +1164,55 @@ exports[`has matching snapshot 1`] = `
 }
 
 @media (forced-colors: active) {
-  .c20.fi-select-item .fi-select-item--query_highlight {
+  .c15.fi-select-item .fi-select-item--query_highlight {
     background-color: Highlight;
   }
 }
 
 @media (forced-colors: active) {
-  .c20.fi-select-item--hasKeyboardFocus {
+  .c15.fi-select-item--hasKeyboardFocus {
     background-color: Highlight;
   }
 }
 
 @media (forced-colors: active) {
-  .c20.fi-select-item--disabled {
+  .c15.fi-select-item--disabled {
     color: GrayText;
   }
 }
 
 @media (forced-colors: active) {
-  .c20.fi-select-item--disabled .fi-select-item--query_highlight {
+  .c15.fi-select-item--disabled .fi-select-item--query_highlight {
     color: GrayText;
   }
 }
 
 @media (forced-colors: active) {
-  .c20.fi-select-item--disabled.fi-select-item:hover {
+  .c15.fi-select-item--disabled.fi-select-item:hover {
     color: GrayText;
   }
 }
 
 @media (forced-colors: active) {
-  .c20.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
+  .c15.fi-select-item--disabled.fi-select-item:hover .fi-select-item--query_highlight {
     color: GrayText;
   }
 }
 
 @media (forced-colors: active) {
-  .c20.fi-select-item:hover {
+  .c15.fi-select-item:hover {
     background-color: Highlight;
   }
 }
 
 @media screen and (forced-colors: active) {
-  .c13.fi-chip--disabled.fi-chip {
+  .c18.fi-chip--disabled.fi-chip {
     color: GrayText;
   }
 }
 
 @media (prefers-reduced-motion) {
-  .c15.fi-loadingSpinner.fi-loadingSpinner--loading .fi-loadingSpinner_icon {
+  .c20.fi-loadingSpinner.fi-loadingSpinner--loading .fi-loadingSpinner_icon {
     animation: rotation 10s infinite linear;
   }
 }
@@ -1242,16 +1246,14 @@ exports[`has matching snapshot 1`] = `
               class="c0 fi-filter-input_functionalityContainer"
             >
               <div
-                aria-expanded="true"
-                aria-haspopup="listbox"
-                aria-owns="3-popover"
                 class="c0 fi-filter-input_input-element-container"
-                role="combobox"
               >
                 <input
                   aria-activedescendant=""
                   aria-autocomplete="list"
                   aria-controls="3-popover"
+                  aria-expanded="true"
+                  aria-haspopup="listbox"
                   aria-invalid="false"
                   aria-labelledby="1-label"
                   aria-multiline="false"
@@ -1261,6 +1263,7 @@ exports[`has matching snapshot 1`] = `
                   data-floating-ui-placement="bottom"
                   id="1"
                   placeholder="Choose your tool(s)"
+                  role="combobox"
                   spellcheck="false"
                   type="text"
                   value=""
@@ -1270,7 +1273,7 @@ exports[`has matching snapshot 1`] = `
                 class="c0 fi-filter-input_action-elements-container"
               >
                 <button
-                  aria-hidden="true"
+                  aria-expanded="true"
                   class="c7 fi-input-toggle-button c8"
                   tabindex="-1"
                   type="button"
@@ -1305,7 +1308,166 @@ exports[`has matching snapshot 1`] = `
           </div>
         </div>
         <div
-          class="c0 fi-chip-list c12"
+          class="fi-multiselect_popover"
+          role="presentation"
+          style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
+        >
+          <div
+            class="c3"
+          >
+            <ul
+              aria-activedescendant=""
+              aria-labelledby="3-label"
+              aria-multiselectable="true"
+              class="c12 fi-select-item-list c13"
+              data-floating-ui-placement="bottom"
+              id="3-popover"
+              role="listbox"
+              tabindex="0"
+            >
+              <li
+                aria-disabled="false"
+                aria-selected="false"
+                class="c14 fi-select-item c15"
+                id="3-jh2435626"
+                role="option"
+                tabindex="-1"
+              >
+                Jackhammer
+              </li>
+              <li
+                aria-disabled="false"
+                aria-selected="true"
+                class="c14 fi-select-item c15 fi-select-item--selected"
+                id="3-h9823523"
+                role="option"
+                tabindex="-1"
+              >
+                Hammer
+                <svg
+                  aria-hidden="true"
+                  class="fi-icon c16 fi-select-item_icon"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 20 20"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    class="fi-icon-base-fill"
+                    d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+                    fill="#222"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </li>
+              <li
+                aria-disabled="false"
+                aria-selected="false"
+                class="c14 fi-select-item c15"
+                id="3-sh908293482"
+                role="option"
+                tabindex="-1"
+              >
+                Sledgehammer
+              </li>
+              <li
+                aria-disabled="false"
+                aria-selected="false"
+                class="c14 fi-select-item c15"
+                id="3-s82502335"
+                role="option"
+                tabindex="-1"
+              >
+                Spade
+              </li>
+              <li
+                aria-disabled="true"
+                aria-selected="true"
+                class="c14 fi-select-item c15 fi-select-item--selected fi-select-item--disabled"
+                id="3-ps9081231"
+                role="option"
+                tabindex="-1"
+              >
+                Powersaw
+                <svg
+                  aria-hidden="true"
+                  class="fi-icon c16 fi-select-item_icon"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 20 20"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    class="fi-icon-base-fill"
+                    d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+                    fill="#222"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </li>
+              <li
+                aria-disabled="false"
+                aria-selected="false"
+                class="c14 fi-select-item c15"
+                id="3-s05111511"
+                role="option"
+                tabindex="-1"
+              >
+                Shovel
+              </li>
+              <li
+                aria-disabled="false"
+                aria-selected="false"
+                class="c14 fi-select-item c15"
+                id="3-is3451261"
+                role="option"
+                tabindex="-1"
+              >
+                Iron stick
+              </li>
+              <li
+                aria-disabled="false"
+                aria-selected="true"
+                class="c14 fi-select-item c15 fi-select-item--selected"
+                id="3-r09282626"
+                role="option"
+                tabindex="-1"
+              >
+                Rake
+                <svg
+                  aria-hidden="true"
+                  class="fi-icon c16 fi-select-item_icon"
+                  focusable="false"
+                  height="1em"
+                  viewBox="0 0 20 20"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    class="fi-icon-base-fill"
+                    d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+                    fill="#222"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </li>
+              <li
+                aria-disabled="true"
+                aria-selected="false"
+                class="c14 fi-select-item c15 fi-select-item--disabled"
+                id="3-ms6126266"
+                role="option"
+                tabindex="-1"
+              >
+                Motorsaw
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="c0 fi-chip-list c17"
           id="2"
         >
           <div
@@ -1313,7 +1475,7 @@ exports[`has matching snapshot 1`] = `
           >
             <button
               aria-disabled="true"
-              class="c7 fi-chip fi-chip--button c13 fi-chip--disabled fi-chip--removable"
+              class="c7 fi-chip fi-chip--button c18 fi-chip--disabled fi-chip--removable"
               type="button"
             >
               <span
@@ -1323,7 +1485,7 @@ exports[`has matching snapshot 1`] = `
               </span>
               <svg
                 aria-hidden="true"
-                class="fi-icon c14 fi-chip--icon fi-icon--cursor-pointer"
+                class="fi-icon c19 fi-chip--icon fi-icon--cursor-pointer"
                 focusable="false"
                 height="1em"
                 viewBox="0 0 24 24"
@@ -1345,7 +1507,7 @@ exports[`has matching snapshot 1`] = `
             </button>
             <button
               aria-disabled="false"
-              class="c7 fi-chip fi-chip--button c13 fi-chip--removable"
+              class="c7 fi-chip fi-chip--button c18 fi-chip--removable"
               type="button"
             >
               <span
@@ -1355,7 +1517,7 @@ exports[`has matching snapshot 1`] = `
               </span>
               <svg
                 aria-hidden="true"
-                class="fi-icon c14 fi-chip--icon fi-icon--cursor-pointer"
+                class="fi-icon c19 fi-chip--icon fi-icon--cursor-pointer"
                 focusable="false"
                 height="1em"
                 viewBox="0 0 24 24"
@@ -1377,7 +1539,7 @@ exports[`has matching snapshot 1`] = `
             </button>
             <button
               aria-disabled="false"
-              class="c7 fi-chip fi-chip--button c13 fi-chip--removable"
+              class="c7 fi-chip fi-chip--button c18 fi-chip--removable"
               type="button"
             >
               <span
@@ -1387,7 +1549,7 @@ exports[`has matching snapshot 1`] = `
               </span>
               <svg
                 aria-hidden="true"
-                class="fi-icon c14 fi-chip--icon fi-icon--cursor-pointer"
+                class="fi-icon c19 fi-chip--icon fi-icon--cursor-pointer"
                 focusable="false"
                 height="1em"
                 viewBox="0 0 24 24"
@@ -1415,7 +1577,7 @@ exports[`has matching snapshot 1`] = `
         />
         <button
           aria-disabled="false"
-          class="c7 fi-button c15 fi-multiselect_removeAllButton fi-button--secondary-light"
+          class="c7 fi-button c20 fi-multiselect_removeAllButton fi-button--secondary-light"
           tabindex="0"
           type="button"
         >
@@ -1424,7 +1586,7 @@ exports[`has matching snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="fi-icon c16"
+              class="fi-icon c21"
               focusable="false"
               height="1em"
               viewBox="0 0 24 24"
@@ -1469,165 +1631,6 @@ exports[`has matching snapshot 1`] = `
       class="c5 c9 fi-visually-hidden"
       id="3-chip-removal-announce"
     />
-  </div>
-  <div
-    class="fi-portal"
-    role="presentation"
-    style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
-    tabindex="-1"
-  >
-    <div
-      class="c3"
-    >
-      <ul
-        aria-activedescendant=""
-        aria-multiselectable="true"
-        class="c17 fi-select-item-list c18"
-        data-floating-ui-placement="bottom"
-        id="3-popover"
-        role="listbox"
-        tabindex="0"
-      >
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c19 fi-select-item c20"
-          id="3-jh2435626"
-          role="option"
-          tabindex="-1"
-        >
-          Jackhammer
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="true"
-          class="c19 fi-select-item c20 fi-select-item--selected"
-          id="3-h9823523"
-          role="option"
-          tabindex="-1"
-        >
-          Hammer
-          <svg
-            aria-hidden="true"
-            class="fi-icon c21 fi-select-item_icon"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fi-icon-base-fill"
-              d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c19 fi-select-item c20"
-          id="3-sh908293482"
-          role="option"
-          tabindex="-1"
-        >
-          Sledgehammer
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c19 fi-select-item c20"
-          id="3-s82502335"
-          role="option"
-          tabindex="-1"
-        >
-          Spade
-        </li>
-        <li
-          aria-disabled="true"
-          aria-selected="true"
-          class="c19 fi-select-item c20 fi-select-item--selected fi-select-item--disabled"
-          id="3-ps9081231"
-          role="option"
-          tabindex="-1"
-        >
-          Powersaw
-          <svg
-            aria-hidden="true"
-            class="fi-icon c21 fi-select-item_icon"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fi-icon-base-fill"
-              d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c19 fi-select-item c20"
-          id="3-s05111511"
-          role="option"
-          tabindex="-1"
-        >
-          Shovel
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c19 fi-select-item c20"
-          id="3-is3451261"
-          role="option"
-          tabindex="-1"
-        >
-          Iron stick
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="true"
-          class="c19 fi-select-item c20 fi-select-item--selected"
-          id="3-r09282626"
-          role="option"
-          tabindex="-1"
-        >
-          Rake
-          <svg
-            aria-hidden="true"
-            class="fi-icon c21 fi-select-item_icon"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fi-icon-base-fill"
-              d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </li>
-        <li
-          aria-disabled="true"
-          aria-selected="false"
-          class="c19 fi-select-item c20 fi-select-item--disabled"
-          id="3-ms6126266"
-          role="option"
-          tabindex="-1"
-        >
-          Motorsaw
-        </li>
-      </ul>
-    </div>
   </div>
 </body>
 `;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -577,6 +577,7 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c20 {
+  display: block;
   position: relative;
   padding: 8px 32px 8px 10px;
   letter-spacing: 0;

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -13,6 +13,7 @@ export const baseStyles = (
   ${buildSpacingCSS(propMargins, true)}
   ${fixInternalMargins()}
   width: 290px;
+  z-index: ${theme.zindexes.menu};
 
   &.fi-single-select {
     & .fi-filter-input_input {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.baseStyles.tsx
@@ -13,7 +13,6 @@ export const baseStyles = (
   ${buildSpacingCSS(propMargins, true)}
   ${fixInternalMargins()}
   width: 290px;
-  z-index: ${theme.zindexes.menu};
 
   &.fi-single-select {
     & .fi-filter-input_input {
@@ -29,6 +28,12 @@ export const baseStyles = (
     &--full-width {
       width: 100%;
     }
+  }
+
+  /* :where() pseudo-class lowers specificity allowing ".<styled-components-hash> :where(.fi-single-select_popover)"
+    to be overridden with popoverClassName prop, unlike ".<styled-components-hash> .fi-single-select_popover" */
+  & :where(.fi-single-select_popover) {
+    z-index: ${theme.zindexes.menu};
   }
 
   &.fi-single-select--open {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -473,8 +473,7 @@ describe('disabled', () => {
 
 describe('custom item addition mode', () => {
   it('should allow user to add & remove their own option as the selected value', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const user = userEvent.setup();
     const { getByRole, getAllByRole, getByText } = render(
       <SingleSelect
         allowItemAddition={true}
@@ -487,7 +486,6 @@ describe('custom item addition mode', () => {
     );
     const input = getByRole('combobox');
     await user.click(input);
-    act(() => jest.advanceTimersByTime(150));
     await user.type(input, 'hamm');
     const items = getAllByRole('option');
     expect(items).toHaveLength(4);
@@ -496,7 +494,7 @@ describe('custom item addition mode', () => {
     await user.click(extraItem);
     await user.tab();
     await user.click(input);
-    act(() => jest.advanceTimersByTime(150));
+    await waitForPosition();
     const appendedItems = getAllByRole('option');
     expect(appendedItems).toHaveLength(10);
     const lastItem = appendedItems[9];
@@ -508,10 +506,9 @@ describe('custom item addition mode', () => {
     expect(input).toHaveValue('');
 
     await user.click(input);
-    act(() => jest.advanceTimersByTime(150));
+    await waitForPosition();
     const resetItems = getAllByRole('option');
     expect(resetItems).toHaveLength(9);
-    jest.useRealTimers();
   });
 });
 
@@ -723,8 +720,7 @@ describe('margin', () => {
 
 describe('keyboard interactions', () => {
   it('should reset input value to selected item when pressing Escape after typing', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const user = userEvent.setup();
     const { getByRole, getByText } = render(BasicSingleSelect);
 
     const input = getByRole('combobox');
@@ -736,20 +732,16 @@ describe('keyboard interactions', () => {
     expect(input).toHaveValue('Rake');
 
     await user.click(input);
-    // Wait for the select timeout in the component to complete before typing
-    act(() => jest.advanceTimersByTime(150));
     await user.type(input, 'something else');
     expect(input).toHaveValue('something else');
 
     // Press Escape - should reset to selected item
     await user.keyboard('{Escape}');
     expect(input).toHaveValue('Rake');
-    jest.useRealTimers();
   });
 
   it('should clear input when pressing Escape with no selected item', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const user = userEvent.setup();
     const { getByRole } = render(
       <SingleSelect
         labelText="SingleSelect"
@@ -765,13 +757,11 @@ describe('keyboard interactions', () => {
 
     // Type something in the input without selecting
     await user.click(input);
-    act(() => jest.advanceTimersByTime(150));
     await user.type(input, 'something');
     expect(input).toHaveValue('something');
 
     // Press Escape - should clear input since no item is selected
     await user.keyboard('{Escape}');
     expect(input).toHaveValue('');
-    jest.useRealTimers();
   });
 });

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -104,7 +104,7 @@ it('should not have basic accessibility issues', async () => {
 it('has matching snapshot', async () => {
   const user = userEvent.setup();
   const { baseElement, getByRole } = render(BasicSingleSelect);
-  const textfield = getByRole('textbox') as HTMLInputElement;
+  const textfield = getByRole('combobox') as HTMLInputElement;
   await user.click(textfield);
   await waitForPosition();
   expect(baseElement).toMatchSnapshot();
@@ -139,8 +139,8 @@ describe('Controlled', () => {
     );
 
     const { getByRole, getByText, rerender } = render(singleSelect);
-    expect(getByRole('textbox')).toHaveValue('Powersaw');
-    const input = getByRole('textbox');
+    expect(getByRole('combobox')).toHaveValue('Powersaw');
+    const input = getByRole('combobox');
     await user.click(input);
     await waitForPosition();
     const item = getByText('Powersaw');
@@ -159,7 +159,7 @@ describe('Controlled', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
-    const rerenderedInput = getByRole('textbox');
+    const rerenderedInput = getByRole('combobox');
     expect(rerenderedInput).toHaveValue('');
   });
 
@@ -203,7 +203,7 @@ describe('Controlled', () => {
     const { getByText, getByRole } = render(singleSelect);
     const clearButton = getByText('Clear selection');
     await user.click(clearButton);
-    expect(getByRole('textbox')).toHaveValue('Turtle');
+    expect(getByRole('combobox')).toHaveValue('Turtle');
   });
 });
 
@@ -230,7 +230,7 @@ describe('filter', () => {
   it('should be available with default selection', async () => {
     const user = userEvent.setup();
     const { getByRole, getAllByRole } = render(BasicSingleSelect);
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     expect(input).toHaveValue('Hammer');
     await user.clear(input);
     await user.type(input, 'h');
@@ -251,7 +251,7 @@ describe('filter', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.type(input, 'h');
     await waitForPosition();
     const items = getAllByRole('option');
@@ -261,7 +261,7 @@ describe('filter', () => {
   it('should be removed onBlur', async () => {
     const user = userEvent.setup();
     const { getByRole, getAllByRole } = render(BasicSingleSelect);
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     expect(input).toHaveValue('Hammer');
     await user.clear(input);
     await user.type(input, 'h');
@@ -281,7 +281,7 @@ describe('filter', () => {
 test('option: should be selected when clicked', async () => {
   const user = userEvent.setup();
   const { getByText, getByRole } = render(BasicSingleSelect);
-  const input = getByRole('textbox');
+  const input = getByRole('combobox');
   await user.click(input);
   await waitForPosition();
   const option = getByText('Rake');
@@ -315,7 +315,7 @@ test('visualPlaceholder: has the given text as placeholder attribute', async () 
       ariaOptionsAvailableText="Options available"
     />,
   );
-  const inputfield = getByRole('textbox') as HTMLInputElement;
+  const inputfield = getByRole('combobox') as HTMLInputElement;
   expect(inputfield).toHaveAttribute('placeholder', 'Select item');
 });
 
@@ -330,7 +330,7 @@ test('id: has the given id', async () => {
       ariaOptionsAvailableText="Options available"
     />,
   );
-  expect(getByRole('textbox')).toHaveAttribute('id', 'cb-123');
+  expect(getByRole('combobox')).toHaveAttribute('id', 'cb-123');
 });
 
 describe('statusText', () => {
@@ -364,7 +364,7 @@ describe('statusText', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
-    expect(getByRole('textbox')).toHaveAttribute(
+    expect(getByRole('combobox')).toHaveAttribute(
       'aria-describedby',
       '123-statusText',
     );
@@ -420,7 +420,7 @@ describe('disabled', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.click(input);
     expect(() => getAllByRole('option')).toThrowError();
   });
@@ -440,7 +440,7 @@ describe('custom item addition mode', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.click(input);
     act(() => jest.advanceTimersByTime(150));
     await user.type(input, 'hamm');
@@ -490,7 +490,7 @@ describe('ariaOptionsAvailable', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.type(input, 'M');
     await waitForPosition();
     const ariaText = getByText(`2 Options available`);
@@ -513,7 +513,7 @@ describe('ariaOptionsAvailable', () => {
         }
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.type(input, 'V');
     await waitForPosition();
     const ariaText = getByText(`There is 1 option available`);
@@ -562,7 +562,7 @@ describe('listProps', () => {
         }}
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.click(input);
     await waitForPosition();
     const menu = getByRole('listbox');
@@ -590,7 +590,7 @@ describe('listItemProps', () => {
         ariaOptionsAvailableText="Options available"
       />,
     );
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     await user.click(input);
     await waitForPosition();
     const option = getByRole('option');
@@ -636,7 +636,7 @@ describe('External update to item array', () => {
   it('updated item array should be visible in input', async () => {
     const user = userEvent.setup();
     const { getByRole, getByTestId } = render(<ModalWithSiblings />);
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
     expect(input).toHaveDisplayValue('Mercury');
 
     const button = getByTestId('changeState');
@@ -682,7 +682,7 @@ describe('keyboard interactions', () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const { getByRole, getByText } = render(BasicSingleSelect);
 
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
 
     // First, select an item
     await user.click(input);
@@ -716,7 +716,7 @@ describe('keyboard interactions', () => {
       />,
     );
 
-    const input = getByRole('textbox');
+    const input = getByRole('combobox');
 
     // Type something in the input without selecting
     await user.click(input);

--- a/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.test.tsx
@@ -276,6 +276,51 @@ describe('filter', () => {
     const options = getAllByRole('option');
     expect(options).toHaveLength(9);
   });
+
+  it('should restore selected value when closed with outside click', async () => {
+    const user = userEvent.setup();
+    const { getByRole, queryByRole } = render(BasicSingleSelect);
+    const input = getByRole('combobox');
+
+    expect(input).toHaveValue('Hammer');
+    await user.clear(input);
+    await user.type(input, 'not selected');
+    await waitForPosition();
+    expect(input).toHaveValue('not selected');
+
+    await user.click(document.body);
+
+    await waitFor(() => {
+      expect(queryByRole('listbox')).not.toBeInTheDocument();
+      expect(input).toHaveValue('Hammer');
+    });
+  });
+
+  it('should clear value when closed with outside click and no selected value', async () => {
+    const user = userEvent.setup();
+    const { getByRole, queryByRole } = render(
+      <SingleSelect
+        labelText="SingleSelect"
+        clearButtonLabel="Clear selection"
+        items={tools}
+        visualPlaceholder="Choose your tool(s)"
+        noItemsText="No items"
+        ariaOptionsAvailableText="Options available"
+      />,
+    );
+    const input = getByRole('combobox');
+
+    await user.type(input, 'not selected');
+    await waitForPosition();
+    expect(input).toHaveValue('not selected');
+
+    await user.click(document.body);
+
+    await waitFor(() => {
+      expect(queryByRole('listbox')).not.toBeInTheDocument();
+      expect(input).toHaveValue('');
+    });
+  });
 });
 
 test('option: should be selected when clicked', async () => {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -409,13 +409,20 @@ class BaseSingleSelect<T> extends Component<
   };
 
   private setFocusedDescendantAfterPopoverIsVisible = (
-    uniqueItemId: string,
+    item: SingleSelectData,
   ) => {
-    // Popover only becomes visible after two requestAnimationFrames
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        this.setState({ focusedDescendantId: uniqueItemId });
-      });
+    /** Popover becomes visible after two requestAnimationFrames,
+     * defer setting focused descendant so that screen readers
+     * will read the list item when opening popover with keyboard
+     */
+    this.setState({ showPopover: true }, () => {
+      if (item) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            this.setState({ focusedDescendantId: item.uniqueItemId });
+          });
+        });
+      }
     });
   };
 
@@ -462,14 +469,7 @@ class BaseSingleSelect<T> extends Component<
             : getNextItem();
 
         if (!this.state.showPopover) {
-          // Open the popover first, then set the focus in the callback after items are in the DOM
-          this.setState({ showPopover: true }, () => {
-            if (nextItem) {
-              this.setFocusedDescendantAfterPopoverIsVisible(
-                nextItem.uniqueItemId,
-              );
-            }
-          });
+          this.setFocusedDescendantAfterPopoverIsVisible(nextItem);
         } else if (nextItem) {
           this.setState({ focusedDescendantId: nextItem.uniqueItemId });
         }
@@ -490,13 +490,7 @@ class BaseSingleSelect<T> extends Component<
             : getPreviousItem();
 
         if (!this.state.showPopover) {
-          this.setState({ showPopover: true }, () => {
-            if (previousItem) {
-              this.setFocusedDescendantAfterPopoverIsVisible(
-                previousItem.uniqueItemId,
-              );
-            }
-          });
+          this.setFocusedDescendantAfterPopoverIsVisible(previousItem);
         } else if (previousItem) {
           this.setState({ focusedDescendantId: previousItem.uniqueItemId });
         }

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -377,6 +377,16 @@ class BaseSingleSelect<T> extends Component<
     }));
   };
 
+  private handleToggleButtonClick(event: React.MouseEvent<HTMLElement>) {
+    event.preventDefault();
+    if (this.state.showPopover) {
+      this.closeMenu();
+    } else {
+      this.setState(() => ({ showPopover: true }));
+    }
+    this.focusToInput();
+  }
+
   private handleItemSelection = (item: (T & SingleSelectData) | null) => {
     if (item !== null && item.disabled) return;
     const {
@@ -709,13 +719,7 @@ class BaseSingleSelect<T> extends Component<
                 ref={this.toggleButtonRef}
                 aria-expanded={showPopover}
                 onClick={(event) => {
-                  event.preventDefault();
-                  this.setState(
-                    (prevState: SingleSelectState<T & SingleSelectData>) => ({
-                      showPopover: !prevState.showPopover,
-                    }),
-                  );
-                  this.focusToInput();
+                  this.handleToggleButtonClick(event);
                 }}
                 tabIndex={-1}
                 disabled={disabled}

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -715,6 +715,7 @@ class BaseSingleSelect<T> extends Component<
               }
             }}
             className={popoverClassName}
+            portal={false}
           >
             <PopoverConsumer>
               {(consumer) => {

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -33,6 +33,7 @@ import { SelectItemAddition } from '../BaseSelect/SelectItemAddition/SelectItemA
 
 const baseClassName = 'fi-single-select';
 const singleSelectClassNames = {
+  popover: `${baseClassName}_popover`,
   valueSelected: `${baseClassName}--value-selected`,
   clearButtonWrapper: `${baseClassName}_clear-button_wrapper`,
   open: `${baseClassName}--open`,
@@ -728,7 +729,10 @@ class BaseSingleSelect<T> extends Component<
                 this.setState({ showPopover: false });
               }
             }}
-            className={popoverClassName}
+            className={classnames(
+              singleSelectClassNames.popover,
+              popoverClassName,
+            )}
             portal={false}
           >
             <PopoverConsumer>

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -317,13 +317,19 @@ class BaseSingleSelect<T> extends Component<
       const focusInPopover = this.popoverListRef.current?.contains(
         ownerDocument.activeElement,
       );
+      const focusInClearButton = this.clearButtonRef.current?.contains(
+        ownerDocument.activeElement,
+      );
       const focusInToggleButton = this.toggleButtonRef.current?.contains(
         ownerDocument.activeElement,
       );
       const focusInInput =
         ownerDocument.activeElement === this.filterInputRef.current;
       const focusInSingleSelect =
-        focusInPopover || focusInInput || focusInToggleButton;
+        focusInPopover ||
+        focusInInput ||
+        focusInToggleButton ||
+        focusInClearButton;
       if (!focusInSingleSelect) {
         this.closeMenu();
       }

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -728,6 +728,7 @@ class BaseSingleSelect<T> extends Component<
                     ref={this.popoverListRef}
                     focusedDescendantId={ariaActiveDescendant}
                     popoverPlacement={consumer?.popoverPlacement}
+                    aria-labelledby={`${id}-label`}
                     {...listProps}
                   >
                     <>

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -609,12 +609,9 @@ class BaseSingleSelect<T> extends Component<
         <Debounce waitFor={debounce}>
           {(debouncer: Function) => (
             <FilterInput
-              inputElementContainerProps={{
-                role: 'combobox',
-                'aria-haspopup': 'listbox',
-                'aria-owns': popoverItemListId,
-                'aria-expanded': showPopover,
-              }}
+              role="combobox"
+              aria-haspopup="listbox"
+              aria-expanded={showPopover}
               aria-activedescendant={ariaActiveDescendant}
               id={id}
               aria-controls={popoverItemListId}

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -687,6 +687,7 @@ class BaseSingleSelect<T> extends Component<
               <InputToggleButton
                 open={showPopover}
                 ref={this.toggleButtonRef}
+                aria-expanded={showPopover}
                 onClick={(event) => {
                   event.preventDefault();
                   this.setState(
@@ -697,7 +698,6 @@ class BaseSingleSelect<T> extends Component<
                   this.preventShowPopoverOnInputFocus = true;
                   this.focusToInputAndSelectText();
                 }}
-                aria-hidden={true}
                 tabIndex={-1}
                 disabled={disabled}
               />

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -717,7 +717,9 @@ class BaseSingleSelect<T> extends Component<
               <InputToggleButton
                 open={showPopover}
                 ref={this.toggleButtonRef}
+                aria-labelledby={`${id}-label`}
                 aria-expanded={showPopover}
+                aria-controls={popoverItemListId}
                 onClick={(event) => {
                   this.handleToggleButtonClick(event);
                 }}

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -207,8 +207,6 @@ class BaseSingleSelect<T> extends Component<
 
   private clearButtonRef: React.RefObject<HTMLButtonElement>;
 
-  private preventShowPopoverOnInputFocus = false;
-
   constructor(
     props: SingleSelectProps<T & SingleSelectData> & SuomifiThemeProp,
   ) {
@@ -357,15 +355,14 @@ class BaseSingleSelect<T> extends Component<
     });
   };
 
-  private focusToInputAndSelectText = () => {
+  private focusToInput = () => {
     if (!!this.filterInputRef && this.filterInputRef.current) {
       this.filterInputRef.current.focus();
-      setTimeout(() => this.filterInputRef.current?.select(), 100);
     }
   };
 
   private focusToInputAndCloseMenu = () => {
-    this.focusToInputAndSelectText();
+    this.focusToInput();
     this.setState((prevState: SingleSelectState<T & SingleSelectData>) => ({
       showPopover: false,
       filterMode: false,
@@ -411,6 +408,17 @@ class BaseSingleSelect<T> extends Component<
     this.focusToInputAndCloseMenu();
   };
 
+  private setFocusedDescendantAfterPopoverIsVisible = (
+    uniqueItemId: string,
+  ) => {
+    // Popover only becomes visible after two requestAnimationFrames
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.setState({ focusedDescendantId: uniqueItemId });
+      });
+    });
+  };
+
   private handleKeyDown = (event: React.KeyboardEvent) => {
     const { filteredItems, focusedDescendantId, filterMode, filterInputValue } =
       this.state;
@@ -442,9 +450,6 @@ class BaseSingleSelect<T> extends Component<
     switch (event.key) {
       case 'ArrowDown': {
         event.preventDefault();
-        if (!this.state.showPopover) {
-          this.setState({ showPopover: true });
-        }
         const nextItem =
           this.props.allowItemAddition &&
           (index === popoverItems.length - 1 || popoverItems.length === 0) &&
@@ -455,7 +460,17 @@ class BaseSingleSelect<T> extends Component<
                 labelText: filterInputValue,
               }
             : getNextItem();
-        if (nextItem) {
+
+        if (!this.state.showPopover) {
+          // Open the popover first, then set the focus in the callback after items are in the DOM
+          this.setState({ showPopover: true }, () => {
+            if (nextItem) {
+              this.setFocusedDescendantAfterPopoverIsVisible(
+                nextItem.uniqueItemId,
+              );
+            }
+          });
+        } else if (nextItem) {
           this.setState({ focusedDescendantId: nextItem.uniqueItemId });
         }
         break;
@@ -463,9 +478,6 @@ class BaseSingleSelect<T> extends Component<
 
       case 'ArrowUp': {
         event.preventDefault();
-        if (!this.state.showPopover) {
-          this.setState({ showPopover: true });
-        }
         const previousItem =
           this.props.allowItemAddition &&
           (index === null || index === 0) &&
@@ -476,7 +488,16 @@ class BaseSingleSelect<T> extends Component<
                 labelText: filterInputValue,
               }
             : getPreviousItem();
-        if (previousItem) {
+
+        if (!this.state.showPopover) {
+          this.setState({ showPopover: true }, () => {
+            if (previousItem) {
+              this.setFocusedDescendantAfterPopoverIsVisible(
+                previousItem.uniqueItemId,
+              );
+            }
+          });
+        } else if (previousItem) {
           this.setState({ focusedDescendantId: previousItem.uniqueItemId });
         }
         break;
@@ -642,14 +663,8 @@ class BaseSingleSelect<T> extends Component<
               }}
               filterFunc={this.filter}
               forwardedRef={this.filterInputRef}
-              onFocus={() => {
-                if (!this.preventShowPopoverOnInputFocus) {
-                  this.setState({ showPopover: true });
-                }
-                this.preventShowPopoverOnInputFocus = false;
-              }}
               onClick={() => {
-                this.focusToInputAndSelectText();
+                this.focusToInput();
                 this.setState({
                   showPopover: true,
                 });
@@ -695,8 +710,7 @@ class BaseSingleSelect<T> extends Component<
                       showPopover: !prevState.showPopover,
                     }),
                   );
-                  this.preventShowPopoverOnInputFocus = true;
-                  this.focusToInputAndSelectText();
+                  this.focusToInput();
                 }}
                 tabIndex={-1}
                 disabled={disabled}

--- a/src/core/Form/Select/SingleSelect/SingleSelect.tsx
+++ b/src/core/Form/Select/SingleSelect/SingleSelect.tsx
@@ -325,12 +325,7 @@ class BaseSingleSelect<T> extends Component<
       const focusInSingleSelect =
         focusInPopover || focusInInput || focusInToggleButton;
       if (!focusInSingleSelect) {
-        this.setState((prevState: SingleSelectState<T & SingleSelectData>) => ({
-          filterInputValue: prevState.selectedItem?.labelText || '',
-          filterMode: false,
-          showPopover: focusInSingleSelect,
-          focusedDescendantId: null,
-        }));
+        this.closeMenu();
       }
     });
   };
@@ -364,11 +359,15 @@ class BaseSingleSelect<T> extends Component<
 
   private focusToInputAndCloseMenu = () => {
     this.focusToInput();
+    this.closeMenu();
+  };
+
+  private closeMenu = () => {
     this.setState((prevState: SingleSelectState<T & SingleSelectData>) => ({
-      showPopover: false,
-      filterMode: false,
-      focusedDescendantId: null,
       filterInputValue: prevState.selectedItem?.labelText || '',
+      filterMode: false,
+      showPopover: false,
+      focusedDescendantId: null,
     }));
   };
 
@@ -529,6 +528,11 @@ class BaseSingleSelect<T> extends Component<
           event.stopPropagation();
         }
         this.focusToInputAndCloseMenu();
+        break;
+      }
+
+      case 'Tab': {
+        this.closeMenu();
         break;
       }
 

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -753,7 +753,6 @@ exports[`has matching snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   width: 290px;
-  z-index: 888;
 }
 
 .c1 .fi-label,
@@ -772,6 +771,10 @@ exports[`has matching snapshot 1`] = `
 
 .c1.fi-single-select--full-width {
   width: 100%;
+}
+
+.c1 :where(.fi-single-select_popover) {
+  z-index: 888;
 }
 
 .c1.fi-single-select--open .fi-filter-input_input {
@@ -960,6 +963,7 @@ exports[`has matching snapshot 1`] = `
         </div>
       </div>
       <div
+        class="fi-single-select_popover"
         role="presentation"
         style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
       >

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -928,7 +928,9 @@ exports[`has matching snapshot 1`] = `
                 </button>
               </div>
               <button
+                aria-controls="2-popover"
                 aria-expanded="true"
+                aria-labelledby="2-label"
                 class="c8 fi-input-toggle-button c12"
                 tabindex="-1"
                 type="button"

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -753,6 +753,7 @@ exports[`has matching snapshot 1`] = `
   line-height: 1.5;
   font-weight: 400;
   width: 290px;
+  z-index: 888;
 }
 
 .c1 .fi-label,
@@ -866,17 +867,15 @@ exports[`has matching snapshot 1`] = `
             class="c0 fi-filter-input_functionalityContainer"
           >
             <div
-              aria-expanded="true"
-              aria-haspopup="listbox"
-              aria-owns="2-popover"
               class="c0 fi-filter-input_input-element-container"
-              role="combobox"
             >
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
                 aria-controls="2-popover"
                 aria-describedby="1-hintText"
+                aria-expanded="true"
+                aria-haspopup="listbox"
                 aria-invalid="false"
                 aria-labelledby="1-label"
                 aria-multiline="false"
@@ -886,6 +885,7 @@ exports[`has matching snapshot 1`] = `
                 data-floating-ui-placement="bottom"
                 id="1"
                 placeholder=""
+                role="combobox"
                 spellcheck="false"
                 type="text"
                 value="Hammer"
@@ -925,7 +925,7 @@ exports[`has matching snapshot 1`] = `
                 </button>
               </div>
               <button
-                aria-hidden="true"
+                aria-expanded="true"
                 class="c8 fi-input-toggle-button c12"
                 tabindex="-1"
                 type="button"
@@ -959,6 +959,131 @@ exports[`has matching snapshot 1`] = `
           </div>
         </div>
       </div>
+      <div
+        role="presentation"
+        style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
+      >
+        <div
+          class="c3"
+        >
+          <ul
+            aria-activedescendant=""
+            aria-labelledby="2-label"
+            class="c15 fi-select-item-list c16"
+            data-floating-ui-placement="bottom"
+            id="2-popover"
+            role="listbox"
+            tabindex="0"
+          >
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="2-jh2435626"
+              role="option"
+              tabindex="-1"
+            >
+              Jackhammer
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="true"
+              class="c17 fi-select-item c18 fi-select-item--selected"
+              id="2-h9823523"
+              role="option"
+              tabindex="-1"
+            >
+              Hammer
+              <svg
+                aria-hidden="true"
+                class="fi-icon c19 fi-select-item_icon"
+                focusable="false"
+                height="1em"
+                viewBox="0 0 20 20"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  class="fi-icon-base-fill"
+                  d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+                  fill="#222"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="2-sh908293482"
+              role="option"
+              tabindex="-1"
+            >
+              Sledgehammer
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="2-s82502335"
+              role="option"
+              tabindex="-1"
+            >
+              Spade
+            </li>
+            <li
+              aria-disabled="true"
+              aria-selected="false"
+              class="c17 fi-select-item c18 fi-select-item--disabled"
+              id="2-ps9081231"
+              role="option"
+              tabindex="-1"
+            >
+              Powersaw
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="2-s05111511"
+              role="option"
+              tabindex="-1"
+            >
+              Shovel
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="2-is3451261"
+              role="option"
+              tabindex="-1"
+            >
+              Iron stick
+            </li>
+            <li
+              aria-disabled="false"
+              aria-selected="false"
+              class="c17 fi-select-item c18"
+              id="2-r09282626"
+              role="option"
+              tabindex="-1"
+            >
+              Rake
+            </li>
+            <li
+              aria-disabled="true"
+              aria-selected="false"
+              class="c17 fi-select-item c18 fi-select-item--disabled"
+              id="2-ms6126266"
+              role="option"
+              tabindex="-1"
+            >
+              Motorsaw
+            </li>
+          </ul>
+        </div>
+      </div>
       <span
         aria-atomic="true"
         aria-live="polite"
@@ -970,132 +1095,6 @@ exports[`has matching snapshot 1`] = `
         class="c5 c10 fi-visually-hidden"
         id="2-loading-announce"
       />
-    </div>
-  </div>
-  <div
-    class="fi-portal"
-    role="presentation"
-    style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
-    tabindex="-1"
-  >
-    <div
-      class="c3"
-    >
-      <ul
-        aria-activedescendant=""
-        class="c15 fi-select-item-list c16"
-        data-floating-ui-placement="bottom"
-        id="2-popover"
-        role="listbox"
-        tabindex="0"
-      >
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c17 fi-select-item c18"
-          id="2-jh2435626"
-          role="option"
-          tabindex="-1"
-        >
-          Jackhammer
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="true"
-          class="c17 fi-select-item c18 fi-select-item--selected"
-          id="2-h9823523"
-          role="option"
-          tabindex="-1"
-        >
-          Hammer
-          <svg
-            aria-hidden="true"
-            class="fi-icon c19 fi-select-item_icon"
-            focusable="false"
-            height="1em"
-            viewBox="0 0 20 20"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              class="fi-icon-base-fill"
-              d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
-              fill="#222"
-              fill-rule="evenodd"
-            />
-          </svg>
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c17 fi-select-item c18"
-          id="2-sh908293482"
-          role="option"
-          tabindex="-1"
-        >
-          Sledgehammer
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c17 fi-select-item c18"
-          id="2-s82502335"
-          role="option"
-          tabindex="-1"
-        >
-          Spade
-        </li>
-        <li
-          aria-disabled="true"
-          aria-selected="false"
-          class="c17 fi-select-item c18 fi-select-item--disabled"
-          id="2-ps9081231"
-          role="option"
-          tabindex="-1"
-        >
-          Powersaw
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c17 fi-select-item c18"
-          id="2-s05111511"
-          role="option"
-          tabindex="-1"
-        >
-          Shovel
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c17 fi-select-item c18"
-          id="2-is3451261"
-          role="option"
-          tabindex="-1"
-        >
-          Iron stick
-        </li>
-        <li
-          aria-disabled="false"
-          aria-selected="false"
-          class="c17 fi-select-item c18"
-          id="2-r09282626"
-          role="option"
-          tabindex="-1"
-        >
-          Rake
-        </li>
-        <li
-          aria-disabled="true"
-          aria-selected="false"
-          class="c17 fi-select-item c18 fi-select-item--disabled"
-          id="2-ms6126266"
-          role="option"
-          tabindex="-1"
-        >
-          Motorsaw
-        </li>
-      </ul>
     </div>
   </div>
 </body>

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -623,6 +623,7 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c18 {
+  display: block;
   position: relative;
   padding: 8px 32px 8px 10px;
   letter-spacing: 0;

--- a/src/core/Popover/Popover.tsx
+++ b/src/core/Popover/Popover.tsx
@@ -41,6 +41,8 @@ export interface PopoverProps extends HtmlDivProps {
   portal?: boolean;
   /** CSS class for custom styles */
   className?: string;
+  /** Tabindex for the popover container element */
+  TabIndex?: number;
 }
 
 export interface PopoverProviderState {
@@ -68,6 +70,7 @@ export const Popover = (props: PopoverProps) => {
     onClickOutside,
     portal = true,
     className,
+    tabIndex,
     ...passProps
   } = props;
 
@@ -188,7 +191,7 @@ export const Popover = (props: PopoverProps) => {
               ...floatingStyles,
               visibility: isPositioned ? 'visible' : 'hidden',
             }}
-            tabIndex={-1}
+            tabIndex={tabIndex}
             role="presentation"
           >
             <HtmlDivWithRef forwardedRef={portalRef} {...passProps}>
@@ -211,7 +214,7 @@ export const Popover = (props: PopoverProps) => {
         ...floatingStyles,
         visibility: isPositioned ? 'visible' : 'hidden',
       }}
-      tabIndex={-1}
+      tabIndex={tabIndex}
       role="presentation"
     >
       <HtmlDivWithRef forwardedRef={portalRef} {...passProps}>


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->
Updates SingleSelect and MultiSelect components to be accessible with iOS VoiceOver.
- Popovers are moved away from portal so that they are near the input element in DOM, and accessible to iOS VoiceOver navigation.
- Popovers have z-index that can be overridden with theme variable or per component with popoverClassName prop.

Updates focus handling so that popover is not automatically opened with keyboard or screen reader focus.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

SingleSelect and MultiSelect have not been accessible to iOS VoiceOver. VoiceOver support for combobox pattern was lacking when these components were introduced.

Focus management is updated to make traversing with mobile screen readers easier, so that user can pass the input field without needing to close it first. 
- Due to focus handling change, Android TalkBack navigation will change so that screen reader user will be able to open the popover from the toggle button or by typing in the field. Double tapping on input field on Android TalkBack doesn't register onClick to open the popover, similarly as in [WAI Combobox pattern example](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-none/).


## How Has This Been Tested?

Developer testing:

- MacOS 26.4.1 VoiceOver: Safari, Chrome 147.0.7727.56 
- Windows 11 NVDA: Edge Version 146.0.3856.59, Chrome 147.0.7727.56
- iOS2 26.3.1 VoiceOver: Safari, Chrome  147.0.7727.47 
- Android TalkBack: Chrome

VoiceOver on Safari cancels reading the first selected item on the list, as it reads the expanded information. This is similar behavior as in [WAI Combobox pattern example](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-none/).

Accessibility testing:

Chrome + NVDA 2025.3: OK
macOS 26 + Safari + VO: OK
iOS 26 + Safari + VO: OK. Focus works correctly even when the popover opens above the field.
macOS 15 + Safari + VO: OK
macOS 14/13 + Safari + VO: Works with ctrl+alt+arrow keys. When using simple arrow key navigation (pressing the down arrow when field has focus), VO will always not announce the options. This is a degradation in macOS 14, where the options are consistently announced.
Android 15 + Chrome + Talkback: OK.


## Screenshots (if appropriate):

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### SingleSelect & MultiSelect
- **Breaking change:** Popover renders inline instead of in a portal
  - Internal CSS classes are added, with a default `z-index` that can be overriden with the `popoverClassName` prop. 
  - Tests that relied on the popover being rendered in a portal element outside the component tree will break. The popover is now a sibling within the component wrapper.
- **Breaking change:** ARIA combobox role moved to the `<input>` element
  - `role="combobox"`, `aria-haspopup`, and `aria-expanded` are now placed directly on the `<input>` element, instead of on a container `<div>` wrapping the input, and `aria-owns` is removed
- **Breaking change:** Toggle button exposed to assistive technology
  - Toggle button now has `aria-expanded` instead of `aria-hidden`
- **Breaking change:** Popover no longer opens automatically on input focus
  - The `onFocus` handler that opened the popover is removed. The popover now opens on click or arrow key only.
- **Breaking change:** Popover's listbox gets `aria-labelledby` to improve screenreader context
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 