### PR TITLE
[Fix] LinkListItem indentation with wrapping content

### DIFF
--- a/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
+++ b/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
@@ -222,6 +222,7 @@ exports[`Simple link list with one item should match snapshot 1`] = `
 .c3.fi-link-list-item {
   list-style: none;
   padding: 0;
+  margin-left: 15px;
 }
 
 .c3.fi-link-list-item .fi-link-list-item_icon {
@@ -229,7 +230,7 @@ exports[`Simple link list with one item should match snapshot 1`] = `
 }
 
 .c3.fi-link-list-item .fi-link-list-item_icon .fi-icon {
-  margin-left: -3px;
+  margin-left: -18px;
   font-size: 16px;
   transform: translateY(0.1em);
 }

--- a/src/core/Link/LinkListItem/LinkListItem.baseStyles.ts
+++ b/src/core/Link/LinkListItem/LinkListItem.baseStyles.ts
@@ -7,10 +7,11 @@ export const LinkListItemStyles = (theme: SuomifiTheme) => css`
   &.fi-link-list-item {
     list-style: none;
     padding: 0;
+    margin-left: 15px;
     & .fi-link-list-item_icon {
       margin-right: 2px;
       & .fi-icon {
-        margin-left: -3px;
+        margin-left: -18px;
         font-size: 16px;
         transform: translateY(0.1em);
         & .fi-icon-base-fill {


### PR DESCRIPTION
## Description
This PR adjusts the styles of `LinkListItem` so that it behaves more like a native list in terms of styles. Mainly meaning that any wrapping text content indents to match the text on the first line instead of aligning to the left edge of the component.

## Motivation and Context
This was an issue reported by services using the component

## How Has This Been Tested?
Tested by running locally on styleguidist on Chrome and checking the new styles.

## Screenshots (if appropriate):
Before:
<img width="968" height="300" alt="image" src="https://github.com/user-attachments/assets/acb4cb95-2085-44e4-8fce-838cc56899a6" />
After:
<img width="984" height="296" alt="image" src="https://github.com/user-attachments/assets/1cc02f43-7956-4c52-be57-495794042b28" />

## Release notes
### LinkListItem
**Breaking change:** Indent wrapping text to align with the first line of text
