### PR TITLE
[Fix] Dropdown and Breadcrumb text scaling

### DIFF
--- a/.styleguidist/accessibility.md
+++ b/.styleguidist/accessibility.md
@@ -18,11 +18,9 @@ Using the Suomi.fi component library does not automatically make your project ac
 
 ## Known issues
 
-Updated 24th April 2026.
+Updated May 8th, 2026.
 
 - **SingleSelect**: The selected state of an option is not read out by JAWS.
-- **Breadcrumb**: Height does not adjust when only text is resized 200%.
-- **Dropdown**: Line-height does not adjust when only text is resized 200%.
 
 ## Our accessibility checklist
 

--- a/src/core/Breadcrumb/Breadcrumb/Breadcrumb.baseStyles.ts
+++ b/src/core/Breadcrumb/Breadcrumb/Breadcrumb.baseStyles.ts
@@ -12,7 +12,6 @@ export const baseStyles = (
   ${font(theme)('bodyTextSmall')}
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)};
-  height: 1.5em;
 
   & .fi-breadcrumb {
     &_list {

--- a/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/core/Breadcrumb/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -155,7 +155,6 @@ exports[`calling render with the same component on the same container does not r
   font-size: 16px;
   line-height: 1.5;
   font-weight: 400;
-  height: 1.5em;
 }
 
 .c1 .fi-breadcrumb_list {

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3465,7 +3465,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
-  line-height: 1.5;
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
@@ -3496,7 +3495,8 @@ exports[`snapshots match date input with datepicker with controlled input value 
   width: 100%;
   min-height: 1.5em;
   display: inline-block;
-  line-height: 1.5em;
+  line-height: 1;
+  padding: 4px 0;
   overflow: hidden;
   vertical-align: middle;
   white-space: nowrap;
@@ -5619,7 +5619,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
-  line-height: 1.5;
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
@@ -5650,7 +5649,8 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   width: 100%;
   min-height: 1.5em;
   display: inline-block;
-  line-height: 1.5em;
+  line-height: 1;
+  padding: 4px 0;
   overflow: hidden;
   vertical-align: middle;
   white-space: nowrap;

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3461,10 +3461,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   line-height: 1;
   position: relative;
   display: inline-block;
-  word-break: break-word;
   width: 100%;
-  overflow-wrap: break-word;
-  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
@@ -3473,7 +3470,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
   user-select: none;
-  white-space: nowrap;
 }
 
 .c12.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -3498,11 +3494,12 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c12.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
-  height: 100%;
+  min-height: 1.5em;
   display: inline-block;
-  line-height: 24px;
-  vertical-align: top;
+  line-height: 1.5em;
   overflow: hidden;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .c12.fi-dropdown .fi-dropdown_popover {
@@ -5618,10 +5615,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   line-height: 1;
   position: relative;
   display: inline-block;
-  word-break: break-word;
   width: 100%;
-  overflow-wrap: break-word;
-  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
@@ -5630,7 +5624,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
   user-select: none;
-  white-space: nowrap;
 }
 
 .c12.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -5655,11 +5648,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 
 .c12.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
-  height: 100%;
+  min-height: 1.5em;
   display: inline-block;
-  line-height: 24px;
-  vertical-align: top;
+  line-height: 1.5em;
   overflow: hidden;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .c12.fi-dropdown .fi-dropdown_popover {

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3500,7 +3500,8 @@ exports[`snapshots match date input with datepicker with controlled input value 
   width: 100%;
   height: 100%;
   display: inline-block;
-  line-height: 1.5;
+  line-height: 24px;
+  vertical-align: top;
   overflow: hidden;
 }
 
@@ -5656,7 +5657,8 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   width: 100%;
   height: 100%;
   display: inline-block;
-  line-height: 1.5;
+  line-height: 24px;
+  vertical-align: top;
   overflow: hidden;
 }
 

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -78,7 +78,8 @@ export const baseStyles = (
       width: 100%;
       height: 100%;
       display: inline-block;
-      line-height: 1.5;
+      line-height: 24px;
+      vertical-align: top;
       overflow: hidden;
     }
 

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -37,10 +37,7 @@ export const baseStyles = (
       ${input(theme)}
       position: relative;
       display: inline-block;
-      word-break: break-word;
       width: 100%;
-      overflow-wrap: break-word;
-      height: 40px;
       padding: 7px 38px 7px 7px;
       border-color: ${theme.colors.depthDark3};
       text-align: left;
@@ -49,7 +46,6 @@ export const baseStyles = (
       box-shadow: ${theme.shadows.actionElementBoxShadow};
       cursor: pointer;
       user-select: none;
-      white-space: nowrap;
 
       /* stylelint-disable no-descending-specificity */
       &:focus-visible {
@@ -76,11 +72,12 @@ export const baseStyles = (
 
     .fi-dropdown_display-value {
       width: 100%;
-      height: 100%;
+      min-height: 1.5em;
       display: inline-block;
-      line-height: 24px;
-      vertical-align: top;
+      line-height: 1.5em;
       overflow: hidden;
+      vertical-align: middle;
+      white-space: nowrap;
     }
 
     .fi-dropdown_popover {

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -41,7 +41,6 @@ export const baseStyles = (
       padding: 7px 38px 7px 7px;
       border-color: ${theme.colors.depthDark3};
       text-align: left;
-      line-height: 1.5;
       background-color: ${theme.colors.whiteBase};
       box-shadow: ${theme.shadows.actionElementBoxShadow};
       cursor: pointer;
@@ -74,7 +73,8 @@ export const baseStyles = (
       width: 100%;
       min-height: 1.5em;
       display: inline-block;
-      line-height: 1.5em;
+      line-height: 1;
+      padding: ${theme.spacing.insetXs} 0;
       overflow: hidden;
       vertical-align: middle;
       white-space: nowrap;

--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -414,7 +414,8 @@ exports[`Basic dropdown should match snapshot 1`] = `
   width: 100%;
   height: 100%;
   display: inline-block;
-  line-height: 1.5;
+  line-height: 24px;
+  vertical-align: top;
   overflow: hidden;
 }
 
@@ -1116,7 +1117,8 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   width: 100%;
   height: 100%;
   display: inline-block;
-  line-height: 1.5;
+  line-height: 24px;
+  vertical-align: top;
   overflow: hidden;
 }
 
@@ -1811,7 +1813,8 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   width: 100%;
   height: 100%;
   display: inline-block;
-  line-height: 1.5;
+  line-height: 24px;
+  vertical-align: top;
   overflow: hidden;
 }
 
@@ -2406,7 +2409,8 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   width: 100%;
   height: 100%;
   display: inline-block;
-  line-height: 1.5;
+  line-height: 24px;
+  vertical-align: top;
   overflow: hidden;
 }
 

--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -379,7 +379,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
-  line-height: 1.5;
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
@@ -410,7 +409,8 @@ exports[`Basic dropdown should match snapshot 1`] = `
   width: 100%;
   min-height: 1.5em;
   display: inline-block;
-  line-height: 1.5em;
+  line-height: 1;
+  padding: 4px 0;
   overflow: hidden;
   vertical-align: middle;
   white-space: nowrap;
@@ -1079,7 +1079,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
-  line-height: 1.5;
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
@@ -1110,7 +1109,8 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   width: 100%;
   min-height: 1.5em;
   display: inline-block;
-  line-height: 1.5em;
+  line-height: 1;
+  padding: 4px 0;
   overflow: hidden;
   vertical-align: middle;
   white-space: nowrap;
@@ -1772,7 +1772,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
-  line-height: 1.5;
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
@@ -1803,7 +1802,8 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   width: 100%;
   min-height: 1.5em;
   display: inline-block;
-  line-height: 1.5em;
+  line-height: 1;
+  padding: 4px 0;
   overflow: hidden;
   vertical-align: middle;
   white-space: nowrap;
@@ -2365,7 +2365,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
-  line-height: 1.5;
   background-color: hsl(0, 0%, 100%);
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
@@ -2396,7 +2395,8 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   width: 100%;
   min-height: 1.5em;
   display: inline-block;
-  line-height: 1.5em;
+  line-height: 1;
+  padding: 4px 0;
   overflow: hidden;
   vertical-align: middle;
   white-space: nowrap;

--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -375,10 +375,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   line-height: 1;
   position: relative;
   display: inline-block;
-  word-break: break-word;
   width: 100%;
-  overflow-wrap: break-word;
-  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
@@ -387,7 +384,6 @@ exports[`Basic dropdown should match snapshot 1`] = `
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
   user-select: none;
-  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -412,11 +408,12 @@ exports[`Basic dropdown should match snapshot 1`] = `
 
 .c1.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
-  height: 100%;
+  min-height: 1.5em;
   display: inline-block;
-  line-height: 24px;
-  vertical-align: top;
+  line-height: 1.5em;
   overflow: hidden;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_popover {
@@ -1078,10 +1075,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   line-height: 1;
   position: relative;
   display: inline-block;
-  word-break: break-word;
   width: 100%;
-  overflow-wrap: break-word;
-  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
@@ -1090,7 +1084,6 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
   user-select: none;
-  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -1115,11 +1108,12 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 
 .c1.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
-  height: 100%;
+  min-height: 1.5em;
   display: inline-block;
-  line-height: 24px;
-  vertical-align: top;
+  line-height: 1.5em;
   overflow: hidden;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_popover {
@@ -1774,10 +1768,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   line-height: 1;
   position: relative;
   display: inline-block;
-  word-break: break-word;
   width: 100%;
-  overflow-wrap: break-word;
-  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
@@ -1786,7 +1777,6 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
   user-select: none;
-  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -1811,11 +1801,12 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 
 .c1.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
-  height: 100%;
+  min-height: 1.5em;
   display: inline-block;
-  line-height: 24px;
-  vertical-align: top;
+  line-height: 1.5em;
   overflow: hidden;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_popover {
@@ -2370,10 +2361,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   line-height: 1;
   position: relative;
   display: inline-block;
-  word-break: break-word;
   width: 100%;
-  overflow-wrap: break-word;
-  height: 40px;
   padding: 7px 38px 7px 7px;
   border-color: hsl(201, 7%, 58%);
   text-align: left;
@@ -2382,7 +2370,6 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   box-shadow: 0 1px 2px 0 hsla(214, 100%, 24%, 0.1) inset;
   cursor: pointer;
   user-select: none;
-  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_button:focus-visible {
@@ -2407,11 +2394,12 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 
 .c1.fi-dropdown .fi-dropdown_display-value {
   width: 100%;
-  height: 100%;
+  min-height: 1.5em;
   display: inline-block;
-  line-height: 24px;
-  vertical-align: top;
+  line-height: 1.5em;
   overflow: hidden;
+  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .c1.fi-dropdown .fi-dropdown_popover {


### PR DESCRIPTION
## Description
This PR Fixes a couple of accessibility issues where an increased font size caused the layout to break or some content not be legible. These issues are fixed with minor tweaks to styles in Dropdown and Breadcrumb components.

## Motivation and Context
These are the last two remaining accessibility issues known in this library, and needed to be addressed.

## How Has This Been Tested?
So far tested in styleguidist using Chrome and Firefox

## Release notes
### Breadcrumb
- **Breaking change:** remove fixed height to support font sizes incresed by user
### Dropdown
- **Breaking change:** Adjust styles of main dropdown button content to support larger font sizes
