### PR TITLE
Feature/wizard navigation error status

### DIFF
--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
@@ -6,25 +6,27 @@ The `<WizardNavigation>` component is used for user interactions that progress i
 - Provide the navigation a descriptive `heading` and use the correct heading level depending on the navigation's location in the page structure.
 - When page content changes along with the phases, make sure this gets conveyed to screen reader users as well
 
-A `<WizardNavigationItem>` can have one of these 6 statuses:
+A `<WizardNavigationItem>` can have one of these statuses:
 
 - `'default'`: An incomplete step which the user can reach
 - `'completed'`: A step where the user has filled all required information
 - `'error'`: Step that is invalid
-- `'current'`: Currently active step
-- `'current-completed'`: Combination of current and completed statuses
-- `'current-error'`: Combination of current and error statuses
 - `'coming'`: A step which is not reachable at the moment (but will become available when e.g. the previous steps have been completed)
 - `'disabled'`: A disabled step which will not become reachable. In most cases you should use `'coming'` instead of this
+- `'current'`: Currently active step - **deprecated, use status `'default'` with prop `active`**
+- `'current-completed'`: Combination of current and completed statuses - **deprecated, use status `'completed'` with prop `active`**
+
+A `<WizardNavigationItem>` has boolean prop `active` to indicate item being the current step.
 
 <div style="border: 1px solid #c8cdd0; padding: 20px 20px 4px 20px; background: #eaf2fa; margin-bottom: 30px;">
 #### Important!
 
 To ensure accessibility, the following aria-attributes must be manually added to the inner `<RouterLink>` components:
 
-- `aria-current="step"` when the wrapping item has `status="current"`
+- `aria-current="step"` when the wrapping item has prop `active` (or deprecated status `current`/`current-completed`)
 - `aria-disabled` when the wrapping item has `status="coming"` or `status="disabled"`
 - A descriptive `aria-label` for any link where the wrapping item has `status="completed"`. The aria-label should indicate that the step is completed
+- A descriptive `aria-label` for any link where the wrapping item has `status="error"`. The aria-label should indicate that the step is invalid
 
 Please refer to the code below for examples.
 
@@ -68,7 +70,7 @@ const Comp = (props) => {
     <WizardNavigationItem status="default">
       <RouterLink href="#">2. Mandate themes</RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem status="current">
+    <WizardNavigationItem status="default" active>
       <RouterLink aria-current="step" href="#">
         3. Selected mandate themes
       </RouterLink>
@@ -114,7 +116,7 @@ const Comp = (props) => {
     <WizardNavigationItem status="error">
       <RouterLink href="#">2. Mandate themes</RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem status="current-error">
+    <WizardNavigationItem status="error" active>
       <RouterLink aria-current="step" href="#">
         3. Selected mandate themes
       </RouterLink>
@@ -168,7 +170,7 @@ const Comp = (props) => {
     <WizardNavigationItem status="default">
       <RouterLink href="#">2. Mandate themes</RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem status="current">
+    <WizardNavigationItem status="default" active>
       <RouterLink aria-current="step" href="#">
         3. Selected mandate themes
       </RouterLink>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.md
@@ -9,9 +9,11 @@ The `<WizardNavigation>` component is used for user interactions that progress i
 A `<WizardNavigationItem>` can have one of these 6 statuses:
 
 - `'default'`: An incomplete step which the user can reach
-- `'current'`: Currently active step
 - `'completed'`: A step where the user has filled all required information
+- `'error'`: Step that is invalid
+- `'current'`: Currently active step
 - `'current-completed'`: Combination of current and completed statuses
+- `'current-error'`: Combination of current and error statuses
 - `'coming'`: A step which is not reachable at the moment (but will become available when e.g. the previous steps have been completed)
 - `'disabled'`: A disabled step which will not become reachable. In most cases you should use `'coming'` instead of this
 
@@ -78,6 +80,52 @@ const Comp = (props) => {
     </WizardNavigationItem>
     <WizardNavigationItem status="coming">
       <RouterLink aria-disabled role="link">
+        5. Summary and validation
+      </RouterLink>
+    </WizardNavigationItem>
+  </WizardNavigation>
+</div>;
+```
+
+### Error and disabled states
+
+```js
+import {
+  WizardNavigation,
+  WizardNavigationItem,
+  RouterLink
+} from 'suomifi-ui-components';
+
+const Comp = (props) => {
+  const { children, ...passProps } = props;
+  return <div {...passProps}>{props.children}</div>;
+};
+
+<div style={{ width: '350px' }}>
+  <WizardNavigation heading="Steps" aria-label="Steps">
+    <WizardNavigationItem status="completed">
+      <RouterLink
+        href="https://suomi.fi"
+        aria-label="1. Parties. This step is completed"
+      >
+        1. Parties
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="error">
+      <RouterLink href="#">2. Mandate themes</RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="current-error">
+      <RouterLink aria-current="step" href="#">
+        3. Selected mandate themes
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="disabled">
+      <RouterLink aria-disabled role="link" href="#">
+        4. Validity
+      </RouterLink>
+    </WizardNavigationItem>
+    <WizardNavigationItem status="coming">
+      <RouterLink aria-disabled role="link" href="#">
         5. Summary and validation
       </RouterLink>
     </WizardNavigationItem>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/WizardNavigation.test.tsx
@@ -16,13 +16,13 @@ const TestWizardNavigation = (
         2. Step
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem status="current">
-      <RouterLink aria-current="step" href="#">
+    <WizardNavigationItem status="error">
+      <RouterLink href="#" aria-label="Step 3. This step has an error">
         3. Step
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem status="coming">
-      <RouterLink aria-disabled tabIndex={-1} href="#">
+    <WizardNavigationItem status="default" active>
+      <RouterLink aria-current="step" href="#">
         4. Step
       </RouterLink>
     </WizardNavigationItem>
@@ -31,14 +31,19 @@ const TestWizardNavigation = (
         5. Step
       </RouterLink>
     </WizardNavigationItem>
-    <WizardNavigationItem status="disabled">
+    <WizardNavigationItem status="coming">
       <RouterLink aria-disabled tabIndex={-1} href="#">
         6. Step
       </RouterLink>
     </WizardNavigationItem>
+    <WizardNavigationItem status="disabled">
+      <RouterLink aria-disabled tabIndex={-1} href="#">
+        7. Step
+      </RouterLink>
+    </WizardNavigationItem>
     <WizardNavigationItem status="coming">
       <RouterLink asComponent="button" aria-disabled tabIndex={-1}>
-        7. Step
+        8. Step
       </RouterLink>
     </WizardNavigationItem>
   </WizardNavigation>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -25,6 +25,30 @@ exports[`calling render with the same component on the same container does not r
   cursor: inherit;
 }
 
+.c10 {
+  vertical-align: baseline;
+}
+
+.c10.fi-icon {
+  display: inline-block;
+}
+
+.c10 .fi-icon-base-fill {
+  fill: currentColor;
+}
+
+.c10 .fi-icon-base-stroke {
+  stroke: currentColor;
+}
+
+.c10.fi-icon--cursor-pointer {
+  cursor: pointer;
+}
+
+.c10.fi-icon--cursor-pointer * {
+  cursor: inherit;
+}
+
 .c7 {
   line-height: 1.15;
   -ms-text-size-adjust: 100%;
@@ -407,7 +431,8 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
-.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus,
+.c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
   text-decoration: none;
   color: hsl(0, 0%, 13%);
 }
@@ -451,51 +476,8 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
-.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
-  text-decoration: none;
-  color: hsl(0, 0%, 13%);
-}
-
-.c5.fi-wizard-navigation-item--current-error {
-  background: hsl(212, 63%, 95%);
-  border-left: 4px solid hsl(212, 63%, 45%);
-  padding-left: calc(20px - 4px);
-}
-
-.c5.fi-wizard-navigation-item--current-error:after {
-  left: 29px;
-  height: 10px;
-}
-
-.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
-  display: flex;
-  margin-right: 10px;
-}
-
-.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon .fi-icon {
-  color: hsl(3, 59%, 43%);
-  background: hsl(0, 0%, 100%);
-  border-radius: 50%;
-  width: 26px;
-  height: 26px;
-}
-
-.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
-  pointer-events: none;
-  color: hsl(0, 0%, 13%);
-  letter-spacing: 0;
-  text-decoration: none;
-  word-break: break-word;
-  overflow-wrap: break-word;
-  -webkit-font-smoothing: antialiased;
-  font-family: 'Source Sans 3','Helvetica Neue','Arial',sans-serif;
-  font-size: 16px;
-  line-height: 1.5;
-  font-weight: 600;
-}
-
-.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
-.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus,
+.c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
   text-decoration: none;
   color: hsl(0, 0%, 13%);
 }
@@ -584,6 +566,38 @@ exports[`calling render with the same component on the same container does not r
 
 .c5.fi-wizard-navigation-item--error .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
   color: hsl(212, 63%, 45%);
+}
+
+.c5.fi-wizard-navigation-item--active {
+  background: hsl(212, 63%, 95%);
+  border-left: 4px solid hsl(212, 63%, 45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--active:after {
+  left: 29px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--active .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(0, 0%, 13%);
+  letter-spacing: 0;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans 3','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.c5.fi-wizard-navigation-item--active .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
+.c5.fi-wizard-navigation-item--active .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus,
+.c5.fi-wizard-navigation-item--active .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  text-decoration: none;
+  color: hsl(0, 0%, 13%);
 }
 
 .c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
@@ -818,7 +832,42 @@ exports[`calling render with the same component on the same container does not r
         </div>
       </li>
       <li
-        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--current"
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--error"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="fi-icon c10"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                class="fi-icon-base-fill"
+                d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0Zm.71 17.29c-.38-.37-1.05-.37-1.42 0-.181.19-.29.44-.29.71 0 .26.109.52.29.71.189.18.45.29.71.29.26 0 .52-.11.71-.29.18-.19.29-.45.29-.71 0-.27-.11-.52-.29-.71ZM12 5a1 1 0 0 0-1 1v8a1 1 0 1 0 2 0V6a1 1 0 0 0-1-1Z"
+                fill="#222"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <a
+            aria-label="Step 3. This step has an error"
+            class="c7 fi-link fi-link--router c8"
+            href="#"
+          >
+            3. Step
+          </a>
+        </div>
+      </li>
+      <li
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--default fi-wizard-navigation-item--active"
       >
         <div
           class="c0 fi-wizard-navigation-item_inner-wrapper"
@@ -830,25 +879,6 @@ exports[`calling render with the same component on the same container does not r
             aria-current="step"
             class="c7 fi-link fi-link--router c8"
             href="#"
-          >
-            3. Step
-          </a>
-        </div>
-      </li>
-      <li
-        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--coming"
-      >
-        <div
-          class="c0 fi-wizard-navigation-item_inner-wrapper"
-        >
-          <span
-            class="c6 fi-wizard-navigation-item_left-icon"
-          />
-          <a
-            aria-disabled="true"
-            class="c7 fi-link fi-link--router c8"
-            href="#"
-            tabindex="-1"
           >
             4. Step
           </a>
@@ -874,8 +904,7 @@ exports[`calling render with the same component on the same container does not r
         </div>
       </li>
       <li
-        aria-disabled="true"
-        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--disabled"
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--coming"
       >
         <div
           class="c0 fi-wizard-navigation-item_inner-wrapper"
@@ -894,6 +923,26 @@ exports[`calling render with the same component on the same container does not r
         </div>
       </li>
       <li
+        aria-disabled="true"
+        class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--disabled"
+      >
+        <div
+          class="c0 fi-wizard-navigation-item_inner-wrapper"
+        >
+          <span
+            class="c6 fi-wizard-navigation-item_left-icon"
+          />
+          <a
+            aria-disabled="true"
+            class="c7 fi-link fi-link--router c8"
+            href="#"
+            tabindex="-1"
+          >
+            7. Step
+          </a>
+        </div>
+      </li>
+      <li
         class="c4 c5 fi-wizard-navigation-item fi-wizard-navigation-item--coming"
       >
         <div
@@ -907,7 +956,7 @@ exports[`calling render with the same component on the same container does not r
             class="fi-link fi-link--router c8"
             tabindex="-1"
           >
-            7. Step
+            8. Step
           </button>
         </div>
       </li>

--- a/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
+++ b/src/core/Navigation/WizardNavigation/WizardNavigation/__snapshots__/WizardNavigation.test.tsx.snap
@@ -325,7 +325,6 @@ exports[`calling render with the same component on the same container does not r
   border: none;
   padding: 0;
   margin: 0;
-  margin-bottom: 1px;
 }
 
 .c5.fi-wizard-navigation-item .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
@@ -344,17 +343,12 @@ exports[`calling render with the same component on the same container does not r
 }
 
 .c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 50%;
-  border: 1px solid hsl(201, 7%, 58%);
   width: 26px;
   height: 26px;
-  line-height: 26px;
-  font-size: 18px;
   margin-right: 10px;
+  border: 1px solid hsl(201, 7%, 58%);
   background: hsl(0, 0%, 100%);
+  border-radius: 50%;
 }
 
 .c5.fi-wizard-navigation-item--default .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
@@ -384,28 +378,18 @@ exports[`calling render with the same component on the same container does not r
   padding-left: calc(20px - 4px);
 }
 
-.c5.fi-wizard-navigation-item--current:hover {
-  border-left: 4px solid hsl(212, 63%, 45%);
-  padding-left: calc(20px - 4px);
-}
-
 .c5.fi-wizard-navigation-item--current:after {
   left: 29px;
   height: 10px;
 }
 
 .c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 50%;
-  border: 1px solid hsl(201, 7%, 58%);
   width: 26px;
   height: 26px;
-  line-height: 26px;
-  font-size: 18px;
   margin-right: 10px;
+  border: 1px solid hsl(201, 7%, 58%);
   background: hsl(0, 0%, 100%);
+  border-radius: 50%;
 }
 
 .c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
@@ -420,7 +404,6 @@ exports[`calling render with the same component on the same container does not r
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  margin-bottom: 1px;
 }
 
 .c5.fi-wizard-navigation-item--current .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
@@ -435,11 +418,6 @@ exports[`calling render with the same component on the same container does not r
   padding-left: calc(20px - 4px);
 }
 
-.c5.fi-wizard-navigation-item--current-completed:hover {
-  border-left: 4px solid hsl(212, 63%, 45%);
-  padding-left: calc(20px - 4px);
-}
-
 .c5.fi-wizard-navigation-item--current-completed:after {
   left: 29px;
   height: 10px;
@@ -447,22 +425,15 @@ exports[`calling render with the same component on the same container does not r
 
 .c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 50%;
-  border: 1px solid hsl(165, 90%, 27%);
-  width: 26px;
-  height: 26px;
-  line-height: 26px;
-  font-size: 18px;
   margin-right: 10px;
-  background: hsl(165, 90%, 27%);
-  color: hsl(0, 0%, 100%);
 }
 
 .c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon .fi-icon {
-  width: 10px;
-  height: 10px;
+  color: hsl(165, 90%, 27%);
+  background: hsl(0, 0%, 100%);
+  border-radius: 50%;
+  width: 26px;
+  height: 26px;
 }
 
 .c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
@@ -477,11 +448,54 @@ exports[`calling render with the same component on the same container does not r
   font-size: 16px;
   line-height: 1.5;
   font-weight: 600;
-  margin-bottom: 1px;
 }
 
 .c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
 .c5.fi-wizard-navigation-item--current-completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
+  text-decoration: none;
+  color: hsl(0, 0%, 13%);
+}
+
+.c5.fi-wizard-navigation-item--current-error {
+  background: hsl(212, 63%, 95%);
+  border-left: 4px solid hsl(212, 63%, 45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--current-error:after {
+  left: 29px;
+  height: 10px;
+}
+
+.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  display: flex;
+  margin-right: 10px;
+}
+
+.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon .fi-icon {
+  color: hsl(3, 59%, 43%);
+  background: hsl(0, 0%, 100%);
+  border-radius: 50%;
+  width: 26px;
+  height: 26px;
+}
+
+.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  pointer-events: none;
+  color: hsl(0, 0%, 13%);
+  letter-spacing: 0;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans 3','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 600;
+}
+
+.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover,
+.c5.fi-wizard-navigation-item--current-error .fi-wizard-navigation-item_inner-wrapper .fi-link--router:focus {
   text-decoration: none;
   color: hsl(0, 0%, 13%);
 }
@@ -497,22 +511,15 @@ exports[`calling render with the same component on the same container does not r
 
 .c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 50%;
-  border: 1px solid hsl(165, 90%, 27%);
-  width: 26px;
-  height: 26px;
-  line-height: 26px;
-  font-size: 18px;
   margin-right: 10px;
-  background: hsl(165, 90%, 27%);
-  color: hsl(0, 0%, 100%);
 }
 
 .c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon .fi-icon {
-  width: 10px;
-  height: 10px;
+  color: hsl(165, 90%, 27%);
+  background: hsl(0, 0%, 100%);
+  border-radius: 50%;
+  width: 26px;
+  height: 26px;
 }
 
 .c5.fi-wizard-navigation-item--completed .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
@@ -536,12 +543,53 @@ exports[`calling render with the same component on the same container does not r
   color: hsl(212, 63%, 45%);
 }
 
+.c5.fi-wizard-navigation-item--error:hover {
+  border-left: 4px solid hsl(212, 63%, 45%);
+  padding-left: calc(20px - 4px);
+}
+
+.c5.fi-wizard-navigation-item--error:hover:after {
+  left: 29px;
+}
+
+.c5.fi-wizard-navigation-item--error .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
+  display: flex;
+  margin-right: 10px;
+}
+
+.c5.fi-wizard-navigation-item--error .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon .fi-icon {
+  color: hsl(3, 59%, 43%);
+  background: hsl(0, 0%, 100%);
+  border-radius: 50%;
+  width: 26px;
+  height: 26px;
+}
+
+.c5.fi-wizard-navigation-item--error .fi-wizard-navigation-item_inner-wrapper .fi-link--router {
+  letter-spacing: 0;
+  text-decoration: none;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  font-family: 'Source Sans 3','Helvetica Neue','Arial',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.c5.fi-wizard-navigation-item--error .fi-wizard-navigation-item_inner-wrapper .fi-link--router:hover {
+  text-decoration: underline;
+}
+
+.c5.fi-wizard-navigation-item--error .fi-wizard-navigation-item_inner-wrapper .fi-link--router:visited {
+  color: hsl(212, 63%, 45%);
+}
+
 .c5.fi-wizard-navigation-item--coming .fi-wizard-navigation-item_inner-wrapper .fi-wizard-navigation-item_left-icon {
   position: relative;
   width: 26px;
   height: 26px;
-  line-height: 26px;
-  font-size: 18px;
   margin-right: 10px;
 }
 
@@ -586,8 +634,6 @@ exports[`calling render with the same component on the same container does not r
   position: relative;
   width: 26px;
   height: 26px;
-  line-height: 26px;
-  font-size: 18px;
   margin-right: 10px;
 }
 
@@ -750,13 +796,13 @@ exports[`calling render with the same component on the same container does not r
               class="fi-icon c9"
               focusable="false"
               height="1em"
-              viewBox="0 0 20 20"
+              viewBox="0 0 24 24"
               width="1em"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
                 class="fi-icon-base-fill"
-                d="M19.447 5.384 8 17.42a1.82 1.82 0 0 1-2.667 0L.552 12.394a2.059 2.059 0 0 1 0-2.805 1.822 1.822 0 0 1 2.666 0l3.449 3.625L16.78 2.581a1.82 1.82 0 0 1 2.666 0 2.053 2.053 0 0 1 0 2.803"
+                d="M12 0c6.617 0 12 5.383 12 12s-5.383 12-12 12S0 18.617 0 12 5.383 0 12 0Zm5.65 8.24a1 1 0 0 0-1.41.11l-5.296 6.18-2.237-2.237a1 1 0 1 0-1.414 1.414l3 3a1 1 0 0 0 1.466-.056l6-7a1 1 0 0 0-.108-1.41Z"
                 fill="#222"
                 fill-rule="evenodd"
               />

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -2,7 +2,7 @@ import { font } from '../../../theme/reset';
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
 
-export const currentHighlight = (theme: SuomifiTheme) => css`
+const currentHighlight = (theme: SuomifiTheme) => css`
   background: ${theme.colors.highlightLight3};
   border-left: 4px solid ${theme.colors.highlightBase};
   padding-left: calc(${theme.spacing.m} - 4px);
@@ -13,7 +13,7 @@ export const currentHighlight = (theme: SuomifiTheme) => css`
   }
 `;
 
-export const hoverHighlight = (theme: SuomifiTheme) => css`
+const hoverHighlight = (theme: SuomifiTheme) => css`
   &:hover {
     border-left: 4px solid ${theme.colors.highlightBase};
     padding-left: calc(${theme.spacing.m} - 4px);
@@ -24,7 +24,7 @@ export const hoverHighlight = (theme: SuomifiTheme) => css`
   }
 `;
 
-export const defaultLink = (theme: SuomifiTheme) => css`
+const defaultLink = (theme: SuomifiTheme) => css`
   ${font(theme)('actionElementInnerText')}
   cursor: pointer;
   &:hover {
@@ -35,31 +35,32 @@ export const defaultLink = (theme: SuomifiTheme) => css`
   }
 `;
 
-export const currentLink = (theme: SuomifiTheme) => css`
+const currentLink = (theme: SuomifiTheme) => css`
   pointer-events: none;
   color: ${theme.colors.blackBase};
   ${font(theme)('actionElementInnerTextBold')}
   &:hover,
-  &:focus {
+  &:focus,
+  &:visited {
     text-decoration: none;
     color: ${theme.colors.blackBase};
   }
 `;
 
-export const stepBase = (theme: SuomifiTheme) => css`
+const stepBase = (theme: SuomifiTheme) => css`
   width: 26px;
   height: 26px;
   margin-right: ${theme.spacing.xs};
 `;
 
-export const stepCircle = (theme: SuomifiTheme) => css`
+const stepCircle = (theme: SuomifiTheme) => css`
   ${stepBase(theme)};
   border: 1px solid ${theme.colors.depthDark3};
   background: ${theme.colors.whiteBase};
   border-radius: 50%;
 `;
 
-export const stepIcon = (theme: SuomifiTheme, color: string) => css`
+const stepIcon = (theme: SuomifiTheme, color: string) => css`
   .fi-wizard-navigation-item_left-icon {
     display: flex;
     margin-right: ${theme.spacing.xs};
@@ -164,18 +165,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       }
     }
 
-    &--current-error {
-      ${currentHighlight(theme)};
-
-      .fi-wizard-navigation-item_inner-wrapper {
-        ${stepIcon(theme, theme.colors.alertBase)};
-
-        .fi-link--router {
-          ${currentLink(theme)};
-        }
-      }
-    }
-
     &--completed {
       ${hoverHighlight(theme)};
 
@@ -196,6 +185,16 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
         .fi-link--router {
           ${defaultLink(theme)};
+        }
+      }
+    }
+
+    &--active {
+      ${currentHighlight(theme)};
+
+      .fi-wizard-navigation-item_inner-wrapper {
+        .fi-link--router {
+          ${currentLink(theme)};
         }
       }
     }

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.baseStyles.tsx
@@ -2,6 +2,77 @@ import { font } from '../../../theme/reset';
 import { css } from 'styled-components';
 import { SuomifiTheme } from '../../../theme';
 
+export const currentHighlight = (theme: SuomifiTheme) => css`
+  background: ${theme.colors.highlightLight3};
+  border-left: 4px solid ${theme.colors.highlightBase};
+  padding-left: calc(${theme.spacing.m} - 4px);
+
+  &:after {
+    left: 29px;
+    height: 10px;
+  }
+`;
+
+export const hoverHighlight = (theme: SuomifiTheme) => css`
+  &:hover {
+    border-left: 4px solid ${theme.colors.highlightBase};
+    padding-left: calc(${theme.spacing.m} - 4px);
+
+    &:after {
+      left: 29px;
+    }
+  }
+`;
+
+export const defaultLink = (theme: SuomifiTheme) => css`
+  ${font(theme)('actionElementInnerText')}
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
+  &:visited {
+    color: ${theme.colors.highlightBase};
+  }
+`;
+
+export const currentLink = (theme: SuomifiTheme) => css`
+  pointer-events: none;
+  color: ${theme.colors.blackBase};
+  ${font(theme)('actionElementInnerTextBold')}
+  &:hover,
+  &:focus {
+    text-decoration: none;
+    color: ${theme.colors.blackBase};
+  }
+`;
+
+export const stepBase = (theme: SuomifiTheme) => css`
+  width: 26px;
+  height: 26px;
+  margin-right: ${theme.spacing.xs};
+`;
+
+export const stepCircle = (theme: SuomifiTheme) => css`
+  ${stepBase(theme)};
+  border: 1px solid ${theme.colors.depthDark3};
+  background: ${theme.colors.whiteBase};
+  border-radius: 50%;
+`;
+
+export const stepIcon = (theme: SuomifiTheme, color: string) => css`
+  .fi-wizard-navigation-item_left-icon {
+    display: flex;
+    margin-right: ${theme.spacing.xs};
+    .fi-icon {
+      color: ${color};
+      background: ${theme.colors.whiteBase};
+      border-radius: 50%;
+      width: 26px;
+      height: 26px;
+    }
+  }
+`;
+
 export const baseStyles = (theme: SuomifiTheme) => css`
   /* stylelint-disable no-descending-specificity */
   /* Nested :hover etc selectors do not work well with this rule. */
@@ -47,7 +118,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         border: none;
         padding: 0;
         margin: 0;
-        margin-bottom: 1px; /* Compensate font size difference */
         &:focus {
           outline: 0;
           border: none;
@@ -57,170 +127,75 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
 
     &--default {
-      &:hover {
-        border-left: 4px solid ${theme.colors.highlightBase};
-        padding-left: calc(${theme.spacing.m} - 4px);
+      ${hoverHighlight(theme)};
 
-        &:after {
-          left: 29px;
-        }
-      }
       .fi-wizard-navigation-item_inner-wrapper {
         .fi-wizard-navigation-item_left-icon {
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          border-radius: 50%;
-          border: 1px solid ${theme.colors.depthDark3};
-          width: 26px;
-          height: 26px;
-          line-height: 26px;
-          font-size: 18px;
-          margin-right: ${theme.spacing.xs};
-          background: ${theme.colors.whiteBase};
+          ${stepCircle(theme)};
         }
         .fi-link--router {
-          ${font(theme)('actionElementInnerText')}
-          cursor: pointer;
-          &:hover {
-            text-decoration: underline;
-          }
-          &:visited {
-            color: ${theme.colors.highlightBase};
-          }
+          ${defaultLink(theme)};
         }
       }
     }
 
     &--current {
-      &:hover {
-        border-left: 4px solid ${theme.colors.highlightBase};
-        padding-left: calc(${theme.spacing.m} - 4px);
-      }
-      background: ${theme.colors.highlightLight3};
-      border-left: 4px solid ${theme.colors.highlightBase};
-      padding-left: calc(${theme.spacing.m} - 4px);
-
-      &:after {
-        left: 29px;
-        height: 10px;
-      }
+      ${currentHighlight(theme)};
 
       .fi-wizard-navigation-item_inner-wrapper {
         .fi-wizard-navigation-item_left-icon {
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          border-radius: 50%;
-          border: 1px solid ${theme.colors.depthDark3};
-          width: 26px;
-          height: 26px;
-          line-height: 26px;
-          font-size: 18px;
-          margin-right: ${theme.spacing.xs};
-          background: ${theme.colors.whiteBase};
+          ${stepCircle(theme)};
         }
         .fi-link--router {
-          pointer-events: none;
-          color: ${theme.colors.blackBase};
-          ${font(theme)('actionElementInnerTextBold')}
-          &:hover,
-          &:focus {
-            text-decoration: none;
-            color: ${theme.colors.blackBase};
-          }
-          margin-bottom: 1px; /* Compensate font size difference */
+          ${currentLink(theme)};
         }
       }
     }
 
     &--current-completed {
-      &:hover {
-        border-left: 4px solid ${theme.colors.highlightBase};
-        padding-left: calc(${theme.spacing.m} - 4px);
-      }
-
-      background: ${theme.colors.highlightLight3};
-      border-left: 4px solid ${theme.colors.highlightBase};
-      padding-left: calc(${theme.spacing.m} - 4px);
-
-      &:after {
-        left: 29px;
-        height: 10px;
-      }
+      ${currentHighlight(theme)};
 
       .fi-wizard-navigation-item_inner-wrapper {
-        .fi-wizard-navigation-item_left-icon {
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          border-radius: 50%;
-          border: 1px solid ${theme.colors.successDark1};
-          width: 26px;
-          height: 26px;
-          line-height: 26px;
-          font-size: 18px;
-          margin-right: ${theme.spacing.xs};
-          background: ${theme.colors.successDark1};
-          color: ${theme.colors.whiteBase};
+        ${stepIcon(theme, theme.colors.successDark1)};
 
-          .fi-icon {
-            width: 10px;
-            height: 10px;
-          }
-        }
         .fi-link--router {
-          pointer-events: none;
-          color: ${theme.colors.blackBase};
-          ${font(theme)('actionElementInnerTextBold')}
-          &:hover,
-          &:focus {
-            text-decoration: none;
-            color: ${theme.colors.blackBase};
-          }
-          margin-bottom: 1px; /* Compensate font size difference */
+          ${currentLink(theme)};
+        }
+      }
+    }
+
+    &--current-error {
+      ${currentHighlight(theme)};
+
+      .fi-wizard-navigation-item_inner-wrapper {
+        ${stepIcon(theme, theme.colors.alertBase)};
+
+        .fi-link--router {
+          ${currentLink(theme)};
         }
       }
     }
 
     &--completed {
-      &:hover {
-        border-left: 4px solid ${theme.colors.highlightBase};
-        padding-left: calc(${theme.spacing.m} - 4px);
+      ${hoverHighlight(theme)};
 
-        &:after {
-          left: 29px;
+      .fi-wizard-navigation-item_inner-wrapper {
+        ${stepIcon(theme, theme.colors.successDark1)};
+
+        .fi-link--router {
+          ${defaultLink(theme)};
         }
       }
-      .fi-wizard-navigation-item_inner-wrapper {
-        .fi-wizard-navigation-item_left-icon {
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          border-radius: 50%;
-          border: 1px solid ${theme.colors.successDark1};
-          width: 26px;
-          height: 26px;
-          line-height: 26px;
-          font-size: 18px;
-          margin-right: ${theme.spacing.xs};
-          background: ${theme.colors.successDark1};
-          color: ${theme.colors.whiteBase};
+    }
 
-          .fi-icon {
-            width: 10px;
-            height: 10px;
-          }
-        }
+    &--error {
+      ${hoverHighlight(theme)};
+
+      .fi-wizard-navigation-item_inner-wrapper {
+        ${stepIcon(theme, theme.colors.alertBase)};
+
         .fi-link--router {
-          ${font(theme)('actionElementInnerText')}
-          cursor: pointer;
-          &:hover {
-            text-decoration: underline;
-          }
-          &:visited {
-            color: ${theme.colors.highlightBase};
-          }
+          ${defaultLink(theme)};
         }
       }
     }
@@ -229,11 +204,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       .fi-wizard-navigation-item_inner-wrapper {
         .fi-wizard-navigation-item_left-icon {
           position: relative;
-          width: 26px;
-          height: 26px;
-          line-height: 26px;
-          font-size: 18px;
-          margin-right: ${theme.spacing.xs};
+          ${stepBase(theme)};
           &:after {
             position: absolute;
             top: 10px;
@@ -267,11 +238,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       .fi-wizard-navigation-item_inner-wrapper {
         .fi-wizard-navigation-item_left-icon {
           position: relative;
-          width: 26px;
-          height: 26px;
-          line-height: 26px;
-          font-size: 18px;
-          margin-right: ${theme.spacing.xs};
+          ${stepBase(theme)};
           &:after {
             position: absolute;
             top: -5px;

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
@@ -4,7 +4,7 @@ import { HtmlDiv, HtmlLi, HtmlSpan } from '../../../../reset';
 import { SuomifiThemeConsumer, SuomifiThemeProp } from '../../../theme';
 import { baseStyles } from './WizardNavigationItem.baseStyles';
 import { styled } from 'styled-components';
-import { IconCheck } from 'suomifi-icons';
+import { IconCheckCircleFilled, IconErrorFilled } from 'suomifi-icons';
 
 export interface WizardNavigationItemProps {
   /** CSS class for custom styles */
@@ -16,7 +16,9 @@ export interface WizardNavigationItemProps {
     | 'default'
     | 'current'
     | 'current-completed'
+    | 'current-error'
     | 'completed'
+    | 'error'
     | 'coming'
     | 'disabled';
 }
@@ -25,7 +27,9 @@ const baseClassName = 'fi-wizard-navigation-item';
 const defaultClassName = `${baseClassName}--default`;
 const currentClassName = `${baseClassName}--current`;
 const currentCompletedClassName = `${baseClassName}--current-completed`;
+const currentErrorClassName = `${baseClassName}--current-error`;
 const completedClassName = `${baseClassName}--completed`;
+const errorClassName = `${baseClassName}--error`;
 const comingClassName = `${baseClassName}--coming`;
 const disabledClassName = `${baseClassName}--disabled`;
 
@@ -43,7 +47,9 @@ const BaseWizardNavigationItem = ({
       [defaultClassName]: status === 'default',
       [currentClassName]: status === 'current',
       [currentCompletedClassName]: status === 'current-completed',
+      [currentErrorClassName]: status === 'current-error',
       [completedClassName]: status === 'completed',
+      [errorClassName]: status === 'error',
       [comingClassName]: status === 'coming',
       [disabledClassName]: status === 'disabled',
     })}
@@ -53,7 +59,10 @@ const BaseWizardNavigationItem = ({
     <HtmlDiv className={innerWrapperClassName}>
       <HtmlSpan className={leftIconClassName}>
         {(status === 'completed' || status === 'current-completed') && (
-          <IconCheck />
+          <IconCheckCircleFilled />
+        )}
+        {(status === 'error' || status === 'current-error') && (
+          <IconErrorFilled />
         )}
       </HtmlSpan>
       {children}

--- a/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
+++ b/src/core/Navigation/WizardNavigation/WizardNavigationItem/WizardNavigationItem.tsx
@@ -11,28 +11,30 @@ export interface WizardNavigationItemProps {
   className?: string;
   /** Use the polymorphic `<RouterLink>` component as child to get intended CSS styling */
   children: ReactNode;
-  /** Status of the item. Affects styling and element reachability */
+  /** Status of the item. Affects styling and element reachability. Note: 'current' and 'current-completed'
+   * are deprecated in favor of the 'active' prop */
   status:
     | 'default'
     | 'current'
     | 'current-completed'
-    | 'current-error'
     | 'completed'
     | 'error'
     | 'coming'
     | 'disabled';
+  /** Whether the item is the active step. Replaces status 'current': use status 'default' + active.
+   * Replaces status 'current-completed': use status 'completed' + active */
+  active?: boolean;
 }
 
 const baseClassName = 'fi-wizard-navigation-item';
 const defaultClassName = `${baseClassName}--default`;
 const currentClassName = `${baseClassName}--current`;
 const currentCompletedClassName = `${baseClassName}--current-completed`;
-const currentErrorClassName = `${baseClassName}--current-error`;
 const completedClassName = `${baseClassName}--completed`;
 const errorClassName = `${baseClassName}--error`;
 const comingClassName = `${baseClassName}--coming`;
 const disabledClassName = `${baseClassName}--disabled`;
-
+const activeClassName = `${baseClassName}--active`;
 const innerWrapperClassName = `${baseClassName}_inner-wrapper`;
 const leftIconClassName = `${baseClassName}_left-icon`;
 
@@ -40,6 +42,7 @@ const BaseWizardNavigationItem = ({
   className,
   children,
   status,
+  active,
   ...passProps
 }: WizardNavigationItemProps) => (
   <HtmlLi
@@ -47,11 +50,11 @@ const BaseWizardNavigationItem = ({
       [defaultClassName]: status === 'default',
       [currentClassName]: status === 'current',
       [currentCompletedClassName]: status === 'current-completed',
-      [currentErrorClassName]: status === 'current-error',
       [completedClassName]: status === 'completed',
       [errorClassName]: status === 'error',
       [comingClassName]: status === 'coming',
       [disabledClassName]: status === 'disabled',
+      [activeClassName]: active,
     })}
     aria-disabled={status === 'disabled' ? true : undefined}
     {...passProps}
@@ -61,9 +64,7 @@ const BaseWizardNavigationItem = ({
         {(status === 'completed' || status === 'current-completed') && (
           <IconCheckCircleFilled />
         )}
-        {(status === 'error' || status === 'current-error') && (
-          <IconErrorFilled />
-        )}
+        {status === 'error' && <IconErrorFilled />}
       </HtmlSpan>
       {children}
     </HtmlDiv>


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

PR adds `error` status to WizardNavigationItem.

PR adds new boolean prop `active` to WizardNavigationItem.

PR deprecates statuses `current` and `current-completed`.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Library users have asked for status `error`.

Indicating when a step is current/active is simplified with new prop `active`. Statuses `current `and `current-completed` are deprecated.

## How Has This Been Tested?

MacOS Chrome and Firefox

## Screenshots (if appropriate):

New error states in default and small screen variants:
<img width="383" height="295" alt="Screenshot 2026-05-08 at 13 34 04" src="https://github.com/user-attachments/assets/2620574e-60b8-4319-b260-3656c4a1d200" />
<img width="342" height="307" alt="image" src="https://github.com/user-attachments/assets/e8ed70e6-f388-4014-9f2d-8ac614c19eed" />

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### WizardNavigation

- Adds prop `active` to indicate the current/active step. This should be used instead of statuses `current` and `current-completed`.
  - Status `current` is deprecated: replace with status `default` and prop `active`
  - Status `current-completed` is deprecated: replace with status `completed` and prop `active`
- Adds status `error`.