### PR TITLE
[Bugfix] Expander Group state

### DIFF
--- a/src/core/Expander/Expander/Expander.md
+++ b/src/core/Expander/Expander/Expander.md
@@ -120,6 +120,7 @@ For screen readers, it is recommended to provide a more descriptive label for th
 
 ```jsx
 import {
+  Block,
   Expander,
   ExpanderGroup,
   ExpanderTitleButton,
@@ -142,18 +143,26 @@ import {
       <Paragraph mb="l">
         You can manage the devices you use:
       </Paragraph>
-      <Paragraph mb="l">
-        <Text variant="bold">In the Suomi.fi application</Text>
+      <Block mb="l">
         <ul>
-          <li>Settings: Login and Security</li>
+          <li>
+            <Text variant="bold">In the Suomi.fi application</Text>
+          </li>
+          <ul>
+            <li>Settings: Login and Security</li>
+          </ul>
         </ul>
-        <Text variant="bold">
-          In the Suomi.fi Web Service or mobile device browser{' '}
-        </Text>
         <ul>
-          <li>Messages section: Device Manager</li>
+          <li>
+            <Text variant="bold">
+              In the Suomi.fi Web Service or mobile device browser
+            </Text>
+          </li>
+          <ul>
+            <li>Messages section: Device Manager</li>
+          </ul>
         </ul>
-      </Paragraph>
+      </Block>
       <Paragraph>
         Device data will include the name of each device and the time
         at which the application has last been used. You can log out
@@ -169,9 +178,11 @@ import {
       Is the application secure?
     </ExpanderTitleButton>
     <ExpanderContent>
-      <Paragraph mb="l">
-        Suomi.fi Messages is a secure way to communicate with
-        organisations that use the service.
+      <Block mb="l">
+        <Paragraph>
+          Suomi.fi Messages is a secure way to communicate with
+          organisations that use the service.
+        </Paragraph>
         <ul>
           <li>
             The messages and attachments shown in the application are
@@ -189,7 +200,7 @@ import {
             who can access your data.
           </li>
         </ul>
-      </Paragraph>
+      </Block>
       <Paragraph>
         If you break your mobile device or lose it, you can sign out
         of the Suomi.fi application either in the Suomi.fi web service
@@ -221,6 +232,7 @@ You can hide the open/close all button of the group with `showToggleAllButton={f
 
 ```jsx
 import {
+  Block,
   Expander,
   ExpanderGroup,
   ExpanderTitleButton,
@@ -244,18 +256,26 @@ import {
       <Paragraph mb="l">
         You can manage the devices you use:
       </Paragraph>
-      <Paragraph mb="l">
-        <Text variant="bold">In the Suomi.fi application</Text>
+      <Block mb="l">
         <ul>
-          <li>Settings: Login and Security</li>
+          <li>
+            <Text variant="bold">In the Suomi.fi application</Text>
+          </li>
+          <ul>
+            <li>Settings: Login and Security</li>
+          </ul>
         </ul>
-        <Text variant="bold">
-          In the Suomi.fi Web Service or mobile device browser{' '}
-        </Text>
         <ul>
-          <li>Messages section: Device Manager</li>
+          <li>
+            <Text variant="bold">
+              In the Suomi.fi Web Service or mobile device browser
+            </Text>
+          </li>
+          <ul>
+            <li>Messages section: Device Manager</li>
+          </ul>
         </ul>
-      </Paragraph>
+      </Block>
       <Paragraph>
         Device data will include the name of each device and the time
         at which the application has last been used. You can log out
@@ -271,9 +291,11 @@ import {
       Is the application secure?
     </ExpanderTitleButton>
     <ExpanderContent>
-      <Paragraph mb="l">
-        Suomi.fi Messages is a secure way to communicate with
-        organisations that use the service.
+      <Block mb="l">
+        <Paragraph>
+          Suomi.fi Messages is a secure way to communicate with
+          organisations that use the service.
+        </Paragraph>
         <ul>
           <li>
             The messages and attachments shown in the application are
@@ -291,7 +313,7 @@ import {
             who can access your data.
           </li>
         </ul>
-      </Paragraph>
+      </Block>
       <Paragraph>
         If you break your mobile device or lose it, you can sign out
         of the Suomi.fi application either in the Suomi.fi web service
@@ -323,6 +345,7 @@ You can control the state of an individual Expander programmatically with the `o
 
 ```jsx
 import {
+  Block,
   Expander,
   ExpanderGroup,
   ExpanderTitleButton,
@@ -383,9 +406,11 @@ const [expanderThreeOpen, setExpanderThreeOpen] = useState(true);
         Is the application secure?
       </ExpanderTitleButton>
       <ExpanderContent>
-        <Paragraph mb="l">
-          Suomi.fi Messages is a secure way to communicate with
-          organisations that use the service.
+        <Block mb="l">
+          <Paragraph>
+            Suomi.fi Messages is a secure way to communicate with
+            organisations that use the service.
+          </Paragraph>
           <ul>
             <li>
               The messages and attachments shown in the application
@@ -403,7 +428,7 @@ const [expanderThreeOpen, setExpanderThreeOpen] = useState(true);
               who can access your data.
             </li>
           </ul>
-        </Paragraph>
+        </Block>
         <Paragraph>
           If you break your mobile device or lose it, you can sign out
           of the Suomi.fi application either in the Suomi.fi web

--- a/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
+++ b/src/core/Expander/ExpanderGroup/ExpanderGroup.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode, forwardRef } from 'react';
+import React, { ReactNode, forwardRef, useEffect } from 'react';
 import { styled } from 'styled-components';
 import classnames from 'classnames';
 import { HtmlDiv, HtmlButton, HtmlSpan, HtmlDivProps } from '../../../reset';
@@ -75,13 +75,6 @@ type ExpanderGroupTargetOpenState = {
   targetOpenState: boolean;
 };
 
-interface ExpanderGroupState {
-  /** Current combined open state of all expanders */
-  allOpen: boolean | undefined;
-  /** State change transition request */
-  expanderGroupOpenState: ExpanderGroupTargetOpenState;
-}
-
 export interface ExpanderGroupProviderState {
   onExpanderOpenChange: (id: string, newState: boolean | undefined) => void;
   expanderGroupOpenState: ExpanderGroupTargetOpenState;
@@ -97,129 +90,110 @@ const defaultProviderValue: ExpanderGroupProviderState = {
 const { Provider, Consumer: ExpanderGroupConsumer } =
   React.createContext(defaultProviderValue);
 
-class BaseExpanderGroup extends Component<
-  ExpanderGroupProps & SuomifiThemeProp
-> {
-  state: ExpanderGroupState = {
-    allOpen: undefined,
-    expanderGroupOpenState: {
+const BaseExpanderGroup = (props: ExpanderGroupProps) => {
+  const {
+    className,
+    children,
+    openAllText,
+    ariaOpenAllText,
+    closeAllText,
+    ariaCloseAllText,
+    showToggleAllButton = true,
+    toggleAllButtonProps,
+    forwardedRef,
+    style,
+    ...rest
+  } = props;
+
+  const [_marginProps, passProps] = separateMarginProps(rest);
+
+  const [expanderGroupOpenState, setExpanderGroupOpenState] =
+    React.useState<ExpanderGroupTargetOpenState>({
       targetOpenState: false,
-    },
-  };
+    });
+  const [expanders, setExpanders] = React.useState<ExpanderOpenStates>({});
+  const [hasOpenExpander, setHasOpenExpander] = React.useState<
+    boolean | undefined
+  >(false);
+  const [allOpen, setAllOpen] = React.useState<boolean | undefined>(undefined);
 
-  /** Expanders by id with current open state */
-  private expanders: ExpanderOpenStates = {};
-
-  /** Number of currently open Expanders */
-  private openExpanderCount = 0;
-
-  /** Number of Expanders inside the ExpanderGroup */
-  private expanderCount = 0;
-
-  /**
-   * This function keeps track of number of expander, number of open expanders
-   * and current state of each expander. Updating is done in granular level
-   * for each change to avoid iterating over the whole Expander set on updates.
-   */
-  handleExpanderOpenChange = (id: string, newState: boolean | undefined) => {
-    if (newState !== undefined) {
-      // change or add new expander state
-      if (this.expanders[id] !== undefined && this.expanders[id] !== newState) {
-        if (newState === true) {
-          this.openExpanderCount += 1;
-        } else {
-          this.openExpanderCount -= 1;
-        }
-      }
-      // add new expander
-      if (this.expanders[id] === undefined) {
-        this.expanderCount += 1;
-        if (newState === true) {
-          this.openExpanderCount += 1;
-        }
-      }
-      this.expanders[id] = newState;
+  useEffect(() => {
+    if (expanders && Object.keys(expanders).length > 0) {
+      const allExpandersOpen = Object.values(expanders).every(
+        (isOpen) => isOpen === true,
+      );
+      setAllOpen(allExpandersOpen);
+      const someOpen = Object.values(expanders).some(
+        (isOpen) => isOpen === true,
+      );
+      setHasOpenExpander(someOpen);
     } else {
-      // remove expander
-      if (this.expanders[id] === true) {
-        this.openExpanderCount -= 1;
+      setHasOpenExpander(false);
+      setAllOpen(false);
+    }
+  }, [expanders]);
+
+  const handleExpanderOpenChange = (
+    id: string,
+    newState: boolean | undefined,
+  ) => {
+    setExpanders((prevExpanders) => {
+      const next = { ...prevExpanders };
+      if (newState !== undefined) {
+        next[id] = newState;
+      } else {
+        delete next[id];
       }
-      this.expanderCount -= 1;
-      delete this.expanders[id];
-    }
-    const allOpen = this.openExpanderCount === this.expanderCount;
-    if (this.state.allOpen !== allOpen) {
-      this.setState({ allOpen });
-    }
+      return next;
+    });
   };
 
-  handleAllToggleClick = () => {
-    this.setState((prevState: ExpanderGroupState) => ({
-      expanderGroupOpenState: {
-        targetOpenState: !prevState.allOpen,
-      },
+  const handleAllToggleClick = () => {
+    setExpanderGroupOpenState(() => ({
+      targetOpenState: !allOpen,
     }));
   };
-
-  render() {
-    const {
-      className,
-      theme,
-      children,
-      openAllText,
-      ariaOpenAllText,
-      closeAllText,
-      ariaCloseAllText,
-      showToggleAllButton = true,
-      toggleAllButtonProps,
-      forwardedRef,
-      style,
-      ...rest
-    } = this.props;
-    const [_marginProps, passProps] = separateMarginProps(rest);
-    const { expanderGroupOpenState, allOpen } = this.state;
-    return (
-      <HtmlDiv
-        {...passProps}
-        className={classnames(className, baseClassName, {
-          [openClassName]: this.openExpanderCount > 0,
-        })}
-        style={style}
-      >
-        {!!showToggleAllButton && (
-          <HtmlButton
-            {...toggleAllButtonProps}
-            onClick={this.handleAllToggleClick}
-            className={classnames(
-              toggleAllButtonProps?.className,
-              openAllButtonClassName,
-            )}
-            forwardedRef={forwardedRef}
-          >
-            <HtmlSpan aria-hidden={true}>
-              {allOpen ? closeAllText : openAllText}
-            </HtmlSpan>
-            <VisuallyHidden>
-              {allOpen
-                ? ariaCloseAllText || closeAllText
-                : ariaOpenAllText || openAllText}
-            </VisuallyHidden>
-          </HtmlButton>
-        )}
-        <HtmlDiv className={expandersContainerClassName}>
-          <Provider
-            value={{
-              onExpanderOpenChange: this.handleExpanderOpenChange,
-              expanderGroupOpenState,
-            }}
-          >
-            {children}
-          </Provider>
-        </HtmlDiv>
+  return (
+    <HtmlDiv
+      {...passProps}
+      className={classnames(className, baseClassName, {
+        [openClassName]: hasOpenExpander,
+      })}
+      style={style}
+    >
+      {!!showToggleAllButton && (
+        <HtmlButton
+          {...toggleAllButtonProps}
+          onClick={handleAllToggleClick}
+          className={classnames(
+            toggleAllButtonProps?.className,
+            openAllButtonClassName,
+          )}
+          forwardedRef={forwardedRef}
+        >
+          <HtmlSpan aria-hidden={true}>
+            {allOpen ? closeAllText : openAllText}
+          </HtmlSpan>
+          <VisuallyHidden>
+            {allOpen
+              ? ariaCloseAllText || closeAllText
+              : ariaOpenAllText || openAllText}
+          </VisuallyHidden>
+        </HtmlButton>
+      )}
+      <HtmlDiv className={expandersContainerClassName}>
+        <Provider
+          value={{
+            onExpanderOpenChange: handleExpanderOpenChange,
+            expanderGroupOpenState,
+          }}
+        >
+          {children}
+        </Provider>
       </HtmlDiv>
-    );
-  }
-}
+    </HtmlDiv>
+  );
+};
 
 const StyledExpanderGroup = styled(
   (props: ExpanderGroupProps & SuomifiThemeProp & GlobalMarginProps) => {


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Updates ExpanderGroup from class based component to function component. Updates Expander examples to fix HTML where ul tags were inside p tags.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

A bug was reported when using ExpanderGroup with React 19. Open all/close all logic was not working. Updating component to use hooks and simplifying open state tracking fixed the issue.

## How Has This Been Tested?

This bug could be reproduced and fix tested with a Next project using React 19. Tested also with Styleguide examples.

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### ExpanderGroup
- ExpanderGroup Open all/Close logic all fixed to work with React 19.