### PR TITLE
[Feature] DatePicker conditional rendering to DOM

### DIFF
--- a/src/core/Form/DateInput/DateInput.md
+++ b/src/core/Form/DateInput/DateInput.md
@@ -118,7 +118,7 @@ Use the `minDate` and `maxDate` props to control the available dates in the date
 import { DateInput } from 'suomifi-ui-components';
 
 const minDate = new Date(2023, 1, 2);
-const maxDate = new Date(2024, 11, 31);
+const maxDate = new Date(2030, 11, 31);
 
 <DateInput
   labelText="Beginning date"
@@ -142,7 +142,7 @@ import { isWithinInterval } from 'date-fns';
 import { useState } from 'react';
 
 const minDate = new Date(2023, 1, 2);
-const maxDate = new Date(2024, 11, 31);
+const maxDate = new Date(2030, 11, 31);
 const [statusText, setStatusText] = React.useState('');
 const [status, setStatus] = React.useState('default');
 const validate = ({ value, date }) => {

--- a/src/core/Form/DateInput/DateInput.test.tsx
+++ b/src/core/Form/DateInput/DateInput.test.tsx
@@ -86,6 +86,9 @@ describe('snapshots match', () => {
         />,
       );
       await user.click(getByRole('button'));
+      await waitFor(() => {
+        expect(baseElement.querySelector('[role="dialog"]')).toBeVisible();
+      });
       expect(baseElement).toMatchSnapshot();
       cleanup();
     });
@@ -112,9 +115,11 @@ describe('keyboard events', () => {
       <DateInput labelText="Date" datePickerEnabled />,
     );
     await user.click(getByRole('button'));
-    expect(baseElement.querySelector('[role="dialog"]')).toBeVisible();
+    await waitFor(() => {
+      expect(baseElement.querySelector('[role="dialog"]')).toBeVisible();
+    });
     await user.keyboard('{Escape}');
-    expect(baseElement.querySelector('[role="dialog"]')).not.toBeVisible();
+    expect(baseElement.querySelector('[role="dialog"]')).toBe(null);
     cleanup();
   });
 });
@@ -281,8 +286,9 @@ describe('props', () => {
   });
 
   describe('datePickerProps', () => {
-    it('has user given className', () => {
-      const { baseElement } = render(
+    it('has user given className', async () => {
+      const user = userEvent.setup({ delay: null });
+      const { baseElement, getByRole } = render(
         <DateInput
           labelText="Date"
           datePickerEnabled
@@ -292,6 +298,7 @@ describe('props', () => {
           }}
         />,
       );
+      await user.click(getByRole('button'));
       const datePicker = baseElement.querySelector('.fi-date-picker');
       expect(datePicker).toHaveClass('custom-datePicker-class');
       expect(datePicker).toHaveAttribute('aria-disabled');
@@ -491,7 +498,7 @@ describe('props', () => {
       it('has focus', async () => {
         const user = userEvent.setup({ delay: null });
         jest.useFakeTimers().setSystemTime(new Date('2020-01-01'));
-        const { getByRole, getByText } = render(
+        const { baseElement, getByRole, getByText } = render(
           <DateInput
             labelText="Date"
             datePickerEnabled
@@ -499,6 +506,9 @@ describe('props', () => {
           />,
         );
         await user.click(getByRole('button'));
+        await waitFor(() => {
+          expect(baseElement.querySelector('[role="dialog"]')).toBeVisible();
+        });
         const dateButton = getByText('15').closest('button');
         expect(dateButton).toHaveFocus();
         cleanup();
@@ -532,6 +542,9 @@ describe('props', () => {
         await user.clear(getByRole('textbox'));
         await user.type(getByRole('textbox'), '2020-8-15');
         await user.click(getByRole('button'));
+        await waitFor(() => {
+          expect(baseElement.querySelector('[role="dialog"]')).toBeVisible();
+        });
         const dateButton = baseElement.querySelector(
           '.fi-month-day_button--selected',
         );
@@ -735,10 +748,12 @@ describe('props', () => {
 
       describe('smallScreen', () => {
         describe('not enabled', () => {
-          it('has position absolute', () => {
-            const { baseElement } = render(
+          it('has position absolute', async () => {
+            const user = userEvent.setup({ delay: null });
+            const { baseElement, getByRole } = render(
               <DateInput labelText="Date" datePickerEnabled />,
             );
+            await user.click(getByRole('button'));
             const dialog = baseElement.querySelector('[role="dialog"]');
             expect(dialog).toHaveClass('fi-date-picker');
             expect(dialog).toHaveStyle('position: absolute');
@@ -747,10 +762,12 @@ describe('props', () => {
         });
 
         describe('enabled', () => {
-          it('does not have position absolute', () => {
-            const { baseElement } = render(
+          it('does not have position absolute', async () => {
+            const user = userEvent.setup({ delay: null });
+            const { baseElement, getByRole } = render(
               <DateInput labelText="Date" smallScreen datePickerEnabled />,
             );
+            await user.click(getByRole('button'));
             const dialog = baseElement.querySelector('.fi-date-picker');
             expect(dialog).toHaveClass('fi-date-picker--small-screen');
             expect(dialog).not.toHaveAttribute('style');
@@ -760,10 +777,15 @@ describe('props', () => {
           it('has current date focused in smallScreen variant', async () => {
             const user = userEvent.setup({ delay: null });
             jest.useFakeTimers().setSystemTime(new Date('2020-01-15'));
-            const { getByRole, getByText } = render(
+            const { baseElement, getByRole, getByText } = render(
               <DateInput labelText="Date" smallScreen datePickerEnabled />,
             );
             await user.click(getByRole('button'));
+            await waitFor(() => {
+              expect(
+                baseElement.querySelector('[role="dialog"]'),
+              ).toBeVisible();
+            });
             const dateButton = getByText('15').closest(
               'button',
             ) as HTMLButtonElement;
@@ -792,6 +814,9 @@ describe('props', () => {
             <DateInput labelText="Date" datePickerEnabled value="1.5.2020" />,
           );
           await user.click(getByRole('button'));
+          await waitFor(() => {
+            expect(baseElement.querySelector('[role="dialog"]')).toBeVisible();
+          });
           const dateButton = baseElement.querySelector(
             '.fi-month-day_button--selected',
           );
@@ -808,6 +833,9 @@ describe('props', () => {
             <DateInput labelText="Date" datePickerEnabled value="1.5.2020" />,
           );
           await user.click(getByRole('button'));
+          await waitFor(() => {
+            expect(baseElement.querySelector('[role="dialog"]')).toBeVisible();
+          });
           const dateButton = baseElement.querySelector(
             '.fi-month-day_button--selected',
           );
@@ -866,6 +894,11 @@ describe('props', () => {
               />,
             );
             await user.click(getByRole('button'));
+            await waitFor(() => {
+              expect(
+                baseElement.querySelector('[role="dialog"]'),
+              ).toBeVisible();
+            });
             const dateButton = baseElement.querySelector(
               '.fi-month-day_button--selected',
             );
@@ -886,6 +919,11 @@ describe('props', () => {
               />,
             );
             await user.click(getByRole('button'));
+            await waitFor(() => {
+              expect(
+                baseElement.querySelector('[role="dialog"]'),
+              ).toBeVisible();
+            });
             const dateButton = baseElement.querySelector(
               '.fi-month-day_button--selected',
             );

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -254,7 +254,7 @@ const BaseDateInput = (props: DateInputProps) => {
     shouldDisableDate,
     minDate: userMinDate,
     maxDate: userMaxDate,
-    initialDate,
+    initialDate = new Date(),
     tooltipComponent,
     style,
     ...rest
@@ -482,21 +482,22 @@ const BaseDateInput = (props: DateInputProps) => {
                   aria-hidden={true}
                 />
               </HtmlButton>
-              <DatePicker
-                openButtonRef={openButtonRef}
-                isOpen={calendarVisible}
-                onClose={(focus) => toggleCalendar(false, focus)}
-                onChange={(eventValue) => onDatePickerChange(eventValue)}
-                shouldDisableDate={shouldDisableDate}
-                initialDate={initialDate}
-                inputValue={inputValueAsDate}
-                texts={texts}
-                minDate={effectiveMinDate}
-                maxDate={effectiveMaxDate}
-                smallScreen={smallScreen}
-                userProps={customDatePickerProps}
-                position={datePickerPosition}
-              />
+              {calendarVisible && (
+                <DatePicker
+                  openButtonRef={openButtonRef}
+                  onClose={(focus) => toggleCalendar(false, focus)}
+                  onChange={(eventValue) => onDatePickerChange(eventValue)}
+                  shouldDisableDate={shouldDisableDate}
+                  initialDate={initialDate}
+                  inputValue={inputValueAsDate}
+                  texts={texts}
+                  minDate={effectiveMinDate}
+                  maxDate={effectiveMaxDate}
+                  smallScreen={smallScreen}
+                  userProps={customDatePickerProps}
+                  position={datePickerPosition}
+                />
+              )}
             </HtmlDiv>
           )}
         </HtmlDiv>

--- a/src/core/Form/DateInput/DateInput.tsx
+++ b/src/core/Form/DateInput/DateInput.tsx
@@ -254,11 +254,13 @@ const BaseDateInput = (props: DateInputProps) => {
     shouldDisableDate,
     minDate: userMinDate,
     maxDate: userMaxDate,
-    initialDate = new Date(),
+    initialDate,
     tooltipComponent,
     style,
     ...rest
   } = props;
+
+  const initialDateRef = useRef<Date>(new Date());
 
   // Calculate default date range
   const defaultMinDate = moveYears(firstDayOfMonth(new Date()), -10);
@@ -488,7 +490,7 @@ const BaseDateInput = (props: DateInputProps) => {
                   onClose={(focus) => toggleCalendar(false, focus)}
                   onChange={(eventValue) => onDatePickerChange(eventValue)}
                   shouldDisableDate={shouldDisableDate}
-                  initialDate={initialDate}
+                  initialDate={initialDate || initialDateRef.current}
                   inputValue={inputValueAsDate}
                   texts={texts}
                   minDate={effectiveMinDate}

--- a/src/core/Form/DateInput/DatePicker/DatePicker.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.baseStyles.tsx
@@ -47,10 +47,6 @@ export const baseStyles = (theme: SuomifiTheme) => css`
     }
   }
 
-  &.fi-date-picker--hidden {
-    visibility: hidden;
-  }
-
   &.fi-date-picker--small-screen-hidden {
     transform: translateZ(0) translateY(100%);
     transition:

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -71,7 +71,7 @@ export interface InternalDatePickerProps
     'onChange' | 'style' | 'aria-hidden' | 'ref'
   >;
   position: datePickerAlignment;
-  /** Defaults to current date if not provided */
+  /** Initial date to focus when date picker is opened */
   initialDate: Date;
 }
 

--- a/src/core/Form/DateInput/DatePicker/DatePicker.tsx
+++ b/src/core/Form/DateInput/DatePicker/DatePicker.tsx
@@ -36,7 +36,6 @@ const baseClassName = 'fi-date-picker';
 
 export const datePickerClassNames = {
   baseClassName,
-  hidden: `${baseClassName}--hidden`,
   smallScreen: `${baseClassName}--small-screen`,
   smallScreenHidden: `${baseClassName}--small-screen-hidden`,
   smallScreenContainer: `${baseClassName}_small-screen-container`,
@@ -52,8 +51,6 @@ export interface InternalDatePickerProps
   extends Omit<DatePickerProps, 'datePickerEnabled'> {
   /** Button ref for positioning dialog and closing dialog on button click */
   openButtonRef: React.RefObject<any>;
-  /** Boolean to open or close calendar dialog */
-  isOpen: boolean;
   /** Callback fired when closing calender */
   onClose: (focus?: boolean) => void;
   /** Callback fired when date is selected  */
@@ -74,12 +71,13 @@ export interface InternalDatePickerProps
     'onChange' | 'style' | 'aria-hidden' | 'ref'
   >;
   position: datePickerAlignment;
+  /** Defaults to current date if not provided */
+  initialDate: Date;
 }
 
 export const BaseDatePicker = (props: InternalDatePickerProps) => {
   const {
     openButtonRef,
-    isOpen,
     onClose,
     onChange,
     shouldDisableDate,
@@ -96,11 +94,13 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
 
   const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
   const [dialogElement, setDialogElement] = useState<HTMLElement | null>(null);
-  const [focusableDate, setFocusableDate] = useState<Date>(new Date());
+  const [focusableDate, setFocusableDate] = useState<Date>(initialDate);
   const [focusedDate, setFocusedDate] = useState<Date | null>(null);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [yearSelectWidth, setYearSelectWidth] = useState<number>(0);
   const [monthSelectWidth, setMonthSelectWidth] = useState<number>(0);
+  const [dropdownWidthsCalculated, setDropdownWidthsCalculated] =
+    useState<boolean>(false);
   const [touchStartX, setTouchStartX] = useState<number | null>(null);
   const [touchStartY, setTouchStartY] = useState<number | null>(null);
   const [dragOffsetY, setDragOffsetY] = useState<number>(0);
@@ -114,6 +114,29 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const dayButtonRef = useRef<HTMLButtonElement>(null);
   const arrowRef = useRef<HTMLDivElement>(null);
+
+  const {
+    refs: floatingUiRefs,
+    floatingStyles,
+    middlewareData,
+    isPositioned,
+  } = useFloating({
+    middleware: [
+      offset(10),
+      flip(),
+      shift(),
+      arrow({
+        element: arrowRef,
+      }),
+    ],
+    whileElementsMounted: autoUpdate,
+    placement:
+      position === 'right'
+        ? 'bottom-start'
+        : position === 'left'
+        ? 'bottom-end'
+        : 'bottom',
+  });
 
   useEnhancedEffect(() => {
     setMountNode(window.document.body);
@@ -137,15 +160,22 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   }, [initialDate]);
 
   useEffect(() => {
-    if (isOpen) {
+    const rafId = requestAnimationFrame(() => {
+      calculateDropdownWidths();
+    });
+    return () => {
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (dialogElement || smallScreen) {
       document.addEventListener('click', globalClickHandler, {
         capture: true,
       });
       document.addEventListener('keydown', globalKeyDownHandler, {
         capture: true,
       });
-      focusDate();
-      calculateDropdownWidths();
       return () => {
         document.removeEventListener('click', globalClickHandler, {
           capture: true,
@@ -155,17 +185,23 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
         });
       };
     }
-  }, [isOpen]);
+  }, [dialogElement, smallScreen]);
 
   useEffect(() => {
-    if (smallScreen && isOpen && smallScreenAppRef.current) {
+    if (isPositioned || smallScreen) {
+      focusDate();
+    }
+  }, [isPositioned, smallScreen]);
+
+  useEffect(() => {
+    if (smallScreen && smallScreenAppRef.current) {
       smallScreenAppRef.current.style.top = '';
       conditionalSmallScreenScroll();
       window.addEventListener('resize', conditionalSmallScreenScroll);
       return () =>
         window.removeEventListener('resize', conditionalSmallScreenScroll);
     }
-  }, [smallScreen, isOpen]);
+  }, [smallScreen]);
 
   const conditionalSmallScreenScroll = (): void => {
     if (smallScreenAppRef.current) {
@@ -201,6 +237,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
     setMonthSelectWidth(
       monthSelectRef.current?.getBoundingClientRect().width || 0,
     );
+    setDropdownWidthsCalculated(true);
   };
 
   const globalClickHandler = (nativeEvent: MouseEvent) => {
@@ -308,29 +345,6 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
     return null;
   };
 
-  const {
-    refs: floatingUiRefs,
-    floatingStyles,
-    middlewareData,
-  } = useFloating({
-    open: isOpen,
-    middleware: [
-      offset(10),
-      flip(),
-      shift(),
-      arrow({
-        element: arrowRef,
-      }),
-    ],
-    whileElementsMounted: autoUpdate,
-    placement:
-      position === 'right'
-        ? 'bottom-start'
-        : position === 'left'
-        ? 'bottom-end'
-        : 'bottom',
-  });
-
   useEffect(() => {
     if (openButtonRef.current) {
       floatingUiRefs.setReference(openButtonRef.current);
@@ -363,9 +377,9 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
   };
 
   const handleDateSelect = (date: Date): void => {
-    handleClose(true);
     onChange(date);
     setFocusableDate(date);
+    handleClose(true);
   };
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -477,21 +491,16 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
 
   const { className: customClassName, ...passProps } = userProps;
 
-  const dialogClasses = [
-    className,
-    baseClassName,
-    customClassName,
-    {
-      [datePickerClassNames.hidden]: !isOpen,
-    },
-  ];
+  const dialogClasses = [className, baseClassName, customClassName];
 
   const defaultDialog = (
     <HtmlDivWithRef
       role="dialog"
-      aria-hidden={!isOpen}
       className={classnames(...dialogClasses)}
-      style={floatingStyles}
+      style={{
+        ...floatingStyles,
+        visibility: isPositioned ? 'visible' : 'hidden',
+      }}
       forwardedRef={setDialogElement}
       {...passProps}
     >
@@ -512,11 +521,10 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
 
   const smallScreenDialog = (
     <HtmlDiv
-      aria-hidden={!isOpen}
       className={classnames(
         ...dialogClasses,
         datePickerClassNames.smallScreen,
-        { [datePickerClassNames.smallScreenHidden]: !isOpen },
+        { [datePickerClassNames.smallScreenHidden]: !dropdownWidthsCalculated },
       )}
     >
       <HtmlDivWithRef
@@ -525,6 +533,7 @@ export const BaseDatePicker = (props: InternalDatePickerProps) => {
         className={classnames(datePickerClassNames.smallScreenContainer, {
           [datePickerClassNames.smallScreenScroll]: smallScreenScroll,
         })}
+        style={{ visibility: dropdownWidthsCalculated ? 'visible' : 'hidden' }}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3702,10 +3702,6 @@ exports[`snapshots match date input with datepicker with controlled input value 
   padding-bottom: 30px;
 }
 
-.c10.fi-date-picker--hidden {
-  visibility: hidden;
-}
-
 .c10.fi-date-picker--small-screen-hidden {
   transform: translateZ(0) translateY(100%);
   transition: transform 200ms cubic-bezier(0.28, 0.84, 0.42, 1),visibility 200ms cubic-bezier(0.28, 0.84, 0.42, 1);
@@ -4004,7 +4000,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
         >
           <label
             class="c4 fi-label_label-span"
-            for="15"
+            for="11"
           >
             Date
           </label>
@@ -4018,7 +4014,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
             <input
               autocomplete="off"
               class="c5 fi-date-input_input"
-              id="15"
+              id="11"
               placeholder="DateInput"
               type="text"
               value="15.1.2020"
@@ -4059,16 +4055,15 @@ exports[`snapshots match date input with datepicker with controlled input value 
           aria-atomic="true"
           aria-live="assertive"
           class="c4 c9 fi-status-text"
-          id="15-statusText"
+          id="11-statusText"
         />
       </div>
     </div>
   </div>
   <div
-    aria-hidden="false"
     class="c2 c10 fi-date-picker"
     role="dialog"
-    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 10px);"
   >
     <div
       class="c0 fi-date-picker_application"
@@ -4079,14 +4074,14 @@ exports[`snapshots match date input with datepicker with controlled input value 
       >
         <div
           class="c0 c12 fi-date-selectors_year-select fi-dropdown"
-          id="16"
+          id="12"
         >
           <div
             class="c2 c3 fi-label"
           >
             <label
               class="c4 c7 fi-visually-hidden"
-              id="16-label"
+              id="12-label"
             >
               Valitse vuosi
             </label>
@@ -4095,20 +4090,20 @@ exports[`snapshots match date input with datepicker with controlled input value 
             class="c0 fi-dropdown_input-wrapper"
           >
             <button
-              aria-controls="16-popover"
+              aria-controls="12-popover"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="16-displayValue 16-label"
+              aria-labelledby="12-displayValue 12-label"
               class="c6 fi-dropdown_button"
               data-floating-ui-placement="bottom"
-              id="16_button"
+              id="12_button"
               tabindex="0"
               type="button"
               value="2020"
             >
               <span
                 class="c4 fi-dropdown_display-value"
-                id="16-displayValue"
+                id="12-displayValue"
               >
                 2020
               </span>
@@ -4128,14 +4123,14 @@ exports[`snapshots match date input with datepicker with controlled input value 
         </div>
         <div
           class="c0 c12 fi-date-selectors_month-select fi-dropdown"
-          id="17"
+          id="13"
         >
           <div
             class="c2 c3 fi-label"
           >
             <label
               class="c4 c7 fi-visually-hidden"
-              id="17-label"
+              id="13-label"
             >
               Valitse kuukausi
             </label>
@@ -4144,20 +4139,20 @@ exports[`snapshots match date input with datepicker with controlled input value 
             class="c0 fi-dropdown_input-wrapper"
           >
             <button
-              aria-controls="17-popover"
+              aria-controls="13-popover"
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="17-displayValue 17-label"
+              aria-labelledby="13-displayValue 13-label"
               class="c6 fi-dropdown_button"
               data-floating-ui-placement="bottom"
-              id="17_button"
+              id="13_button"
               tabindex="0"
               type="button"
               value="0"
             >
               <span
                 class="c4 fi-dropdown_display-value"
-                id="17-displayValue"
+                id="13-displayValue"
               >
                 Tammikuu
               </span>
@@ -4832,6 +4827,8 @@ exports[`snapshots match date input with datepicker with controlled input value 
     <div
       aria-hidden="true"
       class="c2 fi-date-picker_floatingui-arrow"
+      data-floatingui-placement="bottom-end"
+      style="left: 0px;"
       tabindex="-1"
     />
   </div>
@@ -5856,10 +5853,6 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   padding-bottom: 30px;
 }
 
-.c10.fi-date-picker--hidden {
-  visibility: hidden;
-}
-
 .c10.fi-date-picker--small-screen-hidden {
   transform: translateZ(0) translateY(100%);
   transition: transform 200ms cubic-bezier(0.28, 0.84, 0.42, 1),visibility 200ms cubic-bezier(0.28, 0.84, 0.42, 1);
@@ -6219,12 +6212,12 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
     </div>
   </div>
   <div
-    aria-hidden="false"
-    class="c0 c10 fi-date-picker fi-date-picker--small-screen"
+    class="c0 c10 fi-date-picker fi-date-picker--small-screen fi-date-picker--small-screen-hidden"
   >
     <div
       class="c2 fi-date-picker_small-screen-container"
       role="dialog"
+      style="visibility: hidden;"
     >
       <div
         class="c2 fi-date-picker_slide-indicator-wrapper"


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

Updates DatePicker to render to DOM conditionally. Previously, DatePicker was always in DOM, when `datePickerEnabled=true`.
<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

## Motivation and Context

When DatePicker was always in DOM, the position calculation sometimes appended extra scrollable whitespace to DOM. There was also a bug where closing the DatePicker sometimes kept the month and year dropdowns visible in DOM.

<!-- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- MacOS: Chrome and Safari with VoiceOver
- Windows: Edge and Chrome with NVDA (Browserstack)
- Android: Chrome with TalkBack
- iOS: Chrome and Safari with VoiceOver

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### DateInput
- **Breaking change:** DatePicker is rendered to DOM conditionally when opened, instead of being always hidden in DOM. Fixes issue where DatePicker's dropdowns were sometimes visible when DatePicker was closed. Fixes issue where position calculation sometimes appended extra whitespace to DOM.