### PR TITLE
[Fix] ErrorSummary margin props and global margins

### DIFF
--- a/src/core/Form/ErrorSummary/ErrorSummary.baseStyles.tsx
+++ b/src/core/Form/ErrorSummary/ErrorSummary.baseStyles.tsx
@@ -2,11 +2,18 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 import { element, font } from '../../theme/reset';
 import { transparentize } from 'polished';
+import { MarginProps, buildSpacingCSS } from '../../theme/utils/spacing';
 
-export const baseStyles = (theme: SuomifiTheme) => css`
+export const baseStyles = (
+  theme: SuomifiTheme,
+  globalMargins?: MarginProps,
+  propMargins?: MarginProps,
+) => css`
   &.fi-error-summary {
     ${element(theme)}
     ${font(theme)('bodyTextSmall')}
+    ${buildSpacingCSS(globalMargins)}
+    ${buildSpacingCSS(propMargins, true)};
     width: 100%;
     padding: 5px 0px 4px 0px;
     border: 1px solid;

--- a/src/core/Form/ErrorSummary/ErrorSummary.tsx
+++ b/src/core/Form/ErrorSummary/ErrorSummary.tsx
@@ -4,8 +4,17 @@ import classnames from 'classnames';
 import { HtmlDiv, HtmlDivWithRef, HtmlDivProps, hLevels } from '../../../reset';
 import { IconErrorFilled } from 'suomifi-icons';
 import { AutoId } from '../../utils/AutoId/AutoId';
-import { SuomifiThemeProp, SuomifiThemeConsumer } from '../../theme';
-import { separateMarginProps, MarginProps } from '../../theme/utils/spacing';
+import {
+  SuomifiThemeProp,
+  SuomifiThemeConsumer,
+  SpacingConsumer,
+} from '../../theme';
+import {
+  separateMarginProps,
+  MarginProps,
+  GlobalMarginProps,
+} from '../../theme/utils/spacing';
+import { filterDuplicateKeys } from '../../../utils/common/common';
 import { baseStyles } from './ErrorSummary.baseStyles';
 import { Heading } from '../../Heading/Heading';
 import { Link } from '../../Link';
@@ -138,32 +147,44 @@ const BaseErrorSummary = (props: ErrorSummaryProps) => {
 };
 
 const StyledErrorSummary = styled(
-  (props: ErrorSummaryProps & SuomifiThemeProp) => {
-    const { theme, ...passProps } = props;
+  (props: ErrorSummaryProps & SuomifiThemeProp & GlobalMarginProps) => {
+    const { theme, globalMargins, ...passProps } = props;
     return <BaseErrorSummary {...passProps} />;
   },
 )`
-  ${({ theme }) => baseStyles(theme)}
+  ${({ theme, globalMargins, ...rest }) => {
+    const [marginProps, _passProps] = separateMarginProps(rest);
+    const cleanedGlobalMargins = filterDuplicateKeys(
+      globalMargins.errorSummary,
+      marginProps,
+    );
+    return baseStyles(theme, cleanedGlobalMargins, marginProps);
+  }}
 `;
 
 const ErrorSummary = forwardRef<HTMLDivElement, ErrorSummaryProps>(
   (props: ErrorSummaryProps, ref: React.RefObject<HTMLDivElement>) => {
     const { id: propId, ...passProps } = props;
     return (
-      <SuomifiThemeConsumer>
-        {({ suomifiTheme }) => (
-          <AutoId id={propId}>
-            {(id) => (
-              <StyledErrorSummary
-                forwardedRef={ref}
-                theme={suomifiTheme}
-                id={id}
-                {...passProps}
-              />
+      <SpacingConsumer>
+        {({ margins }) => (
+          <SuomifiThemeConsumer>
+            {({ suomifiTheme }) => (
+              <AutoId id={propId}>
+                {(id) => (
+                  <StyledErrorSummary
+                    forwardedRef={ref}
+                    theme={suomifiTheme}
+                    globalMargins={margins}
+                    id={id}
+                    {...passProps}
+                  />
+                )}
+              </AutoId>
             )}
-          </AutoId>
+          </SuomifiThemeConsumer>
         )}
-      </SuomifiThemeConsumer>
+      </SpacingConsumer>
     );
   },
 );

--- a/src/core/Form/ErrorSummary/ErrorSummary.tsx
+++ b/src/core/Form/ErrorSummary/ErrorSummary.tsx
@@ -20,7 +20,7 @@ import { Heading } from '../../Heading/Heading';
 import { Link } from '../../Link';
 
 const baseClassName = 'fi-error-summary';
-const inlineAlertClassNames = {
+const errorSummaryClassNames = {
   styleWrapper: `${baseClassName}_style-wrapper`,
   content: `${baseClassName}_content`,
   heading: `${baseClassName}_heading`,
@@ -106,23 +106,23 @@ const BaseErrorSummary = (props: ErrorSummaryProps) => {
       asProp="section"
       {...passProps}
       className={classnames(baseClassName, className, {
-        [inlineAlertClassNames.smallScreen]: !!smallScreen,
+        [errorSummaryClassNames.smallScreen]: !!smallScreen,
       })}
       style={{ ...passProps?.style }}
     >
-      <HtmlDiv className={inlineAlertClassNames.styleWrapper}>
-        <IconErrorFilled className={classnames(inlineAlertClassNames.icon)} />
+      <HtmlDiv className={errorSummaryClassNames.styleWrapper}>
+        <IconErrorFilled className={classnames(errorSummaryClassNames.icon)} />
 
-        <HtmlDiv className={inlineAlertClassNames.textContentWrapper} id={id}>
+        <HtmlDiv className={errorSummaryClassNames.textContentWrapper} id={id}>
           <Heading
             variant={headingVariant}
-            className={inlineAlertClassNames.heading}
+            className={errorSummaryClassNames.heading}
             ref={headingRef}
             tabIndex={0}
           >
             {headingText}
           </Heading>
-          <HtmlDiv className={inlineAlertClassNames.content}>
+          <HtmlDiv className={errorSummaryClassNames.content}>
             {items && (
               <ul>
                 {items.map((item) => (

--- a/src/core/theme/SpacingProvider/SpacingProvider.tsx
+++ b/src/core/theme/SpacingProvider/SpacingProvider.tsx
@@ -41,6 +41,7 @@ export const SpacingProvider = (props: SpacingProviderProps) => {
     dropdown: null,
     expander: null,
     expanderGroup: null,
+    errorSummary: null,
     externalLink: null,
     fileInput: null,
     heading: null,

--- a/src/core/theme/utils/spacing.ts
+++ b/src/core/theme/utils/spacing.ts
@@ -70,6 +70,7 @@ export type GlobalMargins = {
   dropdown?: MarginProps;
   expander?: MarginProps;
   expanderGroup?: MarginProps;
+  errorSummary?: MarginProps;
   externalLink?: MarginProps;
   fileInput?: MarginProps;
   heading?: MarginProps;


### PR DESCRIPTION
## Description
This PR applies global margins and adds support for margin props to `ErrorSummary`. It also fixes a copy-paste error where ErrorSummary class name object was named `inlineAlertClassNames`

## Motivation and Context
Missing feature needed to be added and a simple code mistake fixed.

## How Has This Been Tested?
Locally on styleguidist on Chrome.

## Release notes
### ErrorSummary
- Add support for margin props and listener for global margins