### PR TITLE
[Feature] Set default styleguidist example width to 900px

### DIFF
--- a/.styleguidist/styleguidist.styles.js
+++ b/.styleguidist/styleguidist.styles.js
@@ -1,7 +1,7 @@
-const grid440px24px = {
+const grid900px24px = {
   display: 'grid',
   rowGap: '24px',
-  maxWidth: '440px',
+  maxWidth: '900px',
   justifyItems: 'start',
 };
 
@@ -85,9 +85,9 @@ module.exports = {
   Playground: {
     preview: {
       '&:not([data-preview="Text"]) > div': {
-        ...grid440px24px,
+        ...grid900px24px,
         '& [example="inverted"]': {
-          ...grid440px24px,
+          ...grid900px24px,
           padding: '24px',
           backgroundColor: '#2A6EBB',
         },

--- a/src/core/Alert/Alert.md
+++ b/src/core/Alert/Alert.md
@@ -24,15 +24,13 @@ import { useState } from 'react';
 const [showAlert, setShowAlert] = useState(true);
 
 showAlert && (
-  <Block style={{ width: '900px' }}>
-    <Alert
-      closeText="Close"
-      onCloseButtonClick={() => setShowAlert(false)}
-    >
-      You are using a beta version of the service. It might contain
-      some bugs or glitches.
-    </Alert>
-  </Block>
+  <Alert
+    closeText="Close"
+    onCloseButtonClick={() => setShowAlert(false)}
+  >
+    You are using a beta version of the service. It might contain some
+    bugs or glitches.
+  </Alert>
 );
 ```
 
@@ -47,16 +45,14 @@ import { useState } from 'react';
 const [showAlert, setShowAlert] = useState(true);
 
 showAlert && (
-  <Block style={{ width: '900px' }}>
-    <Alert
-      status="warning"
-      closeText="Close"
-      onCloseButtonClick={() => setShowAlert(false)}
-    >
-      The service will be temporarily unavailable on 5.6.2021 at 21.00
-      – 23.59 due to maintenance.
-    </Alert>
-  </Block>
+  <Alert
+    status="warning"
+    closeText="Close"
+    onCloseButtonClick={() => setShowAlert(false)}
+  >
+    The service will be temporarily unavailable on 5.6.2021 at 21.00 –
+    23.59 due to maintenance.
+  </Alert>
 );
 ```
 
@@ -71,16 +67,14 @@ import { useState } from 'react';
 const [showAlert, setShowAlert] = useState(true);
 
 showAlert && (
-  <Block style={{ width: '900px' }}>
-    <Alert
-      status="error"
-      closeText="Close"
-      onCloseButtonClick={() => setShowAlert(false)}
-    >
-      We are currently experiencing disruptions in the service.
-      Submitting applications is not possible.
-    </Alert>
-  </Block>
+  <Alert
+    status="error"
+    closeText="Close"
+    onCloseButtonClick={() => setShowAlert(false)}
+  >
+    We are currently experiencing disruptions in the service.
+    Submitting applications is not possible.
+  </Alert>
 );
 ```
 
@@ -95,16 +89,14 @@ import { useState } from 'react';
 const [showAlert, setShowAlert] = useState(true);
 
 showAlert && (
-  <Block style={{ width: '900px' }}>
-    <Alert
-      smallScreen
-      closeText="Close"
-      onCloseButtonClick={() => setShowAlert(false)}
-    >
-      You are using a beta version of the service. It might contain
-      some bugs or glitches.
-    </Alert>
-  </Block>
+  <Alert
+    smallScreen
+    closeText="Close"
+    onCloseButtonClick={() => setShowAlert(false)}
+  >
+    You are using a beta version of the service. It might contain some
+    bugs or glitches.
+  </Alert>
 );
 ```
 

--- a/src/core/Form/ErrorSummary/ErrorSummary.md
+++ b/src/core/Form/ErrorSummary/ErrorSummary.md
@@ -121,7 +121,7 @@ const validateForm = () => {
   }
 };
 
-<Block style={{ width: '700px' }}>
+<Block style={{ width: '100%' }}>
   {errorSummaryItems.length > 0 && (
     <ErrorSummary
       headingText="The following problems were found in the form"

--- a/src/core/Pagination/Pagination.md
+++ b/src/core/Pagination/Pagination.md
@@ -38,7 +38,7 @@ const [current, setCurrent] = React.useState(2);
 const lastPage = 8;
 const headingRef = useRef();
 
-<Block style={{ width: '600px' }}>
+<Block style={{ width: '100%' }}>
   <Block
     padding="xl"
     mb="l"

--- a/src/core/Table/Table.md
+++ b/src/core/Table/Table.md
@@ -70,7 +70,7 @@ const data: TableRow<typeof columns>[] = [
 This ensures TypeScript will show an error if you forget to include any column key in your data objects.
 
 ```jsx
-import { Table, Link } from 'suomifi-ui-components';
+import { Table, Link, Block } from 'suomifi-ui-components';
 import React from 'react';
 
 const columns = [
@@ -141,13 +141,13 @@ const data = [
   }
 ];
 
-<div style={{ width: '900px' }}>
+<Block>
   <Table
     caption="People in the project"
     columns={columns}
     data={data}
   />
-</div>;
+</Block>;
 ```
 
 ### Sorting
@@ -162,7 +162,7 @@ You can also apply a default sort order when the table first renders by using th
 Always use the `tableSortedAriaLiveText()` function as demonstrated below to give screen readers information about table sorting.
 
 ```jsx
-import { Table, Link } from 'suomifi-ui-components';
+import { Table, Link, Block } from 'suomifi-ui-components';
 import React, { useState } from 'react';
 
 const columns = [
@@ -279,7 +279,7 @@ const customDataSort = (key, dir) => {
   setData(sortedData);
 };
 
-<div style={{ width: '920px' }}>
+<Block>
   <Table
     caption="People in the project"
     columns={columns}
@@ -314,7 +314,7 @@ const customDataSort = (key, dir) => {
       }`
     }
   />
-</div>;
+</Block>;
 ```
 
 ### Selecting rows
@@ -332,7 +332,7 @@ Individual rows can be disabled from selection by adding `rowSelectionDisabled: 
 You can control the selected rows programmatically by using the `controlledSelectedRowIds` prop as shown in the third example below.
 
 ```jsx
-import { Table, Link, Button } from 'suomifi-ui-components';
+import { Table, Link, Button, Block } from 'suomifi-ui-components';
 import React, { useState } from 'react';
 
 const columns = [
@@ -427,7 +427,7 @@ const data = [
 const [controlledSelectedRowIds, setControlledSelectedRowIds] =
   useState([]);
 
-<div style={{ width: '1000px' }}>
+<Block>
   <Table
     caption="People in the project"
     columns={columns}
@@ -466,7 +466,7 @@ const [controlledSelectedRowIds, setControlledSelectedRowIds] =
     }
     mt="xl"
   />
-</div>;
+</Block>;
 ```
 
 ### Condensed table
@@ -474,7 +474,7 @@ const [controlledSelectedRowIds, setControlledSelectedRowIds] =
 Use the `condensed` prop to decrease vertical padding in table cells
 
 ```jsx
-import { Table, Link } from 'suomifi-ui-components';
+import { Table, Link, Block } from 'suomifi-ui-components';
 import React from 'react';
 
 const columns = [
@@ -544,14 +544,14 @@ const data = [
   }
 ];
 
-<div style={{ width: '900px' }}>
+<Block>
   <Table
     caption="People in the project"
     columns={columns}
     data={data}
     condensed
   />
-</div>;
+</Block>;
 ```
 
 ### Horizontal scroll (mobile)
@@ -561,7 +561,7 @@ By default, the `<Table>` component does not wrap its content to multiple rows b
 It is important to set `overflow: auto` to the table's container element. On mobile screens it is also recommended to give the table's heading as a separate element instead of using the `caption` prop. This makes it so that only the table scrolls and the heading stays in place.
 
 ```jsx
-import { Table, Link, Heading } from 'suomifi-ui-components';
+import { Table, Link, Heading, Block } from 'suomifi-ui-components';
 import React from 'react';
 
 const columns = [
@@ -635,14 +635,14 @@ const data = [
   <Heading variant="h3" id="table-heading">
     People in the project
   </Heading>
-  <div style={{ width: '350px', overflowX: 'auto' }}>
+  <Block style={{ width: '350px', overflowX: 'auto' }}>
     <Table
       columns={columns}
       data={data}
       condensed
       aria-labelledby="table-heading"
     />
-  </div>
+  </Block>
 </>;
 ```
 
@@ -810,7 +810,7 @@ const [data, setData] = useState(fullData.slice(0, 5));
 const [currentPage, setCurrentPage] = React.useState(1);
 
 <>
-  <div style={{ width: '900px' }}>
+  <Block>
     <Table
       caption="People in the project"
       columns={columns}
@@ -843,7 +843,7 @@ const [currentPage, setCurrentPage] = React.useState(1);
         style={{ textAlign: 'center' }}
       />
     </Block>
-  </div>
+  </Block>
 </>;
 ```
 
@@ -943,7 +943,7 @@ const simulateLoading = () => {
   setTimeout(() => setLoading(false), 3000);
 };
 
-<div style={{ width: '900px' }}>
+<div>
   <Button onClick={simulateLoading} disabled={loading} mb="l">
     Simulate loading
   </Button>


### PR DESCRIPTION
## Description
Styleguidist contains a lot of examples with custom widths to represent the components as they most often appear in layouts. This, however, causes them to overflow outside the view when viewed on smaller screens.

This PR sets the default width for the examples to 900px to provide better responsiveness. Examples that benefit from a narrower container can and are still shown in a width that supports them best.

## Motivation and Context
The responsiveness for some examples was bad due to custom containers wider than the default.

## How Has This Been Tested?
Tested by running styleguidist locally on chrome and checking the component widths with desktop, tablet and mobile widths.

## Release notes
### General
- Adjust default width of styleguidist examples
