### PR TITLE
[Fix] Input height variance

### DIFF
--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -297,7 +297,7 @@ exports[`snapshots match date input error status with statustext 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -754,7 +754,7 @@ exports[`snapshots match date input hidden label with placeholder 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -1198,7 +1198,7 @@ exports[`snapshots match date input hint text 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -1631,7 +1631,7 @@ exports[`snapshots match date input minimal implementation 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -2057,7 +2057,7 @@ exports[`snapshots match date input optional text 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -2512,7 +2512,7 @@ exports[`snapshots match date input success status with statustext 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -3455,7 +3455,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -3867,7 +3867,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -5606,7 +5606,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -6018,7 +6018,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;

--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -369,7 +369,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -1069,7 +1069,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -1762,7 +1762,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -2355,7 +2355,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;

--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -24,7 +24,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     & .fi-filter-input_action-elements-container {
       position: absolute;
-      height: 40px;
+      height: 100%;
       right: 0;
       top: 0;
       display: flex;

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -208,7 +208,7 @@ exports[`snapshot matches 1`] = `
 
 .c1 .fi-filter-input_functionalityContainer .fi-filter-input_action-elements-container {
   position: absolute;
-  height: 40px;
+  height: 100%;
   right: 0;
   top: 0;
   display: flex;
@@ -277,7 +277,7 @@ exports[`snapshot matches 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -57,7 +57,7 @@ export const baseStyles = (
       background-color: ${theme.colors.whiteBase};
       color: ${theme.colors.blackBase};
       ${containerIEFocus(theme)}
-      height: 40px;
+      min-height: 40px;
       width: 100%;
       box-sizing: border-box;
       border: 1px solid ${theme.colors.depthDark3};

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -67,7 +67,8 @@ export const baseStyles = (
         position: absolute;
         width: 18px;
         height: 18px;
-        top: ${theme.spacing.insetL};
+        top: 50%;
+        transform: translateY(-50%);
         right: ${theme.spacing.insetL};
         & .fi-icon-base-fill {
           fill: ${theme.colors.depthDark1};
@@ -138,7 +139,8 @@ export const baseStyles = (
 
       &-clear {
         position: absolute;
-        top: 0;
+        top: 50%;
+        transform: translateY(-50%);
         right: 0px;
         clip: rect(0 0 0 0);
         height: 1px;
@@ -219,7 +221,7 @@ export const baseStyles = (
       overflow: visible;
       height: 20px;
       width: 20px;
-      margin: 9px;
+      margin: 0 9px;
       &:hover {
         background: ${theme.colors.highlightLight3};
       }

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -410,7 +410,7 @@ exports[`snapshot should have matching default structure 1`] = `
 .c1 .fi-search-input_input-element-container {
   background-color: hsl(0, 0%, 100%);
   color: hsl(0, 0%, 13%);
-  height: 40px;
+  min-height: 40px;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid hsl(201, 7%, 58%);
@@ -453,7 +453,7 @@ exports[`snapshot should have matching default structure 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -1354,7 +1354,7 @@ exports[`snapshot should have matching structure with suggestions open 1`] = `
 .c1 .fi-search-input_input-element-container {
   background-color: hsl(0, 0%, 100%);
   color: hsl(0, 0%, 13%);
-  height: 40px;
+  min-height: 40px;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid hsl(201, 7%, 58%);
@@ -1397,7 +1397,7 @@ exports[`snapshot should have matching structure with suggestions open 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -432,7 +432,8 @@ exports[`snapshot should have matching default structure 1`] = `
   position: absolute;
   width: 18px;
   height: 18px;
-  top: 10px;
+  top: 50%;
+  transform: translateY(-50%);
   right: 10px;
 }
 
@@ -518,7 +519,8 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c1 .fi-search-input_button-clear {
   position: absolute;
-  top: 0;
+  top: 50%;
+  transform: translateY(-50%);
   right: 0px;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -600,7 +602,7 @@ exports[`snapshot should have matching default structure 1`] = `
   overflow: visible;
   height: 20px;
   width: 20px;
-  margin: 9px;
+  margin: 0 9px;
 }
 
 .c1.fi-search-input--not-empty .fi-search-input_button-clear:hover {
@@ -1376,7 +1378,8 @@ exports[`snapshot should have matching structure with suggestions open 1`] = `
   position: absolute;
   width: 18px;
   height: 18px;
-  top: 10px;
+  top: 50%;
+  transform: translateY(-50%);
   right: 10px;
 }
 
@@ -1462,7 +1465,8 @@ exports[`snapshot should have matching structure with suggestions open 1`] = `
 
 .c1 .fi-search-input_button-clear {
   position: absolute;
-  top: 0;
+  top: 50%;
+  transform: translateY(-50%);
   right: 0px;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -1544,7 +1548,7 @@ exports[`snapshot should have matching structure with suggestions open 1`] = `
   overflow: visible;
   height: 20px;
   width: 20px;
-  margin: 9px;
+  margin: 0 9px;
 }
 
 .c1.fi-search-input--not-empty .fi-search-input_button-clear:hover {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -421,7 +421,7 @@ exports[`has matching snapshot 1`] = `
 
 .c2 .fi-filter-input_functionalityContainer .fi-filter-input_action-elements-container {
   position: absolute;
-  height: 40px;
+  height: 100%;
   right: 0;
   top: 0;
   display: flex;
@@ -490,7 +490,7 @@ exports[`has matching snapshot 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -414,7 +414,7 @@ exports[`has matching snapshot 1`] = `
 
 .c2 .fi-filter-input_functionalityContainer .fi-filter-input_action-elements-container {
   position: absolute;
-  height: 40px;
+  height: 100%;
   right: 0;
   top: 0;
   display: flex;
@@ -483,7 +483,7 @@ exports[`has matching snapshot 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -125,16 +125,16 @@ export const baseStyles = (
     & .fi-text-input_input {
       border: 2px solid ${theme.colors.alertBase};
       padding-left: 9px;
-      padding-top: 7px;
-      padding-bottom: 7px;
+      padding-top: 5px;
+      padding-bottom: 5px;
     }
   }
   &.fi-text-input--success {
     & .fi-text-input_input {
       border: 2px solid ${theme.colors.successBase};
       padding-left: 9px;
-      padding-top: 7px;
-      padding-bottom: 7px;
+      padding-top: 5px;
+      padding-bottom: 5px;
     }
   }
   &.fi-text-input--disabled {

--- a/src/core/Form/TextInput/TextInput.baseStyles.tsx
+++ b/src/core/Form/TextInput/TextInput.baseStyles.tsx
@@ -116,7 +116,8 @@ export const baseStyles = (
       position: absolute;
       width: 18px;
       height: 18px;
-      top: ${theme.spacing.insetL};
+      top: 50%;
+      transform: translateY(-50%);
       right: ${theme.spacing.insetL};
     }
   }

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -356,7 +356,8 @@ exports[`snapshots match error status with statustext 1`] = `
   position: absolute;
   width: 18px;
   height: 18px;
-  top: 10px;
+  top: 50%;
+  transform: translateY(-50%);
   right: 10px;
 }
 
@@ -787,7 +788,8 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   position: absolute;
   width: 18px;
   height: 18px;
-  top: 10px;
+  top: 50%;
+  transform: translateY(-50%);
   right: 10px;
 }
 
@@ -1188,7 +1190,8 @@ exports[`snapshots match minimal implementation 1`] = `
   position: absolute;
   width: 18px;
   height: 18px;
-  top: 10px;
+  top: 50%;
+  transform: translateY(-50%);
   right: 10px;
 }
 

--- a/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/core/Form/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -314,7 +314,7 @@ exports[`snapshots match error status with statustext 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -363,15 +363,15 @@ exports[`snapshots match error status with statustext 1`] = `
 .c1.fi-text-input--error .fi-text-input_input {
   border: 2px solid hsl(3, 59%, 43%);
   padding-left: 9px;
-  padding-top: 7px;
-  padding-bottom: 7px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .c1.fi-text-input--success .fi-text-input_input {
   border: 2px solid hsl(166, 90%, 34%);
   padding-left: 9px;
-  padding-top: 7px;
-  padding-bottom: 7px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .c1.fi-text-input--disabled .fi-text-input_input {
@@ -745,7 +745,7 @@ exports[`snapshots match hidden label with placeholder 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -794,15 +794,15 @@ exports[`snapshots match hidden label with placeholder 1`] = `
 .c1.fi-text-input--error .fi-text-input_input {
   border: 2px solid hsl(3, 59%, 43%);
   padding-left: 9px;
-  padding-top: 7px;
-  padding-bottom: 7px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .c1.fi-text-input--success .fi-text-input_input {
   border: 2px solid hsl(166, 90%, 34%);
   padding-left: 9px;
-  padding-top: 7px;
-  padding-bottom: 7px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .c1.fi-text-input--disabled .fi-text-input_input {
@@ -1146,7 +1146,7 @@ exports[`snapshots match minimal implementation 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
@@ -1195,15 +1195,15 @@ exports[`snapshots match minimal implementation 1`] = `
 .c1.fi-text-input--error .fi-text-input_input {
   border: 2px solid hsl(3, 59%, 43%);
   padding-left: 9px;
-  padding-top: 7px;
-  padding-bottom: 7px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .c1.fi-text-input--success .fi-text-input_input {
   border: 2px solid hsl(166, 90%, 34%);
   padding-left: 9px;
-  padding-top: 7px;
-  padding-bottom: 7px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .c1.fi-text-input--disabled .fi-text-input_input {

--- a/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
+++ b/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
@@ -82,7 +82,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       cursor: default;
       pointer-events: none;
       right: 0px;
-      height: 40px;
+      height: 100%;
       width: 40px;
       border-radius: 0 ${theme.radiuses.basic} ${theme.radiuses.basic} 0;
       border: 0;

--- a/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
+++ b/src/core/Pagination/PageInput/PageInput.baseStyles.tsx
@@ -46,7 +46,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
         }
       }
       width: 100%;
-      height: 40px;
+      min-height: 40px;
       box-sizing: border-box;
       border: 1px solid ${theme.colors.depthDark3};
       border-radius: ${theme.radiuses.basic};

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -463,7 +463,7 @@ exports[`snapshot should have matching default structure 1`] = `
   cursor: default;
   pointer-events: none;
   right: 0px;
-  height: 40px;
+  height: 100%;
   width: 40px;
   border-radius: 0 2px 2px 0;
   border: 0;

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -370,7 +370,7 @@ exports[`snapshot should have matching default structure 1`] = `
   background-color: hsl(0, 0%, 100%);
   color: hsl(0, 0%, 13%);
   width: 100%;
-  height: 40px;
+  min-height: 40px;
   box-sizing: border-box;
   border: 1px solid hsl(201, 7%, 58%);
   border-radius: 2px;
@@ -430,7 +430,7 @@ exports[`snapshot should have matching default structure 1`] = `
   font-weight: 400;
   min-width: 245px;
   max-width: 100%;
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;

--- a/src/core/theme/reset/index.ts
+++ b/src/core/theme/reset/index.ts
@@ -24,7 +24,7 @@ export const input = (theme: SuomifiTheme) => css`
   ${font(theme)('actionElementInnerText')}
   min-width: 245px;
   max-width: 100%;
-  padding: ${theme.spacing.insetM} ${theme.spacing.insetXl};
+  padding: ${theme.spacing.insetS} ${theme.spacing.insetXl};
   border: 1px solid ${theme.colors.depthLight1};
   border-radius: ${theme.radiuses.basic};
   line-height: 1;


### PR DESCRIPTION
## Description
This PR addresses an issue where input height would vary based on browser and display. This was due to the recent font change and some styles just happening to play nicely with the old one but not with the new one.

Decreasing the vertical padding in some components and using min-height fixes the issue and improves user experience when the user sets a higher font size value from the browser settings.

## Motivation and Context
This was a clear bug that was reported by projects using the library

## How Has This Been Tested?
Tested in styleguidist on brave, chrome and firefox with default and increased font sizes

## Release notes
### SingleSelect, MultiSelect, Pagination, TextInput, Dropdown, DateInput, SearchInput
- **Breaking change:** Change internal paddings and make component more flexible in terms of user-increased font sizes 
  - Fixes height of input from elements fluctuating between 40-42px (depending on browser and screen) with Source Sans 3

