### PR TITLE
[Feature] RadioButton: display text as block

### DIFF
--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -108,6 +108,7 @@ export const baseStyles = (
       ${theme.typography.bodyTextSmall};
     }
     & .fi-radio-button_label {
+      display: block;
       font-size: 16px;
       position: relative;
       cursor: pointer;

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -162,6 +162,7 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -497,6 +498,7 @@ exports[`className should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -832,6 +834,7 @@ exports[`disabled should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -1185,6 +1188,7 @@ exports[`hintText should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -1527,6 +1531,7 @@ exports[`id should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -1862,6 +1867,7 @@ exports[`name should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -2198,6 +2204,7 @@ exports[`value should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -2525,6 +2532,7 @@ exports[`variant should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -370,6 +370,7 @@ exports[`default, with only required props should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -1041,6 +1042,7 @@ exports[`props className should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -1712,6 +1714,7 @@ exports[`props defaultValue should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -2419,6 +2422,7 @@ exports[`props groupStatus and statusText should match snapshot 1`] = `
 }
 
 .c8.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -3130,6 +3134,7 @@ exports[`props hintText should match snapshot 1`] = `
 }
 
 .c8.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -3806,6 +3811,7 @@ exports[`props id should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -4477,6 +4483,7 @@ exports[`props label should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -5159,6 +5166,7 @@ exports[`props labelMode should match snapshot 1`] = `
 }
 
 .c8.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -5830,6 +5838,7 @@ exports[`props name should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;
@@ -6501,6 +6510,7 @@ exports[`props value should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_label {
+  display: block;
   font-size: 16px;
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Aligns text in RadioButton to left, in case of long text that wraps to multiple lines.

## Motivation and Context

Text is aligned to keep the text style unified with hintText. Additionally this unifies styling with CheckBox, where text is likewise aligned to left if it wraps to multiple lines.

<!-- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?

Tested with Styleguide, MacOS Chrome and Safari.

## Screenshots (if appropriate):

Old style:
<img width="307" height="228" alt="image" src="https://github.com/user-attachments/assets/7cd1ba6c-5f83-4a6c-8855-ef928a33df40" />

New style:
<img width="283" height="238" alt="Screenshot 2026-07-01 at 14 19 53" src="https://github.com/user-attachments/assets/1911714a-9b92-4c84-96ea-442b9ab097f5" />

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### RadioButton
- **Breaking change**: Text content is displayed as `block` to align text to left, in case long text wraps to multiple lines