### PR TITLE
[Feature] Icon alignment adjustments

### DIFF
--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -541,7 +541,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
 
 .c11.fi-dropdown_item .fi-dropdown_item_icon {
   position: absolute;
-  top: 14px;
+  top: calc(50% - 6px);
   right: 10px;
   height: 12px;
   width: 12px;
@@ -1243,7 +1243,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 
 .c11.fi-dropdown_item .fi-dropdown_item_icon {
   position: absolute;
-  top: 14px;
+  top: calc(50% - 6px);
   right: 10px;
   height: 12px;
   width: 12px;
@@ -1938,7 +1938,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 
 .c11.fi-dropdown_item .fi-dropdown_item_icon {
   position: absolute;
-  top: 14px;
+  top: calc(50% - 6px);
   right: 10px;
   height: 12px;
   width: 12px;

--- a/src/core/Form/Dropdown/DropdownItem/DropdownItem.basestyles.tsx
+++ b/src/core/Form/Dropdown/DropdownItem/DropdownItem.basestyles.tsx
@@ -21,7 +21,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     .fi-dropdown_item_icon {
       position: absolute;
-      top: 14px;
+      top: calc(50% - 6px);
       right: 10px;
       height: 12px;
       width: 12px;

--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -50,11 +50,10 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   }
 
   & .fi-filter-input_input-element-container {
+    position: relative;
     ${containerIEFocus(theme)}
 
     &:focus-within {
-      position: relative;
-
       &::after {
         ${theme.focuses.absoluteFocus}
       }

--- a/src/core/Form/FilterInput/FilterInput.tsx
+++ b/src/core/Form/FilterInput/FilterInput.tsx
@@ -215,18 +215,18 @@ class BaseFilterInput<T> extends Component<FilterInputProps & InnerRef> {
                 onChange={onChangeHandler}
                 aria-multiline={false}
               />
+              {React.Children.count(children) > 0 && (
+                <HtmlDiv
+                  className={filterInputClassNames.actionElementsContainer}
+                  onMouseDownCapture={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                >
+                  {children}
+                </HtmlDiv>
+              )}
             </HtmlDiv>
-            {React.Children.count(children) > 0 && (
-              <HtmlDiv
-                className={filterInputClassNames.actionElementsContainer}
-                onMouseDownCapture={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-              >
-                {children}
-              </HtmlDiv>
-            )}
             <StatusText
               id={statusTextId}
               className={classnames({

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -234,6 +234,10 @@ exports[`snapshot matches 1`] = `
   margin-top: 5px;
 }
 
+.c1 .fi-filter-input_input-element-container {
+  position: relative;
+}
+
 .c1 .fi-filter-input_input-element-container >input:focus {
   outline-color: hsl(196, 77%, 44%);
   outline-width: 2px;
@@ -243,10 +247,6 @@ exports[`snapshot matches 1`] = `
 
 .c1 .fi-filter-input_input-element-container:focus-within >input:focus {
   outline: none;
-}
-
-.c1 .fi-filter-input_input-element-container:focus-within {
-  position: relative;
 }
 
 .c1 .fi-filter-input_input-element-container:focus-within::after {

--- a/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
+++ b/src/core/Form/SearchInput/SearchInput.baseStyles.tsx
@@ -196,6 +196,12 @@ export const baseStyles = (
     }
   }
 
+  &.fi-search-input--no-search-button.fi-search-input--error {
+    & .fi-search-input_input-element-container {
+      border-right: 1px solid ${theme.colors.alertBase};
+    }
+  }
+
   &.fi-search-input--error {
     & .fi-search-input_input-element-container {
       border: 1px solid ${theme.colors.alertBase};

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -1194,7 +1194,7 @@ exports[`snapshot should have matching structure with suggestions open 1`] = `
 
 .c15.fi-select-item .fi-select-item_icon {
   position: absolute;
-  top: 14px;
+  top: calc(50% - 6px);
   right: 10px;
   height: 12px;
   width: 12px;

--- a/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
+++ b/src/core/Form/SearchInput/__snapshots__/SearchInput.test.tsx.snap
@@ -579,6 +579,10 @@ exports[`snapshot should have matching default structure 1`] = `
   max-width: none;
 }
 
+.c1.fi-search-input--no-search-button.fi-search-input--error .fi-search-input_input-element-container {
+  border-right: 1px solid hsl(3, 59%, 43%);
+}
+
 .c1.fi-search-input--error .fi-search-input_input-element-container {
   border: 1px solid hsl(3, 59%, 43%);
   border-right: 0;
@@ -1523,6 +1527,10 @@ exports[`snapshot should have matching structure with suggestions open 1`] = `
 
 .c1.fi-search-input--full-width .fi-search-input_input-element-container {
   max-width: none;
+}
+
+.c1.fi-search-input--no-search-button.fi-search-input--error .fi-search-input_input-element-container {
+  border-right: 1px solid hsl(3, 59%, 43%);
 }
 
 .c1.fi-search-input--error .fi-search-input_input-element-container {

--- a/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
+++ b/src/core/Form/Select/BaseSelect/SelectItem/SelectItem.baseStyles.tsx
@@ -25,7 +25,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
 
     & .fi-select-item_icon {
       position: absolute;
-      top: 14px;
+      top: calc(50% - 6px);
       right: 10px;
       height: 12px;
       width: 12px;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -607,7 +607,7 @@ exports[`has matching snapshot 1`] = `
 
 .c15.fi-select-item .fi-select-item_icon {
   position: absolute;
-  top: 14px;
+  top: calc(50% - 6px);
   right: 10px;
   height: 12px;
   width: 12px;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -447,6 +447,10 @@ exports[`has matching snapshot 1`] = `
   margin-top: 5px;
 }
 
+.c2 .fi-filter-input_input-element-container {
+  position: relative;
+}
+
 .c2 .fi-filter-input_input-element-container >input:focus {
   outline-color: hsl(196, 77%, 44%);
   outline-width: 2px;
@@ -456,10 +460,6 @@ exports[`has matching snapshot 1`] = `
 
 .c2 .fi-filter-input_input-element-container:focus-within >input:focus {
   outline: none;
-}
-
-.c2 .fi-filter-input_input-element-container:focus-within {
-  position: relative;
 }
 
 .c2 .fi-filter-input_input-element-container:focus-within::after {
@@ -1269,38 +1269,38 @@ exports[`has matching snapshot 1`] = `
                   type="text"
                   value=""
                 />
-              </div>
-              <div
-                class="c0 fi-filter-input_action-elements-container"
-              >
-                <button
-                  aria-controls="3-popover"
-                  aria-expanded="true"
-                  aria-labelledby="3-label"
-                  class="c7 fi-input-toggle-button c8"
-                  tabindex="-1"
-                  type="button"
+                <div
+                  class="c0 fi-filter-input_action-elements-container"
                 >
-                  <span
-                    class="c5 c9 fi-visually-hidden"
-                  />
-                  <svg
-                    aria-hidden="true"
-                    class="fi-icon c10 fi-input-toggle-button_icon"
-                    focusable="false"
-                    height="1em"
-                    viewBox="0 0 10 10"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <button
+                    aria-controls="3-popover"
+                    aria-expanded="true"
+                    aria-labelledby="3-label"
+                    class="c7 fi-input-toggle-button c8"
+                    tabindex="-1"
+                    type="button"
                   >
-                    <path
-                      class="fi-icon-base-fill"
-                      d="M5 2 1 8h8z"
-                      fill="#212121"
-                      fill-rule="evenodd"
+                    <span
+                      class="c5 c9 fi-visually-hidden"
                     />
-                  </svg>
-                </button>
+                    <svg
+                      aria-hidden="true"
+                      class="fi-icon c10 fi-input-toggle-button_icon"
+                      focusable="false"
+                      height="1em"
+                      viewBox="0 0 10 10"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        class="fi-icon-base-fill"
+                        d="M5 2 1 8h8z"
+                        fill="#212121"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
               </div>
               <span
                 aria-atomic="true"

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -653,7 +653,7 @@ exports[`has matching snapshot 1`] = `
 
 .c18.fi-select-item .fi-select-item_icon {
   position: absolute;
-  top: 14px;
+  top: calc(50% - 6px);
   right: 10px;
   height: 12px;
   width: 12px;

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -440,6 +440,10 @@ exports[`has matching snapshot 1`] = `
   margin-top: 5px;
 }
 
+.c2 .fi-filter-input_input-element-container {
+  position: relative;
+}
+
 .c2 .fi-filter-input_input-element-container >input:focus {
   outline-color: hsl(196, 77%, 44%);
   outline-width: 2px;
@@ -449,10 +453,6 @@ exports[`has matching snapshot 1`] = `
 
 .c2 .fi-filter-input_input-element-container:focus-within >input:focus {
   outline: none;
-}
-
-.c2 .fi-filter-input_input-element-container:focus-within {
-  position: relative;
 }
 
 .c2 .fi-filter-input_input-element-container:focus-within::after {
@@ -894,68 +894,68 @@ exports[`has matching snapshot 1`] = `
                 type="text"
                 value="Hammer"
               />
-            </div>
-            <div
-              class="c0 fi-filter-input_action-elements-container"
-            >
               <div
-                class="c0 fi-single-select_clear-button_wrapper"
+                class="c0 fi-filter-input_action-elements-container"
               >
+                <div
+                  class="c0 fi-single-select_clear-button_wrapper"
+                >
+                  <button
+                    class="c8 fi-input-clear-button c9"
+                    type="button"
+                  >
+                    <span
+                      class="c5 c10 fi-visually-hidden"
+                    >
+                      Clear selection
+                    </span>
+                    <svg
+                      aria-hidden="true"
+                      class="fi-icon c11 fi-input-clear-button_icon"
+                      focusable="false"
+                      height="1em"
+                      viewBox="0 0 24 24"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        class="fi-icon-base-fill"
+                        d="M4.75 3.3 12 10.55l7.25-7.25a1.026 1.026 0 0 1 1.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 0 1-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 0 1-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 0 1 4.75 3.3Z"
+                        fill="#212121"
+                        fill-rule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                </div>
                 <button
-                  class="c8 fi-input-clear-button c9"
+                  aria-controls="2-popover"
+                  aria-expanded="true"
+                  aria-labelledby="2-label"
+                  class="c8 fi-input-toggle-button c12"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
                     class="c5 c10 fi-visually-hidden"
-                  >
-                    Clear selection
-                  </span>
+                  />
                   <svg
                     aria-hidden="true"
-                    class="fi-icon c11 fi-input-clear-button_icon"
+                    class="fi-icon c13 fi-input-toggle-button_icon"
                     focusable="false"
                     height="1em"
-                    viewBox="0 0 24 24"
+                    viewBox="0 0 10 10"
                     width="1em"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
                       class="fi-icon-base-fill"
-                      d="M4.75 3.3 12 10.55l7.25-7.25a1.026 1.026 0 0 1 1.45 1.45L13.45 12l7.25 7.25a1.026 1.026 0 0 1-1.45 1.45L12 13.45 4.75 20.7a1.026 1.026 0 0 1-1.45-1.45L10.55 12 3.3 4.75A1.026 1.026 0 0 1 4.75 3.3Z"
+                      d="M5 2 1 8h8z"
                       fill="#212121"
                       fill-rule="evenodd"
                     />
                   </svg>
                 </button>
               </div>
-              <button
-                aria-controls="2-popover"
-                aria-expanded="true"
-                aria-labelledby="2-label"
-                class="c8 fi-input-toggle-button c12"
-                tabindex="-1"
-                type="button"
-              >
-                <span
-                  class="c5 c10 fi-visually-hidden"
-                />
-                <svg
-                  aria-hidden="true"
-                  class="fi-icon c13 fi-input-toggle-button_icon"
-                  focusable="false"
-                  height="1em"
-                  viewBox="0 0 10 10"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    class="fi-icon-base-fill"
-                    d="M5 2 1 8h8z"
-                    fill="#212121"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </button>
             </div>
             <span
               aria-atomic="true"

--- a/src/core/Pagination/Pagination.baseStyles.ts
+++ b/src/core/Pagination/Pagination.baseStyles.ts
@@ -24,7 +24,6 @@ export const baseStyles = (
 
       & .fi-pagination_arrow-button {
         min-width: 40px;
-        height: 40px;
         width: 40px;
         padding-left: 0;
         padding-right: 0;

--- a/src/core/Pagination/Pagination.baseStyles.ts
+++ b/src/core/Pagination/Pagination.baseStyles.ts
@@ -24,10 +24,16 @@ export const baseStyles = (
 
       & .fi-pagination_arrow-button {
         min-width: 40px;
+        height: 40px;
         width: 40px;
         padding-left: 0;
         padding-right: 0;
         margin: 0;
+
+        & .fi-button_icon {
+          display: flex;
+          margin-top: 2px;
+        }
 
         & > .fi-button_icon > .fi-icon {
           margin-right: auto;

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -838,7 +838,6 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c1.fi-pagination .fi-pagination_buttons-wrapper .fi-pagination_arrow-button {
   min-width: 40px;
-  height: 40px;
   width: 40px;
   padding-left: 0;
   padding-right: 0;

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -838,10 +838,16 @@ exports[`snapshot should have matching default structure 1`] = `
 
 .c1.fi-pagination .fi-pagination_buttons-wrapper .fi-pagination_arrow-button {
   min-width: 40px;
+  height: 40px;
   width: 40px;
   padding-left: 0;
   padding-right: 0;
   margin: 0;
+}
+
+.c1.fi-pagination .fi-pagination_buttons-wrapper .fi-pagination_arrow-button .fi-button_icon {
+  display: flex;
+  margin-top: 2px;
 }
 
 .c1.fi-pagination .fi-pagination_buttons-wrapper .fi-pagination_arrow-button>.fi-button_icon>.fi-icon {

--- a/src/core/Tooltip/TooltipToggleButton/TooltipToggleButton.baseStyles.tsx
+++ b/src/core/Tooltip/TooltipToggleButton/TooltipToggleButton.baseStyles.tsx
@@ -2,7 +2,7 @@ import { css } from 'styled-components';
 import { SuomifiTheme } from '../../theme';
 
 export const baseStyles = (theme: SuomifiTheme) => css`
-  display: inline;
+  display: inline-flex;
   height: 16px;
   width: 16px;
   margin-left: 5px;

--- a/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/core/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -233,7 +233,7 @@ exports[`Basic tooltip should match snapshot 1`] = `
 }
 
 .c1 {
-  display: inline;
+  display: inline-flex;
   height: 16px;
   width: 16px;
   margin-left: 5px;
@@ -399,7 +399,7 @@ exports[`margin should have margin style from margin prop 1`] = `
 }
 
 .c1 {
-  display: inline;
+  display: inline-flex;
   height: 16px;
   width: 16px;
   margin-left: 5px;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Aligns icons vertically inside components Label, SingleSelect, MultiSelect, Dropdown and Pagination when minimum font size of browser is increased.

Fixes SearchInput variant having no border, when it has status error and no search button.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Several icons were positioned off-center if user increases minimum font size of browser to very large.

## How Has This Been Tested?

Tested with MacOS Chrome, MacOS Firefox, MacOS Safari, Windows Edge, iOS Safari, iOS Chrome

## Screenshots (if appropriate):

Examples have minimum font size of browser increased, which misaligns the icons.

### Aligns Tooltip icon in Label component with text content
<img width="250" height="auto" alt="image" src="https://github.com/user-attachments/assets/6981d767-641d-4d87-b768-2383dcb2f2b0" />
<img width="250" height="auto" alt="image" src="https://github.com/user-attachments/assets/4a2d1aef-d5ca-42e4-87c6-751951b07495" />

### Aligns SingleSelect's and MultiSelect's selected item icon with text content
<img width="200" height="auto" alt="image" src="https://github.com/user-attachments/assets/98a3a46c-2f93-4051-b97a-d7e386ae8eb6" />
<img width="200" height="auto" alt="image" src="https://github.com/user-attachments/assets/7514bfe1-2bc4-428e-8de9-8e422e7b631e" />

### Aligns toggle icon and remove icon inside Dropdown, SingleSelect and MultiSelect
<img width="200" height="auto" alt="image" src="https://github.com/user-attachments/assets/ffa90794-0a1c-4e63-abfe-24835dd57e48" />
<img width="200" height="auto" alt="image" src="https://github.com/user-attachments/assets/1c2221e2-49e3-46c3-bcf9-193d548b83ab" />

### Aligns icons inside Pagination buttons
<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/70593ecf-4c5c-4372-b056-96782c04a500" />
<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/7c4ba4ed-93ac-46ef-a4af-59264f424886" />

### Fixes SearchInput variant missing border
<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/c7f0eb82-a23c-46b1-96fa-3178f1b1a73b" />
<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/5f79005e-e558-4dc8-a703-5dc2936dd273" />


## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### Pagination
- Aligns Previous/Next icons vertically inside buttons (fixes alignment with large font size)

### Dropdown
- Aligns selected item indicator vertically (fixes alignment with large font size)
 
### SingleSelect, MultiSelect
- Aligns Open/Close icon, Remove icon, and selected item indicator vertically (fixes alignment with large font size)

### Label
- Aligns Tooltip button vertically (fixes alignment with large font size)

### SearchInput
- Fixes SearchInput missing part of error border, if used without search button
