### PR TITLE
[Bugfix] Update character count when controlled value is changed

### DIFF
--- a/src/core/Form/TextInput/TextInput.test.tsx
+++ b/src/core/Form/TextInput/TextInput.test.tsx
@@ -347,6 +347,49 @@ describe('Character counter', () => {
     ).toHaveTextContent('26/20');
   });
 
+  it('should display correct character count when controlled value is changed', async () => {
+    const { container, rerender } = render(
+      <TextInput
+        labelText="label"
+        data-testid="cc-input"
+        characterLimit={20}
+        ariaCharactersRemainingText={(amount) =>
+          `You have ${amount} characters remaining`
+        }
+        ariaCharactersExceededText={(amount) =>
+          `You have ${amount} characters too many`
+        }
+        value="Lorem ipsum dolor"
+      />,
+    );
+    expect(
+      container.getElementsByClassName('fi-text-input_character-counter')
+        .length,
+    ).toBe(1);
+    expect(
+      container.getElementsByClassName('fi-text-input_character-counter')[0],
+    ).toHaveTextContent('17/20');
+
+    rerender(
+      <TextInput
+        labelText="label"
+        data-testid="cc-input"
+        characterLimit={20}
+        ariaCharactersRemainingText={(amount) =>
+          `You have ${amount} characters remaining`
+        }
+        ariaCharactersExceededText={(amount) =>
+          `You have ${amount} characters too many`
+        }
+        value=""
+      />,
+    );
+
+    expect(
+      container.getElementsByClassName('fi-text-input_character-counter')[0],
+    ).toHaveTextContent('0/20');
+  });
+
   it('should have correct screen reader status text', async () => {
     const user = userEvent.setup({ delay: null });
     const { container, getByTestId } = render(

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -157,10 +157,13 @@ const BaseTextInput = (props: InternalTextInputProps) => {
   const [_marginProps, passProps] = separateMarginProps(rest);
 
   useEffect(() => {
-    if (characterLimit !== undefined && inputRef.current?.value.length) {
+    if (
+      characterLimit !== undefined &&
+      inputRef.current?.value.length !== undefined
+    ) {
       setCharCount(inputRef.current?.value.length);
     }
-  }, []);
+  }, [characterLimit, passProps?.value]);
 
   const inputRef = useRef<HTMLInputElement>(null);
 

--- a/src/core/Form/TextInput/TextInput.tsx
+++ b/src/core/Form/TextInput/TextInput.tsx
@@ -152,6 +152,8 @@ const BaseTextInput = (props: InternalTextInputProps) => {
     characterLimit,
     ariaCharactersRemainingText,
     ariaCharactersExceededText,
+    value,
+    disabled,
     ...rest
   } = props;
   const [_marginProps, passProps] = separateMarginProps(rest);
@@ -163,7 +165,7 @@ const BaseTextInput = (props: InternalTextInputProps) => {
     ) {
       setCharCount(inputRef.current?.value.length);
     }
-  }, [characterLimit, passProps?.value]);
+  }, [characterLimit, value]);
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -205,7 +207,7 @@ const BaseTextInput = (props: InternalTextInputProps) => {
   return (
     <HtmlDiv
       className={classnames(baseClassName, className, {
-        [textInputClassNames.disabled]: !!passProps.disabled,
+        [textInputClassNames.disabled]: !!disabled,
         [textInputClassNames.icon]: !!icon,
         [textInputClassNames.error]: status === 'error',
         [textInputClassNames.success]: status === 'success',
@@ -231,6 +233,8 @@ const BaseTextInput = (props: InternalTextInputProps) => {
             {(debouncer: Function) => (
               <HtmlInput
                 {...passProps}
+                value={value}
+                disabled={disabled}
                 id={id}
                 className={textInputClassNames.inputElement}
                 type={type}
@@ -258,7 +262,7 @@ const BaseTextInput = (props: InternalTextInputProps) => {
             })}
             status={status}
             ariaLiveMode={statusTextAriaLiveMode}
-            disabled={passProps.disabled}
+            disabled={disabled}
           >
             {characterLimit && (
               <VisuallyHidden>{characterCounterAriaText}</VisuallyHidden>

--- a/src/core/Form/Textarea/Textarea.test.tsx
+++ b/src/core/Form/Textarea/Textarea.test.tsx
@@ -347,6 +347,47 @@ describe('props', () => {
       ).toHaveTextContent('26/20');
     });
 
+    it('should update character count when controlled value is changed', async () => {
+      const { container, rerender } = render(
+        <Textarea
+          labelText="label"
+          characterLimit={20}
+          ariaCharactersRemainingText={(amount) =>
+            `You have ${amount} characters remaining`
+          }
+          ariaCharactersExceededText={(amount) =>
+            `You have ${amount} characters too many`
+          }
+          value="Lorem ipsum dolor"
+        />,
+      );
+      expect(
+        container.getElementsByClassName('fi-textarea_character-counter')
+          .length,
+      ).toBe(1);
+      expect(
+        container.getElementsByClassName('fi-textarea_character-counter')[0],
+      ).toHaveTextContent('17/20');
+
+      rerender(
+        <Textarea
+          labelText="label"
+          characterLimit={20}
+          ariaCharactersRemainingText={(amount) =>
+            `You have ${amount} characters remaining`
+          }
+          ariaCharactersExceededText={(amount) =>
+            `You have ${amount} characters too many`
+          }
+          value=""
+        />,
+      );
+
+      expect(
+        container.getElementsByClassName('fi-textarea_character-counter')[0],
+      ).toHaveTextContent('0/20');
+    });
+
     it('should have correct screen reader status text', async () => {
       const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       const { container, getByTestId } = render(

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -138,6 +138,7 @@ const BaseTextarea = (props: TextareaProps) => {
     characterLimit,
     ariaCharactersRemainingText,
     ariaCharactersExceededText,
+    value,
     ...rest
   } = props;
   const [_marginProps, passProps] = separateMarginProps(rest);
@@ -169,7 +170,7 @@ const BaseTextarea = (props: TextareaProps) => {
     ) {
       setCharCount(inputRef.current?.value.length);
     }
-  }, [characterLimit, passProps?.value]);
+  }, [characterLimit, value]);
 
   const handleOnChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     if (typingTimer) {
@@ -239,6 +240,7 @@ const BaseTextarea = (props: TextareaProps) => {
             ariaDescribedBy,
           ])}
           onChange={handleOnChange}
+          value={value}
           {...passProps}
           {...onClickProps}
         />

--- a/src/core/Form/Textarea/Textarea.tsx
+++ b/src/core/Form/Textarea/Textarea.tsx
@@ -163,10 +163,13 @@ const BaseTextarea = (props: TextareaProps) => {
   const hintTextId = hintText ? `${id}-hintText` : undefined;
 
   useEffect(() => {
-    if (characterLimit !== undefined && inputRef.current?.value.length) {
+    if (
+      characterLimit !== undefined &&
+      inputRef.current?.value.length !== undefined
+    ) {
       setCharCount(inputRef.current?.value.length);
     }
-  }, []);
+  }, [characterLimit, passProps?.value]);
 
   const handleOnChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     if (typingTimer) {


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

PR updates useEffect to update the character counter's amount when characterLimit or input's value is changed.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Changing controlled value did not update the amount in character counter, because the amount was updated with the input's onChange event or useEffect which was called when mounted.

## How Has This Been Tested?

Tested with components in Styleguidist and added tests.

## Screenshots (if appropriate):

Previous bug (text emptied with reset button):
<img width="304" height="324" alt="image" src="https://github.com/user-attachments/assets/5575e086-b52a-4b2f-a055-29a61cd4ab11" />


## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### Textarea, TextInput
- Fixes character counter to display correct amount when component is used with controlled value