### PR TITLE
[Fix] Adjust dropdown and select min-width

### DIFF
--- a/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
+++ b/src/core/Form/DateInput/DatePicker/DateSelectors/DateSelectors.baseStyles.tsx
@@ -16,6 +16,7 @@ export const baseStyles = (
     margin: 0;
     margin-right: ${theme.spacing.xs};
     width: ${yearSelectWidth}px;
+    min-width: 90px;
     .fi-dropdown_button {
       min-width: 90px;
     }
@@ -25,6 +26,7 @@ export const baseStyles = (
     margin: 0;
     margin-right: ${theme.spacing.xxs};
     width: ${monthSelectWidth}px;
+    min-width: 145px;
     .fi-dropdown_button {
       min-width: 145px;
     }

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3410,6 +3410,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
 
 .c12 {
   width: 290px;
+  min-width: 160px;
 }
 
 .c12 .fi-label,
@@ -3459,6 +3460,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
+  min-width: 160px;
   position: relative;
   display: inline-block;
   width: 100%;
@@ -3611,6 +3613,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin: 0;
   margin-right: 10px;
   width: 0px;
+  min-width: 90px;
 }
 
 .c11 .fi-date-selectors_year-select .fi-dropdown_button {
@@ -3621,6 +3624,7 @@ exports[`snapshots match date input with datepicker with controlled input value 
   margin: 0;
   margin-right: 5px;
   width: 0px;
+  min-width: 145px;
 }
 
 .c11 .fi-date-selectors_month-select .fi-dropdown_button {
@@ -5561,6 +5565,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 
 .c12 {
   width: 290px;
+  min-width: 160px;
 }
 
 .c12 .fi-label,
@@ -5610,6 +5615,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
+  min-width: 160px;
   position: relative;
   display: inline-block;
   width: 100%;
@@ -5762,6 +5768,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   margin: 0;
   margin-right: 10px;
   width: 0px;
+  min-width: 90px;
 }
 
 .c11 .fi-date-selectors_year-select .fi-dropdown_button {
@@ -5772,6 +5779,7 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
   margin: 0;
   margin-right: 5px;
   width: 0px;
+  min-width: 145px;
 }
 
 .c11 .fi-date-selectors_month-select .fi-dropdown_button {

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -9,6 +9,7 @@ export const baseStyles = (
   propMargins?: MarginProps,
 ) => css`
   width: 290px;
+  min-width: 100px;
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
   ${fixInternalMargins()}
@@ -35,6 +36,7 @@ export const baseStyles = (
 
     .fi-dropdown_button {
       ${input(theme)}
+      min-width: 100px;
       position: relative;
       display: inline-block;
       width: 100%;

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.baseStyles.tsx
@@ -9,7 +9,7 @@ export const baseStyles = (
   propMargins?: MarginProps,
 ) => css`
   width: 290px;
-  min-width: 100px;
+  min-width: 160px;
   ${buildSpacingCSS(globalMargins)}
   ${buildSpacingCSS(propMargins, true)}
   ${fixInternalMargins()}
@@ -36,7 +36,7 @@ export const baseStyles = (
 
     .fi-dropdown_button {
       ${input(theme)}
-      min-width: 100px;
+      min-width: 160px;
       position: relative;
       display: inline-block;
       width: 100%;

--- a/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
+++ b/src/core/Form/Dropdown/Dropdown/Dropdown.tsx
@@ -125,7 +125,9 @@ export interface DropdownProps<T extends string = string>
   /** Visual hint to show if nothing is selected and no value or defaultValue is provided.
    * Should not be used for instructions since assistive technologies don't reliably read a placeholder text */
   visualPlaceholder?: ReactNode;
-  /** Always show the visual placeholder instead of the selected value. Makes the Dropdown act as an action menu. */
+  /** Always show the visual placeholder instead of the selected value. Makes the Dropdown act as an action menu.
+   * Deprecated - will be removed in future releases. Use action menu to trigger actions.
+   */
   alwaysShowVisualPlaceholder?: boolean;
   /** Hides or shows the label. Label element is always present, but can be visually hidden.
    * @default visible

--- a/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/core/Form/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -324,6 +324,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
 
 .c1 {
   width: 290px;
+  min-width: 160px;
 }
 
 .c1 .fi-label,
@@ -373,6 +374,7 @@ exports[`Basic dropdown should match snapshot 1`] = `
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
+  min-width: 160px;
   position: relative;
   display: inline-block;
   width: 100%;
@@ -1024,6 +1026,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
 
 .c1 {
   width: 290px;
+  min-width: 160px;
 }
 
 .c1 .fi-label,
@@ -1073,6 +1076,7 @@ exports[`Controlled Dropdown should match snapshot 1`] = `
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
+  min-width: 160px;
   position: relative;
   display: inline-block;
   width: 100%;
@@ -1717,6 +1721,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
 
 .c1 {
   width: 290px;
+  min-width: 160px;
 }
 
 .c1 .fi-label,
@@ -1766,6 +1771,7 @@ exports[`Dropdown with additional aria-label should match snapshot 1`] = `
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
+  min-width: 160px;
   position: relative;
   display: inline-block;
   width: 100%;
@@ -2310,6 +2316,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
 
 .c1 {
   width: 290px;
+  min-width: 160px;
 }
 
 .c1 .fi-label,
@@ -2359,6 +2366,7 @@ exports[`Dropdown with hidden label should match snapshot 1`] = `
   border: 1px solid hsl(202, 7%, 80%);
   border-radius: 2px;
   line-height: 1;
+  min-width: 160px;
   position: relative;
   display: inline-block;
   width: 100%;

--- a/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
+++ b/src/core/Form/FilterInput/FilterInput.baseStyles.tsx
@@ -8,6 +8,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   & .fi-filter-input_wrapper {
     display: inline-block;
     width: 100%;
+    min-width: 160px;
 
     & .fi-filter-input_label--visible {
       margin-bottom: ${theme.spacing.xs};
@@ -63,7 +64,7 @@ export const baseStyles = (theme: SuomifiTheme) => css`
   & .fi-filter-input_input {
     ${input(theme)}
     background-color: ${theme.colors.whiteBase};
-    min-width: 40px;
+    min-width: 160px;
     width: 100%;
     min-height: 40px;
     padding-left: ${theme.spacing.insetL};

--- a/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
+++ b/src/core/Form/FilterInput/__snapshots__/FilterInput.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`snapshot matches 1`] = `
 .c1 .fi-filter-input_wrapper {
   display: inline-block;
   width: 100%;
+  min-width: 160px;
 }
 
 .c1 .fi-filter-input_wrapper .fi-filter-input_label--visible {
@@ -282,7 +283,7 @@ exports[`snapshot matches 1`] = `
   border-radius: 2px;
   line-height: 1;
   background-color: hsl(0, 0%, 100%);
-  min-width: 40px;
+  min-width: 160px;
   width: 100%;
   min-height: 40px;
   padding-left: 10px;

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -404,6 +404,7 @@ exports[`has matching snapshot 1`] = `
 .c2 .fi-filter-input_wrapper {
   display: inline-block;
   width: 100%;
+  min-width: 160px;
 }
 
 .c2 .fi-filter-input_wrapper .fi-filter-input_label--visible {
@@ -495,7 +496,7 @@ exports[`has matching snapshot 1`] = `
   border-radius: 2px;
   line-height: 1;
   background-color: hsl(0, 0%, 100%);
-  min-width: 40px;
+  min-width: 160px;
   width: 100%;
   min-height: 40px;
   padding-left: 10px;

--- a/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
+++ b/src/core/Form/Select/SingleSelect/__snapshots__/SingleSelect.test.tsx.snap
@@ -397,6 +397,7 @@ exports[`has matching snapshot 1`] = `
 .c2 .fi-filter-input_wrapper {
   display: inline-block;
   width: 100%;
+  min-width: 160px;
 }
 
 .c2 .fi-filter-input_wrapper .fi-filter-input_label--visible {
@@ -488,7 +489,7 @@ exports[`has matching snapshot 1`] = `
   border-radius: 2px;
   line-height: 1;
   background-color: hsl(0, 0%, 100%);
-  min-width: 40px;
+  min-width: 160px;
   width: 100%;
   min-height: 40px;
   padding-left: 10px;


### PR DESCRIPTION
## Description
Dropdown had a somewhat high min-width value of 245px previously. This PR lowers it to 160px and also sets the same minimum width to the select components. Some adjustments were made to datepicker styles in order to accomodate these changes.

## Motivation and Context
Some projects needed dropdown to be somewhat narrower in certain context. This PR makes that possible and there was no huge reason to have the minimum width as high as it was.

## How Has This Been Tested?
Tested locally on styleguidist on chrome

## Release notes
### Dropdown
**Breaking change:** Set minimum width of container and open button to 160px
### SingleSelect, MultiSelect
**Breaking change:** Set minimum width of container and input to 160px
