### PR TITLE
[Fix] Modal: Remove aria-modal=false

### DIFF
--- a/src/core/Modal/Modal/Modal.tsx
+++ b/src/core/Modal/Modal/Modal.tsx
@@ -162,7 +162,7 @@ class BaseModal extends Component<InternalModalProps> {
           [modalClassNames.noScroll]: scrollable === false,
         })}
         ariaHideApp={!!appElementId}
-        aria={{ modal: false, labelledby: ariaLabelledBy }}
+        aria={{ labelledby: ariaLabelledBy }}
         isOpen={visible}
         onAfterOpen={() => {
           this.toggleBodyScroll();

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -835,7 +835,7 @@ exports[`Basic modal should match snapshot 1`] = `
     >
       <div
         aria-labelledby="test12"
-        aria-modal="false"
+        aria-modal="true"
         class="ReactModal__Content fi-modal"
         role="dialog"
         tabindex="-1"

--- a/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
+++ b/src/core/Modal/ModalContent/__snapshots__/ModalContent.test.tsx.snap
@@ -440,7 +440,7 @@ exports[`Basic ModalContent should match snapshot 1`] = `
       class="ReactModal__Overlay fi-modal_overlay"
     >
       <div
-        aria-modal="false"
+        aria-modal="true"
         class="ReactModal__Content fi-modal"
         role="dialog"
         tabindex="-1"

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -539,7 +539,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
       class="ReactModal__Overlay fi-modal_overlay"
     >
       <div
-        aria-modal="false"
+        aria-modal="true"
         class="ReactModal__Content fi-modal"
         role="dialog"
         tabindex="-1"


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Removes aria-modal="false" from Modal component. The value defaults to ReactModal's default, aria-modal="true".

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Aria-modal attribute of opened modal did not reflect the true state of the dialog. Aria-modal communicates to assistive technology whether the element in question is modal or not.

Aria-modal="false" was needed previously for VoiceOver + Safari on MacOS, so that the values in popovers (SingleSelect, MultiSelect, Dropdown) would be read.

## How Has This Been Tested?

Tested with MacOS 26.6, VoiceOver + Safari, that this attribute is no longer needed. Also tested iOS 26.5.2, VoiceOver + Safari.

Test setup: Modal that had SingleSelect, MultiSelect, and Dropdown as content. Tested Dropdown with both portal modes, portal={true} (the default) and portal={false}. Values of the components were read in all cases with VoiceOver + Safari.

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### Modal
- Sets aria-modal attribute to true.