### PR TITLE
[Feature] Minimum release age for npm packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
   "ignorePatterns": [
     "**/*.config.*",
     "jest/*.js",
+    "scripts/*.js",
     "node_modules/",
     "dist/**/*"
   ],

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,6 @@
 @type:registry=https://registry.npmjs.org/
 registry=https://registry.npmjs.org/
 save-exact=true
+min-release-age=7
+min-release-age-exclude[]=suomifi-icons
+min-release-age-exclude[]=suomifi-design-tokens

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "a11y"
   ],
   "scripts": {
-    "prepare": "npm-run-all husky:install build",
+    "prepare": "npm-run-all check:npm-version husky:install build",
+    "check:npm-version": "node scripts/check-npm-version.js",
     "husky:install": "husky install",
     "pre-commit": "lint-staged",
     "pre-push": "npm run validate",

--- a/scripts/check-npm-version.js
+++ b/scripts/check-npm-version.js
@@ -1,0 +1,15 @@
+const { execSync } = require('child_process');
+const semver = require('semver');
+
+// Only check in dev (skip in CI if needed)
+if (process.env.CI) process.exit(0);
+
+const npmVersion = execSync('npm --version', { encoding: 'utf-8' }).trim();
+
+if (!semver.gte(npmVersion, '11.10.0')) {
+  console.warn(
+    `\n⚠️  npm ${npmVersion} detected. Library development requires npm >=11.10.0 for min-release-age security.\n` +
+      `    Run: npm install -g npm@latest\n`,
+  );
+  process.exit(1);
+}

--- a/scripts/check-npm-version.js
+++ b/scripts/check-npm-version.js
@@ -8,8 +8,7 @@ const npmVersion = execSync('npm --version', { encoding: 'utf-8' }).trim();
 
 if (!semver.gte(npmVersion, '11.10.0')) {
   console.warn(
-    `\n⚠️  npm ${npmVersion} detected. Library development requires npm >=11.10.0 for min-release-age security.\n` +
-      `    Run: npm install -g npm@latest\n`,
+    `\n⚠️  npm ${npmVersion} detected. Library development requires npm >=11.10.0 for min-release-age security.\n`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Description
This PR adds `min-release-age` of 7 days to the project's npm config in for protection against supply chain attacks. It also adds exceptions to the rule for our own libraries.

## Motivation and Context
After the recent supply chain attacks it became important to add new safeguards against falling victim to one.

## How Has This Been Tested?
Tested by trying to install a newer package and seeing it was blocked by npm.

## Screenshots (if appropriate):
<img width="1630" height="34" alt="image" src="https://github.com/user-attachments/assets/c05a03ab-cb5e-4a0f-a097-14c119cf712a" />

## Release notes
### General
- Add `min-release-age` for npm packages
