### PR TITLE
[Fix] Checkbox and radiobutton element alignment

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@
 
 For testing: [React-testing-library](https://github.com/kentcdodds/react-testing-library) run by [Jest](https://github.com/facebook/jest) with [ts-jest](https://github.com/kulshekhar/ts-jest) (code coverage with built-in [Istanbul](https://github.com/istanbuljs)). Code style with [Prettier](https://github.com/prettier/prettier).
 
-**Note!** Before installing dependencies, make sure you are using npm v11.19.0 or newer in order to utilize `min-release-age` as a safety measure.
+**Note!** Before installing dependencies, make sure you are using npm version 11.10.0 or newer in order to utilize `min-release-age` as a safety measure.
 
 After cloning suomifi-ui-components, run `npm install` to fetch its dependencies. Then, you can run several commands:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,6 +6,8 @@
 
 For testing: [React-testing-library](https://github.com/kentcdodds/react-testing-library) run by [Jest](https://github.com/facebook/jest) with [ts-jest](https://github.com/kulshekhar/ts-jest) (code coverage with built-in [Istanbul](https://github.com/istanbuljs)). Code style with [Prettier](https://github.com/prettier/prettier).
 
+**Note!** Before installing dependencies, make sure you are using npm v11.19.0 or newer in order to utilize `min-release-age` as a safety measure.
+
 After cloning suomifi-ui-components, run `npm install` to fetch its dependencies. Then, you can run several commands:
 
 1. `npm run start` runs Styleguidist for displaying components stories.

--- a/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
+++ b/src/core/Form/Checkbox/Checkbox.baseStyles.tsx
@@ -144,7 +144,7 @@ export const baseStyles = (
       content: '';
       position: absolute;
       left: 0px;
-      top: ${theme.spacing.xxs};
+      top: 0.25em;
       box-sizing: border-box;
       height: 18px;
       width: 18px;
@@ -169,7 +169,7 @@ export const baseStyles = (
         content: '';
         position: absolute;
         pointer-events: none;
-        top: 4px;
+        top: calc(0.25em - 1px);
         left: -1px;
         border-radius: 2px;
         background-color: transparent;

--- a/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`props children has matching snapshot 1`] = `
   content: '';
   position: absolute;
   left: 0px;
-  top: 5px;
+  top: 0.25em;
   box-sizing: border-box;
   height: 18px;
   width: 18px;
@@ -199,7 +199,7 @@ exports[`props children has matching snapshot 1`] = `
   content: '';
   position: absolute;
   pointer-events: none;
-  top: 4px;
+  top: calc(0.25em - 1px);
   left: -1px;
   border-radius: 2px;
   background-color: transparent;

--- a/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/core/Form/Checkbox/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -309,7 +309,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   content: '';
   position: absolute;
   left: 0px;
-  top: 5px;
+  top: 0.25em;
   box-sizing: border-box;
   height: 18px;
   width: 18px;
@@ -330,7 +330,7 @@ exports[`default, with only required props should match snapshot 1`] = `
   content: '';
   position: absolute;
   pointer-events: none;
-  top: 4px;
+  top: calc(0.25em - 1px);
   left: -1px;
   border-radius: 2px;
   background-color: transparent;

--- a/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
+++ b/src/core/Form/RadioButton/RadioButton.baseStyles.tsx
@@ -124,7 +124,7 @@ export const baseStyles = (
       top: 5px;
       left: 2px;
       + .fi-radio-button_icon_wrapper {
-        top: 3px;
+        top: 0.1em;
         left: 0;
         margin: 2px;
         height: 18px;

--- a/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -517,7 +517,7 @@ exports[`className should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -853,7 +853,7 @@ exports[`disabled should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -1207,7 +1207,7 @@ exports[`hintText should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -1550,7 +1550,7 @@ exports[`id should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -1886,7 +1886,7 @@ exports[`name should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -2223,7 +2223,7 @@ exports[`value should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -2551,7 +2551,7 @@ exports[`variant should match snapshot 1`] = `
 }
 
 .c1.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;

--- a/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
+++ b/src/core/Form/RadioButton/__snapshots__/RadioButtonGroup.test.tsx.snap
@@ -389,7 +389,7 @@ exports[`default, with only required props should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -1061,7 +1061,7 @@ exports[`props className should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -1733,7 +1733,7 @@ exports[`props defaultValue should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -2441,7 +2441,7 @@ exports[`props groupStatus and statusText should match snapshot 1`] = `
 }
 
 .c8.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -3153,7 +3153,7 @@ exports[`props hintText should match snapshot 1`] = `
 }
 
 .c8.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -3830,7 +3830,7 @@ exports[`props id should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -4502,7 +4502,7 @@ exports[`props label should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -5185,7 +5185,7 @@ exports[`props labelMode should match snapshot 1`] = `
 }
 
 .c8.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -5857,7 +5857,7 @@ exports[`props name should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;
@@ -6529,7 +6529,7 @@ exports[`props value should match snapshot 1`] = `
 }
 
 .c7.fi-radio-button .fi-radio-button_input +.fi-radio-button_icon_wrapper {
-  top: 3px;
+  top: 0.1em;
   left: 0;
   margin: 2px;
   height: 18px;


### PR DESCRIPTION
## Description
This PR changes the positioning of the radiobutton and checkbox visual elements slightly to align the elements with the new font, which has a slightly different baseline than the old one.

It also adds a mention about the minimum suggested npm version to `development.md`

## Motivation and Context
The elements were visually slightly out of place after the font change from Source Sans Pro to Source Sans 3

## How Has This Been Tested?
Running locally on styleguidist and testing different browsers, zoom level and forced font sizes

## Screenshots (if appropriate):
Before:
<img width="372" height="112" alt="image" src="https://github.com/user-attachments/assets/a942e586-0b61-4f21-b74b-8fc5d44eba90" />
After:
<img width="286" height="98" alt="image" src="https://github.com/user-attachments/assets/705c4caa-5232-4dae-a660-e6a7db634b0a" />

## Release notes
### RadioButton
* **Breaking change:** change element alignment to fix positioning with new font
### Checkbox
* **Breaking change:** change element alignment to fix positioning with new font