### PR TITLE
[Fix] Chip remove icon position on large fonts

### DIFF
--- a/src/core/Chip/Chip/Chip.baseStyles.tsx
+++ b/src/core/Chip/Chip/Chip.baseStyles.tsx
@@ -26,21 +26,21 @@ export const baseStyles = (
   }
 
   &.fi-chip--removable {
-    padding-top: ${theme.spacing.insetXxs};
-    padding-right: 22px;
-    padding-bottom: ${theme.spacing.insetXxs};
-    padding-left: ${theme.spacing.insetL};
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: ${theme.spacing.insetXxs} ${theme.spacing.insetL};
     position: relative;
 
     & .fi-chip--icon {
-      position: absolute;
-      top: 8px;
-      right: 10px;
+      flex-shrink: 0;
+      margin-left: ${theme.spacing.xs};
       height: 12px;
       width: 12px;
     }
 
     & .fi-chip--content {
+      flex-grow: 1;
       margin-right: ${theme.spacing.xs};
     }
 

--- a/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/core/Chip/Chip/__snapshots__/Chip.test.tsx.snap
@@ -159,22 +159,22 @@ exports[`children should match snapshot 1`] = `
 }
 
 .c1.fi-chip--removable {
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 10px;
   position: relative;
 }
 
 .c1.fi-chip--removable .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
+  flex-shrink: 0;
+  margin-left: 10px;
   height: 12px;
   width: 12px;
 }
 
 .c1.fi-chip--removable .fi-chip--content {
+  flex-grow: 1;
   margin-right: 10px;
 }
 
@@ -366,22 +366,22 @@ exports[`classnames should match snapshot 1`] = `
 }
 
 .c1.fi-chip--removable {
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 10px;
   position: relative;
 }
 
 .c1.fi-chip--removable .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
+  flex-shrink: 0;
+  margin-left: 10px;
   height: 12px;
   width: 12px;
 }
 
 .c1.fi-chip--removable .fi-chip--content {
+  flex-grow: 1;
   margin-right: 10px;
 }
 
@@ -569,22 +569,22 @@ exports[`disabled should match snapshot 1`] = `
 }
 
 .c1.fi-chip--removable {
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 10px;
   position: relative;
 }
 
 .c1.fi-chip--removable .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
+  flex-shrink: 0;
+  margin-left: 10px;
   height: 12px;
   width: 12px;
 }
 
 .c1.fi-chip--removable .fi-chip--content {
+  flex-grow: 1;
   margin-right: 10px;
 }
 

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -741,22 +741,22 @@ exports[`has matching snapshot 1`] = `
 }
 
 .c18.fi-chip--removable {
-  padding-top: 2px;
-  padding-right: 22px;
-  padding-bottom: 2px;
-  padding-left: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 10px;
   position: relative;
 }
 
 .c18.fi-chip--removable .fi-chip--icon {
-  position: absolute;
-  top: 8px;
-  right: 10px;
+  flex-shrink: 0;
+  margin-left: 10px;
   height: 12px;
   width: 12px;
 }
 
 .c18.fi-chip--removable .fi-chip--content {
+  flex-grow: 1;
   margin-right: 10px;
 }
 


### PR DESCRIPTION
## Description
Sometimes the chip content might span multiple lines so that the component itself grows vertically as well. This PR fixes the icon position, so that it is vertically centered in those cases as well.

## How Has This Been Tested?
Tested locally in styleguidist with regular and forced larger font sizes on firefox and chrome.

## Screenshots (if appropriate):
Before:
<img width="442" height="100" alt="image" src="https://github.com/user-attachments/assets/eee3915f-b9b1-4ca4-8a6c-2d53e0853121" />
After:
<img width="442" height="97" alt="Screenshot 2026-08-13 at 13 16 33" src="https://github.com/user-attachments/assets/3be8ea5d-7c37-4a58-b0aa-551074c85ca7" />


## Release notes
### Chip
- Center remove icon vertically when height is larger than default
