### PR TITLE
[Fix] Fix LinkList item alignment when text spans multiple lines

### DIFF
--- a/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
+++ b/src/core/Link/LinkList/__snapshots__/LinkList.test.tsx.snap
@@ -226,7 +226,7 @@ exports[`Simple link list with one item should match snapshot 1`] = `
 }
 
 .c3.fi-link-list-item .fi-link-list-item_icon {
-  margin-right: 2px;
+  display: inline-block;
 }
 
 .c3.fi-link-list-item .fi-link-list-item_icon .fi-icon {

--- a/src/core/Link/LinkListItem/LinkListItem.baseStyles.ts
+++ b/src/core/Link/LinkListItem/LinkListItem.baseStyles.ts
@@ -9,7 +9,7 @@ export const LinkListItemStyles = (theme: SuomifiTheme) => css`
     padding: 0;
     margin-left: 15px;
     & .fi-link-list-item_icon {
-      margin-right: 2px;
+      display: inline-block;
       & .fi-icon {
         margin-left: -18px;
         font-size: 16px;


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Fixes LinkListItem alignment when text spans multiple lines.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

Library users reported that text was not aligned. Aligment was different at least with Firefox vs Chrome.

## How Has This Been Tested?

Tested with MacOS 26.6. Safari, Firefox 151, Chrome 151.0.7922.170, and Edge 151.
Tested with Browserstack Windows 11: Edge 151, Firefox 153, Chrome 151.
## Screenshots (if appropriate):

Alignment with Firefox before fix - 3rd item's first row alignment different than 3rd item's second row
<img width="322" height="140" alt="image" src="https://github.com/user-attachments/assets/09f3071a-601a-4137-a413-918ecd020700" />

Alignment with Firefox after fix
<img width="378" height="146" alt="image" src="https://github.com/user-attachments/assets/293c50c7-025b-444b-9d14-b9e9f62eb2f7" />

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### LinkListItem

- **Breaking change:** Display LinkListItem's icon as inline-block to align overflowing text lines