### PR TITLE
[Fix] Notification button icon wraps on some browsers

### DIFF
--- a/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
+++ b/src/core/ActionMenu/__snapshots__/ActionMenu.test.tsx.snap
@@ -489,6 +489,10 @@ exports[`Basic ActionMenu should match snapshot 1`] = `
   fill: hsl(202, 7%, 67%);
 }
 
+.c5 .fi-button_icon {
+  display: inline-block;
+}
+
 .c5>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;
@@ -1270,6 +1274,10 @@ exports[`Disabled ActionMenu should match snapshot 1`] = `
 
 .c5.fi-button--secondary-light .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(202, 7%, 67%);
+}
+
+.c5 .fi-button_icon {
+  display: inline-block;
 }
 
 .c5>.fi-button_icon>.fi-icon {
@@ -2055,6 +2063,10 @@ exports[`No borders variant should match snapshot 1`] = `
   fill: hsl(202, 7%, 67%);
 }
 
+.c5 .fi-button_icon {
+  display: inline-block;
+}
+
 .c5>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;
@@ -2836,6 +2848,10 @@ exports[`movement in ActionMenu should match snapshot 1`] = `
 
 .c5.fi-button--secondary-light .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(202, 7%, 67%);
+}
+
+.c5 .fi-button_icon {
+  display: inline-block;
 }
 
 .c5>.fi-button_icon>.fi-icon {
@@ -3620,6 +3636,10 @@ exports[`movement in ActionMenu should match snapshot 2`] = `
 
 .c5.fi-button--secondary-light .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(202, 7%, 67%);
+}
+
+.c5 .fi-button_icon {
+  display: inline-block;
 }
 
 .c5>.fi-button_icon>.fi-icon {

--- a/src/core/Button/Button.baseStyles.tsx
+++ b/src/core/Button/Button.baseStyles.tsx
@@ -184,7 +184,11 @@ export const baseStyles = (
   ${secondaryNoBorderStyles(theme)}
 
   ${secondaryLightStyles(theme)}
-  
+
+  & .fi-button_icon {
+    display: inline-block;
+  }
+
   & > .fi-button_icon > .fi-icon {
     width: 16px;
     height: 16px;

--- a/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/src/core/Form/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -3165,6 +3165,10 @@ exports[`snapshots match date input with datepicker with controlled input value 
   fill: hsl(202, 7%, 67%);
 }
 
+.c13 .fi-button_icon {
+  display: inline-block;
+}
+
 .c13>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;
@@ -5318,6 +5322,10 @@ exports[`snapshots match date input with datepicker with smallScreen 1`] = `
 
 .c13.fi-button--secondary-light .fi-button_loading-icon .fi-icon-component-brand-fill {
   fill: hsl(202, 7%, 67%);
+}
+
+.c13 .fi-button_icon {
+  display: inline-block;
 }
 
 .c13>.fi-button_icon>.fi-icon {

--- a/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/core/Form/Select/MultiSelect/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -1017,6 +1017,10 @@ exports[`has matching snapshot 1`] = `
   fill: hsl(202, 7%, 67%);
 }
 
+.c20 .fi-button_icon {
+  display: inline-block;
+}
+
 .c20>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;

--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -753,6 +753,10 @@ exports[`Basic modal should match snapshot 1`] = `
   fill: hsl(202, 7%, 67%);
 }
 
+.c10 .fi-button_icon {
+  display: inline-block;
+}
+
 .c10>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -458,6 +458,10 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   fill: hsl(202, 7%, 67%);
 }
 
+.c6 .fi-button_icon {
+  display: inline-block;
+}
+
 .c6>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;

--- a/src/core/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/core/Notification/__snapshots__/Notification.test.tsx.snap
@@ -647,6 +647,10 @@ exports[`props children should match snapshot 1`] = `
   fill: hsl(202, 7%, 67%);
 }
 
+.c9 .fi-button_icon {
+  display: inline-block;
+}
+
 .c9>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;

--- a/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/core/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -758,6 +758,10 @@ exports[`snapshot should have matching default structure 1`] = `
   fill: hsl(202, 7%, 67%);
 }
 
+.c6 .fi-button_icon {
+  display: inline-block;
+}
+
 .c6>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;

--- a/src/core/ReorderableList/ReorderableList/__snapshots__/ReorderableList.test.tsx.snap
+++ b/src/core/ReorderableList/ReorderableList/__snapshots__/ReorderableList.test.tsx.snap
@@ -431,6 +431,10 @@ exports[`ReorderableList should match snapshot 1`] = `
   fill: hsl(202, 7%, 67%);
 }
 
+.c6 .fi-button_icon {
+  display: inline-block;
+}
+
 .c6>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;

--- a/src/core/ReorderableList/ReorderableListItem/__snapshots__/ReorderableListItem.test.tsx.snap
+++ b/src/core/ReorderableList/ReorderableListItem/__snapshots__/ReorderableListItem.test.tsx.snap
@@ -431,6 +431,10 @@ exports[`ReorderableListItem should match snapshot 1`] = `
   fill: hsl(202, 7%, 67%);
 }
 
+.c6 .fi-button_icon {
+  display: inline-block;
+}
+
 .c6>.fi-button_icon>.fi-icon {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
## Description
The icon in the notification close button has started wrapping to the next line on Firefox and Safari, when the notification is narrow. This PR fixes the issue by adding `display: inline-block` to the icon wrapper.

## Motivation and Context
This was a bug reported by services using the library and needed to be fixed.

## How Has This Been Tested?
Tested by running locally in styleguidist on Chrome, Firefox and Safari.

## Screenshots (if appropriate):
Before:
<img width="928" height="292" alt="image" src="https://github.com/user-attachments/assets/9756dbc6-987d-4a57-9981-2317278fd3fe" />
After:
<img width="908" height="276" alt="image" src="https://github.com/user-attachments/assets/dd4bdf68-ed02-44b2-9950-240adbec2aa2" />


## Release notes
### Notification
- Fix issue where close button icon wraps to new line on narrow notifications on some browsers
