### PR TITLE
[Feature] Modal: Remove pointer-events from gradient overlay

### DIFF
--- a/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/core/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -492,6 +492,7 @@ exports[`Basic modal should match snapshot 1`] = `
   width: 100%;
   top: -51px;
   border-bottom: 1px solid hsl(202, 7%, 80%);
+  pointer-events: none;
 }
 
 .c7.fi-modal_footer .fi-modal_footer_content-gradient-overlay .fi-modal_footer_content-gradient {

--- a/src/core/Modal/ModalFooter/ModalFooter.baseStyles.tsx
+++ b/src/core/Modal/ModalFooter/ModalFooter.baseStyles.tsx
@@ -24,6 +24,8 @@ export const baseStyles = (theme: SuomifiTheme) => css`
       width: 100%;
       top: -51px;
       border-bottom: 1px solid ${theme.colors.depthLight1};
+      pointer-events: none;
+
       & .fi-modal_footer_content-gradient {
         height: 50px;
         margin: 0 ${theme.spacing.m} 0 ${theme.spacing.m};

--- a/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
+++ b/src/core/Modal/ModalFooter/__snapshots__/ModalFooter.test.tsx.snap
@@ -197,6 +197,7 @@ exports[`Basic ModalFooter should match snapshot 1`] = `
   width: 100%;
   top: -51px;
   border-bottom: 1px solid hsl(202, 7%, 80%);
+  pointer-events: none;
 }
 
 .c2.fi-modal_footer .fi-modal_footer_content-gradient-overlay .fi-modal_footer_content-gradient {


### PR DESCRIPTION
<!-- Have you followed the guidelines in our Contributing document?
https://github.com/vrk-kpa/suomifi-ui-components/blob/develop/CONTRIBUTING.md
Have you checked to ensure there aren't other open Pull Requests for the same update/change?
Hopefully you did not remove any lock-files, tests or linter-rules to pass the CI-automation? -->

## Description

<!-- Describe your changes in detail -->
<!-- Add [Feature] or [BreakingChange] to the title -->

Enables interacting with elements underneath gradient overlay in Modal component.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

When Modal has long content and is scrollable, a gradient overlay is applied to indicate to users, that the Modal content continues. The gradient overlay however prevented user from interacting with the elements under it.

## How Has This Been Tested?

Tested with MacOS Chrome and Firefox, that user can click elements (Button, TextInput) and select text undearneath the gradient overlay.

## Screenshots (if appropriate):

Example of Button underneath gradient overlay.

<img width="600" height="auto" alt="image" src="https://github.com/user-attachments/assets/42ae29fd-6cf1-4f68-a3ca-b7d653cc691e" />

## Release notes

<!-- Description of the essential contents of this pull request for release notes. Breaking changes to API or design and new features are especially important. Preferably one line or one paragraph at maximum. -->

### Modal
- Enables user to click elements beneath gradient overlay in scrollable Modals